### PR TITLE
Fix bundle extraction crash when aspire-managed.exe is locked

### DIFF
--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -173,16 +173,20 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     /// <summary>
     /// Removes well-known layout subdirectories before re-extraction.
     /// Preserves the bin/ directory (which contains the CLI binary itself).
+    /// If a directory cannot be deleted (e.g. a process is still using files
+    /// inside it), it is renamed to {dir}.old.{timestamp} so extraction can
+    /// proceed. The stale directory will be cleaned up on the next successful
+    /// extraction.
     /// </summary>
     internal static void CleanLayoutDirectories(string layoutPath)
     {
         foreach (var dir in s_layoutDirectories)
         {
+            // Clean up stale .old directories from previous runs first
+            FileDeleteHelper.TryCleanupOldItems(layoutPath, dir);
+
             var fullPath = Path.Combine(layoutPath, dir);
-            if (Directory.Exists(fullPath))
-            {
-                Directory.Delete(fullPath, recursive: true);
-            }
+            FileDeleteHelper.TryDeleteDirectory(fullPath);
         }
 
         // Remove version marker so it's rewritten after extraction

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -375,17 +375,18 @@ internal sealed class UpdateCommand : BaseCommand
             }
 
             // Backup current executable if it exists
-            var unixTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            var backupPath = $"{targetExePath}.old.{unixTimestamp}";
+            var exeDir = Path.GetDirectoryName(targetExePath)!;
+            FileDeleteHelper.TryCleanupOldItems(exeDir, exeName);
+
+            string? backupPath = null;
             if (File.Exists(targetExePath))
             {
                 InteractionService.DisplayMessage(KnownEmojis.FloppyDisk, "Backing up current CLI...");
-                _logger.LogDebug("Creating backup: {BackupPath}", backupPath);
-
-                // Clean up old backup files
-                CleanupOldBackupFiles(targetExePath);
 
                 // Rename current executable to .old.[timestamp]
+                var unixTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                backupPath = $"{targetExePath}.old.{unixTimestamp}";
+                _logger.LogDebug("Creating backup: {BackupPath}", backupPath);
                 File.Move(targetExePath, backupPath);
             }
 
@@ -410,7 +411,7 @@ internal sealed class UpdateCommand : BaseCommand
                 }
 
                 // If we get here, the update was successful, clean up old backups
-                CleanupOldBackupFiles(targetExePath);
+                FileDeleteHelper.TryCleanupOldItems(exeDir, exeName);
 
                 // The new binary will extract its embedded bundle on first run via EnsureExtractedAsync.
                 // No proactive extraction needed — the payload is inside the new binary's embedded resources,
