### PR TITLE
[release/13.2] Backport: Fix 13.2 IDE execution regressions for Azure Functions and class library projects (#15714)

### DIFF
--- a/extension/src/dcp/AspireDcpServer.ts
+++ b/extension/src/dcp/AspireDcpServer.ts
@@ -140,7 +140,7 @@ export default class AspireDcpServer {
                     const config = await createDebugSessionConfiguration(
                         aspireDebugSession.configuration,
                         launchConfig,
-                        payload.args ?? [],
+                        payload.args,
                         payload.env ?? [],
                         { debug: launchConfig.mode === "Debug", runId, debugSessionId: dcpId, isApphost: false, debugSession: aspireDebugSession },
                         foundDebuggerExtension

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -15,7 +15,9 @@ import {
     mergeEnvironmentVariables,
     determineArguments,
     determineWorkingDirectory,
-    determineServerReadyAction
+    determineServerReadyAction,
+    LaunchProfileCommandName,
+    expandEnvironmentVariables
 } from '../launchProfiles';
 import { AspireDebugSession } from '../AspireDebugSession';
 
@@ -253,7 +255,29 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
                 env.push({ name: "ASPIRE_DASHBOARD_AI_DISABLED", value: "true" });
             }
 
-            if (!isFileBasedApp(projectPath)) {
+            if (baseProfile?.commandName?.toLowerCase() === LaunchProfileCommandName.executable && baseProfile.executablePath) {
+                // For Executable command profiles (e.g., class library integrations), the launch profile
+                // specifies an external executable to run instead of the project output.
+                // Build the project to ensure dependencies are compiled, then launch
+                // using the profile's executable path and command line arguments.
+                // Expand environment variable references (e.g. $(HOME)) that VS handles natively
+                // but aren't expanded by the coreclr debugger.
+                await dotNetService.buildDotNetProject(projectPath);
+
+                debugConfiguration.program = expandEnvironmentVariables(baseProfile.executablePath);
+                if (debugConfiguration.args) {
+                    debugConfiguration.args = expandEnvironmentVariables(debugConfiguration.args);
+                } else if (baseProfile.commandLineArgs) {
+                    // Fall back to launch profile args if run session args were empty
+                    debugConfiguration.args = expandEnvironmentVariables(baseProfile.commandLineArgs);
+                }
+                debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(
+                    baseProfile?.environmentVariables,
+                    debugConfiguration.env,
+                    env
+                ));
+            }
+            else if (!isFileBasedApp(projectPath)) {
                 const outputPath = await dotNetService.getDotNetTargetPath(projectPath);
                 if ((!(await doesFileExist(outputPath)) || launchOptions.forceBuild)) {
                     await dotNetService.buildDotNetProject(projectPath);

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -27,6 +27,26 @@ export interface LaunchProfile {
     useSSL?: boolean;
 }
 
+/**
+ * Expands environment variable references in a string.
+ * Supports $(VAR) and %VAR% syntax used by launch profiles.
+ */
+export function expandEnvironmentVariables(value: string): string {
+    // Expand $(VAR) syntax (used by VS and MSBuild-style launch profiles)
+    let result = value.replace(/\$\(([^)]+)\)/g, (_, varName) => process.env[varName] ?? '');
+    // Expand %VAR% syntax (Windows)
+    result = result.replace(/%([^%]+)%/g, (_, varName) => process.env[varName] ?? '');
+    return result;
+}
+
+/**
+ * Well-known launch profile command names (lowercased for case-insensitive comparison).
+ */
+export const LaunchProfileCommandName = {
+    project: 'project',
+    executable: 'executable',
+} as const;
+
 export interface LaunchSettings {
     profiles: { [key: string]: LaunchProfile };
 }
@@ -128,7 +148,7 @@ export function determineBaseLaunchProfile(
 
     // If launch_profile is absent, choose the first one with commandName='Project'
     for (const [name, profile] of Object.entries(launchSettings.profiles)) {
-        if (profile.commandName === 'Project') {
+        if (profile.commandName?.toLowerCase() === LaunchProfileCommandName.project) {
             extensionLogOutputChannel.debug(`Using default launch profile: ${name}`);
             return { profile, profileName: name };
         }
@@ -209,13 +229,14 @@ export function determineWorkingDirectory(
     baseProfile: LaunchProfile | null
 ): string {
     if (baseProfile?.workingDirectory) {
+        const workingDirectory = expandEnvironmentVariables(baseProfile.workingDirectory);
         // If working directory is relative, resolve it relative to project directory
-        if (path.isAbsolute(baseProfile.workingDirectory)) {
-            extensionLogOutputChannel.debug(`Using absolute working directory from launch profile: ${baseProfile.workingDirectory}`);
-            return baseProfile.workingDirectory;
+        if (path.isAbsolute(workingDirectory)) {
+            extensionLogOutputChannel.debug(`Using absolute working directory from launch profile: ${workingDirectory}`);
+            return workingDirectory;
         } else {
             const projectDir = path.dirname(projectPath);
-            const workingDir = path.resolve(projectDir, baseProfile.workingDirectory);
+            const workingDir = path.resolve(projectDir, workingDirectory);
             extensionLogOutputChannel.debug(`Using relative working directory from launch profile: ${workingDir}`);
             return workingDir;
         }

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -185,4 +185,143 @@ suite('Dotnet Debugger Extension Tests', () => {
         // cleanup
         fs.rmSync(tempDir, { recursive: true, force: true });
     });
+
+    test('uses executable path for Executable command launch profiles instead of project output', async () => {
+        // Bug #15647: Executable command profiles use the executablePath and
+        // commandLineArgs to define how to run the class library project. The extension
+        // should use executablePath as the program instead of the project's output DLL.
+        const fs = require('fs');
+        const os = require('os');
+        const path = require('path');
+
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+        const projectDir = path.join(tempDir, 'MyClassLibFunction');
+        const propertiesDir = path.join(projectDir, 'Properties');
+        fs.mkdirSync(propertiesDir, { recursive: true });
+
+        const projectPath = path.join(projectDir, 'MyClassLibFunction.csproj');
+        fs.writeFileSync(projectPath, '<Project></Project>');
+
+        const launchSettings = {
+            profiles: {
+                'Aspire_my-function': {
+                    commandName: 'Executable',
+                    executablePath: 'dotnet',
+                    commandLineArgs: 'exec --depsfile ./MyClassLibFunction.deps.json --runtimeconfig ./MyClassLibFunction.runtimeconfig.json RuntimeSupport.dll MyClassLibFunction::MyClassLibFunction.Function::FunctionHandler',
+                    workingDirectory: 'bin/Debug/net10.0/',
+                    environmentVariables: {
+                        FUNCTION_ENV: 'test'
+                    }
+                }
+            }
+        };
+
+        fs.writeFileSync(path.join(propertiesDir, 'launchSettings.json'), JSON.stringify(launchSettings, null, 2));
+
+        // The output path would be a class library DLL - this should NOT be used as program
+        const outputPath = path.join(projectDir, 'bin', 'Debug', 'net10.0', 'MyClassLibFunction.dll');
+        const { extension, dotNetService } = createDebuggerExtension(outputPath, null, true, true);
+
+        const launchConfig: ProjectLaunchConfiguration = {
+            type: 'project',
+            project_path: projectPath,
+            launch_profile: 'Aspire_my-function'
+        };
+
+        const debugConfig: AspireResourceExtendedDebugConfiguration = {
+            runId: '1',
+            debugSessionId: '1',
+            type: 'coreclr',
+            name: 'Test Debug Config',
+            request: 'launch'
+        };
+
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+        // program should be the executable path from the profile, NOT the project output DLL
+        assert.strictEqual(debugConfig.program, 'dotnet');
+
+        // args should come from the profile's commandLineArgs
+        assert.strictEqual(debugConfig.args, 'exec --depsfile ./MyClassLibFunction.deps.json --runtimeconfig ./MyClassLibFunction.runtimeconfig.json RuntimeSupport.dll MyClassLibFunction::MyClassLibFunction.Function::FunctionHandler');
+
+        // cwd should resolve to the profile's working directory
+        assert.strictEqual(debugConfig.cwd, path.resolve(projectDir, 'bin/Debug/net10.0/'));
+
+        // env should include the profile's environment variables
+        assert.strictEqual(debugConfig.env.FUNCTION_ENV, 'test');
+
+        // project should still be built (to compile the class library dependencies)
+        assert.strictEqual(dotNetService.buildDotNetProjectStub.calledOnce, true);
+
+        // cleanup
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('expands environment variables in Executable profile executablePath and commandLineArgs', async () => {
+        // Executable launch profiles may contain $(VAR) references (e.g. $(HOME)) that
+        // VS expands natively but the coreclr debugger does not. The extension must expand
+        // these before passing them to the debug configuration.
+        const fs = require('fs');
+        const os = require('os');
+        const path = require('path');
+
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+        const projectDir = path.join(tempDir, 'MyToolProject');
+        const propertiesDir = path.join(projectDir, 'Properties');
+        fs.mkdirSync(propertiesDir, { recursive: true });
+
+        const projectPath = path.join(projectDir, 'MyToolProject.csproj');
+        fs.writeFileSync(projectPath, '<Project></Project>');
+
+        // Set up a test env var so expansion is deterministic
+        const envVarName = 'ASPIRE_TEST_TOOL_ROOT';
+        const envVarValue = '/opt/tools';
+        process.env[envVarName] = envVarValue;
+
+        const launchSettings = {
+            profiles: {
+                'Aspire_my-tool': {
+                    commandName: 'Executable',
+                    executablePath: '$(' + envVarName + ')/bin/dotnet',
+                    commandLineArgs: 'exec --depsfile ./MyToolProject.deps.json $(' + envVarName + ')/lib/RuntimeSupport.dll MyToolProject::MyToolProject.Function::Handler',
+                    workingDirectory: 'bin/Debug/net10.0/'
+                }
+            }
+        };
+
+        fs.writeFileSync(path.join(propertiesDir, 'launchSettings.json'), JSON.stringify(launchSettings, null, 2));
+
+        const outputPath = path.join(projectDir, 'bin', 'Debug', 'net10.0', 'MyToolProject.dll');
+        const { extension, dotNetService } = createDebuggerExtension(outputPath, null, true, true);
+
+        const launchConfig: ProjectLaunchConfiguration = {
+            type: 'project',
+            project_path: projectPath,
+            launch_profile: 'Aspire_my-tool'
+        };
+
+        const debugConfig: AspireResourceExtendedDebugConfiguration = {
+            runId: '1',
+            debugSessionId: '1',
+            type: 'coreclr',
+            name: 'Test Debug Config',
+            request: 'launch'
+        };
+
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+        // executablePath should have $(VAR) expanded
+        assert.strictEqual(debugConfig.program, `${envVarValue}/bin/dotnet`);
+
+        // commandLineArgs should also have $(VAR) expanded
+        assert.strictEqual(debugConfig.args, `exec --depsfile ./MyToolProject.deps.json ${envVarValue}/lib/RuntimeSupport.dll MyToolProject::MyToolProject.Function::Handler`);
+
+        // cleanup
+        delete process.env[envVarName];
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
 });

--- a/extension/src/test/launchProfiles.test.ts
+++ b/extension/src/test/launchProfiles.test.ts
@@ -9,6 +9,7 @@ import {
     determineWorkingDirectory,
     determineServerReadyAction,
     readLaunchSettings,
+    expandEnvironmentVariables,
     LaunchSettings,
     LaunchProfile
 } from '../debugger/launchProfiles';
@@ -480,6 +481,34 @@ suite('Launch Profile Tests', () => {
 
             assert.strictEqual(result, path.join('C:', 'project'));
         });
+
+        test('expands environment variables in working directory before resolving', () => {
+            process.env['TEST_WD_ROOT'] = '/opt/app';
+            const baseProfile: LaunchProfile = {
+                commandName: 'Executable',
+                workingDirectory: '$(TEST_WD_ROOT)/output'
+            };
+
+            const result = determineWorkingDirectory('/dummy/project.csproj', baseProfile);
+
+            // $(TEST_WD_ROOT) expands to /opt/app, making it an absolute path
+            assert.strictEqual(result, '/opt/app/output');
+            delete process.env['TEST_WD_ROOT'];
+        });
+
+        test('expands environment variables in relative working directory', () => {
+            process.env['TEST_WD_SUBDIR'] = 'build-output';
+            const baseProfile: LaunchProfile = {
+                commandName: 'Executable',
+                workingDirectory: '$(TEST_WD_SUBDIR)/bin'
+            };
+
+            const result = determineWorkingDirectory('/projects/myapp/myapp.csproj', baseProfile);
+
+            // $(TEST_WD_SUBDIR) expands to build-output, still relative, resolved against project dir
+            assert.strictEqual(result, path.resolve('/projects/myapp', 'build-output/bin'));
+            delete process.env['TEST_WD_SUBDIR'];
+        });
     });
 
     suite('determineServerReadyAction', () => {
@@ -725,6 +754,58 @@ suite('Launch Profile Tests', () => {
             assert.notStrictEqual(result, null);
             assert.strictEqual(result!.profiles['https'].applicationUrl, 'https://localhost:5001');
             assert.strictEqual(result!.profiles['https'].environmentVariables!.ASPNETCORE_ENVIRONMENT, 'Development');
+        });
+    });
+
+    suite('expandEnvironmentVariables', () => {
+        test('expands $(VAR) syntax from process.env', () => {
+            process.env['TEST_EXPAND_VAR'] = '/test/path';
+            const result = expandEnvironmentVariables('$(TEST_EXPAND_VAR)/subfolder');
+            assert.strictEqual(result, '/test/path/subfolder');
+            delete process.env['TEST_EXPAND_VAR'];
+        });
+
+        test('expands %VAR% syntax from process.env', () => {
+            process.env['TEST_EXPAND_WIN'] = 'C:\\Users\\test';
+            const result = expandEnvironmentVariables('%TEST_EXPAND_WIN%\\subfolder');
+            assert.strictEqual(result, 'C:\\Users\\test\\subfolder');
+            delete process.env['TEST_EXPAND_WIN'];
+        });
+
+        test('expands multiple variables in one string', () => {
+            process.env['TEST_HOME'] = '/home/user';
+            process.env['TEST_VERSION'] = '1.0.0';
+            const result = expandEnvironmentVariables('$(TEST_HOME)/.store/tool/$(TEST_VERSION)/content');
+            assert.strictEqual(result, '/home/user/.store/tool/1.0.0/content');
+            delete process.env['TEST_HOME'];
+            delete process.env['TEST_VERSION'];
+        });
+
+        test('replaces undefined variables with empty string', () => {
+            delete process.env['NONEXISTENT_VAR_12345'];
+            const result = expandEnvironmentVariables('prefix/$(NONEXISTENT_VAR_12345)/suffix');
+            assert.strictEqual(result, 'prefix//suffix');
+        });
+
+        test('returns string unchanged when no variables present', () => {
+            const result = expandEnvironmentVariables('/plain/path/no/vars');
+            assert.strictEqual(result, '/plain/path/no/vars');
+        });
+
+        test('expands HOME variable like AWS Lambda launch profiles use', () => {
+            const home = process.env['HOME'] ?? '';
+            const input = '$(HOME)/.dotnet/tools/.store/amazon.lambda.testtool/0.13.0/content/RuntimeSupport.dll';
+            const result = expandEnvironmentVariables(input);
+            assert.strictEqual(result, `${home}/.dotnet/tools/.store/amazon.lambda.testtool/0.13.0/content/RuntimeSupport.dll`);
+        });
+
+        test('handles mixed $(VAR) and %VAR% in same string', () => {
+            process.env['TEST_MIX_A'] = 'alpha';
+            process.env['TEST_MIX_B'] = 'beta';
+            const result = expandEnvironmentVariables('$(TEST_MIX_A)/%TEST_MIX_B%/end');
+            assert.strictEqual(result, 'alpha/beta/end');
+            delete process.env['TEST_MIX_A'];
+            delete process.env['TEST_MIX_B'];
         });
     });
 });

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1379,6 +1379,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
                 var projectArgs = new List<string>();
 
+                var isInDebugSession = !string.IsNullOrEmpty(_configuration[DebugSessionPortVar]);
+
                 if (project.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation))
                 {
                     exe.Spec.ExecutionType = ExecutionType.IDE;
@@ -1386,23 +1388,26 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
                     if (supportsDebuggingAnnotation.LaunchConfigurationType is "project")
                     {
-                        var projectLaunchConfiguration = new ProjectLaunchConfiguration();
-                        projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
-                        projectLaunchConfiguration.Mode = _configuration[KnownConfigNames.DebugSessionRunMode]
-                            ?? (Debugger.IsAttached ? ExecutableLaunchMode.Debug : ExecutableLaunchMode.NoDebug);
-
-                        projectLaunchConfiguration.DisableLaunchProfile = project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _);
-                        // Use the effective launch profile which has fallback logic
-                        if (!projectLaunchConfiguration.DisableLaunchProfile && project.GetEffectiveLaunchProfile() is NamedLaunchProfile namedLaunchProfile)
-                        {
-                            projectLaunchConfiguration.LaunchProfile = namedLaunchProfile.Name;
-                        }
-
                         // We want this annotation even if we are not using IDE execution; see ToSnapshot() for details.
-                        exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, projectLaunchConfiguration);
+                        exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, CreateProjectLaunchConfiguration(project, projectMetadata));
                     }
                     // Non-project launch types (e.g. azure-functions) have their launch configuration
-                    // applied later in CreateExecutableAsync() after endpoints are allocated.
+                    // applied later in CreateExecutableAsync() after endpoints are allocated,
+                    // unless the IDE didn't send DEBUG_SESSION_INFO (handled by the fallback branch below).
+                }
+                else if (ShouldFallBackToIdeExecution(isInDebugSession, supportsDebuggingAnnotation))
+                {
+                    // Fall back to IDE execution with a standard ProjectLaunchConfiguration when:
+                    // 1. No SupportsDebuggingAnnotation exists (e.g. AddResource-based ProjectResource
+                    //    subclasses that don't call WithDebugSupport). These should get the same IDE
+                    //    treatment that AddProject provides by default.
+                    // 2. The annotation exists but the IDE did not send DEBUG_SESSION_INFO (Visual Studio
+                    //    scenario). VS handles all project resources natively, so non-"project" types
+                    //    like "azure-functions" still need IDE execution with ProjectLaunchConfiguration.
+                    exe.Spec.ExecutionType = ExecutionType.IDE;
+                    exe.Spec.FallbackExecutionTypes = [ExecutionType.Process];
+
+                    exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, CreateProjectLaunchConfiguration(project, projectMetadata));
                 }
                 else
                 {
@@ -1460,6 +1465,45 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 _appResources.Add(exeAppResource);
             }
         }
+    }
+
+    /// <summary>
+    /// Determines whether to fall back to IDE execution for a project resource that did not
+    /// pass <see cref="ExtensionUtils.SupportsDebugging"/>. Returns <see langword="true"/> when
+    /// the app host is running inside a debug session and either the resource has no
+    /// <see cref="SupportsDebuggingAnnotation"/> (e.g. AddResource-based subclasses) or the
+    /// IDE did not send <c>DEBUG_SESSION_INFO</c> (Visual Studio scenario).
+    /// </summary>
+    private bool ShouldFallBackToIdeExecution(bool isInDebugSession, SupportsDebuggingAnnotation? supportsDebuggingAnnotation)
+    {
+        if (!isInDebugSession)
+        {
+            return false;
+        }
+
+        if (supportsDebuggingAnnotation is not null && !string.IsNullOrEmpty(_configuration[KnownConfigNames.DebugSessionInfo]))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private ProjectLaunchConfiguration CreateProjectLaunchConfiguration(ProjectResource project, IProjectMetadata projectMetadata)
+    {
+        var projectLaunchConfiguration = new ProjectLaunchConfiguration();
+        projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
+        projectLaunchConfiguration.Mode = _configuration[KnownConfigNames.DebugSessionRunMode]
+            ?? (Debugger.IsAttached ? ExecutableLaunchMode.Debug : ExecutableLaunchMode.NoDebug);
+
+        projectLaunchConfiguration.DisableLaunchProfile = project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _);
+        // Use the effective launch profile which has fallback logic
+        if (!projectLaunchConfiguration.DisableLaunchProfile && project.GetEffectiveLaunchProfile() is NamedLaunchProfile namedLaunchProfile)
+        {
+            projectLaunchConfiguration.LaunchProfile = namedLaunchProfile.Name;
+        }
+
+        return projectLaunchConfiguration;
     }
 
     private void EnsureRequiredAnnotations(IResource resource)

