### PR TITLE
Improve CLI debug logging defaults

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
@@ -274,26 +274,35 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
             logger.LogDebug("Connected to AppHost backchannel at {SocketPath} (retryCount={RetryCount})", socketPath, retryCount);
 
             var stream = new NetworkStream(socket, true);
-            var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(stream, stream, BackchannelJsonSerializerContext.CreateRpcMessageFormatter()));
-            rpc.StartListening();
-
-            var capabilities = await rpc.InvokeWithCancellationAsync<string[]>(
-                "GetCapabilitiesAsync",
-                [],
-                cancellationToken);
-
-            if (!capabilities.Any(s => s == BaselineCapability))
+            JsonRpc? rpc = null;
+            try
             {
-                throw new AppHostIncompatibleException(
-                    string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostIncompatibleWithCli, BaselineCapability),
-                    BaselineCapability
-                    );
+                rpc = new JsonRpc(new HeaderDelimitedMessageHandler(stream, stream, BackchannelJsonSerializerContext.CreateRpcMessageFormatter()));
+                rpc.StartListening();
+
+                var capabilities = await rpc.InvokeWithCancellationAsync<string[]>(
+                    "GetCapabilitiesAsync",
+                    [],
+                    cancellationToken);
+
+                if (!capabilities.Any(s => s == BaselineCapability))
+                {
+                    throw new AppHostIncompatibleException(
+                        string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostIncompatibleWithCli, BaselineCapability),
+                        BaselineCapability
+                        );
+                }
+
+                // Set up auto-reconnect if enabled
+                if (autoReconnect)
+                {
+                    rpc.Disconnected += OnDisconnected;
+                }
             }
-
-            // Set up auto-reconnect if enabled
-            if (autoReconnect)
+            catch
             {
-                rpc.Disconnected += OnDisconnected;
+                rpc?.Dispose();
+                throw;
             }
 
             lock (_lock)
@@ -381,6 +390,11 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
                 retryCount++;
                 // Socket not ready yet, wait and retry
                 await Task.Delay(500, _cancellationToken).ConfigureAwait(false);
+            }
+            catch (SocketException)
+            {
+                // Timeout exceeded — fall through to warning
+                break;
             }
         }
 

--- a/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
@@ -17,8 +17,8 @@ internal interface IAppHostCliBackchannel
     Task<DashboardUrlsState> GetDashboardUrlsAsync(CancellationToken cancellationToken);
     IAsyncEnumerable<BackchannelLogEntry> GetAppHostLogEntriesAsync(CancellationToken cancellationToken);
     IAsyncEnumerable<RpcResourceState> GetResourceStatesAsync(CancellationToken cancellationToken);
-    Task ConnectAsync(string socketPath, CancellationToken cancellationToken);
-    Task ConnectAsync(string socketPath, bool autoReconnect, CancellationToken cancellationToken);
+    Task ConnectAsync(string socketPath, int retryCount, CancellationToken cancellationToken);
+    Task ConnectAsync(string socketPath, bool autoReconnect, int retryCount, CancellationToken cancellationToken);
     IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync(CancellationToken cancellationToken);
     Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken);
     Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
@@ -245,10 +245,10 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
         logger.LogWarning("Timed out waiting for backchannel reconnection");
     }
 
-    public Task ConnectAsync(string socketPath, CancellationToken cancellationToken)
-        => ConnectAsync(socketPath, autoReconnect: false, cancellationToken);
+    public Task ConnectAsync(string socketPath, int retryCount, CancellationToken cancellationToken)
+        => ConnectAsync(socketPath, autoReconnect: false, retryCount: retryCount, cancellationToken);
 
