### PR TITLE
Updated to cache pfx dev certs on Windows and Linux to avoid binary level changes between runs

### DIFF
--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -193,8 +193,9 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
     }
 
     // Well-known location on disk where dev-cert key material is cached on macOS.
-    private static readonly string s_macOSUserDevCertificateLocation = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire", "dev-certs", "https");
+    private static readonly string s_userDevCertificateLocation = Path.Combine(
+        Environment.GetFolderPath(Envi
+                // We only cache PEM certificates on MacOSronment.SpecialFolder.UserProfile), ".aspire", "dev-certs", "https");
 
     private static readonly SemaphoreSlim s_certificateCacheSemaphore = new(1, 1);
 
@@ -257,13 +258,12 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
         CancellationToken cancellationToken)
     {
         char[]? pemKey = null;
-        var keyFileName = Path.Join(s_macOSUserDevCertificateLocation, $"{lookup}.key");
+        var keyFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.key");
 
+        // We only cache PEM certificates on MacOS to avoid repeated keychain prompts.
+        // There's no concern of binary differences for PEM certs with persistent containers.
         if (OperatingSystem.IsMacOS() && certificate.IsAspNetCoreDevelopmentCertificate())
         {
-            // On macOS, we cache development certificate key material to avoid triggering repeated
-            // keychain prompts when referencing the development certificate key. We don't do this
-            // for other OSes or other certificates.
             try
             {
                 if (File.Exists(keyFileName))
@@ -316,7 +316,7 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
                 // On macOS, cache the development certificate key material
                 try
                 {
-                    Directory.CreateDirectory(s_macOSUserDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
+                    Directory.CreateDirectory(s_userDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
 
                     await File.WriteAllTextAsync(keyFileName, new string(pemKey), cancellationToken).ConfigureAwait(false);
                 }
@@ -336,12 +336,12 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
         string lookup)
     {
         byte[]? pfxBytes = null;
-        var pfxFileName = Path.Join(s_macOSUserDevCertificateLocation, $"{lookup}.pfx");
+        var pfxFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.pfx");
 
-        if (OperatingSystem.IsMacOS() && certificate.IsAspNetCoreDevelopmentCertificate())
+        // We cache PFX dev certs for all OSes to ensure consistent binary output for persistent containers
+        // in addition to avoiding repeated keychain prompts on MacOS.
+        if (certificate.IsAspNetCoreDevelopmentCertificate())
         {
-            // On macOS, we cache development certificate key material to avoid triggering repeated
-            // keychain prompts when referencing the development certificate key.
             try
             {
                 if (File.Exists(pfxFileName))
@@ -367,11 +367,11 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
         {
             pfxBytes = certificate.Export(X509ContentType.Pfx, password);
 
-            if (pfxBytes is not null && OperatingSystem.IsMacOS() && certificate.IsAspNetCoreDevelopmentCertificate())
+            if (pfxBytes is not null && certificate.IsAspNetCoreDevelopmentCertificate())
             {
                 try
                 {
-                    Directory.CreateDirectory(s_macOSUserDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
+                    Directory.CreateDirectory(s_userDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
 
                     File.WriteAllBytes(pfxFileName, pfxBytes);
                 }

--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -194,8 +194,7 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
 
     // Well-known location on disk where dev-cert key material is cached on macOS.
     private static readonly string s_userDevCertificateLocation = Path.Combine(
-        Environment.GetFolderPath(Envi
-                // We only cache PEM certificates on MacOSronment.SpecialFolder.UserProfile), ".aspire", "dev-certs", "https");
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire", "dev-certs", "https");
 
     private static readonly SemaphoreSlim s_certificateCacheSemaphore = new(1, 1);
 

--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -370,7 +370,14 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
             {
                 try
                 {
-                    Directory.CreateDirectory(s_userDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
+                    if (OperatingSystem.IsWindows())
+                    {
+                        Directory.CreateDirectory(s_userDevCertificateLocation);
+                    }
+                    else
+                    {
+                        Directory.CreateDirectory(s_userDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
+                    }
 
                     File.WriteAllBytes(pfxFileName, pfxBytes);
                 }


### PR DESCRIPTION
## Description

We cache dev cert PFX output on Mac (to avoid repeated keychain access prompts), but not Windows and Linux. This unfortunately can result in the PFX binary representation changing between runs which can invalidate the persistent container config hash.

This change adds PFX caching on Windows and Linux to avoid invalidating persistent containers that reference PFX format dev certs.

Fixes #15626

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