--- a/src/Aspire.Hosting/Utils/ExtensionUtils.cs
+++ b/src/Aspire.Hosting/Utils/ExtensionUtils.cs
@@ -18,10 +18,16 @@ internal static class ExtensionUtils
     {
         var supportedLaunchConfigurations = GetSupportedLaunchConfigurations(configuration);
 
-        return builder.TryGetLastAnnotation(out supportsDebuggingAnnotation)
-            && !string.IsNullOrEmpty(configuration[DcpExecutor.DebugSessionPortVar])
-            && ((supportedLaunchConfigurations is null && supportsDebuggingAnnotation.LaunchConfigurationType == "project") // per DCP spec, project resources support debugging if no launch configurations are specified
-                || (supportedLaunchConfigurations is not null && supportedLaunchConfigurations.Contains(supportsDebuggingAnnotation.LaunchConfigurationType)));
+        if (!builder.TryGetLastAnnotation(out supportsDebuggingAnnotation)
+            || string.IsNullOrEmpty(configuration[DcpExecutor.DebugSessionPortVar]))
+        {
+            return false;
+        }
+
+        // Per DCP IDE execution spec, project launch configuration support is implicit.
+        // Custom launch types (for example, azure-functions) must be explicitly advertised.
+        return supportsDebuggingAnnotation.LaunchConfigurationType == "project"
+            || (supportedLaunchConfigurations is not null && supportedLaunchConfigurations.Contains(supportsDebuggingAnnotation.LaunchConfigurationType));
     }
 
     private static string[]? GetSupportedLaunchConfigurations(IConfiguration configuration)

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2129,6 +2129,346 @@ public class DcpExecutorTests
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
     }
 