@@ -426,7 +427,7 @@ internal sealed class UpdateCommand : BaseCommand
             {
                 // If anything goes wrong, restore the backup
                 _logger.LogWarning("Update failed, restoring backup");
-                if (File.Exists(backupPath))
+                if (backupPath is not null && File.Exists(backupPath))
                 {
                     if (File.Exists(targetExePath))
                     {
@@ -519,39 +520,6 @@ internal sealed class UpdateCommand : BaseCommand
         catch
         {
             return null;
-        }
-    }
-
-    internal void CleanupOldBackupFiles(string targetExePath)
-    {
-        try
-        {
-            var directory = Path.GetDirectoryName(targetExePath);
-            if (string.IsNullOrEmpty(directory))
-            {
-                return;
-            }
-
-            var exeName = Path.GetFileName(targetExePath);
-            var searchPattern = $"{exeName}.old.*";
-
-            var oldBackupFiles = Directory.GetFiles(directory, searchPattern);
-            foreach (var backupFile in oldBackupFiles)
-            {
-                try
-                {
-                    File.Delete(backupFile);
-                    _logger.LogDebug("Deleted old backup file: {BackupFile}", backupFile);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "Failed to delete old backup file: {BackupFile}", backupFile);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to cleanup old backup files for: {TargetExePath}", targetExePath);
         }
     }
 

--- a/src/Aspire.Cli/Utils/FileDeleteHelper.cs
+++ b/src/Aspire.Cli/Utils/FileDeleteHelper.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Helpers for deleting files and directories that may be locked by another
+/// process (e.g. <c>aspire-managed.exe</c> still running from a previous CLI
+/// session).
+///
+/// On Windows a running process holds an exclusive lock on its executable,
+/// so <see cref="Directory.Delete(string, bool)"/> throws
+/// <see cref="UnauthorizedAccessException"/>. Rather than failing the entire
+/// operation, these helpers rename the locked item to
+/// <c>{name}.old.{tickcount}</c> and let the caller proceed. The stale
+/// renamed items are best-effort cleaned up on subsequent invocations via
+/// <see cref="TryCleanupOldItems"/>.
+/// </summary>
+internal static class FileDeleteHelper
+{
+    /// <summary>
+    /// Attempts to delete a directory recursively. If deletion fails because
+    /// a file inside the directory is locked by another process, the directory
+    /// is renamed to <c>{path}.old.{tickcount}</c> so the caller can create a
+    /// fresh replacement. Returns <see langword="true"/> if the directory was
+    /// deleted or renamed, <see langword="false"/> if it did not exist.
+    /// </summary>
+    internal static bool TryDeleteDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // A process still has a file open inside this directory
+            // (e.g. aspire-managed.exe from a previous CLI session).
+            // Rename it so the caller can proceed with a fresh directory.
+            try
+            {
+                var renamedPath = $"{path}.old.{Environment.TickCount64}";
+                Directory.Move(path, renamedPath);
+            }
+            catch (Exception)
+            {
+                // Rename also failed — nothing more we can do.
+                // The caller's extraction will fail and surface a
+                // "run aspire setup --force" message.
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to delete a file. If deletion fails because the file is locked
+    /// by another process, the file is renamed to <c>{path}.old.{tickcount}</c>
+    /// so the caller can write a fresh replacement. Returns
+    /// <see langword="true"/> if the file was deleted or renamed,
+    /// <see langword="false"/> if it did not exist.
+    /// </summary>
+    internal static bool TryDeleteFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            try
+            {
+                var renamedPath = $"{path}.old.{Environment.TickCount64}";
+                File.Move(path, renamedPath);
+            }
+            catch (Exception)
+            {
+                // Rename also failed — nothing more we can do.
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Best-effort cleanup of stale <c>.old.{tickcount}</c> items (both files
+    /// and directories) that were left behind by previous
+    /// <see cref="TryDeleteDirectory"/> or <see cref="TryDeleteFile"/> calls.
+    /// Items that are still locked are silently skipped — they will be retried
+    /// on the next invocation.
+    /// </summary>
+    internal static void TryCleanupOldItems(string directory, string name)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return;
+        }
+
+        var pattern = $"{name}.old.*";
+
+        foreach (var oldDir in Directory.EnumerateDirectories(directory, pattern))
+        {
+            try
+            {
+                Directory.Delete(oldDir, recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Still in use — leave it for the next attempt
+            }
+        }
+
+        foreach (var oldFile in Directory.EnumerateFiles(directory, pattern))
+        {
+            try
+            {
+                File.Delete(oldFile);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Still in use
+            }
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -93,10 +93,8 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         File.WriteAllText(oldBackup2, "test");
         File.WriteAllText(otherFile, "test");
 
-        var updateCommand = CreateUpdateCommand(workspace);
-
         // Act
-        updateCommand.CleanupOldBackupFiles(targetExePath);
+        FileDeleteHelper.TryCleanupOldItems(workspace.WorkspaceRoot.FullName, "aspire.exe");
 
         // Assert
         Assert.False(File.Exists(oldBackup1), "Old backup file should be deleted");
@@ -109,17 +107,14 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
     {
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var targetExePath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.exe");
         var oldBackup = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.exe.old.1234567890");
 
         // Create and lock the backup file
         File.WriteAllText(oldBackup, "test");
         using var fileStream = new FileStream(oldBackup, FileMode.Open, FileAccess.Read, FileShare.None);
 
-        var updateCommand = CreateUpdateCommand(workspace);
-
         // Act & Assert - should not throw exception
-        updateCommand.CleanupOldBackupFiles(targetExePath);
+        FileDeleteHelper.TryCleanupOldItems(workspace.WorkspaceRoot.FullName, "aspire.exe");
 
         // On Windows, locked files cannot be deleted, so the file should still exist
         // On Mac/Linux, locked files can be deleted, so the file may be deleted
@@ -136,13 +131,8 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void CleanupOldBackupFiles_HandlesNonExistentDirectory()
     {
-        // Arrange
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var nonExistentPath = Path.Combine("C:", "NonExistent", "aspire.exe");
-        var updateCommand = CreateUpdateCommand(workspace);
-
         // Act & Assert - should not throw exception
-        updateCommand.CleanupOldBackupFiles(nonExistentPath);
+        FileDeleteHelper.TryCleanupOldItems(Path.Combine("C:", "NonExistent"), "aspire.exe");
     }
 
     [Fact]
@@ -150,18 +140,9 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
     {
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var targetExePath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.exe");
-        var updateCommand = CreateUpdateCommand(workspace);
 
         // Act & Assert - should not throw exception
-        updateCommand.CleanupOldBackupFiles(targetExePath);
-    }
-
-    private UpdateCommand CreateUpdateCommand(TemporaryWorkspace workspace)
-    {
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
-        return provider.GetRequiredService<UpdateCommand>();
+        FileDeleteHelper.TryCleanupOldItems(workspace.WorkspaceRoot.FullName, "aspire.exe");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

When a previous CLI session's `aspire-managed.exe` process is still running (e.g. from `aspire run`), `BundleService.CleanLayoutDirectories` fails with `UnauthorizedAccessException` trying to delete the `managed/` directory. On Windows, a running process holds an exclusive lock on its executable, so `Directory.Delete` throws. This crashes the CLI with "Bundle extraction failed. Run 'aspire setup --force' to retry" — even though the fix is simply to get the old directory out of the way.

**Changes:**

- Introduce `FileDeleteHelper` in `src/Aspire.Cli/Utils/` with:
  - `TryDeleteDirectory` — deletes a directory, or renames it to `{name}.old.{tickcount}` if locked
  - `TryDeleteFile` — same for files
  - `TryCleanupOldItems` — best-effort cleanup of stale `.old.*` leftovers from previous runs
- Update `BundleService.CleanLayoutDirectories` to use `FileDeleteHelper` instead of raw `Directory.Delete`
- Refactor `UpdateCommand` to use the same shared helper, replacing its inline `CleanupOldBackupFiles` method

This follows the existing rename-on-lock pattern already used by `UpdateCommand` for CLI self-update (`.old.{timestamp}` backups).

Fixes https://github.com/microsoft/aspire/issues/15781

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
