### PR TITLE
Support upgrading F# and VB projects

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectFileExtensions.cs
+++ b/src/Aspire.Cli/Projects/ProjectFileExtensions.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Projects;
+
+internal static class ProjectFileExtensions
+{
+    public static readonly HashSet<string> Supported = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".csproj", ".fsproj", ".vbproj" };
+}

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -374,9 +374,10 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
     internal static async Task UpdateSdkVersionInAppHostAsync(FileInfo projectFile, NuGetPackageCli package, IInteractionService interactionService, SdkMigrationInfo migrationInfo)
     {
-        if (string.Equals(projectFile.Extension, ".csproj", StringComparison.OrdinalIgnoreCase))
+        // Handles .cs|fs|vbproj files
+        if (ProjectFileExtensions.Supported.Contains(projectFile.Extension))
         {
-            await UpdateSdkVersionInCsprojAppHostAsync(projectFile, package);
+            await UpdateSdkVersionInProjectAppHostAsync(projectFile, package);
 
             // Display migration feedback messages
             if (migrationInfo.WillMigrateToNewFormat)
@@ -401,7 +402,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         }
     }
 
-    internal static async Task UpdateSdkVersionInCsprojAppHostAsync(FileInfo projectFile, NuGetPackageCli package)
+    internal static async Task UpdateSdkVersionInProjectAppHostAsync(FileInfo projectFile, NuGetPackageCli package)
     {
         var projectDocument = new XmlDocument();
         projectDocument.PreserveWhitespace = true;

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -2374,12 +2374,15 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain("Aspire.Hosting.Redis", directoryPackagesContent);
     }
 
-    [Fact]
-    public async Task UpdateSdkVersionInCsprojAppHostAsync_MigratesFromOldFormatToNewFormat()
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".fsproj")]
+    [InlineData(".vbproj")]
+    public async Task UpdateSdkVersionInCsprojAppHostAsync_MigratesFromOldFormatToNewFormat(string projectExtension)
     {
         // Arrange - tests migration from old <Sdk Name="..."> to new <Project Sdk="..."> format
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj");
+        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, $"AppHost{projectExtension}");
         var originalContent = """
             <Project Sdk="Microsoft.NET.Sdk">
                 <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.0" />
@@ -2395,19 +2398,24 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var package = new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "13.0.2", Source = "nuget.org" };
 
         // Act
-        await ProjectUpdater.UpdateSdkVersionInCsprojAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
+        await ProjectUpdater.UpdateSdkVersionInProjectAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
 
         // Assert
         var updatedContent = await File.ReadAllTextAsync(projectFile);
-        await Verify(updatedContent, extension: "xml");
+        await Verify(updatedContent, extension: "xml")
+            .UseFileName($"ProjectUpdaterTests.{nameof(UpdateSdkVersionInCsprojAppHostAsync_MigratesFromOldFormatToNewFormat)}")
+            .DisableRequireUniquePrefix();
     }
 
-    [Fact]
-    public async Task UpdateSdkVersionInCsprojAppHostAsync_UpdatesExistingNewFormat()
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".fsproj")]
+    [InlineData(".vbproj")]
+    public async Task UpdateSdkVersionInCsprojAppHostAsync_UpdatesExistingNewFormat(string projectExtension)
     {
         // Arrange - tests updating a project already using the new format
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj");
+        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, $"AppHost{projectExtension}");
         var originalContent = """
             <Project Sdk="Aspire.AppHost.Sdk/13.0.1">
                 <PropertyGroup>
@@ -2422,19 +2430,24 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var package = new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "13.0.2", Source = "nuget.org" };
 
         // Act
-        await ProjectUpdater.UpdateSdkVersionInCsprojAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
+        await ProjectUpdater.UpdateSdkVersionInProjectAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
 
         // Assert
         var updatedContent = await File.ReadAllTextAsync(projectFile);
-        await Verify(updatedContent, extension: "xml");
+        await Verify(updatedContent, extension: "xml")
+            .UseFileName($"ProjectUpdaterTests.{nameof(UpdateSdkVersionInCsprojAppHostAsync_UpdatesExistingNewFormat)}")
+            .DisableRequireUniquePrefix();
     }
 
-    [Fact]
-    public async Task UpdateSdkVersionInCsprojAppHostAsync_RemovesAspireHostingAppHostPackageReference()
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".fsproj")]
+    [InlineData(".vbproj")]
+    public async Task UpdateSdkVersionInCsprojAppHostAsync_RemovesAspireHostingAppHostPackageReference(string projectExtension)
     {
         // Arrange - tests removal of obsolete Aspire.Hosting.AppHost package reference
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj");
+        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, $"AppHost{projectExtension}");
         var originalContent = """
             <Project Sdk="Microsoft.NET.Sdk">
                 <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.0" />
@@ -2454,19 +2467,24 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var package = new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "13.0.2", Source = "nuget.org" };
 
         // Act
-        await ProjectUpdater.UpdateSdkVersionInCsprojAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
+        await ProjectUpdater.UpdateSdkVersionInProjectAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
 
         // Assert
         var updatedContent = await File.ReadAllTextAsync(projectFile);
-        await Verify(updatedContent, extension: "xml");
+        await Verify(updatedContent, extension: "xml")
+            .UseFileName($"ProjectUpdaterTests.{nameof(UpdateSdkVersionInCsprojAppHostAsync_RemovesAspireHostingAppHostPackageReference)}")
+            .DisableRequireUniquePrefix();
     }
 
-    [Fact]
-    public async Task UpdateSdkVersionInCsprojAppHostAsync_RemovesEmptyItemGroupAfterPackageRemoval()
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".fsproj")]
+    [InlineData(".vbproj")]
+    public async Task UpdateSdkVersionInCsprojAppHostAsync_RemovesEmptyItemGroupAfterPackageRemoval(string projectExtension)
     {
         // Arrange - tests that empty ItemGroup is removed after Aspire.Hosting.AppHost removal
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj");
+        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, $"AppHost{projectExtension}");
         var originalContent = """
             <Project Sdk="Microsoft.NET.Sdk">
                 <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.0" />