+    [Fact]
+    public async Task ProjectExecutable_DebugSessionInfoWithoutProjectStillDefaultsToProjectSupport()
+    {
+        // Bug #15606/#15647: VS Code extension sends SupportedLaunchConfigurations=["azure-functions"]
+        // (not including "project"). Standard project resources should still get IDE execution because
+        // "project" launch support is implicit in DCP.
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddProject<Projects.ServiceA>("ServiceA");
+
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["coreclr"],
+            SupportedLaunchConfigurations = ["azure-functions"]
+        };
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(runSessionInfo),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "ServiceA");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+
+        Assert.True(exe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
+        Assert.Single(launchConfigs);
+        Assert.Equal("project", launchConfigs[0].Type);
+    }
+
+    [Fact]
+    public async Task ProjectWithNonProjectAnnotation_DebugSessionWithoutInfo_FallsBackToProjectIdeExecution()
+    {
+        // Bug #15378: Simulates the Visual Studio scenario for projects with custom debug types.
+        // VS sets DEBUG_SESSION_PORT but does NOT send DEBUG_SESSION_INFO. A project resource
+        // with a non-"project" SupportsDebuggingAnnotation (e.g., "azure-functions") should still
+        // get ExecutionType.IDE with a ProjectLaunchConfiguration so VS can launch and debug it.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+        projectBuilder.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.NotNull(exe.Spec.FallbackExecutionTypes);
+        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes));
+
+        Assert.True(exe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
+        Assert.Single(launchConfigs);
+        Assert.Equal("project", launchConfigs[0].Type);
+    }
+
+    [Fact]
+    public async Task ProjectWithNonProjectAnnotation_VSCodeExplicitlyUnsupported_RunsInProcess()
+    {
+        // Guard: When VS Code extension sends DEBUG_SESSION_INFO with SupportedLaunchConfigurations
+        // that do NOT include the custom type, the resource should fall to Process mode. This ensures
+        // the else-if branch doesn't over-capture VS Code scenarios.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+        projectBuilder.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["coreclr"],
+            SupportedLaunchConfigurations = ["project"]
+        };
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(runSessionInfo),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "proj");
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+    }
+
+    [Fact]
+    public async Task ProjectWithNonProjectAnnotation_NoDebugSession_RunsInProcess()
+    {
+        // Guard: When there's no debug session (CLI scenario, no DEBUG_SESSION_PORT),
+        // projects with custom annotations should fall to Process execution.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+        projectBuilder.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "proj");
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+    }
+
+    [Fact]
+    public async Task ProjectWithNonProjectAnnotation_VSCodeWithMatchingSupport_RunsInIde()
+    {
+        // When VS Code extension sends DEBUG_SESSION_INFO with SupportedLaunchConfigurations
+        // that DO include the custom type, the resource should get IDE execution via the
+        // primary SupportsDebugging path (not the VS fallback).
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+        projectBuilder.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["coreclr"],
+            SupportedLaunchConfigurations = ["project", "azure-functions"]
+        };
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(runSessionInfo),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+    }
+
+    [Fact]
+    public async Task StandardAndCustomProjects_VSScenario_BothRunInIde()
+    {
+        // End-to-end VS scenario: a standard project and a custom-debug-type project both
+        // in the same AppHost. Both should get IDE execution when launched from VS
+        // (DEBUG_SESSION_PORT set, no DEBUG_SESSION_INFO).
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddProject<Projects.ServiceA>("standard-project");
+
+        var customProject = builder.AddProject<TestProject>("custom-project", launchProfileName: null);
+        var annotationToRemove = customProject.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            customProject.Resource.Annotations.Remove(annotationToRemove);
+        }
+        customProject.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var dcpExes = kubernetesService.CreatedResources.OfType<Executable>().ToList();
+        Assert.Equal(2, dcpExes.Count);
+
+        var standardExe = Assert.Single(dcpExes, e => e.AppModelResourceName == "standard-project");
+        Assert.Equal(ExecutionType.IDE, standardExe.Spec.ExecutionType);
+
+        var customExe = Assert.Single(dcpExes, e => e.AppModelResourceName == "custom-project");
+        Assert.Equal(ExecutionType.IDE, customExe.Spec.ExecutionType);
+        Assert.NotNull(customExe.Spec.FallbackExecutionTypes);
+        Assert.Equal(ExecutionType.Process, Assert.Single(customExe.Spec.FallbackExecutionTypes));
+
+        Assert.True(customExe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
+        Assert.Single(launchConfigs);
+        Assert.Equal("project", launchConfigs[0].Type);
+    }
+
+    [Fact]
+    public async Task StandardAndCustomProjects_VSCodeScenario_BothRunInIde()
+    {
+        // Combined VS Code scenario for bugs #15606/#15647 and class library projects:
+        // VS Code extension sends SupportedLaunchConfigurations=["azure-functions"] (not "project").
+        // A standard project (type "project") should still get IDE (implicit support).
+        // A project with "azure-functions" annotation should also get IDE (explicit match).
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddProject<Projects.ServiceA>("standard-project");
+
+        var customProject = builder.AddProject<TestProject>("functions-project", launchProfileName: null);
+        var annotationToRemove = customProject.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            customProject.Resource.Annotations.Remove(annotationToRemove);
+        }
+        customProject.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["coreclr"],
+            SupportedLaunchConfigurations = ["azure-functions"]
+        };
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(runSessionInfo),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var dcpExes = kubernetesService.CreatedResources.OfType<Executable>().ToList();
+        Assert.Equal(2, dcpExes.Count);
+
+        // Standard project: IDE via implicit "project" support (bug #15606/#15647 fix)
+        var standardExe = Assert.Single(dcpExes, e => e.AppModelResourceName == "standard-project");
+        Assert.Equal(ExecutionType.IDE, standardExe.Spec.ExecutionType);
+        Assert.True(standardExe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var standardConfigs));
+        Assert.Single(standardConfigs);
+        Assert.Equal("project", standardConfigs[0].Type);
+
+        // Azure Functions project: IDE via explicit "azure-functions" support
+        var functionsExe = Assert.Single(dcpExes, e => e.AppModelResourceName == "functions-project");
+        Assert.Equal(ExecutionType.IDE, functionsExe.Spec.ExecutionType);
+    }
+
+    [Fact]
+    public async Task ProjectWithNonProjectAnnotation_VSFallback_HasProcessFallbackExecutionType()
+    {
+        // Verifies the VS else-if branch sets FallbackExecutionTypes to [Process],
+        // ensuring DCP can fall back gracefully if IDE launch fails.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+        projectBuilder.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.NotNull(exe.Spec.FallbackExecutionTypes);
+        Assert.Single(exe.Spec.FallbackExecutionTypes);
+        Assert.Equal(ExecutionType.Process, exe.Spec.FallbackExecutionTypes[0]);
+    }
+
     [Theory]
     [InlineData()]
     [InlineData("alias1", "alias2")]