-    public async Task ConnectAsync(string socketPath, bool autoReconnect, CancellationToken cancellationToken)
+    public async Task ConnectAsync(string socketPath, bool autoReconnect, int retryCount, CancellationToken cancellationToken)
     {
         try
         {
@@ -266,11 +266,12 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
             _autoReconnect = autoReconnect;
             _cancellationToken = cancellationToken;
 
-            logger.LogDebug("Connecting to AppHost backchannel at {SocketPath} (autoReconnect={AutoReconnect})", socketPath, autoReconnect);
+            var connectingLogLevel = retryCount % 10 == 0 ? LogLevel.Debug : LogLevel.Trace;
+            logger.Log(connectingLogLevel, "Connecting to AppHost backchannel at {SocketPath} (autoReconnect={AutoReconnect}, retryCount={RetryCount})", socketPath, autoReconnect, retryCount);
             var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             var endpoint = new UnixDomainSocketEndPoint(socketPath);
             await socket.ConnectAsync(endpoint, cancellationToken);
-            logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
+            logger.LogDebug("Connected to AppHost backchannel at {SocketPath} (retryCount={RetryCount})", socketPath, retryCount);
 
             var stream = new NetworkStream(socket, true);
             var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(stream, stream, BackchannelJsonSerializerContext.CreateRpcMessageFormatter()));
@@ -366,16 +367,18 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
         var startTime = DateTime.UtcNow;
         var maxWait = TimeSpan.FromSeconds(30);
 
+        var retryCount = 0;
         while (!_cancellationToken.IsCancellationRequested)
         {
             try
             {
-                await ConnectAsync(_socketPath, _autoReconnect, _cancellationToken).ConfigureAwait(false);
+                await ConnectAsync(_socketPath, _autoReconnect, retryCount, _cancellationToken).ConfigureAwait(false);
                 logger.LogInformation("Successfully reconnected to backchannel");
                 return;
             }
             catch (SocketException) when (DateTime.UtcNow - startTime < maxWait)
             {
+                retryCount++;
                 // Socket not ready yet, wait and retry
                 await Task.Delay(500, _cancellationToken).ConfigureAwait(false);
             }

--- a/src/Aspire.Cli/Configuration/Features.cs
+++ b/src/Aspire.Cli/Configuration/Features.cs
@@ -14,7 +14,7 @@ internal sealed class Features(IConfiguration configuration, ILogger<Features> l
         
         var value = configuration[configKey];
         
-        logger.LogDebug("Feature check: {Feature}, ConfigKey: {ConfigKey}, Value: '{Value}', DefaultValue: {DefaultValue}",
+        logger.LogTrace("Feature check: {Feature}, ConfigKey: {ConfigKey}, Value: '{Value}', DefaultValue: {DefaultValue}",
             feature, configKey, value ?? "(null)", defaultValue);
         
         if (string.IsNullOrEmpty(value))

--- a/src/Aspire.Cli/DotNet/DotNetCliExecution.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliExecution.cs
@@ -159,7 +159,7 @@ internal sealed class DotNetCliExecution : IDotNetCliExecution
             {
                 if (!suppressLogging)
                 {
-                    _logger.LogDebug(
+                    _logger.LogTrace(
                         "dotnet({ProcessId}) {Identifier}: {Line}",
                         _process.Id,
                         identifier,

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -153,9 +153,8 @@ internal sealed class DotNetCliRunner(
         {
             try
             {
-                var attempt = connectionAttempts++;
-                logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, attempt);
-                await backchannel.ConnectAsync(socketPath, attempt, cancellationToken).ConfigureAwait(false);
+                logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts);
+                await backchannel.ConnectAsync(socketPath, connectionAttempts, cancellationToken).ConfigureAwait(false);
                 backchannelCompletionSource.SetResult(backchannel);
                 // Note: We intentionally do not call Environment.Exit when the backchannel disconnects.
                 // The CLI should complete normally and return the appropriate exit code based on the
@@ -212,6 +211,10 @@ internal sealed class DotNetCliRunner(
                 logger.LogError(ex, "An unexpected error occurred while trying to connect to the backchannel.");
                 backchannelCompletionSource.SetException(ex);
                 throw;
+            }
+            finally
+            {
+                connectionAttempts++;
             }
 
         } while (await timer.WaitForNextTickAsync(cancellationToken));

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -153,8 +153,9 @@ internal sealed class DotNetCliRunner(
         {
             try
             {
-                logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts);
-                await backchannel.ConnectAsync(socketPath, connectionAttempts++, cancellationToken).ConfigureAwait(false);
+                var attempt = connectionAttempts++;
+                logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, attempt);
+                await backchannel.ConnectAsync(socketPath, attempt, cancellationToken).ConfigureAwait(false);
                 backchannelCompletionSource.SetResult(backchannel);
                 // Note: We intentionally do not call Environment.Exit when the backchannel disconnects.
                 // The CLI should complete normally and return the appropriate exit code based on the

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -153,8 +153,8 @@ internal sealed class DotNetCliRunner(
         {
             try
             {
-                logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts++);
-                await backchannel.ConnectAsync(socketPath, cancellationToken).ConfigureAwait(false);
+                logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts);
+                await backchannel.ConnectAsync(socketPath, connectionAttempts++, cancellationToken).ConfigureAwait(false);
                 backchannelCompletionSource.SetResult(backchannel);
                 // Note: We intentionally do not call Environment.Exit when the backchannel disconnects.
                 // The CLI should complete normally and return the appropriate exit code based on the

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -215,6 +215,15 @@ public class Program
                 builder.AddFilter("Aspire.Cli", consoleLogLevel.Value);
                 builder.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
             }
+            else
+            {
+                // Default writing debug level logs to file.
+                builder.AddFilter<FileLoggerProvider>(null, LogLevel.Debug);
+
+                // These categories are very verbose at Debug; only capture them at Info unless an explicit log level is requested.
+                builder.AddFilter<FileLoggerProvider>("Microsoft.Extensions.Http.DefaultHttpClientFactory", LogLevel.Information);
+                builder.AddFilter<FileLoggerProvider>("Aspire.Cli.Certificates.NativeCertificateToolRunner", LogLevel.Information);
+            }
 
             // Configure console logging based on --verbosity or --debug
             if (consoleLogLevel is not null && !isMcpStartCommand && extensionEndpoint is null)
@@ -284,6 +293,9 @@ public class Program
 
         // Register file logger provider for components that write directly to the log file
         builder.Services.AddSingleton(startupContext.FileLoggerProvider);
+
+        // Register logging options so components can read the user's chosen log level
+        builder.Services.AddSingleton(startupContext.LoggingOptions);
 
         // Configure OpenTelemetry tracing. TelemetryManager reads configuration and creates
         // separate TracerProvider instances:

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -220,7 +220,8 @@ public class Program
                 // Default writing debug level logs to file.
                 builder.AddFilter<FileLoggerProvider>(null, LogLevel.Debug);
 
-                // These categories are very verbose at Debug; only capture them at Info unless an explicit log level is requested.
+                // These categories are very verbose at Debug; suppress their Debug output by
+                // raising the minimum to Information unless an explicit log level is requested.
                 builder.AddFilter<FileLoggerProvider>("Microsoft.Extensions.Http.DefaultHttpClientFactory", LogLevel.Information);
                 builder.AddFilter<FileLoggerProvider>("Aspire.Cli.Certificates.NativeCertificateToolRunner", LogLevel.Information);
             }

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -32,6 +32,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     private readonly IDotNetSdkInstaller _sdkInstaller;
     private readonly RunningInstanceManager _runningInstanceManager;
     private readonly Diagnostics.FileLoggerProvider _fileLoggerProvider;
+    private readonly Program.CliLoggingOptions _loggingOptions;
 
     private static readonly string[] s_detectionPatterns = ["*.csproj", "*.fsproj", "*.vbproj", "apphost.cs"];
     internal static IReadOnlyCollection<string> ProjectExtensions { get; } =
@@ -47,6 +48,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         IDotNetSdkInstaller sdkInstaller,
         ILogger<DotNetAppHostProject> logger,
         Diagnostics.FileLoggerProvider fileLoggerProvider,
+        Program.CliLoggingOptions loggingOptions,
         TimeProvider? timeProvider = null)
     {
         _runner = runner;
@@ -58,6 +60,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         _sdkInstaller = sdkInstaller;
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;
+        _loggingOptions = loggingOptions;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
     }
@@ -227,6 +230,12 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             isolatedUserSecretsId = await ConfigureIsolatedModeAsync(effectiveAppHostFile, env, cancellationToken);
             _logger.LogInformation("Aspire run isolated. Isolated UserSecretsId: {IsolatedUserSecretsId}", isolatedUserSecretsId);
         }
+
+        // Enable debug logging in the app host so that debug-level output is
+        // captured in the CLI log file for diagnostics. Defaults to Debug but
+        // can be overridden via --log-level.
+        var appHostLogLevel = _loggingOptions.ConsoleLogLevel ?? LogLevel.Debug;
+        env["Logging__LogLevel__Default"] = appHostLogLevel.ToString();
 
         if (context.WaitForDebugger)
         {

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -395,7 +395,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         var projectFileName = Path.Combine(_projectModelPath, ProjectFileName);
 
         // Log the full project XML for debugging
-        _logger.LogDebug("Generated AppHostServer project file:\n{ProjectXml}", doc.ToString());
+        _logger.LogTrace("Generated AppHostServer project file:\n{ProjectXml}", doc.ToString());
 
         doc.Save(projectFileName);
 
@@ -510,7 +510,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         {
             if (e.Data is not null)
             {
-                _logger.LogDebug("AppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
+                _logger.LogTrace("AppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
                 outputCollector.AppendOutput(e.Data);
             }
         };
@@ -518,7 +518,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         {
             if (e.Data is not null)
             {
-                _logger.LogDebug("AppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
+                _logger.LogTrace("AppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
                 outputCollector.AppendError(e.Data);
             }
         };

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -958,9 +958,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         {
             try
             {
-                _logger.LogTrace("Attempting to connect to AppHost server backchannel at {SocketPath} (attempt {Attempt})", socketPath, ++connectionAttempts);
+                _logger.LogTrace("Attempting to connect to AppHost server backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts);
                 // Pass enableHotReload as autoReconnect - the backchannel will handle reconnection internally
-                await _backchannel.ConnectAsync(socketPath, autoReconnect: enableHotReload, cancellationToken).ConfigureAwait(false);
+                await _backchannel.ConnectAsync(socketPath, autoReconnect: enableHotReload, retryCount: connectionAttempts++, cancellationToken).ConfigureAwait(false);
                 backchannelCompletionSource.TrySetResult(_backchannel);
                 _logger.LogDebug("Connected to AppHost server backchannel at {SocketPath}", socketPath);
                 return;

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -960,7 +960,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             {
                 _logger.LogTrace("Attempting to connect to AppHost server backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts);
                 // Pass enableHotReload as autoReconnect - the backchannel will handle reconnection internally
-                await _backchannel.ConnectAsync(socketPath, autoReconnect: enableHotReload, retryCount: connectionAttempts++, cancellationToken).ConfigureAwait(false);
+                await _backchannel.ConnectAsync(socketPath, autoReconnect: enableHotReload, retryCount: connectionAttempts, cancellationToken).ConfigureAwait(false);
                 backchannelCompletionSource.TrySetResult(_backchannel);
                 _logger.LogDebug("Connected to AppHost server backchannel at {SocketPath}", socketPath);
                 return;
@@ -1000,6 +1000,10 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 _logger.LogError(ex, "Failed to connect to AppHost server backchannel");
                 backchannelCompletionSource.TrySetException(ex);
                 return;
+            }
+            finally
+            {
+                connectionAttempts++;
             }
         }
     }

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -484,7 +484,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         {
             if (e.Data is not null)
             {
-                _logger.LogDebug("PrebuiltAppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
+                _logger.LogTrace("PrebuiltAppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
                 outputCollector.AppendOutput(e.Data);
             }
         };
@@ -492,7 +492,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         {
             if (e.Data is not null)
             {
-                _logger.LogDebug("PrebuiltAppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
+                _logger.LogTrace("PrebuiltAppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
                 outputCollector.AppendError(e.Data);
             }
         };

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -78,7 +78,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             }
             else
             {
-                _logger.LogDebug("{Language}({ProcessId}) stdout: {Line}", _language, process.Id, e.Data);
+                _logger.LogTrace("{Language}({ProcessId}) stdout: {Line}", _language, process.Id, e.Data);
                 outputCollector.AppendOutput(e.Data);
             }
         };
@@ -92,7 +92,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             }
             else
             {
-                _logger.LogDebug("{Language}({ProcessId}) stderr: {Line}", _language, process.Id, e.Data);
+                _logger.LogTrace("{Language}({ProcessId}) stderr: {Line}", _language, process.Id, e.Data);
                 outputCollector.AppendError(e.Data);
             }
         };

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -105,6 +105,10 @@ internal sealed class CapabilityDispatcher
             {
                 _logger.LogError("{Message} at {Location}", diagnostic.Message, diagnostic.Location);
             }
+            else if (diagnostic.Severity == AtsDiagnosticSeverity.Info)
+            {
+                _logger.LogDebug("{Message} at {Location}", diagnostic.Message, diagnostic.Location);
+            }
             else
             {
                 _logger.LogWarning("{Message} at {Location}", diagnostic.Message, diagnostic.Location);

--- a/src/Aspire.Hosting.RemoteHost/AtsContextFactory.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsContextFactory.cs
@@ -39,6 +39,10 @@ internal sealed class AtsContextFactory
             {
                 logger.LogError("[ATS] {Message} at {Location}", diagnostic.Message, diagnostic.Location);
             }
+            else if (diagnostic.Severity == AtsDiagnosticSeverity.Info)
+            {
+                logger.LogDebug("[ATS] {Message} at {Location}", diagnostic.Message, diagnostic.Location);
+            }
             else
             {
                 logger.LogWarning("[ATS] {Message} at {Location}", diagnostic.Message, diagnostic.Location);

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -828,8 +828,8 @@ internal sealed class TestPromptBackchannel : IAppHostCliBackchannel
         await Task.CompletedTask; // Suppress CS1998
         yield break;
     }
-    public Task ConnectAsync(string socketPath, CancellationToken cancellationToken) => Task.CompletedTask;
-    public Task ConnectAsync(string socketPath, bool autoReconnect, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task ConnectAsync(string socketPath, int retryCount, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task ConnectAsync(string socketPath, bool autoReconnect, int retryCount, CancellationToken cancellationToken) => Task.CompletedTask;
     public Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken) => Task.FromResult(new[] { "baseline.v2" });
 
     public async IAsyncEnumerable<CommandOutput> ExecAsync([EnumeratorCancellation] CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
@@ -93,10 +93,10 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
         }
     }
 
-    public Task ConnectAsync(string socketPath, CancellationToken cancellationToken)
-        => ConnectAsync(socketPath, autoReconnect: false, cancellationToken);
+    public Task ConnectAsync(string socketPath, int retryCount, CancellationToken cancellationToken)
+        => ConnectAsync(socketPath, autoReconnect: false, retryCount: retryCount, cancellationToken);
 
-    public async Task ConnectAsync(string socketPath, bool autoReconnect, CancellationToken cancellationToken)
+    public async Task ConnectAsync(string socketPath, bool autoReconnect, int retryCount, CancellationToken cancellationToken)
     {
         ConnectAsyncCalled?.SetResult();
         if (ConnectAsyncCallback != null)

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -84,6 +84,7 @@ internal static class CliTestHelper
         var testLogsDirectory = Path.Combine(options.WorkingDirectory.FullName, ".aspire", "logs");
         var testLogFilePath = FileLoggerProvider.GenerateLogFilePath(testLogsDirectory, TimeProvider.System);
         services.AddSingleton(new FileLoggerProvider(testLogFilePath, new TestStartupErrorWriter()));
+        services.AddSingleton(new Program.CliLoggingOptions(ConsoleLogLevel: null, DebugMode: false, LogsDirectory: testLogsDirectory, LogFilePath: testLogFilePath));
 
         services.AddMemoryCache();
 


### PR DESCRIPTION
## Description

Improves CLI debug logging defaults to make diagnostics more useful out of the box.

**Changes:**
- **Default log file level → Debug**: The CLI log file now captures Debug-level messages by default (previously limited to Information by the framework default). This gives richer diagnostics without needing `--debug`.
- **App host debug logging**: Sets `Logging__LogLevel__Default=Debug` on the app host environment so debug output is captured in the CLI log file. Respects `--log-level` if specified.
- **ATS diagnostics**: Info-severity ATS scanner diagnostics (e.g., "Discovered: ...") are now logged at Debug instead of Warning in both `AtsContextFactory` and `CapabilityDispatcher`.
- **Backchannel retry tracking**: Added `retryCount` parameter to `ConnectAsync` for connection attempt visibility in logs. Connecting log level varies by retry count (Debug every 10th attempt, Trace otherwise).
- **Reduced duplication**: Process stdout/stderr logging in `ProcessGuestLauncher`, `PrebuiltAppHostServer`, and `DotNetBasedAppHostServerProject` changed to Trace to avoid duplicating output already captured by `OutputCollector` at Info level.
- **Noisy category filtering**: `DefaultHttpClientFactory` and `NativeCertificateToolRunner` filtered to Trace by default to reduce noise.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