@@ -2485,19 +2503,24 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var package = new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "13.0.2", Source = "nuget.org" };
 
         // Act
-        await ProjectUpdater.UpdateSdkVersionInCsprojAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
+        await ProjectUpdater.UpdateSdkVersionInProjectAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
 
         // Assert
         var updatedContent = await File.ReadAllTextAsync(projectFile);
-        await Verify(updatedContent, extension: "xml");
+        await Verify(updatedContent, extension: "xml")
+            .UseFileName($"ProjectUpdaterTests.{nameof(UpdateSdkVersionInCsprojAppHostAsync_RemovesEmptyItemGroupAfterPackageRemoval)}")
+            .DisableRequireUniquePrefix();
     }
 
-    [Fact]
-    public async Task UpdateSdkVersionInCsprojAppHostAsync_PreservesOtherSdksInAttribute()
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".fsproj")]
+    [InlineData(".vbproj")]
+    public async Task UpdateSdkVersionInCsprojAppHostAsync_PreservesOtherSdksInAttribute(string projectExtension)
     {
         // Arrange - tests that other SDKs in the attribute are preserved
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj");
+        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, $"AppHost{projectExtension}");
         var originalContent = """
             <Project Sdk="Aspire.AppHost.Sdk/13.0.1;Microsoft.NET.Sdk.Web">
                 <PropertyGroup>
@@ -2512,20 +2535,25 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var package = new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "13.0.2", Source = "nuget.org" };
 
         // Act
-        await ProjectUpdater.UpdateSdkVersionInCsprojAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
+        await ProjectUpdater.UpdateSdkVersionInProjectAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
 
         // Assert
         var updatedContent = await File.ReadAllTextAsync(projectFile);
-        await Verify(updatedContent, extension: "xml");
+        await Verify(updatedContent, extension: "xml")
+            .UseFileName($"ProjectUpdaterTests.{nameof(UpdateSdkVersionInCsprojAppHostAsync_PreservesOtherSdksInAttribute)}")
+            .DisableRequireUniquePrefix();
     }
 
-    [Fact]
-    public async Task UpdateSdkVersionInCsprojAppHostAsync_DoesNotMatchSimilarSdkName()
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".fsproj")]
+    [InlineData(".vbproj")]
+    public async Task UpdateSdkVersionInCsprojAppHostAsync_DoesNotMatchSimilarSdkName(string projectExtension)
     {
         // Arrange - tests that Aspire.AppHost.SdkFoo doesn't match as the Aspire SDK
         // In this case, the old <Sdk Name="..."> element is used, so it's a migration scenario
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj");
+        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, $"AppHost{projectExtension}");
         var originalContent = """
             <Project Sdk="Aspire.AppHost.SdkFoo/1.0.0">
                 <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.0" />
@@ -2540,14 +2568,20 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var package = new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "13.0.2", Source = "nuget.org" };
 
         // Act
-        await ProjectUpdater.UpdateSdkVersionInCsprojAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
+        await ProjectUpdater.UpdateSdkVersionInProjectAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
 
         // Assert
         var updatedContent = await File.ReadAllTextAsync(projectFile);
-        await Verify(updatedContent, extension: "xml");
+        await Verify(updatedContent, extension: "xml")
+            .UseFileName($"ProjectUpdaterTests.{nameof(UpdateSdkVersionInCsprojAppHostAsync_DoesNotMatchSimilarSdkName)}")
+            .DisableRequireUniquePrefix();
     }
-    [Fact]
-    public async Task UpdateSdkVersionInCsprojAppHostAsync_RemovesPackageVersionFromDirectoryPackagesPropsForCpm()
+
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".fsproj")]
+    [InlineData(".vbproj")]
+    public async Task UpdateSdkVersionInCsprojAppHostAsync_RemovesPackageVersionFromDirectoryPackagesPropsForCpm(string projectExtension)
     {
         // Arrange - simulates a CPM project with an old-format AppHost that has
         // Aspire.Hosting.AppHost in both csproj (as PackageReference) and
@@ -2556,7 +2590,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         // must also be removed to avoid NU1009.
         // See: https://github.com/microsoft/aspire/issues/14550
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj");
+        var projectFile = Path.Combine(workspace.WorkspaceRoot.FullName, $"AppHost{projectExtension}");
         var originalContent = """
             <Project Sdk="Microsoft.NET.Sdk">
                 <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.0" />
@@ -2590,7 +2624,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var package = new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "13.0.2", Source = "nuget.org" };
 
         // Act
-        await ProjectUpdater.UpdateSdkVersionInCsprojAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
+        await ProjectUpdater.UpdateSdkVersionInProjectAppHostAsync(new FileInfo(projectFile), package).DefaultTimeout();
 
         // Assert - PackageVersion for Aspire.Hosting.AppHost should be removed from Directory.Packages.props
         var updatedPropsContent = await File.ReadAllTextAsync(directoryPackagesPropsFile);


### PR DESCRIPTION
## Description

AppHost projects written in F# or VB could not be upgraded using `aspire update` because their project file extension was not supported. This PR brings support for that.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