@@ -2167,9 +2507,13 @@ public class DcpExecutorTests
     }
 
     [Fact]
-    public async Task ProjectExecutable_NoSupportsDebuggingAnnotation_RunsInProcessMode()
+    public async Task ProjectExecutable_NoSupportsDebuggingAnnotation_InDebugSession_RunsInIdeMode()
     {
-        // Arrange
+        // ProjectResource subclasses added via AddResource (not AddProject) may not have
+        // a SupportsDebuggingAnnotation (e.g. third-party integrations). When in a debug session, these
+        // should still default to IDE execution with ProjectLaunchConfiguration — matching
+        // the pre-13.2 behavior. External integrations should not be forced to call the
+        // experimental WithDebugSupport API to get basic IDE execution.
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
             AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
@@ -2179,7 +2523,7 @@ public class DcpExecutorTests
         var projectBuilder = builder.AddProject<Projects.ServiceA>("ServiceA", launchProfileName: null);
         // Remove the SupportsDebuggingAnnotation that AddProject adds by default
         var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
-        if (annotationToRemove != null)
+        if (annotationToRemove is not null)
         {
             projectBuilder.Resource.Annotations.Remove(annotationToRemove);
         }
@@ -2198,15 +2542,125 @@ public class DcpExecutorTests
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
         var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
 
-        // Act
         await appExecutor.RunApplicationAsync();
 
-        // Assert
-        var dcpExes = kubernetesService.CreatedResources.OfType<Executable>().ToList();
-        Assert.Single(dcpExes);
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "ServiceA");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.NotNull(exe.Spec.FallbackExecutionTypes);
+        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes));
 
-        var exe = Assert.Single(dcpExes, e => e.AppModelResourceName == "ServiceA");
+        Assert.True(exe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
+        Assert.Single(launchConfigs);
+        Assert.Equal("project", launchConfigs[0].Type);
+    }
+
+    [Fact]
+    public async Task ProjectExecutable_NoSupportsDebuggingAnnotation_NoDebugSession_RunsInProcessMode()
+    {
+        // When there's no debug session (CLI scenario), projects without annotations
+        // should still run in Process mode.
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        var projectBuilder = builder.AddProject<Projects.ServiceA>("ServiceA", launchProfileName: null);
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "ServiceA");
         Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+    }
+
+    [Fact]
+    public async Task ProjectExecutable_NoAnnotation_ExecutableLaunchProfile_InDebugSession_RunsInIdeMode()
+    {
+        // Class library projects with commandName=Executable launch profiles (e.g. AWS Lambda
+        // using "dotnet exec ...") should get IDE execution so both VS and VS Code can debug them.
+        // VS natively handles Executable command profiles; VS Code's extension detects the
+        // Executable commandName and uses the profile's executablePath + args.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProjectWithExecutableLaunchProfile>("TestFunction",
+            launchProfileName: "Aspire_TestFunction");
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "TestFunction");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.NotNull(exe.Spec.FallbackExecutionTypes);
+        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes));
+
+        Assert.True(exe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
+        Assert.Single(launchConfigs);
+        Assert.Equal("Aspire_TestFunction", launchConfigs[0].LaunchProfile);
+
+        // Project args should be empty — the Executable profile's command line args are NOT
+        // injected into project args (that was the old Process fallback behavior).
+        Assert.True(exe.TryGetAnnotationAsObjectList<string>(CustomResource.ResourceProjectArgsAnnotation, out var projectArgs));
+        Assert.Empty(projectArgs);
+    }
+
+    [Fact]
+    public async Task ProjectExecutable_NoAnnotation_ProjectLaunchProfile_InDebugSession_RunsInIdeMode()
+    {
+        // When a project without SupportsDebuggingAnnotation has a normal Project launch profile
+        // (not Executable), it should still get IDE execution in a debug session.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProjectWithLaunchSettings>("proj", launchProfileName: "http");
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "proj");
+        // Should be IDE, because it's a normal Project profile
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.NotNull(exe.Spec.FallbackExecutionTypes);
+        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes));
     }
 
     [Theory]
@@ -2667,6 +3121,24 @@ public class DcpExecutorTests
     private sealed class CustomChildResource(string name, IResource parent) : Resource(name), IResourceWithParent
     {
         public IResource Parent => parent;
+    }
+
+    private sealed class TestProjectWithExecutableLaunchProfile : IProjectMetadata
+    {
+        public string ProjectPath => "TestProjectWithExecutableLaunchProfile";
+        public LaunchSettings LaunchSettings { get; } = CreateLaunchSettings();
+
+        private static LaunchSettings CreateLaunchSettings()
+        {
+            var settings = new LaunchSettings();
+            settings.Profiles["Aspire_TestFunction"] = new LaunchProfile
+            {
+                CommandName = "Executable",
+                ExecutablePath = "dotnet",
+                CommandLineArgs = "exec --depsfile ./TestLib.deps.json --runtimeconfig ./TestLib.runtimeconfig.json $(HOME)/.dotnet/tools/TestTool.dll TestLib::TestLib.Functions::Handler"
+            };
+            return settings;
+        }
     }
 
 }


### PR DESCRIPTION
## Description

Backport of #15714 to `release/13.2`.

Fixes regressions introduced in Aspire 13.2 where project resources using custom debug types (Azure Functions, AWS Lambda class libraries) or added via `AddResource` without `WithDebugSupport` no longer received IDE execution in Visual Studio or VS Code, breaking debugging and symbol loading.

### Changes backported

**Aspire.Hosting (C#):**
- `DcpExecutor.PrepareProjectExecutables()`: Adds a fallback branch that provides IDE execution with a standard `ProjectLaunchConfiguration` when in a debug session but either no `SupportsDebuggingAnnotation` exists (e.g. `AddResource`-based `ProjectResource` subclasses) or the IDE did not send `DEBUG_SESSION_INFO` (Visual Studio scenario where VS handles all project types natively). Restores pre-13.2 behavior.
- `ExtensionUtils.SupportsDebugging()`: Makes `"project"` launch configuration support implicit per DCP spec, so standard projects always get IDE execution even when the extension only advertises custom launch types.

**VS Code Extension (TypeScript):**
- Adds support for `Executable` command launch profiles used by AWS Lambda. When the launch profile specifies `commandName: "Executable"` with an `executablePath`, the extension builds the project and uses the profile's executable path as the debug program instead of the project output DLL.
- Adds `expandEnvironmentVariables()` to handle `$(VAR)` and `%VAR%` syntax in launch profile paths (e.g., `$(HOME)` used by AWS Lambda tool paths).
- Makes launch profile `commandName` comparison case-insensitive.
- Expands env var references in `determineWorkingDirectory`.

**Only files necessary for the fix are included** — playground apps from the original PR are excluded.

### Merge conflicts resolved
No merge conflicts — the changes applied cleanly to `release/13.2`.

### Validation
- Manual testing in VS, VS Code, and CLI have all been done.
- Norm has also confirmed that the Visual Studio experience is fixed for AWS.

Fixes #15606
Fixes #15647
Fixes #15378
Fixes #15699

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No