### PR TITLE
Add polyglot withImagePushOptions support

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ContainerImagePushOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerImagePushOptions.cs
@@ -15,6 +15,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// to construct the complete image reference including registry endpoint and tag.
 /// </remarks>
 [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
+[AspireExport(ExposeProperties = true)]
 public sealed class ContainerImagePushOptions
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ContainerImagePushOptionsCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerImagePushOptionsCallbackContext.cs
@@ -14,6 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// to customize how the container image is named and tagged when pushed to a registry.
 /// </remarks>
 [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
+[AspireExport(ExposeProperties = true)]
 public sealed class ContainerImagePushOptionsCallbackContext
 {
     /// <summary>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3991,7 +3991,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
-    [AspireExport("withImagePushOptions", Description = "Sets image push options via callback")]
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the async callback overload.")]
     public static IResourceBuilder<T> WithImagePushOptions<T>(
         this IResourceBuilder<T> builder,
         Action<ContainerImagePushOptionsCallbackContext> callback)
@@ -4031,7 +4031,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
-    [AspireExportIgnore(Reason = "Polyglot app hosts use the synchronous Action<> overload via withImagePushOptions.")]
+    [AspireExport("withImagePushOptions", Description = "Sets image push options via callback")]
     public static IResourceBuilder<T> WithImagePushOptions<T>(
         this IResourceBuilder<T> builder,
         Func<ContainerImagePushOptionsCallbackContext, Task> callback)

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3978,7 +3978,6 @@ public static class ResourceBuilderExtensions
     /// The callback receives a <see cref="ContainerImagePushOptionsCallbackContext"/> that provides access to the resource
     /// and the <see cref="ContainerImagePushOptions"/> that can be modified.
     /// Multiple callbacks can be registered on the same resource, and they will be invoked in the order they were added.
-    /// <para>This method is not available in polyglot app hosts.</para>
     /// </remarks>
     /// <example>
     /// Configure a custom image name and tag for a container resource:
@@ -3992,7 +3991,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
-    [AspireExportIgnore(Reason = "ContainerImagePushOptionsCallbackContext exposes IResource — not usable from polyglot hosts.")]
+    [AspireExport("withImagePushOptions", Description = "Sets image push options via callback")]
     public static IResourceBuilder<T> WithImagePushOptions<T>(
         this IResourceBuilder<T> builder,
         Action<ContainerImagePushOptionsCallbackContext> callback)
@@ -4018,7 +4017,6 @@ public static class ResourceBuilderExtensions
     /// The callback receives a <see cref="ContainerImagePushOptionsCallbackContext"/> that provides access to the resource
     /// and the <see cref="ContainerImagePushOptions"/> that can be modified.
     /// Multiple callbacks can be registered on the same resource, and they will be invoked in the order they were added.
-    /// <para>This method is not available in polyglot app hosts.</para>
     /// </remarks>
     /// <example>
     /// Configure image options asynchronously by retrieving values from configuration:
@@ -4033,7 +4031,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
-    [AspireExportIgnore(Reason = "ContainerImagePushOptionsCallbackContext exposes IResource — not usable from polyglot hosts.")]
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the synchronous Action<> overload via withImagePushOptions.")]
     public static IResourceBuilder<T> WithImagePushOptions<T>(
         this IResourceBuilder<T> builder,
         Func<ContainerImagePushOptionsCallbackContext, Task> callback)

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -4031,7 +4031,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
-    [AspireExport("withImagePushOptions", Description = "Sets image push options via callback")]
+[AspireExport(Description = "Sets image push options via callback")]
     public static IResourceBuilder<T> WithImagePushOptions<T>(
         this IResourceBuilder<T> builder,
         Func<ContainerImagePushOptionsCallbackContext, Task> callback)

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -127,12 +127,23 @@ const (
 	EndpointPropertyTlsEnabled EndpointProperty = "TlsEnabled"
 )
 
+// HttpCommandResultMode represents HttpCommandResultMode.
+type HttpCommandResultMode string
+
+const (
+	HttpCommandResultModeNone HttpCommandResultMode = "None"
+	HttpCommandResultModeAuto HttpCommandResultMode = "Auto"
+	HttpCommandResultModeJson HttpCommandResultMode = "Json"
+	HttpCommandResultModeText HttpCommandResultMode = "Text"
+)
+
 // CommandResultFormat represents CommandResultFormat.
 type CommandResultFormat string
 
 const (
 	CommandResultFormatText CommandResultFormat = "Text"
 	CommandResultFormatJson CommandResultFormat = "Json"
+	CommandResultFormatMarkdown CommandResultFormat = "Markdown"
 )
 
 // UrlDisplayLocation represents UrlDisplayLocation.
@@ -165,6 +176,20 @@ const (
 // ============================================================================
 // DTOs
 // ============================================================================
+
+// AddContainerOptions represents AddContainerOptions.
+type AddContainerOptions struct {
+	Image string `json:"Image,omitempty"`
+	Tag string `json:"Tag,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *AddContainerOptions) ToMap() map[string]any {
+	return map[string]any{
+		"Image": SerializeValue(d.Image),
+		"Tag": SerializeValue(d.Tag),
+	}
+}
 
 // CreateBuilderOptions represents CreateBuilderOptions.
 type CreateBuilderOptions struct {
@@ -214,6 +239,24 @@ func (d *ResourceEventDto) ToMap() map[string]any {
 	}
 }
 
+// ReferenceEnvironmentInjectionOptions represents ReferenceEnvironmentInjectionOptions.
+type ReferenceEnvironmentInjectionOptions struct {
+	ConnectionString bool `json:"ConnectionString,omitempty"`
+	ConnectionProperties bool `json:"ConnectionProperties,omitempty"`
+	ServiceDiscovery bool `json:"ServiceDiscovery,omitempty"`
+	Endpoints bool `json:"Endpoints,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *ReferenceEnvironmentInjectionOptions) ToMap() map[string]any {
+	return map[string]any{
+		"ConnectionString": SerializeValue(d.ConnectionString),
+		"ConnectionProperties": SerializeValue(d.ConnectionProperties),
+		"ServiceDiscovery": SerializeValue(d.ServiceDiscovery),
+		"Endpoints": SerializeValue(d.Endpoints),
+	}
+}
+
 // CommandOptions represents CommandOptions.
 type CommandOptions struct {
 	Description string `json:"Description,omitempty"`
@@ -238,13 +281,69 @@ func (d *CommandOptions) ToMap() map[string]any {
 	}
 }
 
+// HttpCommandExportOptions represents HttpCommandExportOptions.
+type HttpCommandExportOptions struct {
+	Description string `json:"Description,omitempty"`
+	ConfirmationMessage string `json:"ConfirmationMessage,omitempty"`
+	IconName string `json:"IconName,omitempty"`
+	IconVariant IconVariant `json:"IconVariant,omitempty"`
+	IsHighlighted bool `json:"IsHighlighted,omitempty"`
+	CommandName string `json:"CommandName,omitempty"`
+	EndpointName string `json:"EndpointName,omitempty"`
+	MethodName string `json:"MethodName,omitempty"`
+	ResultMode HttpCommandResultMode `json:"ResultMode,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *HttpCommandExportOptions) ToMap() map[string]any {
+	return map[string]any{
+		"Description": SerializeValue(d.Description),
+		"ConfirmationMessage": SerializeValue(d.ConfirmationMessage),
+		"IconName": SerializeValue(d.IconName),
+		"IconVariant": SerializeValue(d.IconVariant),
+		"IsHighlighted": SerializeValue(d.IsHighlighted),
+		"CommandName": SerializeValue(d.CommandName),
+		"EndpointName": SerializeValue(d.EndpointName),
+		"MethodName": SerializeValue(d.MethodName),
+		"ResultMode": SerializeValue(d.ResultMode),
+	}
+}
+
+// GenerateParameterDefault represents GenerateParameterDefault.
+type GenerateParameterDefault struct {
+	MinLength float64 `json:"MinLength,omitempty"`
+	Lower bool `json:"Lower,omitempty"`
+	Upper bool `json:"Upper,omitempty"`
+	Numeric bool `json:"Numeric,omitempty"`
+	Special bool `json:"Special,omitempty"`
+	MinLower float64 `json:"MinLower,omitempty"`
+	MinUpper float64 `json:"MinUpper,omitempty"`
+	MinNumeric float64 `json:"MinNumeric,omitempty"`
+	MinSpecial float64 `json:"MinSpecial,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *GenerateParameterDefault) ToMap() map[string]any {
+	return map[string]any{
+		"MinLength": SerializeValue(d.MinLength),
+		"Lower": SerializeValue(d.Lower),
+		"Upper": SerializeValue(d.Upper),
+		"Numeric": SerializeValue(d.Numeric),
+		"Special": SerializeValue(d.Special),
+		"MinLower": SerializeValue(d.MinLower),
+		"MinUpper": SerializeValue(d.MinUpper),
+		"MinNumeric": SerializeValue(d.MinNumeric),
+		"MinSpecial": SerializeValue(d.MinSpecial),
+	}
+}
+
 // ExecuteCommandResult represents ExecuteCommandResult.
 type ExecuteCommandResult struct {
 	Success bool `json:"Success,omitempty"`
 	Canceled bool `json:"Canceled,omitempty"`
 	ErrorMessage string `json:"ErrorMessage,omitempty"`
-	Result string `json:"Result,omitempty"`
-	ResultFormat CommandResultFormat `json:"ResultFormat,omitempty"`
+	Message string `json:"Message,omitempty"`
+	Data *CommandResultData `json:"Data,omitempty"`
 }
 
 // ToMap converts the DTO to a map for JSON serialization.
@@ -253,8 +352,24 @@ func (d *ExecuteCommandResult) ToMap() map[string]any {
 		"Success": SerializeValue(d.Success),
 		"Canceled": SerializeValue(d.Canceled),
 		"ErrorMessage": SerializeValue(d.ErrorMessage),
-		"Result": SerializeValue(d.Result),
-		"ResultFormat": SerializeValue(d.ResultFormat),
+		"Message": SerializeValue(d.Message),
+		"Data": SerializeValue(d.Data),
+	}
+}
+
+// CommandResultData represents CommandResultData.
+type CommandResultData struct {
+	Value string `json:"Value,omitempty"`
+	Format CommandResultFormat `json:"Format,omitempty"`
+	DisplayImmediately bool `json:"DisplayImmediately,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *CommandResultData) ToMap() map[string]any {
+	return map[string]any{
+		"Value": SerializeValue(d.Value),
+		"Format": SerializeValue(d.Format),
+		"DisplayImmediately": SerializeValue(d.DisplayImmediately),
 	}
 }
 
@@ -693,6 +808,19 @@ func (s *CSharpAppResource) WithArgsCallback(callback func(...any) any) (*IResou
 	return result.(*IResourceWithArgs), nil
 }
 
+// WithReferenceEnvironment configures which reference values are injected into environment variables
+func (s *CSharpAppResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["options"] = SerializeValue(options)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEnvironment), nil
+}
+
 // WithReference adds a reference to another resource
 func (s *CSharpAppResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -753,6 +881,67 @@ func (s *CSharpAppResource) WithReferenceEndpoint(endpointReference *EndpointRef
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithEndpointCallback updates a named endpoint via callback
+func (s *CSharpAppResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpEndpointCallback updates an HTTP endpoint via callback
+func (s *CSharpAppResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
+func (s *CSharpAppResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -1123,6 +1312,23 @@ func (s *CSharpAppResource) WithCommand(name string, displayName string, execute
 	return result.(*IResource), nil
 }
 
+// WithHttpCommand adds an HTTP resource command
+func (s *CSharpAppResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["path"] = SerializeValue(path)
+	reqArgs["displayName"] = SerializeValue(displayName)
+	if options != nil {
+		reqArgs["options"] = SerializeValue(options)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *CSharpAppResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -1174,6 +1380,20 @@ func (s *CSharpAppResource) WithoutHttpsCertificate() (*IResourceWithEnvironment
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *CSharpAppResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -1974,8 +2194,8 @@ func (s *ConnectionStringResource) WithRequiredCommand(command string, helpLink 
 	return result.(*IResource), nil
 }
 
-// WithConnectionProperty adds a connection property with a reference expression
-func (s *ConnectionStringResource) WithConnectionProperty(name string, value *ReferenceExpression) (*IResourceWithConnectionString, error) {
+// WithConnectionProperty adds a connection property with a string or reference expression value
+func (s *ConnectionStringResource) WithConnectionProperty(name string, value any) (*IResourceWithConnectionString, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -2199,6 +2419,20 @@ func (s *ConnectionStringResource) WithCommand(name string, displayName string, 
 		reqArgs["commandOptions"] = SerializeValue(commandOptions)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *ConnectionStringResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2887,6 +3121,42 @@ func (s *ContainerImagePushOptionsCallbackContext) SetOptions(value *ContainerIm
 	return result.(*ContainerImagePushOptionsCallbackContext), nil
 }
 
+// ContainerImageReference wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference.
+type ContainerImageReference struct {
+	HandleWrapperBase
+}
+
+// NewContainerImageReference creates a new ContainerImageReference.
+func NewContainerImageReference(handle *Handle, client *AspireClient) *ContainerImageReference {
+	return &ContainerImageReference{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// ContainerMountAnnotation wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation.
+type ContainerMountAnnotation struct {
+	HandleWrapperBase
+}
+
+// NewContainerMountAnnotation creates a new ContainerMountAnnotation.
+func NewContainerMountAnnotation(handle *Handle, client *AspireClient) *ContainerMountAnnotation {
+	return &ContainerMountAnnotation{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// ContainerPortReference wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference.
+type ContainerPortReference struct {
+	HandleWrapperBase
+}
+
+// NewContainerPortReference creates a new ContainerPortReference.
+func NewContainerPortReference(handle *Handle, client *AspireClient) *ContainerPortReference {
+	return &ContainerPortReference{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
 // ContainerRegistryResource wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerRegistryResource.
 type ContainerRegistryResource struct {
 	ResourceBuilderBase
@@ -3060,6 +3330,20 @@ func (s *ContainerRegistryResource) WithCommand(name string, displayName string,
 		reqArgs["commandOptions"] = SerializeValue(commandOptions)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *ContainerRegistryResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3749,14 +4033,14 @@ func (s *ContainerResource) WithContainerName(name string) (*ContainerResource, 
 	return result.(*ContainerResource), nil
 }
 
-// WithBuildArg adds a build argument from a parameter resource
-func (s *ContainerResource) WithBuildArg(name string, value *ParameterResource) (*ContainerResource, error) {
+// WithBuildArg adds a build argument from a string value or parameter resource
+func (s *ContainerResource) WithBuildArg(name string, value any) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3771,6 +4055,27 @@ func (s *ContainerResource) WithBuildSecret(name string, value *ParameterResourc
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerResource), nil
+}
+
+// WithContainerCertificatePaths overrides container certificate bundle and directory paths used for trust configuration
+func (s *ContainerResource) WithContainerCertificatePaths(customCertificatesDestination *string, defaultCertificateBundlePaths []string, defaultCertificateDirectoryPaths []string) (*ContainerResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if customCertificatesDestination != nil {
+		reqArgs["customCertificatesDestination"] = SerializeValue(customCertificatesDestination)
+	}
+	if defaultCertificateBundlePaths != nil {
+		reqArgs["defaultCertificateBundlePaths"] = SerializeValue(defaultCertificateBundlePaths)
+	}
+	if defaultCertificateDirectoryPaths != nil {
+		reqArgs["defaultCertificateDirectoryPaths"] = SerializeValue(defaultCertificateDirectoryPaths)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withContainerCertificatePaths", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -4005,6 +4310,19 @@ func (s *ContainerResource) WithArgsCallback(callback func(...any) any) (*IResou
 	return result.(*IResourceWithArgs), nil
 }
 
+// WithReferenceEnvironment configures which reference values are injected into environment variables
+func (s *ContainerResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["options"] = SerializeValue(options)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEnvironment), nil
+}
+
 // WithReference adds a reference to another resource
 func (s *ContainerResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -4065,6 +4383,67 @@ func (s *ContainerResource) WithReferenceEndpoint(endpointReference *EndpointRef
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithEndpointCallback updates a named endpoint via callback
+func (s *ContainerResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpEndpointCallback updates an HTTP endpoint via callback
+func (s *ContainerResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
+func (s *ContainerResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -4421,6 +4800,23 @@ func (s *ContainerResource) WithCommand(name string, displayName string, execute
 	return result.(*IResource), nil
 }
 
+// WithHttpCommand adds an HTTP resource command
+func (s *ContainerResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["path"] = SerializeValue(path)
+	reqArgs["displayName"] = SerializeValue(displayName)
+	if options != nil {
+		reqArgs["options"] = SerializeValue(options)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *ContainerResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -4472,6 +4868,20 @@ func (s *ContainerResource) WithoutHttpsCertificate() (*IResourceWithEnvironment
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *ContainerResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -5626,6 +6036,19 @@ func (s *DotnetToolResource) WithArgsCallback(callback func(...any) any) (*IReso
 	return result.(*IResourceWithArgs), nil
 }
 
+// WithReferenceEnvironment configures which reference values are injected into environment variables
+func (s *DotnetToolResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["options"] = SerializeValue(options)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEnvironment), nil
+}
+
 // WithReference adds a reference to another resource
 func (s *DotnetToolResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -5686,6 +6109,67 @@ func (s *DotnetToolResource) WithReferenceEndpoint(endpointReference *EndpointRe
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithEndpointCallback updates a named endpoint via callback
+func (s *DotnetToolResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpEndpointCallback updates an HTTP endpoint via callback
+func (s *DotnetToolResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
+func (s *DotnetToolResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -6042,6 +6526,23 @@ func (s *DotnetToolResource) WithCommand(name string, displayName string, execut
 	return result.(*IResource), nil
 }
 
+// WithHttpCommand adds an HTTP resource command
+func (s *DotnetToolResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["path"] = SerializeValue(path)
+	reqArgs["displayName"] = SerializeValue(displayName)
+	if options != nil {
+		reqArgs["options"] = SerializeValue(options)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *DotnetToolResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -6093,6 +6594,20 @@ func (s *DotnetToolResource) WithoutHttpsCertificate() (*IResourceWithEnvironmen
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *DotnetToolResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -6973,6 +7488,280 @@ func (s *EndpointReferenceExpression) ValueExpression() (*string, error) {
 	return result.(*string), nil
 }
 
+// EndpointUpdateContext wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext.
+type EndpointUpdateContext struct {
+	HandleWrapperBase
+}
+
+// NewEndpointUpdateContext creates a new EndpointUpdateContext.
+func NewEndpointUpdateContext(handle *Handle, client *AspireClient) *EndpointUpdateContext {
+	return &EndpointUpdateContext{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// Name gets the Name property
+func (s *EndpointUpdateContext) Name() (*string, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.name", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*string), nil
+}
+
+// Protocol gets the Protocol property
+func (s *EndpointUpdateContext) Protocol() (*ProtocolType, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.protocol", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ProtocolType), nil
+}
+
+// SetProtocol sets the Protocol property
+func (s *EndpointUpdateContext) SetProtocol(value ProtocolType) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setProtocol", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// Port gets the Port property
+func (s *EndpointUpdateContext) Port() (*float64, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.port", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*float64), nil
+}
+
+// SetPort sets the Port property
+func (s *EndpointUpdateContext) SetPort(value float64) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setPort", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// TargetPort gets the TargetPort property
+func (s *EndpointUpdateContext) TargetPort() (*float64, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetPort", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*float64), nil
+}
+
+// SetTargetPort sets the TargetPort property
+func (s *EndpointUpdateContext) SetTargetPort(value float64) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetPort", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// UriScheme gets the UriScheme property
+func (s *EndpointUpdateContext) UriScheme() (*string, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.uriScheme", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*string), nil
+}
+
+// SetUriScheme sets the UriScheme property
+func (s *EndpointUpdateContext) SetUriScheme(value string) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setUriScheme", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// TargetHost gets the TargetHost property
+func (s *EndpointUpdateContext) TargetHost() (*string, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetHost", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*string), nil
+}
+
+// SetTargetHost sets the TargetHost property
+func (s *EndpointUpdateContext) SetTargetHost(value string) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetHost", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// Transport gets the Transport property
+func (s *EndpointUpdateContext) Transport() (*string, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.transport", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*string), nil
+}
+
+// SetTransport sets the Transport property
+func (s *EndpointUpdateContext) SetTransport(value string) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTransport", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// IsExternal gets the IsExternal property
+func (s *EndpointUpdateContext) IsExternal() (*bool, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.isExternal", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*bool), nil
+}
+
+// SetIsExternal sets the IsExternal property
+func (s *EndpointUpdateContext) SetIsExternal(value bool) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setIsExternal", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// IsProxied gets the IsProxied property
+func (s *EndpointUpdateContext) IsProxied() (*bool, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.isProxied", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*bool), nil
+}
+
+// SetIsProxied sets the IsProxied property
+func (s *EndpointUpdateContext) SetIsProxied(value bool) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setIsProxied", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// ExcludeReferenceEndpoint gets the ExcludeReferenceEndpoint property
+func (s *EndpointUpdateContext) ExcludeReferenceEndpoint() (*bool, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.excludeReferenceEndpoint", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*bool), nil
+}
+
+// SetExcludeReferenceEndpoint sets the ExcludeReferenceEndpoint property
+func (s *EndpointUpdateContext) SetExcludeReferenceEndpoint(value bool) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setExcludeReferenceEndpoint", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
+// TlsEnabled gets the TlsEnabled property
+func (s *EndpointUpdateContext) TlsEnabled() (*bool, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.tlsEnabled", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*bool), nil
+}
+
+// SetTlsEnabled sets the TlsEnabled property
+func (s *EndpointUpdateContext) SetTlsEnabled(value bool) (*EndpointUpdateContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTlsEnabled", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointUpdateContext), nil
+}
+
 // EnvironmentCallbackContext wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.
 type EnvironmentCallbackContext struct {
 	HandleWrapperBase
@@ -7323,6 +8112,19 @@ func (s *ExecutableResource) WithArgsCallback(callback func(...any) any) (*IReso
 	return result.(*IResourceWithArgs), nil
 }
 
+// WithReferenceEnvironment configures which reference values are injected into environment variables
+func (s *ExecutableResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["options"] = SerializeValue(options)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEnvironment), nil
+}
+
 // WithReference adds a reference to another resource
 func (s *ExecutableResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -7383,6 +8185,67 @@ func (s *ExecutableResource) WithReferenceEndpoint(endpointReference *EndpointRe
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithEndpointCallback updates a named endpoint via callback
+func (s *ExecutableResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpEndpointCallback updates an HTTP endpoint via callback
+func (s *ExecutableResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
+func (s *ExecutableResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -7739,6 +8602,23 @@ func (s *ExecutableResource) WithCommand(name string, displayName string, execut
 	return result.(*IResource), nil
 }
 
+// WithHttpCommand adds an HTTP resource command
+func (s *ExecutableResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["path"] = SerializeValue(path)
+	reqArgs["displayName"] = SerializeValue(displayName)
+	if options != nil {
+		reqArgs["options"] = SerializeValue(options)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *ExecutableResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -7790,6 +8670,20 @@ func (s *ExecutableResource) WithoutHttpsCertificate() (*IResourceWithEnvironmen
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *ExecutableResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -8711,6 +9605,20 @@ func (s *ExternalServiceResource) WithCommand(name string, displayName string, e
 	return result.(*IResource), nil
 }
 
+// WithRelationship adds a relationship to another resource
+func (s *ExternalServiceResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
+}
+
 // WithParentRelationship sets the parent relationship
 func (s *ExternalServiceResource) WithParentRelationship(parent *IResource) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -9390,7 +10298,7 @@ func (s *IDistributedApplicationBuilder) AddContainerRegistryFromString(name str
 }
 
 // AddContainer adds a container resource
-func (s *IDistributedApplicationBuilder) AddContainer(name string, image string) (*ContainerResource, error) {
+func (s *IDistributedApplicationBuilder) AddContainer(name string, image any) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -9543,6 +10451,18 @@ func (s *IDistributedApplicationBuilder) ExecutionContext() (*DistributedApplica
 	return result.(*DistributedApplicationExecutionContext), nil
 }
 
+// Pipeline gets the Pipeline property
+func (s *IDistributedApplicationBuilder) Pipeline() (*IDistributedApplicationPipeline, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/IDistributedApplicationBuilder.pipeline", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IDistributedApplicationPipeline), nil
+}
+
 // UserSecretsManager gets the UserSecretsManager property
 func (s *IDistributedApplicationBuilder) UserSecretsManager() (*IUserSecretsManager, error) {
 	reqArgs := map[string]any{
@@ -9620,6 +10540,26 @@ func (s *IDistributedApplicationBuilder) AddParameterFromConfiguration(name stri
 	return result.(*ParameterResource), nil
 }
 
+// AddParameterWithGeneratedValue adds a parameter with a generated default value
+func (s *IDistributedApplicationBuilder) AddParameterWithGeneratedValue(name string, value *GenerateParameterDefault, secret *bool, persist *bool) (*ParameterResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["name"] = SerializeValue(name)
+	reqArgs["value"] = SerializeValue(value)
+	if secret != nil {
+		reqArgs["secret"] = SerializeValue(secret)
+	}
+	if persist != nil {
+		reqArgs["persist"] = SerializeValue(persist)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/addParameterWithGeneratedValue", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ParameterResource), nil
+}
+
 // AddConnectionString adds a connection string resource
 func (s *IDistributedApplicationBuilder) AddConnectionString(name string, environmentVariableName *string) (*IResourceWithConnectionString, error) {
 	reqArgs := map[string]any{
@@ -9634,6 +10574,20 @@ func (s *IDistributedApplicationBuilder) AddConnectionString(name string, enviro
 		return nil, err
 	}
 	return result.(*IResourceWithConnectionString), nil
+}
+
+// AddProjectWithoutLaunchProfile adds a .NET project resource without a launch profile
+func (s *IDistributedApplicationBuilder) AddProjectWithoutLaunchProfile(name string, projectPath string) (*ProjectResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["name"] = SerializeValue(name)
+	reqArgs["projectPath"] = SerializeValue(projectPath)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/addProjectWithoutLaunchProfile", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ProjectResource), nil
 }
 
 // AddProject adds a .NET project resource
@@ -9801,6 +10755,49 @@ func (s *IDistributedApplicationEventing) Unsubscribe(subscription *DistributedA
 	}
 	reqArgs["subscription"] = SerializeValue(subscription)
 	_, err := s.Client().InvokeCapability("Aspire.Hosting.Eventing/IDistributedApplicationEventing.unsubscribe", reqArgs)
+	return err
+}
+
+// IDistributedApplicationPipeline wraps a handle for Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline.
+type IDistributedApplicationPipeline struct {
+	HandleWrapperBase
+}
+
+// NewIDistributedApplicationPipeline creates a new IDistributedApplicationPipeline.
+func NewIDistributedApplicationPipeline(handle *Handle, client *AspireClient) *IDistributedApplicationPipeline {
+	return &IDistributedApplicationPipeline{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// AddStep adds a pipeline step to the application
+func (s *IDistributedApplicationPipeline) AddStep(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string) error {
+	reqArgs := map[string]any{
+		"pipeline": SerializeValue(s.Handle()),
+	}
+	reqArgs["stepName"] = SerializeValue(stepName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	_, err := s.Client().InvokeCapability("Aspire.Hosting/addStep", reqArgs)
+	return err
+}
+
+// Configure configures the application pipeline via a callback
+func (s *IDistributedApplicationPipeline) Configure(callback func(...any) any) error {
+	reqArgs := map[string]any{
+		"pipeline": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	_, err := s.Client().InvokeCapability("Aspire.Hosting/configure", reqArgs)
 	return err
 }
 
@@ -10700,6 +11697,20 @@ func (s *ParameterResource) WithCommand(name string, displayName string, execute
 		reqArgs["commandOptions"] = SerializeValue(commandOptions)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *ParameterResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -12053,6 +13064,19 @@ func (s *ProjectResource) WithArgsCallback(callback func(...any) any) (*IResourc
 	return result.(*IResourceWithArgs), nil
 }
 
+// WithReferenceEnvironment configures which reference values are injected into environment variables
+func (s *ProjectResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["options"] = SerializeValue(options)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEnvironment), nil
+}
+
 // WithReference adds a reference to another resource
 func (s *ProjectResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -12113,6 +13137,67 @@ func (s *ProjectResource) WithReferenceEndpoint(endpointReference *EndpointRefer
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithEndpointCallback updates a named endpoint via callback
+func (s *ProjectResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpEndpointCallback updates an HTTP endpoint via callback
+func (s *ProjectResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
+func (s *ProjectResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -12483,6 +13568,23 @@ func (s *ProjectResource) WithCommand(name string, displayName string, executeCo
 	return result.(*IResource), nil
 }
 
+// WithHttpCommand adds an HTTP resource command
+func (s *ProjectResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["path"] = SerializeValue(path)
+	reqArgs["displayName"] = SerializeValue(displayName)
+	if options != nil {
+		reqArgs["options"] = SerializeValue(options)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *ProjectResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -12534,6 +13636,20 @@ func (s *ProjectResource) WithoutHttpsCertificate() (*IResourceWithEnvironment, 
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *ProjectResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -13928,14 +15044,14 @@ func (s *TestDatabaseResource) WithContainerName(name string) (*ContainerResourc
 	return result.(*ContainerResource), nil
 }
 
-// WithBuildArg adds a build argument from a parameter resource
-func (s *TestDatabaseResource) WithBuildArg(name string, value *ParameterResource) (*ContainerResource, error) {
+// WithBuildArg adds a build argument from a string value or parameter resource
+func (s *TestDatabaseResource) WithBuildArg(name string, value any) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13950,6 +15066,27 @@ func (s *TestDatabaseResource) WithBuildSecret(name string, value *ParameterReso
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerResource), nil
+}
+
+// WithContainerCertificatePaths overrides container certificate bundle and directory paths used for trust configuration
+func (s *TestDatabaseResource) WithContainerCertificatePaths(customCertificatesDestination *string, defaultCertificateBundlePaths []string, defaultCertificateDirectoryPaths []string) (*ContainerResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if customCertificatesDestination != nil {
+		reqArgs["customCertificatesDestination"] = SerializeValue(customCertificatesDestination)
+	}
+	if defaultCertificateBundlePaths != nil {
+		reqArgs["defaultCertificateBundlePaths"] = SerializeValue(defaultCertificateBundlePaths)
+	}
+	if defaultCertificateDirectoryPaths != nil {
+		reqArgs["defaultCertificateDirectoryPaths"] = SerializeValue(defaultCertificateDirectoryPaths)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withContainerCertificatePaths", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -14184,6 +15321,19 @@ func (s *TestDatabaseResource) WithArgsCallback(callback func(...any) any) (*IRe
 	return result.(*IResourceWithArgs), nil
 }
 
+// WithReferenceEnvironment configures which reference values are injected into environment variables
+func (s *TestDatabaseResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["options"] = SerializeValue(options)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEnvironment), nil
+}
+
 // WithReference adds a reference to another resource
 func (s *TestDatabaseResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -14244,6 +15394,67 @@ func (s *TestDatabaseResource) WithReferenceEndpoint(endpointReference *Endpoint
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithEndpointCallback updates a named endpoint via callback
+func (s *TestDatabaseResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpEndpointCallback updates an HTTP endpoint via callback
+func (s *TestDatabaseResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
+func (s *TestDatabaseResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -14600,6 +15811,23 @@ func (s *TestDatabaseResource) WithCommand(name string, displayName string, exec
 	return result.(*IResource), nil
 }
 
+// WithHttpCommand adds an HTTP resource command
+func (s *TestDatabaseResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["path"] = SerializeValue(path)
+	reqArgs["displayName"] = SerializeValue(displayName)
+	if options != nil {
+		reqArgs["options"] = SerializeValue(options)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *TestDatabaseResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -14651,6 +15879,20 @@ func (s *TestDatabaseResource) WithoutHttpsCertificate() (*IResourceWithEnvironm
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *TestDatabaseResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -15562,14 +16804,14 @@ func (s *TestRedisResource) WithContainerName(name string) (*ContainerResource, 
 	return result.(*ContainerResource), nil
 }
 
-// WithBuildArg adds a build argument from a parameter resource
-func (s *TestRedisResource) WithBuildArg(name string, value *ParameterResource) (*ContainerResource, error) {
+// WithBuildArg adds a build argument from a string value or parameter resource
+func (s *TestRedisResource) WithBuildArg(name string, value any) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -15584,6 +16826,27 @@ func (s *TestRedisResource) WithBuildSecret(name string, value *ParameterResourc
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerResource), nil
+}
+
+// WithContainerCertificatePaths overrides container certificate bundle and directory paths used for trust configuration
+func (s *TestRedisResource) WithContainerCertificatePaths(customCertificatesDestination *string, defaultCertificateBundlePaths []string, defaultCertificateDirectoryPaths []string) (*ContainerResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if customCertificatesDestination != nil {
+		reqArgs["customCertificatesDestination"] = SerializeValue(customCertificatesDestination)
+	}
+	if defaultCertificateBundlePaths != nil {
+		reqArgs["defaultCertificateBundlePaths"] = SerializeValue(defaultCertificateBundlePaths)
+	}
+	if defaultCertificateDirectoryPaths != nil {
+		reqArgs["defaultCertificateDirectoryPaths"] = SerializeValue(defaultCertificateDirectoryPaths)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withContainerCertificatePaths", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -15790,8 +17053,8 @@ func (s *TestRedisResource) WithEnvironmentConnectionString(envVarName string, r
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithConnectionProperty adds a connection property with a reference expression
-func (s *TestRedisResource) WithConnectionProperty(name string, value *ReferenceExpression) (*IResourceWithConnectionString, error) {
+// WithConnectionProperty adds a connection property with a string or reference expression value
+func (s *TestRedisResource) WithConnectionProperty(name string, value any) (*IResourceWithConnectionString, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -15844,6 +17107,19 @@ func (s *TestRedisResource) WithArgsCallback(callback func(...any) any) (*IResou
 		return nil, err
 	}
 	return result.(*IResourceWithArgs), nil
+}
+
+// WithReferenceEnvironment configures which reference values are injected into environment variables
+func (s *TestRedisResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["options"] = SerializeValue(options)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEnvironment), nil
 }
 
 // WithReference adds a reference to another resource
@@ -15919,6 +17195,67 @@ func (s *TestRedisResource) WithReferenceEndpoint(endpointReference *EndpointRef
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithEndpointCallback updates a named endpoint via callback
+func (s *TestRedisResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpEndpointCallback updates an HTTP endpoint via callback
+func (s *TestRedisResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
+func (s *TestRedisResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -16275,6 +17612,23 @@ func (s *TestRedisResource) WithCommand(name string, displayName string, execute
 	return result.(*IResource), nil
 }
 
+// WithHttpCommand adds an HTTP resource command
+func (s *TestRedisResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["path"] = SerializeValue(path)
+	reqArgs["displayName"] = SerializeValue(displayName)
+	if options != nil {
+		reqArgs["options"] = SerializeValue(options)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *TestRedisResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -16326,6 +17680,20 @@ func (s *TestRedisResource) WithoutHttpsCertificate() (*IResourceWithEnvironment
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *TestRedisResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -17421,14 +18789,14 @@ func (s *TestVaultResource) WithContainerName(name string) (*ContainerResource, 
 	return result.(*ContainerResource), nil
 }
 
-// WithBuildArg adds a build argument from a parameter resource
-func (s *TestVaultResource) WithBuildArg(name string, value *ParameterResource) (*ContainerResource, error) {
+// WithBuildArg adds a build argument from a string value or parameter resource
+func (s *TestVaultResource) WithBuildArg(name string, value any) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -17443,6 +18811,27 @@ func (s *TestVaultResource) WithBuildSecret(name string, value *ParameterResourc
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerResource), nil
+}
+
+// WithContainerCertificatePaths overrides container certificate bundle and directory paths used for trust configuration
+func (s *TestVaultResource) WithContainerCertificatePaths(customCertificatesDestination *string, defaultCertificateBundlePaths []string, defaultCertificateDirectoryPaths []string) (*ContainerResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if customCertificatesDestination != nil {
+		reqArgs["customCertificatesDestination"] = SerializeValue(customCertificatesDestination)
+	}
+	if defaultCertificateBundlePaths != nil {
+		reqArgs["defaultCertificateBundlePaths"] = SerializeValue(defaultCertificateBundlePaths)
+	}
+	if defaultCertificateDirectoryPaths != nil {
+		reqArgs["defaultCertificateDirectoryPaths"] = SerializeValue(defaultCertificateDirectoryPaths)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withContainerCertificatePaths", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -17677,6 +19066,19 @@ func (s *TestVaultResource) WithArgsCallback(callback func(...any) any) (*IResou
 	return result.(*IResourceWithArgs), nil
 }
 
+// WithReferenceEnvironment configures which reference values are injected into environment variables
+func (s *TestVaultResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["options"] = SerializeValue(options)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEnvironment), nil
+}
+
 // WithReference adds a reference to another resource
 func (s *TestVaultResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -17737,6 +19139,67 @@ func (s *TestVaultResource) WithReferenceEndpoint(endpointReference *EndpointRef
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithEndpointCallback updates a named endpoint via callback
+func (s *TestVaultResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpEndpointCallback updates an HTTP endpoint via callback
+func (s *TestVaultResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
+// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
+func (s *TestVaultResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if createIfNotExists != nil {
+		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -18093,6 +19556,23 @@ func (s *TestVaultResource) WithCommand(name string, displayName string, execute
 	return result.(*IResource), nil
 }
 
+// WithHttpCommand adds an HTTP resource command
+func (s *TestVaultResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["path"] = SerializeValue(path)
+	reqArgs["displayName"] = SerializeValue(displayName)
+	if options != nil {
+		reqArgs["options"] = SerializeValue(options)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResourceWithEndpoints), nil
+}
+
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *TestVaultResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -18144,6 +19624,20 @@ func (s *TestVaultResource) WithoutHttpsCertificate() (*IResourceWithEnvironment
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// WithRelationship adds a relationship to another resource
+func (s *TestVaultResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
+	reqArgs["type"] = SerializeValue(type_)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -18831,6 +20325,9 @@ func init() {
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder", func(h *Handle, c *AspireClient) any {
 		return NewIDistributedApplicationBuilder(h, c)
 	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline", func(h *Handle, c *AspireClient) any {
+		return NewIDistributedApplicationPipeline(h, c)
+	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.DistributedApplication", func(h *Handle, c *AspireClient) any {
 		return NewDistributedApplication(h, c)
 	})
@@ -18869,6 +20366,15 @@ func init() {
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource", func(h *Handle, c *AspireClient) any {
 		return NewParameterResource(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation", func(h *Handle, c *AspireClient) any {
+		return NewContainerMountAnnotation(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference", func(h *Handle, c *AspireClient) any {
+		return NewContainerImageReference(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference", func(h *Handle, c *AspireClient) any {
+		return NewContainerPortReference(h, c)
 	})
 	RegisterHandleWrapper("System.ComponentModel/System.IServiceProvider", func(h *Handle, c *AspireClient) any {
 		return NewIServiceProvider(h, c)
@@ -18971,6 +20477,9 @@ func init() {
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReferenceExpression", func(h *Handle, c *AspireClient) any {
 		return NewEndpointReferenceExpression(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext", func(h *Handle, c *AspireClient) any {
+		return NewEndpointUpdateContext(h, c)
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext", func(h *Handle, c *AspireClient) any {
 		return NewEnvironmentCallbackContext(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -127,23 +127,12 @@ const (
 	EndpointPropertyTlsEnabled EndpointProperty = "TlsEnabled"
 )
 
-// HttpCommandResultMode represents HttpCommandResultMode.
-type HttpCommandResultMode string
-
-const (
-	HttpCommandResultModeNone HttpCommandResultMode = "None"
-	HttpCommandResultModeAuto HttpCommandResultMode = "Auto"
-	HttpCommandResultModeJson HttpCommandResultMode = "Json"
-	HttpCommandResultModeText HttpCommandResultMode = "Text"
-)
-
 // CommandResultFormat represents CommandResultFormat.
 type CommandResultFormat string
 
 const (
 	CommandResultFormatText CommandResultFormat = "Text"
 	CommandResultFormatJson CommandResultFormat = "Json"
-	CommandResultFormatMarkdown CommandResultFormat = "Markdown"
 )
 
 // UrlDisplayLocation represents UrlDisplayLocation.
@@ -176,20 +165,6 @@ const (
 // ============================================================================
 // DTOs
 // ============================================================================
-
-// AddContainerOptions represents AddContainerOptions.
-type AddContainerOptions struct {
-	Image string `json:"Image,omitempty"`
-	Tag string `json:"Tag,omitempty"`
-}
-
-// ToMap converts the DTO to a map for JSON serialization.
-func (d *AddContainerOptions) ToMap() map[string]any {
-	return map[string]any{
-		"Image": SerializeValue(d.Image),
-		"Tag": SerializeValue(d.Tag),
-	}
-}
 
 // CreateBuilderOptions represents CreateBuilderOptions.
 type CreateBuilderOptions struct {
@@ -239,24 +214,6 @@ func (d *ResourceEventDto) ToMap() map[string]any {
 	}
 }
 
-// ReferenceEnvironmentInjectionOptions represents ReferenceEnvironmentInjectionOptions.
-type ReferenceEnvironmentInjectionOptions struct {
-	ConnectionString bool `json:"ConnectionString,omitempty"`
-	ConnectionProperties bool `json:"ConnectionProperties,omitempty"`
-	ServiceDiscovery bool `json:"ServiceDiscovery,omitempty"`
-	Endpoints bool `json:"Endpoints,omitempty"`
-}
-
-// ToMap converts the DTO to a map for JSON serialization.
-func (d *ReferenceEnvironmentInjectionOptions) ToMap() map[string]any {
-	return map[string]any{
-		"ConnectionString": SerializeValue(d.ConnectionString),
-		"ConnectionProperties": SerializeValue(d.ConnectionProperties),
-		"ServiceDiscovery": SerializeValue(d.ServiceDiscovery),
-		"Endpoints": SerializeValue(d.Endpoints),
-	}
-}
-
 // CommandOptions represents CommandOptions.
 type CommandOptions struct {
 	Description string `json:"Description,omitempty"`
@@ -281,69 +238,13 @@ func (d *CommandOptions) ToMap() map[string]any {
 	}
 }
 
-// HttpCommandExportOptions represents HttpCommandExportOptions.
-type HttpCommandExportOptions struct {
-	Description string `json:"Description,omitempty"`
-	ConfirmationMessage string `json:"ConfirmationMessage,omitempty"`
-	IconName string `json:"IconName,omitempty"`
-	IconVariant IconVariant `json:"IconVariant,omitempty"`
-	IsHighlighted bool `json:"IsHighlighted,omitempty"`
-	CommandName string `json:"CommandName,omitempty"`
-	EndpointName string `json:"EndpointName,omitempty"`
-	MethodName string `json:"MethodName,omitempty"`
-	ResultMode HttpCommandResultMode `json:"ResultMode,omitempty"`
-}
-
-// ToMap converts the DTO to a map for JSON serialization.
-func (d *HttpCommandExportOptions) ToMap() map[string]any {
-	return map[string]any{
-		"Description": SerializeValue(d.Description),
-		"ConfirmationMessage": SerializeValue(d.ConfirmationMessage),
-		"IconName": SerializeValue(d.IconName),
-		"IconVariant": SerializeValue(d.IconVariant),
-		"IsHighlighted": SerializeValue(d.IsHighlighted),
-		"CommandName": SerializeValue(d.CommandName),
-		"EndpointName": SerializeValue(d.EndpointName),
-		"MethodName": SerializeValue(d.MethodName),
-		"ResultMode": SerializeValue(d.ResultMode),
-	}
-}
-
-// GenerateParameterDefault represents GenerateParameterDefault.
-type GenerateParameterDefault struct {
-	MinLength float64 `json:"MinLength,omitempty"`
-	Lower bool `json:"Lower,omitempty"`
-	Upper bool `json:"Upper,omitempty"`
-	Numeric bool `json:"Numeric,omitempty"`
-	Special bool `json:"Special,omitempty"`
-	MinLower float64 `json:"MinLower,omitempty"`
-	MinUpper float64 `json:"MinUpper,omitempty"`
-	MinNumeric float64 `json:"MinNumeric,omitempty"`
-	MinSpecial float64 `json:"MinSpecial,omitempty"`
-}
-
-// ToMap converts the DTO to a map for JSON serialization.
-func (d *GenerateParameterDefault) ToMap() map[string]any {
-	return map[string]any{
-		"MinLength": SerializeValue(d.MinLength),
-		"Lower": SerializeValue(d.Lower),
-		"Upper": SerializeValue(d.Upper),
-		"Numeric": SerializeValue(d.Numeric),
-		"Special": SerializeValue(d.Special),
-		"MinLower": SerializeValue(d.MinLower),
-		"MinUpper": SerializeValue(d.MinUpper),
-		"MinNumeric": SerializeValue(d.MinNumeric),
-		"MinSpecial": SerializeValue(d.MinSpecial),
-	}
-}
-
 // ExecuteCommandResult represents ExecuteCommandResult.
 type ExecuteCommandResult struct {
 	Success bool `json:"Success,omitempty"`
 	Canceled bool `json:"Canceled,omitempty"`
 	ErrorMessage string `json:"ErrorMessage,omitempty"`
-	Message string `json:"Message,omitempty"`
-	Data *CommandResultData `json:"Data,omitempty"`
+	Result string `json:"Result,omitempty"`
+	ResultFormat CommandResultFormat `json:"ResultFormat,omitempty"`
 }
 
 // ToMap converts the DTO to a map for JSON serialization.
@@ -352,24 +253,8 @@ func (d *ExecuteCommandResult) ToMap() map[string]any {
 		"Success": SerializeValue(d.Success),
 		"Canceled": SerializeValue(d.Canceled),
 		"ErrorMessage": SerializeValue(d.ErrorMessage),
-		"Message": SerializeValue(d.Message),
-		"Data": SerializeValue(d.Data),
-	}
-}
-
-// CommandResultData represents CommandResultData.
-type CommandResultData struct {
-	Value string `json:"Value,omitempty"`
-	Format CommandResultFormat `json:"Format,omitempty"`
-	DisplayImmediately bool `json:"DisplayImmediately,omitempty"`
-}
-
-// ToMap converts the DTO to a map for JSON serialization.
-func (d *CommandResultData) ToMap() map[string]any {
-	return map[string]any{
-		"Value": SerializeValue(d.Value),
-		"Format": SerializeValue(d.Format),
-		"DisplayImmediately": SerializeValue(d.DisplayImmediately),
+		"Result": SerializeValue(d.Result),
+		"ResultFormat": SerializeValue(d.ResultFormat),
 	}
 }
 
@@ -808,19 +693,6 @@ func (s *CSharpAppResource) WithArgsCallback(callback func(...any) any) (*IResou
 	return result.(*IResourceWithArgs), nil
 }
 
-// WithReferenceEnvironment configures which reference values are injected into environment variables
-func (s *CSharpAppResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["options"] = SerializeValue(options)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithReference adds a reference to another resource
 func (s *CSharpAppResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -881,67 +753,6 @@ func (s *CSharpAppResource) WithReferenceEndpoint(endpointReference *EndpointRef
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEndpointCallback updates a named endpoint via callback
-func (s *CSharpAppResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["endpointName"] = SerializeValue(endpointName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpEndpointCallback updates an HTTP endpoint via callback
-func (s *CSharpAppResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
-func (s *CSharpAppResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -1312,23 +1123,6 @@ func (s *CSharpAppResource) WithCommand(name string, displayName string, execute
 	return result.(*IResource), nil
 }
 
-// WithHttpCommand adds an HTTP resource command
-func (s *CSharpAppResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["displayName"] = SerializeValue(displayName)
-	if options != nil {
-		reqArgs["options"] = SerializeValue(options)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *CSharpAppResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -1380,20 +1174,6 @@ func (s *CSharpAppResource) WithoutHttpsCertificate() (*IResourceWithEnvironment
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *CSharpAppResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -1482,6 +1262,21 @@ func (s *CSharpAppResource) ExcludeFromMcp() (*IResource, error) {
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// WithImagePushOptions sets image push options via callback
+func (s *CSharpAppResource) WithImagePushOptions(callback func(...any) any) (*IComputeResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IComputeResource), nil
 }
 
 // WithRemoteImageName sets the remote image name for publishing
@@ -2179,8 +1974,8 @@ func (s *ConnectionStringResource) WithRequiredCommand(command string, helpLink 
 	return result.(*IResource), nil
 }
 
-// WithConnectionProperty adds a connection property with a string or reference expression value
-func (s *ConnectionStringResource) WithConnectionProperty(name string, value any) (*IResourceWithConnectionString, error) {
+// WithConnectionProperty adds a connection property with a reference expression
+func (s *ConnectionStringResource) WithConnectionProperty(name string, value *ReferenceExpression) (*IResourceWithConnectionString, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -2404,20 +2199,6 @@ func (s *ConnectionStringResource) WithCommand(name string, displayName string, 
 		reqArgs["commandOptions"] = SerializeValue(commandOptions)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *ConnectionStringResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2955,40 +2736,155 @@ func (s *ConnectionStringResource) WithMergeRouteMiddleware(path string, method 
 	return result.(*IResource), nil
 }
 
-// ContainerImageReference wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference.
-type ContainerImageReference struct {
+// ContainerImagePushOptions wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions.
+type ContainerImagePushOptions struct {
 	HandleWrapperBase
 }
 
-// NewContainerImageReference creates a new ContainerImageReference.
-func NewContainerImageReference(handle *Handle, client *AspireClient) *ContainerImageReference {
-	return &ContainerImageReference{
+// NewContainerImagePushOptions creates a new ContainerImagePushOptions.
+func NewContainerImagePushOptions(handle *Handle, client *AspireClient) *ContainerImagePushOptions {
+	return &ContainerImagePushOptions{
 		HandleWrapperBase: NewHandleWrapperBase(handle, client),
 	}
 }
 
-// ContainerMountAnnotation wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation.
-type ContainerMountAnnotation struct {
+// RemoteImageName gets the RemoteImageName property
+func (s *ContainerImagePushOptions) RemoteImageName() (*string, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageName", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*string), nil
+}
+
+// SetRemoteImageName sets the RemoteImageName property
+func (s *ContainerImagePushOptions) SetRemoteImageName(value string) (*ContainerImagePushOptions, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageName", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerImagePushOptions), nil
+}
+
+// RemoteImageTag gets the RemoteImageTag property
+func (s *ContainerImagePushOptions) RemoteImageTag() (*string, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageTag", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*string), nil
+}
+
+// SetRemoteImageTag sets the RemoteImageTag property
+func (s *ContainerImagePushOptions) SetRemoteImageTag(value string) (*ContainerImagePushOptions, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageTag", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerImagePushOptions), nil
+}
+
+// ContainerImagePushOptionsCallbackContext wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext.
+type ContainerImagePushOptionsCallbackContext struct {
 	HandleWrapperBase
 }
 
-// NewContainerMountAnnotation creates a new ContainerMountAnnotation.
-func NewContainerMountAnnotation(handle *Handle, client *AspireClient) *ContainerMountAnnotation {
-	return &ContainerMountAnnotation{
+// NewContainerImagePushOptionsCallbackContext creates a new ContainerImagePushOptionsCallbackContext.
+func NewContainerImagePushOptionsCallbackContext(handle *Handle, client *AspireClient) *ContainerImagePushOptionsCallbackContext {
+	return &ContainerImagePushOptionsCallbackContext{
 		HandleWrapperBase: NewHandleWrapperBase(handle, client),
 	}
 }
 
-// ContainerPortReference wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference.
-type ContainerPortReference struct {
-	HandleWrapperBase
+// Resource gets the Resource property
+func (s *ContainerImagePushOptionsCallbackContext) Resource() (*IResource, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.resource", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IResource), nil
 }
 
-// NewContainerPortReference creates a new ContainerPortReference.
-func NewContainerPortReference(handle *Handle, client *AspireClient) *ContainerPortReference {
-	return &ContainerPortReference{
-		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+// SetResource sets the Resource property
+func (s *ContainerImagePushOptionsCallbackContext) SetResource(value *IResource) (*ContainerImagePushOptionsCallbackContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
 	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setResource", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerImagePushOptionsCallbackContext), nil
+}
+
+// CancellationToken gets the CancellationToken property
+func (s *ContainerImagePushOptionsCallbackContext) CancellationToken() (*CancellationToken, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.cancellationToken", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*CancellationToken), nil
+}
+
+// SetCancellationToken sets the CancellationToken property
+func (s *ContainerImagePushOptionsCallbackContext) SetCancellationToken(value *CancellationToken) (*ContainerImagePushOptionsCallbackContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	if value != nil {
+		reqArgs["value"] = RegisterCancellation(value, s.Client())
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setCancellationToken", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerImagePushOptionsCallbackContext), nil
+}
+
+// Options gets the Options property
+func (s *ContainerImagePushOptionsCallbackContext) Options() (*ContainerImagePushOptions, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.options", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerImagePushOptions), nil
+}
+
+// SetOptions sets the Options property
+func (s *ContainerImagePushOptionsCallbackContext) SetOptions(value *ContainerImagePushOptions) (*ContainerImagePushOptionsCallbackContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["value"] = SerializeValue(value)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerImagePushOptionsCallbackContext), nil
 }
 
 // ContainerRegistryResource wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerRegistryResource.
@@ -3164,20 +3060,6 @@ func (s *ContainerRegistryResource) WithCommand(name string, displayName string,
 		reqArgs["commandOptions"] = SerializeValue(commandOptions)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *ContainerRegistryResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3867,14 +3749,14 @@ func (s *ContainerResource) WithContainerName(name string) (*ContainerResource, 
 	return result.(*ContainerResource), nil
 }
 
-// WithBuildArg adds a build argument from a string value or parameter resource
-func (s *ContainerResource) WithBuildArg(name string, value any) (*ContainerResource, error) {
+// WithBuildArg adds a build argument from a parameter resource
+func (s *ContainerResource) WithBuildArg(name string, value *ParameterResource) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3889,27 +3771,6 @@ func (s *ContainerResource) WithBuildSecret(name string, value *ParameterResourc
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ContainerResource), nil
-}
-
-// WithContainerCertificatePaths overrides container certificate bundle and directory paths used for trust configuration
-func (s *ContainerResource) WithContainerCertificatePaths(customCertificatesDestination *string, defaultCertificateBundlePaths []string, defaultCertificateDirectoryPaths []string) (*ContainerResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if customCertificatesDestination != nil {
-		reqArgs["customCertificatesDestination"] = SerializeValue(customCertificatesDestination)
-	}
-	if defaultCertificateBundlePaths != nil {
-		reqArgs["defaultCertificateBundlePaths"] = SerializeValue(defaultCertificateBundlePaths)
-	}
-	if defaultCertificateDirectoryPaths != nil {
-		reqArgs["defaultCertificateDirectoryPaths"] = SerializeValue(defaultCertificateDirectoryPaths)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withContainerCertificatePaths", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -4144,19 +4005,6 @@ func (s *ContainerResource) WithArgsCallback(callback func(...any) any) (*IResou
 	return result.(*IResourceWithArgs), nil
 }
 
-// WithReferenceEnvironment configures which reference values are injected into environment variables
-func (s *ContainerResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["options"] = SerializeValue(options)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithReference adds a reference to another resource
 func (s *ContainerResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -4217,67 +4065,6 @@ func (s *ContainerResource) WithReferenceEndpoint(endpointReference *EndpointRef
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEndpointCallback updates a named endpoint via callback
-func (s *ContainerResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["endpointName"] = SerializeValue(endpointName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpEndpointCallback updates an HTTP endpoint via callback
-func (s *ContainerResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
-func (s *ContainerResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -4634,23 +4421,6 @@ func (s *ContainerResource) WithCommand(name string, displayName string, execute
 	return result.(*IResource), nil
 }
 
-// WithHttpCommand adds an HTTP resource command
-func (s *ContainerResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["displayName"] = SerializeValue(displayName)
-	if options != nil {
-		reqArgs["options"] = SerializeValue(options)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *ContainerResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -4702,20 +4472,6 @@ func (s *ContainerResource) WithoutHttpsCertificate() (*IResourceWithEnvironment
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *ContainerResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -4804,6 +4560,21 @@ func (s *ContainerResource) ExcludeFromMcp() (*IResource, error) {
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// WithImagePushOptions sets image push options via callback
+func (s *ContainerResource) WithImagePushOptions(callback func(...any) any) (*IComputeResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IComputeResource), nil
 }
 
 // WithRemoteImageName sets the remote image name for publishing
@@ -5855,19 +5626,6 @@ func (s *DotnetToolResource) WithArgsCallback(callback func(...any) any) (*IReso
 	return result.(*IResourceWithArgs), nil
 }
 
-// WithReferenceEnvironment configures which reference values are injected into environment variables
-func (s *DotnetToolResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["options"] = SerializeValue(options)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithReference adds a reference to another resource
 func (s *DotnetToolResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -5928,67 +5686,6 @@ func (s *DotnetToolResource) WithReferenceEndpoint(endpointReference *EndpointRe
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEndpointCallback updates a named endpoint via callback
-func (s *DotnetToolResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["endpointName"] = SerializeValue(endpointName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpEndpointCallback updates an HTTP endpoint via callback
-func (s *DotnetToolResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
-func (s *DotnetToolResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -6345,23 +6042,6 @@ func (s *DotnetToolResource) WithCommand(name string, displayName string, execut
 	return result.(*IResource), nil
 }
 
-// WithHttpCommand adds an HTTP resource command
-func (s *DotnetToolResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["displayName"] = SerializeValue(displayName)
-	if options != nil {
-		reqArgs["options"] = SerializeValue(options)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *DotnetToolResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -6413,20 +6093,6 @@ func (s *DotnetToolResource) WithoutHttpsCertificate() (*IResourceWithEnvironmen
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *DotnetToolResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -6515,6 +6181,21 @@ func (s *DotnetToolResource) ExcludeFromMcp() (*IResource, error) {
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// WithImagePushOptions sets image push options via callback
+func (s *DotnetToolResource) WithImagePushOptions(callback func(...any) any) (*IComputeResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IComputeResource), nil
 }
 
 // WithRemoteImageName sets the remote image name for publishing
@@ -7292,280 +6973,6 @@ func (s *EndpointReferenceExpression) ValueExpression() (*string, error) {
 	return result.(*string), nil
 }
 
-// EndpointUpdateContext wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext.
-type EndpointUpdateContext struct {
-	HandleWrapperBase
-}
-
-// NewEndpointUpdateContext creates a new EndpointUpdateContext.
-func NewEndpointUpdateContext(handle *Handle, client *AspireClient) *EndpointUpdateContext {
-	return &EndpointUpdateContext{
-		HandleWrapperBase: NewHandleWrapperBase(handle, client),
-	}
-}
-
-// Name gets the Name property
-func (s *EndpointUpdateContext) Name() (*string, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.name", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*string), nil
-}
-
-// Protocol gets the Protocol property
-func (s *EndpointUpdateContext) Protocol() (*ProtocolType, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.protocol", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ProtocolType), nil
-}
-
-// SetProtocol sets the Protocol property
-func (s *EndpointUpdateContext) SetProtocol(value ProtocolType) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setProtocol", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// Port gets the Port property
-func (s *EndpointUpdateContext) Port() (*float64, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.port", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*float64), nil
-}
-
-// SetPort sets the Port property
-func (s *EndpointUpdateContext) SetPort(value float64) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setPort", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// TargetPort gets the TargetPort property
-func (s *EndpointUpdateContext) TargetPort() (*float64, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetPort", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*float64), nil
-}
-
-// SetTargetPort sets the TargetPort property
-func (s *EndpointUpdateContext) SetTargetPort(value float64) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetPort", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// UriScheme gets the UriScheme property
-func (s *EndpointUpdateContext) UriScheme() (*string, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.uriScheme", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*string), nil
-}
-
-// SetUriScheme sets the UriScheme property
-func (s *EndpointUpdateContext) SetUriScheme(value string) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setUriScheme", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// TargetHost gets the TargetHost property
-func (s *EndpointUpdateContext) TargetHost() (*string, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetHost", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*string), nil
-}
-
-// SetTargetHost sets the TargetHost property
-func (s *EndpointUpdateContext) SetTargetHost(value string) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetHost", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// Transport gets the Transport property
-func (s *EndpointUpdateContext) Transport() (*string, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.transport", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*string), nil
-}
-
-// SetTransport sets the Transport property
-func (s *EndpointUpdateContext) SetTransport(value string) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTransport", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// IsExternal gets the IsExternal property
-func (s *EndpointUpdateContext) IsExternal() (*bool, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.isExternal", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*bool), nil
-}
-
-// SetIsExternal sets the IsExternal property
-func (s *EndpointUpdateContext) SetIsExternal(value bool) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setIsExternal", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// IsProxied gets the IsProxied property
-func (s *EndpointUpdateContext) IsProxied() (*bool, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.isProxied", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*bool), nil
-}
-
-// SetIsProxied sets the IsProxied property
-func (s *EndpointUpdateContext) SetIsProxied(value bool) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setIsProxied", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// ExcludeReferenceEndpoint gets the ExcludeReferenceEndpoint property
-func (s *EndpointUpdateContext) ExcludeReferenceEndpoint() (*bool, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.excludeReferenceEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*bool), nil
-}
-
-// SetExcludeReferenceEndpoint sets the ExcludeReferenceEndpoint property
-func (s *EndpointUpdateContext) SetExcludeReferenceEndpoint(value bool) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setExcludeReferenceEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
-// TlsEnabled gets the TlsEnabled property
-func (s *EndpointUpdateContext) TlsEnabled() (*bool, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.tlsEnabled", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*bool), nil
-}
-
-// SetTlsEnabled sets the TlsEnabled property
-func (s *EndpointUpdateContext) SetTlsEnabled(value bool) (*EndpointUpdateContext, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTlsEnabled", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*EndpointUpdateContext), nil
-}
-
 // EnvironmentCallbackContext wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.
 type EnvironmentCallbackContext struct {
 	HandleWrapperBase
@@ -7916,19 +7323,6 @@ func (s *ExecutableResource) WithArgsCallback(callback func(...any) any) (*IReso
 	return result.(*IResourceWithArgs), nil
 }
 
-// WithReferenceEnvironment configures which reference values are injected into environment variables
-func (s *ExecutableResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["options"] = SerializeValue(options)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithReference adds a reference to another resource
 func (s *ExecutableResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -7989,67 +7383,6 @@ func (s *ExecutableResource) WithReferenceEndpoint(endpointReference *EndpointRe
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEndpointCallback updates a named endpoint via callback
-func (s *ExecutableResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["endpointName"] = SerializeValue(endpointName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpEndpointCallback updates an HTTP endpoint via callback
-func (s *ExecutableResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
-func (s *ExecutableResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -8406,23 +7739,6 @@ func (s *ExecutableResource) WithCommand(name string, displayName string, execut
 	return result.(*IResource), nil
 }
 
-// WithHttpCommand adds an HTTP resource command
-func (s *ExecutableResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["displayName"] = SerializeValue(displayName)
-	if options != nil {
-		reqArgs["options"] = SerializeValue(options)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *ExecutableResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -8474,20 +7790,6 @@ func (s *ExecutableResource) WithoutHttpsCertificate() (*IResourceWithEnvironmen
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *ExecutableResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -8576,6 +7878,21 @@ func (s *ExecutableResource) ExcludeFromMcp() (*IResource, error) {
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// WithImagePushOptions sets image push options via callback
+func (s *ExecutableResource) WithImagePushOptions(callback func(...any) any) (*IComputeResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IComputeResource), nil
 }
 
 // WithRemoteImageName sets the remote image name for publishing
@@ -9394,20 +8711,6 @@ func (s *ExternalServiceResource) WithCommand(name string, displayName string, e
 	return result.(*IResource), nil
 }
 
-// WithRelationship adds a relationship to another resource
-func (s *ExternalServiceResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
-}
-
 // WithParentRelationship sets the parent relationship
 func (s *ExternalServiceResource) WithParentRelationship(parent *IResource) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -10087,7 +9390,7 @@ func (s *IDistributedApplicationBuilder) AddContainerRegistryFromString(name str
 }
 
 // AddContainer adds a container resource
-func (s *IDistributedApplicationBuilder) AddContainer(name string, image any) (*ContainerResource, error) {
+func (s *IDistributedApplicationBuilder) AddContainer(name string, image string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -10240,18 +9543,6 @@ func (s *IDistributedApplicationBuilder) ExecutionContext() (*DistributedApplica
 	return result.(*DistributedApplicationExecutionContext), nil
 }
 
-// Pipeline gets the Pipeline property
-func (s *IDistributedApplicationBuilder) Pipeline() (*IDistributedApplicationPipeline, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/IDistributedApplicationBuilder.pipeline", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IDistributedApplicationPipeline), nil
-}
-
 // UserSecretsManager gets the UserSecretsManager property
 func (s *IDistributedApplicationBuilder) UserSecretsManager() (*IUserSecretsManager, error) {
 	reqArgs := map[string]any{
@@ -10329,26 +9620,6 @@ func (s *IDistributedApplicationBuilder) AddParameterFromConfiguration(name stri
 	return result.(*ParameterResource), nil
 }
 
-// AddParameterWithGeneratedValue adds a parameter with a generated default value
-func (s *IDistributedApplicationBuilder) AddParameterWithGeneratedValue(name string, value *GenerateParameterDefault, secret *bool, persist *bool) (*ParameterResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	if secret != nil {
-		reqArgs["secret"] = SerializeValue(secret)
-	}
-	if persist != nil {
-		reqArgs["persist"] = SerializeValue(persist)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/addParameterWithGeneratedValue", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ParameterResource), nil
-}
-
 // AddConnectionString adds a connection string resource
 func (s *IDistributedApplicationBuilder) AddConnectionString(name string, environmentVariableName *string) (*IResourceWithConnectionString, error) {
 	reqArgs := map[string]any{
@@ -10363,20 +9634,6 @@ func (s *IDistributedApplicationBuilder) AddConnectionString(name string, enviro
 		return nil, err
 	}
 	return result.(*IResourceWithConnectionString), nil
-}
-
-// AddProjectWithoutLaunchProfile adds a .NET project resource without a launch profile
-func (s *IDistributedApplicationBuilder) AddProjectWithoutLaunchProfile(name string, projectPath string) (*ProjectResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["projectPath"] = SerializeValue(projectPath)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/addProjectWithoutLaunchProfile", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ProjectResource), nil
 }
 
 // AddProject adds a .NET project resource
@@ -10544,49 +9801,6 @@ func (s *IDistributedApplicationEventing) Unsubscribe(subscription *DistributedA
 	}
 	reqArgs["subscription"] = SerializeValue(subscription)
 	_, err := s.Client().InvokeCapability("Aspire.Hosting.Eventing/IDistributedApplicationEventing.unsubscribe", reqArgs)
-	return err
-}
-
-// IDistributedApplicationPipeline wraps a handle for Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline.
-type IDistributedApplicationPipeline struct {
-	HandleWrapperBase
-}
-
-// NewIDistributedApplicationPipeline creates a new IDistributedApplicationPipeline.
-func NewIDistributedApplicationPipeline(handle *Handle, client *AspireClient) *IDistributedApplicationPipeline {
-	return &IDistributedApplicationPipeline{
-		HandleWrapperBase: NewHandleWrapperBase(handle, client),
-	}
-}
-
-// AddStep adds a pipeline step to the application
-func (s *IDistributedApplicationPipeline) AddStep(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string) error {
-	reqArgs := map[string]any{
-		"pipeline": SerializeValue(s.Handle()),
-	}
-	reqArgs["stepName"] = SerializeValue(stepName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if dependsOn != nil {
-		reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	}
-	if requiredBy != nil {
-		reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	}
-	_, err := s.Client().InvokeCapability("Aspire.Hosting/addStep", reqArgs)
-	return err
-}
-
-// Configure configures the application pipeline via a callback
-func (s *IDistributedApplicationPipeline) Configure(callback func(...any) any) error {
-	reqArgs := map[string]any{
-		"pipeline": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	_, err := s.Client().InvokeCapability("Aspire.Hosting/configure", reqArgs)
 	return err
 }
 
@@ -11486,20 +10700,6 @@ func (s *ParameterResource) WithCommand(name string, displayName string, execute
 		reqArgs["commandOptions"] = SerializeValue(commandOptions)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *ParameterResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -12853,19 +12053,6 @@ func (s *ProjectResource) WithArgsCallback(callback func(...any) any) (*IResourc
 	return result.(*IResourceWithArgs), nil
 }
 
-// WithReferenceEnvironment configures which reference values are injected into environment variables
-func (s *ProjectResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["options"] = SerializeValue(options)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithReference adds a reference to another resource
 func (s *ProjectResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -12926,67 +12113,6 @@ func (s *ProjectResource) WithReferenceEndpoint(endpointReference *EndpointRefer
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEndpointCallback updates a named endpoint via callback
-func (s *ProjectResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["endpointName"] = SerializeValue(endpointName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpEndpointCallback updates an HTTP endpoint via callback
-func (s *ProjectResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
-func (s *ProjectResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -13357,23 +12483,6 @@ func (s *ProjectResource) WithCommand(name string, displayName string, executeCo
 	return result.(*IResource), nil
 }
 
-// WithHttpCommand adds an HTTP resource command
-func (s *ProjectResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["displayName"] = SerializeValue(displayName)
-	if options != nil {
-		reqArgs["options"] = SerializeValue(options)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *ProjectResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -13425,20 +12534,6 @@ func (s *ProjectResource) WithoutHttpsCertificate() (*IResourceWithEnvironment, 
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *ProjectResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -13527,6 +12622,21 @@ func (s *ProjectResource) ExcludeFromMcp() (*IResource, error) {
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// WithImagePushOptions sets image push options via callback
+func (s *ProjectResource) WithImagePushOptions(callback func(...any) any) (*IComputeResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IComputeResource), nil
 }
 
 // WithRemoteImageName sets the remote image name for publishing
@@ -14818,14 +13928,14 @@ func (s *TestDatabaseResource) WithContainerName(name string) (*ContainerResourc
 	return result.(*ContainerResource), nil
 }
 
-// WithBuildArg adds a build argument from a string value or parameter resource
-func (s *TestDatabaseResource) WithBuildArg(name string, value any) (*ContainerResource, error) {
+// WithBuildArg adds a build argument from a parameter resource
+func (s *TestDatabaseResource) WithBuildArg(name string, value *ParameterResource) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -14840,27 +13950,6 @@ func (s *TestDatabaseResource) WithBuildSecret(name string, value *ParameterReso
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ContainerResource), nil
-}
-
-// WithContainerCertificatePaths overrides container certificate bundle and directory paths used for trust configuration
-func (s *TestDatabaseResource) WithContainerCertificatePaths(customCertificatesDestination *string, defaultCertificateBundlePaths []string, defaultCertificateDirectoryPaths []string) (*ContainerResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if customCertificatesDestination != nil {
-		reqArgs["customCertificatesDestination"] = SerializeValue(customCertificatesDestination)
-	}
-	if defaultCertificateBundlePaths != nil {
-		reqArgs["defaultCertificateBundlePaths"] = SerializeValue(defaultCertificateBundlePaths)
-	}
-	if defaultCertificateDirectoryPaths != nil {
-		reqArgs["defaultCertificateDirectoryPaths"] = SerializeValue(defaultCertificateDirectoryPaths)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withContainerCertificatePaths", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -15095,19 +14184,6 @@ func (s *TestDatabaseResource) WithArgsCallback(callback func(...any) any) (*IRe
 	return result.(*IResourceWithArgs), nil
 }
 
-// WithReferenceEnvironment configures which reference values are injected into environment variables
-func (s *TestDatabaseResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["options"] = SerializeValue(options)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithReference adds a reference to another resource
 func (s *TestDatabaseResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -15168,67 +14244,6 @@ func (s *TestDatabaseResource) WithReferenceEndpoint(endpointReference *Endpoint
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEndpointCallback updates a named endpoint via callback
-func (s *TestDatabaseResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["endpointName"] = SerializeValue(endpointName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpEndpointCallback updates an HTTP endpoint via callback
-func (s *TestDatabaseResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
-func (s *TestDatabaseResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -15585,23 +14600,6 @@ func (s *TestDatabaseResource) WithCommand(name string, displayName string, exec
 	return result.(*IResource), nil
 }
 
-// WithHttpCommand adds an HTTP resource command
-func (s *TestDatabaseResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["displayName"] = SerializeValue(displayName)
-	if options != nil {
-		reqArgs["options"] = SerializeValue(options)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *TestDatabaseResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -15653,20 +14651,6 @@ func (s *TestDatabaseResource) WithoutHttpsCertificate() (*IResourceWithEnvironm
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *TestDatabaseResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -15755,6 +14739,21 @@ func (s *TestDatabaseResource) ExcludeFromMcp() (*IResource, error) {
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// WithImagePushOptions sets image push options via callback
+func (s *TestDatabaseResource) WithImagePushOptions(callback func(...any) any) (*IComputeResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IComputeResource), nil
 }
 
 // WithRemoteImageName sets the remote image name for publishing
@@ -16563,14 +15562,14 @@ func (s *TestRedisResource) WithContainerName(name string) (*ContainerResource, 
 	return result.(*ContainerResource), nil
 }
 
-// WithBuildArg adds a build argument from a string value or parameter resource
-func (s *TestRedisResource) WithBuildArg(name string, value any) (*ContainerResource, error) {
+// WithBuildArg adds a build argument from a parameter resource
+func (s *TestRedisResource) WithBuildArg(name string, value *ParameterResource) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16585,27 +15584,6 @@ func (s *TestRedisResource) WithBuildSecret(name string, value *ParameterResourc
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ContainerResource), nil
-}
-
-// WithContainerCertificatePaths overrides container certificate bundle and directory paths used for trust configuration
-func (s *TestRedisResource) WithContainerCertificatePaths(customCertificatesDestination *string, defaultCertificateBundlePaths []string, defaultCertificateDirectoryPaths []string) (*ContainerResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if customCertificatesDestination != nil {
-		reqArgs["customCertificatesDestination"] = SerializeValue(customCertificatesDestination)
-	}
-	if defaultCertificateBundlePaths != nil {
-		reqArgs["defaultCertificateBundlePaths"] = SerializeValue(defaultCertificateBundlePaths)
-	}
-	if defaultCertificateDirectoryPaths != nil {
-		reqArgs["defaultCertificateDirectoryPaths"] = SerializeValue(defaultCertificateDirectoryPaths)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withContainerCertificatePaths", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16812,8 +15790,8 @@ func (s *TestRedisResource) WithEnvironmentConnectionString(envVarName string, r
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithConnectionProperty adds a connection property with a string or reference expression value
-func (s *TestRedisResource) WithConnectionProperty(name string, value any) (*IResourceWithConnectionString, error) {
+// WithConnectionProperty adds a connection property with a reference expression
+func (s *TestRedisResource) WithConnectionProperty(name string, value *ReferenceExpression) (*IResourceWithConnectionString, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -16866,19 +15844,6 @@ func (s *TestRedisResource) WithArgsCallback(callback func(...any) any) (*IResou
 		return nil, err
 	}
 	return result.(*IResourceWithArgs), nil
-}
-
-// WithReferenceEnvironment configures which reference values are injected into environment variables
-func (s *TestRedisResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["options"] = SerializeValue(options)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
 }
 
 // WithReference adds a reference to another resource
@@ -16954,67 +15919,6 @@ func (s *TestRedisResource) WithReferenceEndpoint(endpointReference *EndpointRef
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEndpointCallback updates a named endpoint via callback
-func (s *TestRedisResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["endpointName"] = SerializeValue(endpointName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpEndpointCallback updates an HTTP endpoint via callback
-func (s *TestRedisResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
-func (s *TestRedisResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -17371,23 +16275,6 @@ func (s *TestRedisResource) WithCommand(name string, displayName string, execute
 	return result.(*IResource), nil
 }
 
-// WithHttpCommand adds an HTTP resource command
-func (s *TestRedisResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["displayName"] = SerializeValue(displayName)
-	if options != nil {
-		reqArgs["options"] = SerializeValue(options)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *TestRedisResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -17439,20 +16326,6 @@ func (s *TestRedisResource) WithoutHttpsCertificate() (*IResourceWithEnvironment
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *TestRedisResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -17541,6 +16414,21 @@ func (s *TestRedisResource) ExcludeFromMcp() (*IResource, error) {
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// WithImagePushOptions sets image push options via callback
+func (s *TestRedisResource) WithImagePushOptions(callback func(...any) any) (*IComputeResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IComputeResource), nil
 }
 
 // WithRemoteImageName sets the remote image name for publishing
@@ -18533,14 +17421,14 @@ func (s *TestVaultResource) WithContainerName(name string) (*ContainerResource, 
 	return result.(*ContainerResource), nil
 }
 
-// WithBuildArg adds a build argument from a string value or parameter resource
-func (s *TestVaultResource) WithBuildArg(name string, value any) (*ContainerResource, error) {
+// WithBuildArg adds a build argument from a parameter resource
+func (s *TestVaultResource) WithBuildArg(name string, value *ParameterResource) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -18555,27 +17443,6 @@ func (s *TestVaultResource) WithBuildSecret(name string, value *ParameterResourc
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ContainerResource), nil
-}
-
-// WithContainerCertificatePaths overrides container certificate bundle and directory paths used for trust configuration
-func (s *TestVaultResource) WithContainerCertificatePaths(customCertificatesDestination *string, defaultCertificateBundlePaths []string, defaultCertificateDirectoryPaths []string) (*ContainerResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if customCertificatesDestination != nil {
-		reqArgs["customCertificatesDestination"] = SerializeValue(customCertificatesDestination)
-	}
-	if defaultCertificateBundlePaths != nil {
-		reqArgs["defaultCertificateBundlePaths"] = SerializeValue(defaultCertificateBundlePaths)
-	}
-	if defaultCertificateDirectoryPaths != nil {
-		reqArgs["defaultCertificateDirectoryPaths"] = SerializeValue(defaultCertificateDirectoryPaths)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withContainerCertificatePaths", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -18810,19 +17677,6 @@ func (s *TestVaultResource) WithArgsCallback(callback func(...any) any) (*IResou
 	return result.(*IResourceWithArgs), nil
 }
 
-// WithReferenceEnvironment configures which reference values are injected into environment variables
-func (s *TestVaultResource) WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["options"] = SerializeValue(options)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReferenceEnvironment", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithReference adds a reference to another resource
 func (s *TestVaultResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -18883,67 +17737,6 @@ func (s *TestVaultResource) WithReferenceEndpoint(endpointReference *EndpointRef
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEndpointCallback updates a named endpoint via callback
-func (s *TestVaultResource) WithEndpointCallback(endpointName string, callback func(...any) any, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["endpointName"] = SerializeValue(endpointName)
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpEndpointCallback updates an HTTP endpoint via callback
-func (s *TestVaultResource) WithHttpEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
-// WithHttpsEndpointCallback updates an HTTPS endpoint via callback
-func (s *TestVaultResource) WithHttpsEndpointCallback(callback func(...any) any, name *string, createIfNotExists *bool) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	if callback != nil {
-		reqArgs["callback"] = RegisterCallback(callback)
-	}
-	if name != nil {
-		reqArgs["name"] = SerializeValue(name)
-	}
-	if createIfNotExists != nil {
-		reqArgs["createIfNotExists"] = SerializeValue(createIfNotExists)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpointCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
 }
 
 // WithEndpoint adds a network endpoint
@@ -19300,23 +18093,6 @@ func (s *TestVaultResource) WithCommand(name string, displayName string, execute
 	return result.(*IResource), nil
 }
 
-// WithHttpCommand adds an HTTP resource command
-func (s *TestVaultResource) WithHttpCommand(path string, displayName string, options *HttpCommandExportOptions) (*IResourceWithEndpoints, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["displayName"] = SerializeValue(displayName)
-	if options != nil {
-		reqArgs["options"] = SerializeValue(options)
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpCommand", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEndpoints), nil
-}
-
 // WithDeveloperCertificateTrust configures developer certificate trust
 func (s *TestVaultResource) WithDeveloperCertificateTrust(trust bool) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -19368,20 +18144,6 @@ func (s *TestVaultResource) WithoutHttpsCertificate() (*IResourceWithEnvironment
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithRelationship adds a relationship to another resource
-func (s *TestVaultResource) WithRelationship(resourceBuilder *IResource, type_ string) (*IResource, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["resourceBuilder"] = SerializeValue(resourceBuilder)
-	reqArgs["type"] = SerializeValue(type_)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderRelationship", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResource), nil
 }
 
 // WithParentRelationship sets the parent relationship
@@ -19470,6 +18232,21 @@ func (s *TestVaultResource) ExcludeFromMcp() (*IResource, error) {
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// WithImagePushOptions sets image push options via callback
+func (s *TestVaultResource) WithImagePushOptions(callback func(...any) any) (*IComputeResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IComputeResource), nil
 }
 
 // WithRemoteImageName sets the remote image name for publishing
@@ -20054,9 +18831,6 @@ func init() {
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder", func(h *Handle, c *AspireClient) any {
 		return NewIDistributedApplicationBuilder(h, c)
 	})
-	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline", func(h *Handle, c *AspireClient) any {
-		return NewIDistributedApplicationPipeline(h, c)
-	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.DistributedApplication", func(h *Handle, c *AspireClient) any {
 		return NewDistributedApplication(h, c)
 	})
@@ -20095,15 +18869,6 @@ func init() {
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource", func(h *Handle, c *AspireClient) any {
 		return NewParameterResource(h, c)
-	})
-	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation", func(h *Handle, c *AspireClient) any {
-		return NewContainerMountAnnotation(h, c)
-	})
-	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference", func(h *Handle, c *AspireClient) any {
-		return NewContainerImageReference(h, c)
-	})
-	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference", func(h *Handle, c *AspireClient) any {
-		return NewContainerPortReference(h, c)
 	})
 	RegisterHandleWrapper("System.ComponentModel/System.IServiceProvider", func(h *Handle, c *AspireClient) any {
 		return NewIServiceProvider(h, c)
@@ -20195,14 +18960,17 @@ func init() {
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent", func(h *Handle, c *AspireClient) any {
 		return NewConnectionStringAvailableEvent(h, c)
 	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions", func(h *Handle, c *AspireClient) any {
+		return NewContainerImagePushOptions(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext", func(h *Handle, c *AspireClient) any {
+		return NewContainerImagePushOptionsCallbackContext(h, c)
+	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DistributedApplicationModel", func(h *Handle, c *AspireClient) any {
 		return NewDistributedApplicationModel(h, c)
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReferenceExpression", func(h *Handle, c *AspireClient) any {
 		return NewEndpointReferenceExpression(h, c)
-	})
-	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext", func(h *Handle, c *AspireClient) any {
-		return NewEndpointUpdateContext(h, c)
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext", func(h *Handle, c *AspireClient) any {
 		return NewEnvironmentCallbackContext(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1,4 +1,4 @@
-// ===== AddContainerOptions.java =====
+﻿// ===== AddContainerOptions.java =====
 // AddContainerOptions.java - GENERATED CODE - DO NOT EDIT
 
 package aspire;
@@ -4144,27 +4144,14 @@ public class ConnectionStringResource extends ResourceBuilderBase {
 
 }
 
-<<<<<<< HEAD
-// ===== ContainerImageReference.java =====
-// ContainerImageReference.java - GENERATED CODE - DO NOT EDIT
-=======
 // ===== ContainerImagePushOptions.java =====
 // ContainerImagePushOptions.java - GENERATED CODE - DO NOT EDIT
->>>>>>> 4ffc78f12 (Add polyglot withImagePushOptions support)
 
 package aspire;
 
 import java.util.*;
 import java.util.function.*;
 
-<<<<<<< HEAD
-/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference. */
-public class ContainerImageReference extends HandleWrapperBase {
-    ContainerImageReference(Handle handle, AspireClient client) {
-        super(handle, client);
-    }
-
-=======
 /** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions. */
 public class ContainerImagePushOptions extends HandleWrapperBase {
     ContainerImagePushOptions(Handle handle, AspireClient client) {
@@ -4268,7 +4255,22 @@ public class ContainerImagePushOptionsCallbackContext extends HandleWrapperBase 
         return (ContainerImagePushOptionsCallbackContext) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setOptions", reqArgs);
     }
 
->>>>>>> 4ffc78f12 (Add polyglot withImagePushOptions support)
+}
+
+// ===== ContainerImageReference.java =====
+// ContainerImageReference.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference. */
+public class ContainerImageReference extends HandleWrapperBase {
+    ContainerImageReference(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
 }
 
 // ===== ContainerLifetime.java =====
@@ -22975,12 +22977,9 @@ public final class WithVolumeOptions {
 .modules/CompleteTaskOptions.java
 .modules/ConnectionStringAvailableEvent.java
 .modules/ConnectionStringResource.java
-<<<<<<< HEAD
-.modules/ContainerImageReference.java
-=======
 .modules/ContainerImagePushOptions.java
 .modules/ContainerImagePushOptionsCallbackContext.java
->>>>>>> 4ffc78f12 (Add polyglot withImagePushOptions support)
+.modules/ContainerImageReference.java
 .modules/ContainerLifetime.java
 .modules/ContainerMountAnnotation.java
 .modules/ContainerPortReference.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1203,6 +1203,8 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeStartEvent", (h, c) -> new BeforeStartEvent(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext", (h, c) -> new CommandLineArgsCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent", (h, c) -> new ConnectionStringAvailableEvent(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions", (h, c) -> new ContainerImagePushOptions(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext", (h, c) -> new ContainerImagePushOptionsCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DistributedApplicationModel", (h, c) -> new DistributedApplicationModel(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReferenceExpression", (h, c) -> new EndpointReferenceExpression(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext", (h, c) -> new EndpointUpdateContext(h, c));
@@ -2378,6 +2380,22 @@ public class CSharpAppResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         getClient().invokeCapability("Aspire.Hosting/excludeFromMcp", reqArgs);
+        return this;
+    }
+
+    /** Sets image push options via callback */
+    public CSharpAppResource withImagePushOptions(AspireAction1<ContainerImagePushOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs);
         return this;
     }
 
@@ -4126,20 +4144,131 @@ public class ConnectionStringResource extends ResourceBuilderBase {
 
 }
 
+<<<<<<< HEAD
 // ===== ContainerImageReference.java =====
 // ContainerImageReference.java - GENERATED CODE - DO NOT EDIT
+=======
+// ===== ContainerImagePushOptions.java =====
+// ContainerImagePushOptions.java - GENERATED CODE - DO NOT EDIT
+>>>>>>> 4ffc78f12 (Add polyglot withImagePushOptions support)
 
 package aspire;
 
 import java.util.*;
 import java.util.function.*;
 
+<<<<<<< HEAD
 /** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference. */
 public class ContainerImageReference extends HandleWrapperBase {
     ContainerImageReference(Handle handle, AspireClient client) {
         super(handle, client);
     }
 
+=======
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions. */
+public class ContainerImagePushOptions extends HandleWrapperBase {
+    ContainerImagePushOptions(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets the RemoteImageName property */
+    public String remoteImageName() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        return (String) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageName", reqArgs);
+    }
+
+    /** Sets the RemoteImageName property */
+    public ContainerImagePushOptions setRemoteImageName(String value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        return (ContainerImagePushOptions) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageName", reqArgs);
+    }
+
+    /** Gets the RemoteImageTag property */
+    public String remoteImageTag() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        return (String) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageTag", reqArgs);
+    }
+
+    /** Sets the RemoteImageTag property */
+    public ContainerImagePushOptions setRemoteImageTag(String value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        return (ContainerImagePushOptions) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageTag", reqArgs);
+    }
+
+}
+
+// ===== ContainerImagePushOptionsCallbackContext.java =====
+// ContainerImagePushOptionsCallbackContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext. */
+public class ContainerImagePushOptionsCallbackContext extends HandleWrapperBase {
+    ContainerImagePushOptionsCallbackContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets the Resource property */
+    public IResource resource() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        return (IResource) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.resource", reqArgs);
+    }
+
+    /** Sets the Resource property */
+    public ContainerImagePushOptionsCallbackContext setResource(IResource value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        return (ContainerImagePushOptionsCallbackContext) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setResource", reqArgs);
+    }
+
+    public ContainerImagePushOptionsCallbackContext setResource(ResourceBuilderBase value) {
+        return setResource(new IResource(value.getHandle(), value.getClient()));
+    }
+
+    /** Gets the CancellationToken property */
+    public CancellationToken cancellationToken() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        return (CancellationToken) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.cancellationToken", reqArgs);
+    }
+
+    /** Sets the CancellationToken property */
+    public ContainerImagePushOptionsCallbackContext setCancellationToken(CancellationToken value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        if (value != null) {
+            reqArgs.put("value", getClient().registerCancellation(value));
+        }
+        return (ContainerImagePushOptionsCallbackContext) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setCancellationToken", reqArgs);
+    }
+
+    /** Gets the Options property */
+    public ContainerImagePushOptions options() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        return (ContainerImagePushOptions) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.options", reqArgs);
+    }
+
+    /** Sets the Options property */
+    public ContainerImagePushOptionsCallbackContext setOptions(ContainerImagePushOptions value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        return (ContainerImagePushOptionsCallbackContext) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setOptions", reqArgs);
+    }
+
+>>>>>>> 4ffc78f12 (Add polyglot withImagePushOptions support)
 }
 
 // ===== ContainerLifetime.java =====
@@ -6060,6 +6189,22 @@ public class ContainerResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Sets image push options via callback */
+    public ContainerResource withImagePushOptions(AspireAction1<ContainerImagePushOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs);
+        return this;
+    }
+
     /** Sets the remote image name for publishing */
     public ContainerResource withRemoteImageName(String remoteImageName) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -7890,6 +8035,22 @@ public class DotnetToolResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         getClient().invokeCapability("Aspire.Hosting/excludeFromMcp", reqArgs);
+        return this;
+    }
+
+    /** Sets image push options via callback */
+    public DotnetToolResource withImagePushOptions(AspireAction1<ContainerImagePushOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs);
         return this;
     }
 
@@ -9835,6 +9996,22 @@ public class ExecutableResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         getClient().invokeCapability("Aspire.Hosting/excludeFromMcp", reqArgs);
+        return this;
+    }
+
+    /** Sets image push options via callback */
+    public ExecutableResource withImagePushOptions(AspireAction1<ContainerImagePushOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs);
         return this;
     }
 
@@ -14989,6 +15166,22 @@ public class ProjectResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Sets image push options via callback */
+    public ProjectResource withImagePushOptions(AspireAction1<ContainerImagePushOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs);
+        return this;
+    }
+
     /** Sets the remote image name for publishing */
     public ProjectResource withRemoteImageName(String remoteImageName) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -17544,6 +17737,22 @@ public class TestDatabaseResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Sets image push options via callback */
+    public TestDatabaseResource withImagePushOptions(AspireAction1<ContainerImagePushOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs);
+        return this;
+    }
+
     /** Sets the remote image name for publishing */
     public TestDatabaseResource withRemoteImageName(String remoteImageName) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -19424,6 +19633,22 @@ public class TestRedisResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         getClient().invokeCapability("Aspire.Hosting/excludeFromMcp", reqArgs);
+        return this;
+    }
+
+    /** Sets image push options via callback */
+    public TestRedisResource withImagePushOptions(AspireAction1<ContainerImagePushOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs);
         return this;
     }
 
@@ -21391,6 +21616,22 @@ public class TestVaultResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Sets image push options via callback */
+    public TestVaultResource withImagePushOptions(AspireAction1<ContainerImagePushOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withImagePushOptions", reqArgs);
+        return this;
+    }
+
     /** Sets the remote image name for publishing */
     public TestVaultResource withRemoteImageName(String remoteImageName) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -22734,7 +22975,12 @@ public final class WithVolumeOptions {
 .modules/CompleteTaskOptions.java
 .modules/ConnectionStringAvailableEvent.java
 .modules/ConnectionStringResource.java
+<<<<<<< HEAD
 .modules/ContainerImageReference.java
+=======
+.modules/ContainerImagePushOptions.java
+.modules/ContainerImagePushOptionsCallbackContext.java
+>>>>>>> 4ffc78f12 (Add polyglot withImagePushOptions support)
 .modules/ContainerLifetime.java
 .modules/ContainerMountAnnotation.java
 .modules/ContainerPortReference.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -2388,8 +2388,8 @@ public class CSharpAppResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         var callbackId = getClient().registerCallback(args -> {
-            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
-            callback.invoke(obj);
+            var arg = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(arg);
             return null;
         });
         if (callbackId != null) {
@@ -6194,8 +6194,8 @@ public class ContainerResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         var callbackId = getClient().registerCallback(args -> {
-            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
-            callback.invoke(obj);
+            var arg = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(arg);
             return null;
         });
         if (callbackId != null) {
@@ -8043,8 +8043,8 @@ public class DotnetToolResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         var callbackId = getClient().registerCallback(args -> {
-            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
-            callback.invoke(obj);
+            var arg = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(arg);
             return null;
         });
         if (callbackId != null) {
@@ -10004,8 +10004,8 @@ public class ExecutableResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         var callbackId = getClient().registerCallback(args -> {
-            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
-            callback.invoke(obj);
+            var arg = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(arg);
             return null;
         });
         if (callbackId != null) {
@@ -15171,8 +15171,8 @@ public class ProjectResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         var callbackId = getClient().registerCallback(args -> {
-            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
-            callback.invoke(obj);
+            var arg = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(arg);
             return null;
         });
         if (callbackId != null) {
@@ -17742,8 +17742,8 @@ public class TestDatabaseResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         var callbackId = getClient().registerCallback(args -> {
-            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
-            callback.invoke(obj);
+            var arg = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(arg);
             return null;
         });
         if (callbackId != null) {
@@ -19641,8 +19641,8 @@ public class TestRedisResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         var callbackId = getClient().registerCallback(args -> {
-            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
-            callback.invoke(obj);
+            var arg = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(arg);
             return null;
         });
         if (callbackId != null) {
@@ -21621,8 +21621,8 @@ public class TestVaultResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         var callbackId = getClient().registerCallback(args -> {
-            var obj = (ContainerImagePushOptionsCallbackContext) args[0];
-            callback.invoke(obj);
+            var arg = (ContainerImagePushOptionsCallbackContext) args[0];
+            callback.invoke(arg);
             return null;
         });
         if (callbackId != null) {

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -3009,6 +3009,114 @@ class ConnectionStringAvailableEvent:
         return typing.cast(AbstractServiceProvider, result)
 
 
+class ContainerImagePushOptions:
+    """Type class for ContainerImagePushOptions."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"ContainerImagePushOptions(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_uncached_property
+    def remote_image_name(self) -> str:
+        """Gets the RemoteImageName property"""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageName',
+            {'context': self._handle}
+        )
+        return typing.cast(str, result)
+
+    @remote_image_name.setter
+    def remote_image_name(self, value: str) -> None:
+        """Sets the RemoteImageName property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageName',
+            {'context': self._handle, 'value': value}
+        )
+
+    @_uncached_property
+    def remote_image_tag(self) -> str:
+        """Gets the RemoteImageTag property"""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageTag',
+            {'context': self._handle}
+        )
+        return typing.cast(str, result)
+
+    @remote_image_tag.setter
+    def remote_image_tag(self, value: str) -> None:
+        """Sets the RemoteImageTag property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageTag',
+            {'context': self._handle, 'value': value}
+        )
+
+
+class ContainerImagePushOptionsCallbackContext:
+    """Type class for ContainerImagePushOptionsCallbackContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"ContainerImagePushOptionsCallbackContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_uncached_property
+    def resource(self) -> AbstractResource:
+        """Gets the Resource property"""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.resource',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractResource, result)
+
+    @resource.setter
+    def resource(self, value: AbstractResource) -> None:
+        """Sets the Resource property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setResource',
+            {'context': self._handle, 'value': value}
+        )
+
+    def cancel(self) -> None:
+        """Cancel the operation."""
+        token: CancellationToken = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.cancellationToken',
+            {'context': self._handle}
+        )
+        token.cancel()
+
+    @_uncached_property
+    def options(self) -> ContainerImagePushOptions:
+        """Gets the Options property"""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.options',
+            {'context': self._handle}
+        )
+        return typing.cast(ContainerImagePushOptions, result)
+
+    @options.setter
+    def options(self, value: ContainerImagePushOptions) -> None:
+        """Sets the Options property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setOptions',
+            {'context': self._handle, 'value': value}
+        )
+
+
 class DistributedApplication:
     """Type class for DistributedApplication."""
 
@@ -5101,6 +5209,10 @@ class AbstractComputeResource(AbstractResource):
     """Abstract base class for AbstractComputeResource interface."""
 
     @abc.abstractmethod
+    def with_image_push_options(self, callback: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]) -> typing.Self:
+        """Sets image push options via callback"""
+
+    @abc.abstractmethod
     def with_remote_image_name(self, remote_image_name: str) -> typing.Self:
         """Sets the remote image name for publishing"""
 
@@ -6532,6 +6644,7 @@ class ContainerResourceKwargs(_BaseResourceKwargs, total=False):
     https_developer_certificate: ParameterResource | typing.Literal[True]
     without_https_certificate: typing.Literal[True]
     http_probe: ProbeType | HttpProbeParameters
+    image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
     remote_image_name: str
     remote_image_tag: str
     volume: str | VolumeParameters
@@ -7231,6 +7344,17 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_image_push_options(self, callback: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]) -> typing.Self:
+        """Sets image push options via callback"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withImagePushOptions',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_remote_image_name(self, remote_image_name: str) -> typing.Self:
         """Sets the remote image name for publishing"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -7791,6 +7915,13 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpProbe', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'http_probe'. Expected: ProbeType or HttpProbeParameters")
+        if _image_push_options := kwargs.pop("image_push_options", None):
+            if _validate_type(_image_push_options, typing.Callable[[ContainerImagePushOptionsCallbackContext], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withImagePushOptions', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'image_push_options'. Expected: Callable[[ContainerImagePushOptionsCallbackContext], None]")
         if _remote_image_name := kwargs.pop("remote_image_name", None):
             if _validate_type(_remote_image_name, str):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -7883,6 +8014,7 @@ class ProjectResourceKwargs(_BaseResourceKwargs, total=False):
     https_developer_certificate: ParameterResource | typing.Literal[True]
     without_https_certificate: typing.Literal[True]
     http_probe: ProbeType | HttpProbeParameters
+    image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
     remote_image_name: str
     remote_image_tag: str
     on_resource_endpoints_allocated: typing.Callable[[ResourceEndpointsAllocatedEvent], None]
@@ -8414,6 +8546,17 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_image_push_options(self, callback: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]) -> typing.Self:
+        """Sets image push options via callback"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withImagePushOptions',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_remote_image_name(self, remote_image_name: str) -> typing.Self:
         """Sets the remote image name for publishing"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -8841,6 +8984,13 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpProbe', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'http_probe'. Expected: ProbeType or HttpProbeParameters")
+        if _image_push_options := kwargs.pop("image_push_options", None):
+            if _validate_type(_image_push_options, typing.Callable[[ContainerImagePushOptionsCallbackContext], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withImagePushOptions', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'image_push_options'. Expected: Callable[[ContainerImagePushOptionsCallbackContext], None]")
         if _remote_image_name := kwargs.pop("remote_image_name", None):
             if _validate_type(_remote_image_name, str):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -8933,6 +9083,7 @@ class ExecutableResourceKwargs(_BaseResourceKwargs, total=False):
     https_developer_certificate: ParameterResource | typing.Literal[True]
     without_https_certificate: typing.Literal[True]
     http_probe: ProbeType | HttpProbeParameters
+    image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
     remote_image_name: str
     remote_image_tag: str
     on_resource_endpoints_allocated: typing.Callable[[ResourceEndpointsAllocatedEvent], None]
@@ -9454,6 +9605,17 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_image_push_options(self, callback: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]) -> typing.Self:
+        """Sets image push options via callback"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withImagePushOptions',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_remote_image_name(self, remote_image_name: str) -> typing.Self:
         """Sets the remote image name for publishing"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -9874,6 +10036,13 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpProbe', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'http_probe'. Expected: ProbeType or HttpProbeParameters")
+        if _image_push_options := kwargs.pop("image_push_options", None):
+            if _validate_type(_image_push_options, typing.Callable[[ContainerImagePushOptionsCallbackContext], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withImagePushOptions', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'image_push_options'. Expected: Callable[[ContainerImagePushOptionsCallbackContext], None]")
         if _remote_image_name := kwargs.pop("remote_image_name", None):
             if _validate_type(_remote_image_name, str):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -10552,6 +10721,8 @@ _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeR
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeStartEvent", BeforeStartEvent)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext", CommandLineArgsCallbackContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent", ConnectionStringAvailableEvent)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions", ContainerImagePushOptions)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext", ContainerImagePushOptionsCallbackContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.DistributedApplication", DistributedApplication)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Eventing.DistributedApplicationEventSubscription", DistributedApplicationEventSubscription)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.DistributedApplicationExecutionContext", DistributedApplicationExecutionContext)

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -315,6 +315,31 @@ impl std::fmt::Display for EndpointProperty {
     }
 }
 
+/// HttpCommandResultMode
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HttpCommandResultMode {
+    #[default]
+    #[serde(rename = "None")]
+    None,
+    #[serde(rename = "Auto")]
+    Auto,
+    #[serde(rename = "Json")]
+    Json,
+    #[serde(rename = "Text")]
+    Text,
+}
+
+impl std::fmt::Display for HttpCommandResultMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::Auto => write!(f, "Auto"),
+            Self::Json => write!(f, "Json"),
+            Self::Text => write!(f, "Text"),
+        }
+    }
+}
+
 /// CommandResultFormat
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CommandResultFormat {
@@ -323,6 +348,8 @@ pub enum CommandResultFormat {
     Text,
     #[serde(rename = "Json")]
     Json,
+    #[serde(rename = "Markdown")]
+    Markdown,
 }
 
 impl std::fmt::Display for CommandResultFormat {
@@ -330,6 +357,7 @@ impl std::fmt::Display for CommandResultFormat {
         match self {
             Self::Text => write!(f, "Text"),
             Self::Json => write!(f, "Json"),
+            Self::Markdown => write!(f, "Markdown"),
         }
     }
 }
@@ -404,6 +432,24 @@ impl std::fmt::Display for TestResourceStatus {
 // DTOs
 // ============================================================================
 
+/// AddContainerOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AddContainerOptions {
+    #[serde(rename = "Image")]
+    pub image: String,
+    #[serde(rename = "Tag")]
+    pub tag: String,
+}
+
+impl AddContainerOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("Image".to_string(), serde_json::to_value(&self.image).unwrap_or(Value::Null));
+        map.insert("Tag".to_string(), serde_json::to_value(&self.tag).unwrap_or(Value::Null));
+        map
+    }
+}
+
 /// CreateBuilderOptions
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CreateBuilderOptions {
@@ -470,6 +516,30 @@ impl ResourceEventDto {
     }
 }
 
+/// ReferenceEnvironmentInjectionOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReferenceEnvironmentInjectionOptions {
+    #[serde(rename = "ConnectionString")]
+    pub connection_string: bool,
+    #[serde(rename = "ConnectionProperties")]
+    pub connection_properties: bool,
+    #[serde(rename = "ServiceDiscovery")]
+    pub service_discovery: bool,
+    #[serde(rename = "Endpoints")]
+    pub endpoints: bool,
+}
+
+impl ReferenceEnvironmentInjectionOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("ConnectionString".to_string(), serde_json::to_value(&self.connection_string).unwrap_or(Value::Null));
+        map.insert("ConnectionProperties".to_string(), serde_json::to_value(&self.connection_properties).unwrap_or(Value::Null));
+        map.insert("ServiceDiscovery".to_string(), serde_json::to_value(&self.service_discovery).unwrap_or(Value::Null));
+        map.insert("Endpoints".to_string(), serde_json::to_value(&self.endpoints).unwrap_or(Value::Null));
+        map
+    }
+}
+
 /// CommandOptions
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CommandOptions {
@@ -503,6 +573,84 @@ impl CommandOptions {
     }
 }
 
+/// HttpCommandExportOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HttpCommandExportOptions {
+    #[serde(rename = "Description")]
+    pub description: String,
+    #[serde(rename = "ConfirmationMessage")]
+    pub confirmation_message: String,
+    #[serde(rename = "IconName")]
+    pub icon_name: String,
+    #[serde(rename = "IconVariant")]
+    pub icon_variant: IconVariant,
+    #[serde(rename = "IsHighlighted")]
+    pub is_highlighted: bool,
+    #[serde(rename = "CommandName")]
+    pub command_name: String,
+    #[serde(rename = "EndpointName")]
+    pub endpoint_name: String,
+    #[serde(rename = "MethodName")]
+    pub method_name: String,
+    #[serde(rename = "ResultMode")]
+    pub result_mode: HttpCommandResultMode,
+}
+
+impl HttpCommandExportOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("Description".to_string(), serde_json::to_value(&self.description).unwrap_or(Value::Null));
+        map.insert("ConfirmationMessage".to_string(), serde_json::to_value(&self.confirmation_message).unwrap_or(Value::Null));
+        map.insert("IconName".to_string(), serde_json::to_value(&self.icon_name).unwrap_or(Value::Null));
+        map.insert("IconVariant".to_string(), serde_json::to_value(&self.icon_variant).unwrap_or(Value::Null));
+        map.insert("IsHighlighted".to_string(), serde_json::to_value(&self.is_highlighted).unwrap_or(Value::Null));
+        map.insert("CommandName".to_string(), serde_json::to_value(&self.command_name).unwrap_or(Value::Null));
+        map.insert("EndpointName".to_string(), serde_json::to_value(&self.endpoint_name).unwrap_or(Value::Null));
+        map.insert("MethodName".to_string(), serde_json::to_value(&self.method_name).unwrap_or(Value::Null));
+        map.insert("ResultMode".to_string(), serde_json::to_value(&self.result_mode).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// GenerateParameterDefault
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GenerateParameterDefault {
+    #[serde(rename = "MinLength")]
+    pub min_length: f64,
+    #[serde(rename = "Lower")]
+    pub lower: bool,
+    #[serde(rename = "Upper")]
+    pub upper: bool,
+    #[serde(rename = "Numeric")]
+    pub numeric: bool,
+    #[serde(rename = "Special")]
+    pub special: bool,
+    #[serde(rename = "MinLower")]
+    pub min_lower: f64,
+    #[serde(rename = "MinUpper")]
+    pub min_upper: f64,
+    #[serde(rename = "MinNumeric")]
+    pub min_numeric: f64,
+    #[serde(rename = "MinSpecial")]
+    pub min_special: f64,
+}
+
+impl GenerateParameterDefault {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("MinLength".to_string(), serde_json::to_value(&self.min_length).unwrap_or(Value::Null));
+        map.insert("Lower".to_string(), serde_json::to_value(&self.lower).unwrap_or(Value::Null));
+        map.insert("Upper".to_string(), serde_json::to_value(&self.upper).unwrap_or(Value::Null));
+        map.insert("Numeric".to_string(), serde_json::to_value(&self.numeric).unwrap_or(Value::Null));
+        map.insert("Special".to_string(), serde_json::to_value(&self.special).unwrap_or(Value::Null));
+        map.insert("MinLower".to_string(), serde_json::to_value(&self.min_lower).unwrap_or(Value::Null));
+        map.insert("MinUpper".to_string(), serde_json::to_value(&self.min_upper).unwrap_or(Value::Null));
+        map.insert("MinNumeric".to_string(), serde_json::to_value(&self.min_numeric).unwrap_or(Value::Null));
+        map.insert("MinSpecial".to_string(), serde_json::to_value(&self.min_special).unwrap_or(Value::Null));
+        map
+    }
+}
+
 /// ExecuteCommandResult
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ExecuteCommandResult {
@@ -512,10 +660,10 @@ pub struct ExecuteCommandResult {
     pub canceled: bool,
     #[serde(rename = "ErrorMessage")]
     pub error_message: String,
-    #[serde(rename = "Result")]
-    pub result: String,
-    #[serde(rename = "ResultFormat")]
-    pub result_format: CommandResultFormat,
+    #[serde(rename = "Message")]
+    pub message: String,
+    #[serde(rename = "Data")]
+    pub data: CommandResultData,
 }
 
 impl ExecuteCommandResult {
@@ -524,8 +672,29 @@ impl ExecuteCommandResult {
         map.insert("Success".to_string(), serde_json::to_value(&self.success).unwrap_or(Value::Null));
         map.insert("Canceled".to_string(), serde_json::to_value(&self.canceled).unwrap_or(Value::Null));
         map.insert("ErrorMessage".to_string(), serde_json::to_value(&self.error_message).unwrap_or(Value::Null));
-        map.insert("Result".to_string(), serde_json::to_value(&self.result).unwrap_or(Value::Null));
-        map.insert("ResultFormat".to_string(), serde_json::to_value(&self.result_format).unwrap_or(Value::Null));
+        map.insert("Message".to_string(), serde_json::to_value(&self.message).unwrap_or(Value::Null));
+        map.insert("Data".to_string(), serde_json::to_value(&self.data).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// CommandResultData
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommandResultData {
+    #[serde(rename = "Value")]
+    pub value: String,
+    #[serde(rename = "Format")]
+    pub format: CommandResultFormat,
+    #[serde(rename = "DisplayImmediately")]
+    pub display_immediately: bool,
+}
+
+impl CommandResultData {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("Value".to_string(), serde_json::to_value(&self.value).unwrap_or(Value::Null));
+        map.insert("Format".to_string(), serde_json::to_value(&self.format).unwrap_or(Value::Null));
+        map.insert("DisplayImmediately".to_string(), serde_json::to_value(&self.display_immediately).unwrap_or(Value::Null));
         map
     }
 }
@@ -970,6 +1139,16 @@ impl CSharpAppResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
+    /// Configures which reference values are injected into environment variables
+    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -1018,6 +1197,55 @@ impl CSharpAppResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Updates a named endpoint via callback
+    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTP endpoint via callback
+    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTPS endpoint via callback
+    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -1318,6 +1546,20 @@ impl CSharpAppResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an HTTP resource command
+    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -1357,6 +1599,17 @@ impl CSharpAppResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -2029,8 +2282,8 @@ impl ConnectionStringResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a connection property with a reference expression
-    pub fn with_connection_property(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
+    /// Adds a connection property with a string or reference expression value
+    pub fn with_connection_property(&self, name: &str, value: Value) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
@@ -2204,6 +2457,17 @@ impl ConnectionStringResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -2769,6 +3033,84 @@ impl ContainerImagePushOptionsCallbackContext {
     }
 }
 
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference
+pub struct ContainerImageReference {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerImageReference {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerImageReference {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation
+pub struct ContainerMountAnnotation {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerMountAnnotation {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerMountAnnotation {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference
+pub struct ContainerPortReference {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerPortReference {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerPortReference {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
 /// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerRegistryResource
 pub struct ContainerRegistryResource {
     handle: Handle,
@@ -2921,6 +3263,17 @@ impl ContainerRegistryResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -3474,13 +3827,13 @@ impl ContainerResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a build argument from a parameter resource
-    pub fn with_build_arg(&self, name: &str, value: &ParameterResource) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    /// Adds a build argument from a string value or parameter resource
+    pub fn with_build_arg(&self, name: &str, value: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -3492,6 +3845,24 @@ impl ContainerResource {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerResource::new(handle, self.client.clone()))
+    }
+
+    /// Overrides container certificate bundle and directory paths used for trust configuration
+    pub fn with_container_certificate_paths(&self, custom_certificates_destination: Option<&str>, default_certificate_bundle_paths: Option<Vec<String>>, default_certificate_directory_paths: Option<Vec<String>>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        if let Some(ref v) = custom_certificates_destination {
+            args.insert("customCertificatesDestination".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = default_certificate_bundle_paths {
+            args.insert("defaultCertificateBundlePaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = default_certificate_directory_paths {
+            args.insert("defaultCertificateDirectoryPaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerCertificatePaths", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -3674,6 +4045,16 @@ impl ContainerResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
+    /// Configures which reference values are injected into environment variables
+    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -3722,6 +4103,55 @@ impl ContainerResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Updates a named endpoint via callback
+    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTP endpoint via callback
+    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTPS endpoint via callback
+    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -4011,6 +4441,20 @@ impl ContainerResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an HTTP resource command
+    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -4050,6 +4494,17 @@ impl ContainerResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -5063,6 +5518,16 @@ impl DotnetToolResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
+    /// Configures which reference values are injected into environment variables
+    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -5111,6 +5576,55 @@ impl DotnetToolResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Updates a named endpoint via callback
+    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTP endpoint via callback
+    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTPS endpoint via callback
+    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -5400,6 +5914,20 @@ impl DotnetToolResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an HTTP resource command
+    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -5439,6 +5967,17 @@ impl DotnetToolResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -6139,6 +6678,220 @@ impl EndpointReferenceExpression {
     }
 }
 
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext
+pub struct EndpointUpdateContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for EndpointUpdateContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl EndpointUpdateContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets the Name property
+    pub fn name(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.name", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Gets the Protocol property
+    pub fn protocol(&self) -> Result<ProtocolType, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.protocol", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the Protocol property
+    pub fn set_protocol(&self, value: ProtocolType) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setProtocol", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the Port property
+    pub fn port(&self) -> Result<f64, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.port", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the Port property
+    pub fn set_port(&self, value: f64) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setPort", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the TargetPort property
+    pub fn target_port(&self) -> Result<f64, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetPort", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the TargetPort property
+    pub fn set_target_port(&self, value: f64) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetPort", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the UriScheme property
+    pub fn uri_scheme(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.uriScheme", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the UriScheme property
+    pub fn set_uri_scheme(&self, value: &str) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setUriScheme", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the TargetHost property
+    pub fn target_host(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetHost", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the TargetHost property
+    pub fn set_target_host(&self, value: &str) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetHost", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the Transport property
+    pub fn transport(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.transport", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the Transport property
+    pub fn set_transport(&self, value: &str) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTransport", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the IsExternal property
+    pub fn is_external(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.isExternal", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the IsExternal property
+    pub fn set_is_external(&self, value: bool) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setIsExternal", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the IsProxied property
+    pub fn is_proxied(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.isProxied", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the IsProxied property
+    pub fn set_is_proxied(&self, value: bool) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setIsProxied", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the ExcludeReferenceEndpoint property
+    pub fn exclude_reference_endpoint(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.excludeReferenceEndpoint", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the ExcludeReferenceEndpoint property
+    pub fn set_exclude_reference_endpoint(&self, value: bool) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setExcludeReferenceEndpoint", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the TlsEnabled property
+    pub fn tls_enabled(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.tlsEnabled", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the TlsEnabled property
+    pub fn set_tls_enabled(&self, value: bool) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTlsEnabled", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
+    }
+}
+
 /// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext
 pub struct EnvironmentCallbackContext {
     handle: Handle,
@@ -6440,6 +7193,16 @@ impl ExecutableResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
+    /// Configures which reference values are injected into environment variables
+    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -6488,6 +7251,55 @@ impl ExecutableResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Updates a named endpoint via callback
+    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTP endpoint via callback
+    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTPS endpoint via callback
+    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -6777,6 +7589,20 @@ impl ExecutableResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an HTTP resource command
+    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -6816,6 +7642,17 @@ impl ExecutableResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -7569,6 +8406,17 @@ impl ExternalServiceResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Sets the parent relationship
     pub fn with_parent_relationship(&self, parent: &IResource) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -8178,7 +9026,7 @@ impl IDistributedApplicationBuilder {
     }
 
     /// Adds a container resource
-    pub fn add_container(&self, name: &str, image: &str) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    pub fn add_container(&self, name: &str, image: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
@@ -8297,6 +9145,15 @@ impl IDistributedApplicationBuilder {
         Ok(DistributedApplicationExecutionContext::new(handle, self.client.clone()))
     }
 
+    /// Gets the Pipeline property
+    pub fn pipeline(&self) -> Result<IDistributedApplicationPipeline, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/IDistributedApplicationBuilder.pipeline", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IDistributedApplicationPipeline::new(handle, self.client.clone()))
+    }
+
     /// Gets the UserSecretsManager property
     pub fn user_secrets_manager(&self) -> Result<IUserSecretsManager, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -8359,6 +9216,23 @@ impl IDistributedApplicationBuilder {
         Ok(ParameterResource::new(handle, self.client.clone()))
     }
 
+    /// Adds a parameter with a generated default value
+    pub fn add_parameter_with_generated_value(&self, name: &str, value: GenerateParameterDefault, secret: Option<bool>, persist: Option<bool>) -> Result<ParameterResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        if let Some(ref v) = secret {
+            args.insert("secret".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = persist {
+            args.insert("persist".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/addParameterWithGeneratedValue", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ParameterResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a connection string resource
     pub fn add_connection_string(&self, name: &str, environment_variable_name: Option<&str>) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -8370,6 +9244,17 @@ impl IDistributedApplicationBuilder {
         let result = self.client.invoke_capability("Aspire.Hosting/addConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithConnectionString::new(handle, self.client.clone()))
+    }
+
+    /// Adds a .NET project resource without a launch profile
+    pub fn add_project_without_launch_profile(&self, name: &str, project_path: &str) -> Result<ProjectResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        args.insert("projectPath".to_string(), serde_json::to_value(&project_path).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/addProjectWithoutLaunchProfile", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ProjectResource::new(handle, self.client.clone()))
     }
 
     /// Adds a .NET project resource
@@ -8533,6 +9418,59 @@ impl IDistributedApplicationEventing {
         args.insert("context".to_string(), self.handle.to_json());
         args.insert("subscription".to_string(), subscription.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting.Eventing/IDistributedApplicationEventing.unsubscribe", args)?;
+        Ok(())
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline
+pub struct IDistributedApplicationPipeline {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for IDistributedApplicationPipeline {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl IDistributedApplicationPipeline {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Adds a pipeline step to the application
+    pub fn add_step(&self, step_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, depends_on: Option<Vec<String>>, required_by: Option<Vec<String>>) -> Result<(), Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("pipeline".to_string(), self.handle.to_json());
+        args.insert("stepName".to_string(), serde_json::to_value(&step_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = depends_on {
+            args.insert("dependsOn".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = required_by {
+            args.insert("requiredBy".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/addStep", args)?;
+        Ok(())
+    }
+
+    /// Configures the application pipeline via a callback
+    pub fn configure(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<(), Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("pipeline".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/configure", args)?;
         Ok(())
     }
 }
@@ -9593,6 +10531,17 @@ impl ParameterResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -10752,6 +11701,16 @@ impl ProjectResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
+    /// Configures which reference values are injected into environment variables
+    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -10800,6 +11759,55 @@ impl ProjectResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Updates a named endpoint via callback
+    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTP endpoint via callback
+    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTPS endpoint via callback
+    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -11100,6 +12108,20 @@ impl ProjectResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an HTTP resource command
+    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -11139,6 +12161,17 @@ impl ProjectResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -12402,13 +13435,13 @@ impl TestDatabaseResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a build argument from a parameter resource
-    pub fn with_build_arg(&self, name: &str, value: &ParameterResource) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    /// Adds a build argument from a string value or parameter resource
+    pub fn with_build_arg(&self, name: &str, value: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -12420,6 +13453,24 @@ impl TestDatabaseResource {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerResource::new(handle, self.client.clone()))
+    }
+
+    /// Overrides container certificate bundle and directory paths used for trust configuration
+    pub fn with_container_certificate_paths(&self, custom_certificates_destination: Option<&str>, default_certificate_bundle_paths: Option<Vec<String>>, default_certificate_directory_paths: Option<Vec<String>>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        if let Some(ref v) = custom_certificates_destination {
+            args.insert("customCertificatesDestination".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = default_certificate_bundle_paths {
+            args.insert("defaultCertificateBundlePaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = default_certificate_directory_paths {
+            args.insert("defaultCertificateDirectoryPaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerCertificatePaths", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -12602,6 +13653,16 @@ impl TestDatabaseResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
+    /// Configures which reference values are injected into environment variables
+    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -12650,6 +13711,55 @@ impl TestDatabaseResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Updates a named endpoint via callback
+    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTP endpoint via callback
+    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTPS endpoint via callback
+    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -12939,6 +14049,20 @@ impl TestDatabaseResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an HTTP resource command
+    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -12978,6 +14102,17 @@ impl TestDatabaseResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -13719,13 +14854,13 @@ impl TestRedisResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a build argument from a parameter resource
-    pub fn with_build_arg(&self, name: &str, value: &ParameterResource) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    /// Adds a build argument from a string value or parameter resource
+    pub fn with_build_arg(&self, name: &str, value: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -13737,6 +14872,24 @@ impl TestRedisResource {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerResource::new(handle, self.client.clone()))
+    }
+
+    /// Overrides container certificate bundle and directory paths used for trust configuration
+    pub fn with_container_certificate_paths(&self, custom_certificates_destination: Option<&str>, default_certificate_bundle_paths: Option<Vec<String>>, default_certificate_directory_paths: Option<Vec<String>>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        if let Some(ref v) = custom_certificates_destination {
+            args.insert("customCertificatesDestination".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = default_certificate_bundle_paths {
+            args.insert("defaultCertificateBundlePaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = default_certificate_directory_paths {
+            args.insert("defaultCertificateDirectoryPaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerCertificatePaths", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -13898,8 +15051,8 @@ impl TestRedisResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Adds a connection property with a reference expression
-    pub fn with_connection_property(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
+    /// Adds a connection property with a string or reference expression value
+    pub fn with_connection_property(&self, name: &str, value: Value) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
@@ -13939,6 +15092,16 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withArgsCallback", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
+    }
+
+    /// Configures which reference values are injected into environment variables
+    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
     /// Adds a reference to another resource
@@ -13998,6 +15161,55 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Updates a named endpoint via callback
+    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTP endpoint via callback
+    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTPS endpoint via callback
+    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -14287,6 +15499,20 @@ impl TestRedisResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an HTTP resource command
+    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -14326,6 +15552,17 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -15209,13 +16446,13 @@ impl TestVaultResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a build argument from a parameter resource
-    pub fn with_build_arg(&self, name: &str, value: &ParameterResource) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    /// Adds a build argument from a string value or parameter resource
+    pub fn with_build_arg(&self, name: &str, value: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -15227,6 +16464,24 @@ impl TestVaultResource {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerResource::new(handle, self.client.clone()))
+    }
+
+    /// Overrides container certificate bundle and directory paths used for trust configuration
+    pub fn with_container_certificate_paths(&self, custom_certificates_destination: Option<&str>, default_certificate_bundle_paths: Option<Vec<String>>, default_certificate_directory_paths: Option<Vec<String>>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        if let Some(ref v) = custom_certificates_destination {
+            args.insert("customCertificatesDestination".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = default_certificate_bundle_paths {
+            args.insert("defaultCertificateBundlePaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = default_certificate_directory_paths {
+            args.insert("defaultCertificateDirectoryPaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerCertificatePaths", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -15409,6 +16664,16 @@ impl TestVaultResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
+    /// Configures which reference values are injected into environment variables
+    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -15457,6 +16722,55 @@ impl TestVaultResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Updates a named endpoint via callback
+    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTP endpoint via callback
+    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Updates an HTTPS endpoint via callback
+    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = name {
+            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = create_if_not_exists {
+            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -15746,6 +17060,20 @@ impl TestVaultResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an HTTP resource command
+    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -15785,6 +17113,17 @@ impl TestVaultResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Adds a relationship to another resource
+    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
+        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -315,31 +315,6 @@ impl std::fmt::Display for EndpointProperty {
     }
 }
 
-/// HttpCommandResultMode
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub enum HttpCommandResultMode {
-    #[default]
-    #[serde(rename = "None")]
-    None,
-    #[serde(rename = "Auto")]
-    Auto,
-    #[serde(rename = "Json")]
-    Json,
-    #[serde(rename = "Text")]
-    Text,
-}
-
-impl std::fmt::Display for HttpCommandResultMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::None => write!(f, "None"),
-            Self::Auto => write!(f, "Auto"),
-            Self::Json => write!(f, "Json"),
-            Self::Text => write!(f, "Text"),
-        }
-    }
-}
-
 /// CommandResultFormat
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CommandResultFormat {
@@ -348,8 +323,6 @@ pub enum CommandResultFormat {
     Text,
     #[serde(rename = "Json")]
     Json,
-    #[serde(rename = "Markdown")]
-    Markdown,
 }
 
 impl std::fmt::Display for CommandResultFormat {
@@ -357,7 +330,6 @@ impl std::fmt::Display for CommandResultFormat {
         match self {
             Self::Text => write!(f, "Text"),
             Self::Json => write!(f, "Json"),
-            Self::Markdown => write!(f, "Markdown"),
         }
     }
 }
@@ -432,24 +404,6 @@ impl std::fmt::Display for TestResourceStatus {
 // DTOs
 // ============================================================================
 
-/// AddContainerOptions
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct AddContainerOptions {
-    #[serde(rename = "Image")]
-    pub image: String,
-    #[serde(rename = "Tag")]
-    pub tag: String,
-}
-
-impl AddContainerOptions {
-    pub fn to_map(&self) -> HashMap<String, Value> {
-        let mut map = HashMap::new();
-        map.insert("Image".to_string(), serde_json::to_value(&self.image).unwrap_or(Value::Null));
-        map.insert("Tag".to_string(), serde_json::to_value(&self.tag).unwrap_or(Value::Null));
-        map
-    }
-}
-
 /// CreateBuilderOptions
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CreateBuilderOptions {
@@ -516,30 +470,6 @@ impl ResourceEventDto {
     }
 }
 
-/// ReferenceEnvironmentInjectionOptions
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ReferenceEnvironmentInjectionOptions {
-    #[serde(rename = "ConnectionString")]
-    pub connection_string: bool,
-    #[serde(rename = "ConnectionProperties")]
-    pub connection_properties: bool,
-    #[serde(rename = "ServiceDiscovery")]
-    pub service_discovery: bool,
-    #[serde(rename = "Endpoints")]
-    pub endpoints: bool,
-}
-
-impl ReferenceEnvironmentInjectionOptions {
-    pub fn to_map(&self) -> HashMap<String, Value> {
-        let mut map = HashMap::new();
-        map.insert("ConnectionString".to_string(), serde_json::to_value(&self.connection_string).unwrap_or(Value::Null));
-        map.insert("ConnectionProperties".to_string(), serde_json::to_value(&self.connection_properties).unwrap_or(Value::Null));
-        map.insert("ServiceDiscovery".to_string(), serde_json::to_value(&self.service_discovery).unwrap_or(Value::Null));
-        map.insert("Endpoints".to_string(), serde_json::to_value(&self.endpoints).unwrap_or(Value::Null));
-        map
-    }
-}
-
 /// CommandOptions
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CommandOptions {
@@ -573,84 +503,6 @@ impl CommandOptions {
     }
 }
 
-/// HttpCommandExportOptions
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct HttpCommandExportOptions {
-    #[serde(rename = "Description")]
-    pub description: String,
-    #[serde(rename = "ConfirmationMessage")]
-    pub confirmation_message: String,
-    #[serde(rename = "IconName")]
-    pub icon_name: String,
-    #[serde(rename = "IconVariant")]
-    pub icon_variant: IconVariant,
-    #[serde(rename = "IsHighlighted")]
-    pub is_highlighted: bool,
-    #[serde(rename = "CommandName")]
-    pub command_name: String,
-    #[serde(rename = "EndpointName")]
-    pub endpoint_name: String,
-    #[serde(rename = "MethodName")]
-    pub method_name: String,
-    #[serde(rename = "ResultMode")]
-    pub result_mode: HttpCommandResultMode,
-}
-
-impl HttpCommandExportOptions {
-    pub fn to_map(&self) -> HashMap<String, Value> {
-        let mut map = HashMap::new();
-        map.insert("Description".to_string(), serde_json::to_value(&self.description).unwrap_or(Value::Null));
-        map.insert("ConfirmationMessage".to_string(), serde_json::to_value(&self.confirmation_message).unwrap_or(Value::Null));
-        map.insert("IconName".to_string(), serde_json::to_value(&self.icon_name).unwrap_or(Value::Null));
-        map.insert("IconVariant".to_string(), serde_json::to_value(&self.icon_variant).unwrap_or(Value::Null));
-        map.insert("IsHighlighted".to_string(), serde_json::to_value(&self.is_highlighted).unwrap_or(Value::Null));
-        map.insert("CommandName".to_string(), serde_json::to_value(&self.command_name).unwrap_or(Value::Null));
-        map.insert("EndpointName".to_string(), serde_json::to_value(&self.endpoint_name).unwrap_or(Value::Null));
-        map.insert("MethodName".to_string(), serde_json::to_value(&self.method_name).unwrap_or(Value::Null));
-        map.insert("ResultMode".to_string(), serde_json::to_value(&self.result_mode).unwrap_or(Value::Null));
-        map
-    }
-}
-
-/// GenerateParameterDefault
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct GenerateParameterDefault {
-    #[serde(rename = "MinLength")]
-    pub min_length: f64,
-    #[serde(rename = "Lower")]
-    pub lower: bool,
-    #[serde(rename = "Upper")]
-    pub upper: bool,
-    #[serde(rename = "Numeric")]
-    pub numeric: bool,
-    #[serde(rename = "Special")]
-    pub special: bool,
-    #[serde(rename = "MinLower")]
-    pub min_lower: f64,
-    #[serde(rename = "MinUpper")]
-    pub min_upper: f64,
-    #[serde(rename = "MinNumeric")]
-    pub min_numeric: f64,
-    #[serde(rename = "MinSpecial")]
-    pub min_special: f64,
-}
-
-impl GenerateParameterDefault {
-    pub fn to_map(&self) -> HashMap<String, Value> {
-        let mut map = HashMap::new();
-        map.insert("MinLength".to_string(), serde_json::to_value(&self.min_length).unwrap_or(Value::Null));
-        map.insert("Lower".to_string(), serde_json::to_value(&self.lower).unwrap_or(Value::Null));
-        map.insert("Upper".to_string(), serde_json::to_value(&self.upper).unwrap_or(Value::Null));
-        map.insert("Numeric".to_string(), serde_json::to_value(&self.numeric).unwrap_or(Value::Null));
-        map.insert("Special".to_string(), serde_json::to_value(&self.special).unwrap_or(Value::Null));
-        map.insert("MinLower".to_string(), serde_json::to_value(&self.min_lower).unwrap_or(Value::Null));
-        map.insert("MinUpper".to_string(), serde_json::to_value(&self.min_upper).unwrap_or(Value::Null));
-        map.insert("MinNumeric".to_string(), serde_json::to_value(&self.min_numeric).unwrap_or(Value::Null));
-        map.insert("MinSpecial".to_string(), serde_json::to_value(&self.min_special).unwrap_or(Value::Null));
-        map
-    }
-}
-
 /// ExecuteCommandResult
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ExecuteCommandResult {
@@ -660,10 +512,10 @@ pub struct ExecuteCommandResult {
     pub canceled: bool,
     #[serde(rename = "ErrorMessage")]
     pub error_message: String,
-    #[serde(rename = "Message")]
-    pub message: String,
-    #[serde(rename = "Data")]
-    pub data: CommandResultData,
+    #[serde(rename = "Result")]
+    pub result: String,
+    #[serde(rename = "ResultFormat")]
+    pub result_format: CommandResultFormat,
 }
 
 impl ExecuteCommandResult {
@@ -672,29 +524,8 @@ impl ExecuteCommandResult {
         map.insert("Success".to_string(), serde_json::to_value(&self.success).unwrap_or(Value::Null));
         map.insert("Canceled".to_string(), serde_json::to_value(&self.canceled).unwrap_or(Value::Null));
         map.insert("ErrorMessage".to_string(), serde_json::to_value(&self.error_message).unwrap_or(Value::Null));
-        map.insert("Message".to_string(), serde_json::to_value(&self.message).unwrap_or(Value::Null));
-        map.insert("Data".to_string(), serde_json::to_value(&self.data).unwrap_or(Value::Null));
-        map
-    }
-}
-
-/// CommandResultData
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CommandResultData {
-    #[serde(rename = "Value")]
-    pub value: String,
-    #[serde(rename = "Format")]
-    pub format: CommandResultFormat,
-    #[serde(rename = "DisplayImmediately")]
-    pub display_immediately: bool,
-}
-
-impl CommandResultData {
-    pub fn to_map(&self) -> HashMap<String, Value> {
-        let mut map = HashMap::new();
-        map.insert("Value".to_string(), serde_json::to_value(&self.value).unwrap_or(Value::Null));
-        map.insert("Format".to_string(), serde_json::to_value(&self.format).unwrap_or(Value::Null));
-        map.insert("DisplayImmediately".to_string(), serde_json::to_value(&self.display_immediately).unwrap_or(Value::Null));
+        map.insert("Result".to_string(), serde_json::to_value(&self.result).unwrap_or(Value::Null));
+        map.insert("ResultFormat".to_string(), serde_json::to_value(&self.result_format).unwrap_or(Value::Null));
         map
     }
 }
@@ -1139,16 +970,6 @@ impl CSharpAppResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
-    /// Configures which reference values are injected into environment variables
-    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -1197,55 +1018,6 @@ impl CSharpAppResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Updates a named endpoint via callback
-    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTP endpoint via callback
-    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTPS endpoint via callback
-    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -1546,20 +1318,6 @@ impl CSharpAppResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds an HTTP resource command
-    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
-        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
-        if let Some(ref v) = options {
-            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -1599,17 +1357,6 @@ impl CSharpAppResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -1683,6 +1430,17 @@ impl CSharpAppResource {
         let result = self.client.invoke_capability("Aspire.Hosting/excludeFromMcp", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Sets image push options via callback
+    pub fn with_image_push_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withImagePushOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
     /// Sets the remote image name for publishing
@@ -2271,8 +2029,8 @@ impl ConnectionStringResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a connection property with a string or reference expression value
-    pub fn with_connection_property(&self, name: &str, value: Value) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
+    /// Adds a connection property with a reference expression
+    pub fn with_connection_property(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
@@ -2446,17 +2204,6 @@ impl ConnectionStringResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -2874,19 +2621,19 @@ impl ConnectionStringResource {
     }
 }
 
-/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference
-pub struct ContainerImageReference {
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions
+pub struct ContainerImagePushOptions {
     handle: Handle,
     client: Arc<AspireClient>,
 }
 
-impl HasHandle for ContainerImageReference {
+impl HasHandle for ContainerImagePushOptions {
     fn handle(&self) -> &Handle {
         &self.handle
     }
 }
 
-impl ContainerImageReference {
+impl ContainerImagePushOptions {
     pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
         Self { handle, client }
     }
@@ -2898,21 +2645,57 @@ impl ContainerImageReference {
     pub fn client(&self) -> &Arc<AspireClient> {
         &self.client
     }
+
+    /// Gets the RemoteImageName property
+    pub fn remote_image_name(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageName", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the RemoteImageName property
+    pub fn set_remote_image_name(&self, value: &str) -> Result<ContainerImagePushOptions, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageName", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerImagePushOptions::new(handle, self.client.clone()))
+    }
+
+    /// Gets the RemoteImageTag property
+    pub fn remote_image_tag(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageTag", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the RemoteImageTag property
+    pub fn set_remote_image_tag(&self, value: &str) -> Result<ContainerImagePushOptions, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageTag", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerImagePushOptions::new(handle, self.client.clone()))
+    }
 }
 
-/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation
-pub struct ContainerMountAnnotation {
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext
+pub struct ContainerImagePushOptionsCallbackContext {
     handle: Handle,
     client: Arc<AspireClient>,
 }
 
-impl HasHandle for ContainerMountAnnotation {
+impl HasHandle for ContainerImagePushOptionsCallbackContext {
     fn handle(&self) -> &Handle {
         &self.handle
     }
 }
 
-impl ContainerMountAnnotation {
+impl ContainerImagePushOptionsCallbackContext {
     pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
         Self { handle, client }
     }
@@ -2924,31 +2707,65 @@ impl ContainerMountAnnotation {
     pub fn client(&self) -> &Arc<AspireClient> {
         &self.client
     }
-}
 
-/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference
-pub struct ContainerPortReference {
-    handle: Handle,
-    client: Arc<AspireClient>,
-}
-
-impl HasHandle for ContainerPortReference {
-    fn handle(&self) -> &Handle {
-        &self.handle
-    }
-}
-
-impl ContainerPortReference {
-    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
-        Self { handle, client }
+    /// Gets the Resource property
+    pub fn resource(&self) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.resource", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
-    pub fn handle(&self) -> &Handle {
-        &self.handle
+    /// Sets the Resource property
+    pub fn set_resource(&self, value: &IResource) -> Result<ContainerImagePushOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), value.handle().to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setResource", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerImagePushOptionsCallbackContext::new(handle, self.client.clone()))
     }
 
-    pub fn client(&self) -> &Arc<AspireClient> {
-        &self.client
+    /// Gets the CancellationToken property
+    pub fn cancellation_token(&self) -> Result<CancellationToken, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.cancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CancellationToken::new(handle, self.client.clone()))
+    }
+
+    /// Sets the CancellationToken property
+    pub fn set_cancellation_token(&self, value: Option<&CancellationToken>) -> Result<ContainerImagePushOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        if let Some(token) = value {
+            let token_id = register_cancellation(token, self.client.clone());
+            args.insert("value".to_string(), Value::String(token_id));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setCancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerImagePushOptionsCallbackContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the Options property
+    pub fn options(&self) -> Result<ContainerImagePushOptions, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.options", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerImagePushOptions::new(handle, self.client.clone()))
+    }
+
+    /// Sets the Options property
+    pub fn set_options(&self, value: &ContainerImagePushOptions) -> Result<ContainerImagePushOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), value.handle().to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerImagePushOptionsCallbackContext::new(handle, self.client.clone()))
     }
 }
 
@@ -3104,17 +2921,6 @@ impl ContainerRegistryResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -3668,13 +3474,13 @@ impl ContainerResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a build argument from a string value or parameter resource
-    pub fn with_build_arg(&self, name: &str, value: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    /// Adds a build argument from a parameter resource
+    pub fn with_build_arg(&self, name: &str, value: &ParameterResource) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
+        args.insert("value".to_string(), value.handle().to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -3686,24 +3492,6 @@ impl ContainerResource {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(ContainerResource::new(handle, self.client.clone()))
-    }
-
-    /// Overrides container certificate bundle and directory paths used for trust configuration
-    pub fn with_container_certificate_paths(&self, custom_certificates_destination: Option<&str>, default_certificate_bundle_paths: Option<Vec<String>>, default_certificate_directory_paths: Option<Vec<String>>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        if let Some(ref v) = custom_certificates_destination {
-            args.insert("customCertificatesDestination".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = default_certificate_bundle_paths {
-            args.insert("defaultCertificateBundlePaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = default_certificate_directory_paths {
-            args.insert("defaultCertificateDirectoryPaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withContainerCertificatePaths", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -3886,16 +3674,6 @@ impl ContainerResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
-    /// Configures which reference values are injected into environment variables
-    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -3944,55 +3722,6 @@ impl ContainerResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Updates a named endpoint via callback
-    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTP endpoint via callback
-    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTPS endpoint via callback
-    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -4282,20 +4011,6 @@ impl ContainerResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds an HTTP resource command
-    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
-        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
-        if let Some(ref v) = options {
-            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -4335,17 +4050,6 @@ impl ContainerResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -4419,6 +4123,17 @@ impl ContainerResource {
         let result = self.client.invoke_capability("Aspire.Hosting/excludeFromMcp", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Sets image push options via callback
+    pub fn with_image_push_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withImagePushOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
     /// Sets the remote image name for publishing
@@ -5348,16 +5063,6 @@ impl DotnetToolResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
-    /// Configures which reference values are injected into environment variables
-    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -5406,55 +5111,6 @@ impl DotnetToolResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Updates a named endpoint via callback
-    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTP endpoint via callback
-    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTPS endpoint via callback
-    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -5744,20 +5400,6 @@ impl DotnetToolResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds an HTTP resource command
-    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
-        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
-        if let Some(ref v) = options {
-            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -5797,17 +5439,6 @@ impl DotnetToolResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -5881,6 +5512,17 @@ impl DotnetToolResource {
         let result = self.client.invoke_capability("Aspire.Hosting/excludeFromMcp", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Sets image push options via callback
+    pub fn with_image_push_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withImagePushOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
     /// Sets the remote image name for publishing
@@ -6497,220 +6139,6 @@ impl EndpointReferenceExpression {
     }
 }
 
-/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext
-pub struct EndpointUpdateContext {
-    handle: Handle,
-    client: Arc<AspireClient>,
-}
-
-impl HasHandle for EndpointUpdateContext {
-    fn handle(&self) -> &Handle {
-        &self.handle
-    }
-}
-
-impl EndpointUpdateContext {
-    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
-        Self { handle, client }
-    }
-
-    pub fn handle(&self) -> &Handle {
-        &self.handle
-    }
-
-    pub fn client(&self) -> &Arc<AspireClient> {
-        &self.client
-    }
-
-    /// Gets the Name property
-    pub fn name(&self) -> Result<String, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.name", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Gets the Protocol property
-    pub fn protocol(&self) -> Result<ProtocolType, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.protocol", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the Protocol property
-    pub fn set_protocol(&self, value: ProtocolType) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setProtocol", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the Port property
-    pub fn port(&self) -> Result<f64, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.port", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the Port property
-    pub fn set_port(&self, value: f64) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setPort", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the TargetPort property
-    pub fn target_port(&self) -> Result<f64, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetPort", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the TargetPort property
-    pub fn set_target_port(&self, value: f64) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetPort", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the UriScheme property
-    pub fn uri_scheme(&self) -> Result<String, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.uriScheme", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the UriScheme property
-    pub fn set_uri_scheme(&self, value: &str) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setUriScheme", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the TargetHost property
-    pub fn target_host(&self) -> Result<String, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetHost", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the TargetHost property
-    pub fn set_target_host(&self, value: &str) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetHost", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the Transport property
-    pub fn transport(&self) -> Result<String, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.transport", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the Transport property
-    pub fn set_transport(&self, value: &str) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTransport", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the IsExternal property
-    pub fn is_external(&self) -> Result<bool, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.isExternal", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the IsExternal property
-    pub fn set_is_external(&self, value: bool) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setIsExternal", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the IsProxied property
-    pub fn is_proxied(&self) -> Result<bool, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.isProxied", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the IsProxied property
-    pub fn set_is_proxied(&self, value: bool) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setIsProxied", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the ExcludeReferenceEndpoint property
-    pub fn exclude_reference_endpoint(&self) -> Result<bool, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.excludeReferenceEndpoint", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the ExcludeReferenceEndpoint property
-    pub fn set_exclude_reference_endpoint(&self, value: bool) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setExcludeReferenceEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-
-    /// Gets the TlsEnabled property
-    pub fn tls_enabled(&self) -> Result<bool, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.tlsEnabled", args)?;
-        Ok(serde_json::from_value(result)?)
-    }
-
-    /// Sets the TlsEnabled property
-    pub fn set_tls_enabled(&self, value: bool) -> Result<EndpointUpdateContext, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTlsEnabled", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(EndpointUpdateContext::new(handle, self.client.clone()))
-    }
-}
-
 /// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext
 pub struct EnvironmentCallbackContext {
     handle: Handle,
@@ -7012,16 +6440,6 @@ impl ExecutableResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
-    /// Configures which reference values are injected into environment variables
-    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7070,55 +6488,6 @@ impl ExecutableResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Updates a named endpoint via callback
-    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTP endpoint via callback
-    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTPS endpoint via callback
-    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -7408,20 +6777,6 @@ impl ExecutableResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds an HTTP resource command
-    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
-        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
-        if let Some(ref v) = options {
-            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7461,17 +6816,6 @@ impl ExecutableResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -7545,6 +6889,17 @@ impl ExecutableResource {
         let result = self.client.invoke_capability("Aspire.Hosting/excludeFromMcp", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Sets image push options via callback
+    pub fn with_image_push_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withImagePushOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
     /// Sets the remote image name for publishing
@@ -8214,17 +7569,6 @@ impl ExternalServiceResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
-    }
-
     /// Sets the parent relationship
     pub fn with_parent_relationship(&self, parent: &IResource) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -8834,7 +8178,7 @@ impl IDistributedApplicationBuilder {
     }
 
     /// Adds a container resource
-    pub fn add_container(&self, name: &str, image: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    pub fn add_container(&self, name: &str, image: &str) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
@@ -8953,15 +8297,6 @@ impl IDistributedApplicationBuilder {
         Ok(DistributedApplicationExecutionContext::new(handle, self.client.clone()))
     }
 
-    /// Gets the Pipeline property
-    pub fn pipeline(&self) -> Result<IDistributedApplicationPipeline, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/IDistributedApplicationBuilder.pipeline", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IDistributedApplicationPipeline::new(handle, self.client.clone()))
-    }
-
     /// Gets the UserSecretsManager property
     pub fn user_secrets_manager(&self) -> Result<IUserSecretsManager, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -9024,23 +8359,6 @@ impl IDistributedApplicationBuilder {
         Ok(ParameterResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a parameter with a generated default value
-    pub fn add_parameter_with_generated_value(&self, name: &str, value: GenerateParameterDefault, secret: Option<bool>, persist: Option<bool>) -> Result<ParameterResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        if let Some(ref v) = secret {
-            args.insert("secret".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = persist {
-            args.insert("persist".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/addParameterWithGeneratedValue", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(ParameterResource::new(handle, self.client.clone()))
-    }
-
     /// Adds a connection string resource
     pub fn add_connection_string(&self, name: &str, environment_variable_name: Option<&str>) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -9052,17 +8370,6 @@ impl IDistributedApplicationBuilder {
         let result = self.client.invoke_capability("Aspire.Hosting/addConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithConnectionString::new(handle, self.client.clone()))
-    }
-
-    /// Adds a .NET project resource without a launch profile
-    pub fn add_project_without_launch_profile(&self, name: &str, project_path: &str) -> Result<ProjectResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("projectPath".to_string(), serde_json::to_value(&project_path).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/addProjectWithoutLaunchProfile", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(ProjectResource::new(handle, self.client.clone()))
     }
 
     /// Adds a .NET project resource
@@ -9226,59 +8533,6 @@ impl IDistributedApplicationEventing {
         args.insert("context".to_string(), self.handle.to_json());
         args.insert("subscription".to_string(), subscription.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting.Eventing/IDistributedApplicationEventing.unsubscribe", args)?;
-        Ok(())
-    }
-}
-
-/// Wrapper for Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline
-pub struct IDistributedApplicationPipeline {
-    handle: Handle,
-    client: Arc<AspireClient>,
-}
-
-impl HasHandle for IDistributedApplicationPipeline {
-    fn handle(&self) -> &Handle {
-        &self.handle
-    }
-}
-
-impl IDistributedApplicationPipeline {
-    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
-        Self { handle, client }
-    }
-
-    pub fn handle(&self) -> &Handle {
-        &self.handle
-    }
-
-    pub fn client(&self) -> &Arc<AspireClient> {
-        &self.client
-    }
-
-    /// Adds a pipeline step to the application
-    pub fn add_step(&self, step_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, depends_on: Option<Vec<String>>, required_by: Option<Vec<String>>) -> Result<(), Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("pipeline".to_string(), self.handle.to_json());
-        args.insert("stepName".to_string(), serde_json::to_value(&step_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = depends_on {
-            args.insert("dependsOn".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = required_by {
-            args.insert("requiredBy".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/addStep", args)?;
-        Ok(())
-    }
-
-    /// Configures the application pipeline via a callback
-    pub fn configure(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<(), Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("pipeline".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        let result = self.client.invoke_capability("Aspire.Hosting/configure", args)?;
         Ok(())
     }
 }
@@ -10339,17 +9593,6 @@ impl ParameterResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -11509,16 +10752,6 @@ impl ProjectResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
-    /// Configures which reference values are injected into environment variables
-    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -11567,55 +10800,6 @@ impl ProjectResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Updates a named endpoint via callback
-    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTP endpoint via callback
-    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTPS endpoint via callback
-    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -11916,20 +11100,6 @@ impl ProjectResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds an HTTP resource command
-    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
-        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
-        if let Some(ref v) = options {
-            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -11969,17 +11139,6 @@ impl ProjectResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -12053,6 +11212,17 @@ impl ProjectResource {
         let result = self.client.invoke_capability("Aspire.Hosting/excludeFromMcp", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Sets image push options via callback
+    pub fn with_image_push_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withImagePushOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
     /// Sets the remote image name for publishing
@@ -13232,13 +12402,13 @@ impl TestDatabaseResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a build argument from a string value or parameter resource
-    pub fn with_build_arg(&self, name: &str, value: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    /// Adds a build argument from a parameter resource
+    pub fn with_build_arg(&self, name: &str, value: &ParameterResource) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
+        args.insert("value".to_string(), value.handle().to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -13250,24 +12420,6 @@ impl TestDatabaseResource {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(ContainerResource::new(handle, self.client.clone()))
-    }
-
-    /// Overrides container certificate bundle and directory paths used for trust configuration
-    pub fn with_container_certificate_paths(&self, custom_certificates_destination: Option<&str>, default_certificate_bundle_paths: Option<Vec<String>>, default_certificate_directory_paths: Option<Vec<String>>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        if let Some(ref v) = custom_certificates_destination {
-            args.insert("customCertificatesDestination".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = default_certificate_bundle_paths {
-            args.insert("defaultCertificateBundlePaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = default_certificate_directory_paths {
-            args.insert("defaultCertificateDirectoryPaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withContainerCertificatePaths", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -13450,16 +12602,6 @@ impl TestDatabaseResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
-    /// Configures which reference values are injected into environment variables
-    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -13508,55 +12650,6 @@ impl TestDatabaseResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Updates a named endpoint via callback
-    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTP endpoint via callback
-    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTPS endpoint via callback
-    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -13846,20 +12939,6 @@ impl TestDatabaseResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds an HTTP resource command
-    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
-        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
-        if let Some(ref v) = options {
-            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -13899,17 +12978,6 @@ impl TestDatabaseResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -13983,6 +13051,17 @@ impl TestDatabaseResource {
         let result = self.client.invoke_capability("Aspire.Hosting/excludeFromMcp", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Sets image push options via callback
+    pub fn with_image_push_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withImagePushOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
     /// Sets the remote image name for publishing
@@ -14640,13 +13719,13 @@ impl TestRedisResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a build argument from a string value or parameter resource
-    pub fn with_build_arg(&self, name: &str, value: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    /// Adds a build argument from a parameter resource
+    pub fn with_build_arg(&self, name: &str, value: &ParameterResource) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
+        args.insert("value".to_string(), value.handle().to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -14658,24 +13737,6 @@ impl TestRedisResource {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(ContainerResource::new(handle, self.client.clone()))
-    }
-
-    /// Overrides container certificate bundle and directory paths used for trust configuration
-    pub fn with_container_certificate_paths(&self, custom_certificates_destination: Option<&str>, default_certificate_bundle_paths: Option<Vec<String>>, default_certificate_directory_paths: Option<Vec<String>>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        if let Some(ref v) = custom_certificates_destination {
-            args.insert("customCertificatesDestination".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = default_certificate_bundle_paths {
-            args.insert("defaultCertificateBundlePaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = default_certificate_directory_paths {
-            args.insert("defaultCertificateDirectoryPaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withContainerCertificatePaths", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -14837,8 +13898,8 @@ impl TestRedisResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Adds a connection property with a string or reference expression value
-    pub fn with_connection_property(&self, name: &str, value: Value) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
+    /// Adds a connection property with a reference expression
+    pub fn with_connection_property(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithConnectionString, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
@@ -14878,16 +13939,6 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withArgsCallback", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
-    }
-
-    /// Configures which reference values are injected into environment variables
-    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
     /// Adds a reference to another resource
@@ -14947,55 +13998,6 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Updates a named endpoint via callback
-    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTP endpoint via callback
-    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTPS endpoint via callback
-    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -15285,20 +14287,6 @@ impl TestRedisResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds an HTTP resource command
-    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
-        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
-        if let Some(ref v) = options {
-            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -15338,17 +14326,6 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -15422,6 +14399,17 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/excludeFromMcp", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Sets image push options via callback
+    pub fn with_image_push_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withImagePushOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
     /// Sets the remote image name for publishing
@@ -16221,13 +15209,13 @@ impl TestVaultResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Adds a build argument from a string value or parameter resource
-    pub fn with_build_arg(&self, name: &str, value: Value) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+    /// Adds a build argument from a parameter resource
+    pub fn with_build_arg(&self, name: &str, value: &ParameterResource) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
+        args.insert("value".to_string(), value.handle().to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -16239,24 +15227,6 @@ impl TestVaultResource {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(ContainerResource::new(handle, self.client.clone()))
-    }
-
-    /// Overrides container certificate bundle and directory paths used for trust configuration
-    pub fn with_container_certificate_paths(&self, custom_certificates_destination: Option<&str>, default_certificate_bundle_paths: Option<Vec<String>>, default_certificate_directory_paths: Option<Vec<String>>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        if let Some(ref v) = custom_certificates_destination {
-            args.insert("customCertificatesDestination".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = default_certificate_bundle_paths {
-            args.insert("defaultCertificateBundlePaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = default_certificate_directory_paths {
-            args.insert("defaultCertificateDirectoryPaths".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withContainerCertificatePaths", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -16439,16 +15409,6 @@ impl TestVaultResource {
         Ok(IResourceWithArgs::new(handle, self.client.clone()))
     }
 
-    /// Configures which reference values are injected into environment variables
-    pub fn with_reference_environment(&self, options: ReferenceEnvironmentInjectionOptions) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEnvironment", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Adds a reference to another resource
     pub fn with_reference(&self, source: &IResource, connection_name: Option<&str>, optional: Option<bool>, name: Option<&str>) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -16497,55 +15457,6 @@ impl TestVaultResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withReferenceEndpoint", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Updates a named endpoint via callback
-    pub fn with_endpoint_callback(&self, endpoint_name: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("endpointName".to_string(), serde_json::to_value(&endpoint_name).unwrap_or(Value::Null));
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTP endpoint via callback
-    pub fn with_http_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
-    /// Updates an HTTPS endpoint via callback
-    pub fn with_https_endpoint_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, name: Option<&str>, create_if_not_exists: Option<bool>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        let callback_id = register_callback(callback);
-        args.insert("callback".to_string(), Value::String(callback_id));
-        if let Some(ref v) = name {
-            args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        if let Some(ref v) = create_if_not_exists {
-            args.insert("createIfNotExists".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsEndpointCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
     }
 
     /// Adds a network endpoint
@@ -16835,20 +15746,6 @@ impl TestVaultResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
-    /// Adds an HTTP resource command
-    pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("path".to_string(), serde_json::to_value(&path).unwrap_or(Value::Null));
-        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
-        if let Some(ref v) = options {
-            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
-        }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpCommand", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
-    }
-
     /// Configures developer certificate trust
     pub fn with_developer_certificate_trust(&self, trust: bool) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -16888,17 +15785,6 @@ impl TestVaultResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withoutHttpsCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Adds a relationship to another resource
-    pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("resourceBuilder".to_string(), resource_builder.handle().to_json());
-        args.insert("type".to_string(), serde_json::to_value(&r#type).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderRelationship", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Sets the parent relationship
@@ -16972,6 +15858,17 @@ impl TestVaultResource {
         let result = self.client.invoke_capability("Aspire.Hosting/excludeFromMcp", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Sets image push options via callback
+    pub fn with_image_push_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withImagePushOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
     /// Sets the remote image name for publishing

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
@@ -798,6 +798,20 @@
     ]
   },
   {
+    CapabilityId: Aspire.Hosting/withImagePushOptions,
+    MethodName: withImagePushOptions,
+    TargetType: {
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IComputeResource,
+      IsInterface: true
+    },
+    ExpandedTargetTypes: [
+      {
+        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+        IsInterface: false
+      }
+    ]
+  },
+  {
     CapabilityId: Aspire.Hosting/withImageRegistry,
     MethodName: withImageRegistry,
     TargetType: {

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1194,7 +1194,7 @@ export interface ContainerImagePushOptionsCallbackContext {
     toJSON(): MarshalledHandle;
     resource: {
         get: () => Promise<Resource>;
-        set: (value: CSharpAppResource | ComputeResource | ConnectionStringResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource) => Promise<void>;
+        set: (value: Awaitable<CSharpAppResource | ComputeResource | ConnectionStringResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>) => Promise<void>;
     };
     cancellationToken: {
         get: () => Promise<CancellationToken>;
@@ -1202,7 +1202,7 @@ export interface ContainerImagePushOptionsCallbackContext {
     };
     options: {
         get: () => Promise<ContainerImagePushOptions>;
-        set: (value: ContainerImagePushOptions) => Promise<void>;
+        set: (value: Awaitable<ContainerImagePushOptions>) => Promise<void>;
     };
 }
 
@@ -1228,7 +1228,8 @@ class ContainerImagePushOptionsCallbackContextImpl implements ContainerImagePush
             );
             return new ResourceImpl(handle, this._client);
         },
-        set: async (value: CSharpAppResource | ComputeResource | ConnectionStringResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource): Promise<void> => {
+        set: async (value: Awaitable<CSharpAppResource | ComputeResource | ConnectionStringResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>): Promise<void> => {
+            value = isPromiseLike(value) ? await value : value;
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setResource',
                 { context: this._handle, value }
@@ -1262,7 +1263,8 @@ class ContainerImagePushOptionsCallbackContextImpl implements ContainerImagePush
             );
             return new ContainerImagePushOptionsImpl(handle, this._client);
         },
-        set: async (value: ContainerImagePushOptions): Promise<void> => {
+        set: async (value: Awaitable<ContainerImagePushOptions>): Promise<void> => {
+            value = isPromiseLike(value) ? await value : value;
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setOptions',
                 { context: this._handle, value }
@@ -10281,7 +10283,7 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new ContainerResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -11279,7 +11281,7 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */
@@ -12722,7 +12724,7 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new CSharpAppResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -13631,7 +13633,7 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */
@@ -15168,7 +15170,7 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new DotnetToolResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -16107,7 +16109,7 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */
@@ -17542,7 +17544,7 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new ExecutableResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -18451,7 +18453,7 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */
@@ -22191,7 +22193,7 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new ProjectResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -23100,7 +23102,7 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */
@@ -24786,7 +24788,7 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new TestDatabaseResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -25784,7 +25786,7 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */
@@ -27546,7 +27548,7 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new TestRedisResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -28748,7 +28750,7 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */
@@ -30506,7 +30508,7 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new TestVaultResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -31519,7 +31521,7 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */
@@ -31747,7 +31749,7 @@ class ComputeResourceImpl extends ResourceBuilderBase<IComputeResourceHandle> im
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {
-        return new ComputeResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+        return new ComputeResourcePromiseImpl(this._withImagePushOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -31801,7 +31803,7 @@ class ComputeResourcePromiseImpl implements ComputeResourcePromise {
 
     /** Sets image push options via callback */
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {
-        return new ComputeResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+        return new ComputeResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)), this._client);
     }
 
     /** Sets the remote image name for publishing */

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -73,6 +73,12 @@ type CommandLineArgsCallbackContextHandle = Handle<'Aspire.Hosting/Aspire.Hostin
 /** Handle to ConnectionStringAvailableEvent */
 type ConnectionStringAvailableEventHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent'>;
 
+/** Handle to ContainerImagePushOptions */
+type ContainerImagePushOptionsHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions'>;
+
+/** Handle to ContainerImagePushOptionsCallbackContext */
+type ContainerImagePushOptionsCallbackContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext'>;
+
 /** Handle to ContainerRegistryResource */
 type ContainerRegistryResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerRegistryResource'>;
 
@@ -1113,6 +1119,155 @@ class ConnectionStringAvailableEventImpl implements ConnectionStringAvailableEve
             );
             return new ServiceProviderImpl(handle, this._client);
         },
+    };
+
+}
+
+// ============================================================================
+// ContainerImagePushOptions
+// ============================================================================
+
+export interface ContainerImagePushOptions {
+    toJSON(): MarshalledHandle;
+    remoteImageName: {
+        get: () => Promise<string>;
+        set: (value: string) => Promise<void>;
+    };
+    remoteImageTag: {
+        get: () => Promise<string>;
+        set: (value: string) => Promise<void>;
+    };
+}
+
+// ============================================================================
+// ContainerImagePushOptionsImpl
+// ============================================================================
+
+/**
+ * Type class for ContainerImagePushOptions.
+ */
+class ContainerImagePushOptionsImpl implements ContainerImagePushOptions {
+    constructor(private _handle: ContainerImagePushOptionsHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Gets the RemoteImageName property */
+    remoteImageName = {
+        get: async (): Promise<string> => {
+            return await this._client.invokeCapability<string>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageName',
+                { context: this._handle }
+            );
+        },
+        set: async (value: string): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageName',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+    /** Gets the RemoteImageTag property */
+    remoteImageTag = {
+        get: async (): Promise<string> => {
+            return await this._client.invokeCapability<string>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageTag',
+                { context: this._handle }
+            );
+        },
+        set: async (value: string): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageTag',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+}
+
+// ============================================================================
+// ContainerImagePushOptionsCallbackContext
+// ============================================================================
+
+export interface ContainerImagePushOptionsCallbackContext {
+    toJSON(): MarshalledHandle;
+    resource: {
+        get: () => Promise<Resource>;
+        set: (value: CSharpAppResource | ComputeResource | ConnectionStringResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource) => Promise<void>;
+    };
+    cancellationToken: {
+        get: () => Promise<CancellationToken>;
+        set: (value: AbortSignal | CancellationToken) => Promise<void>;
+    };
+    options: {
+        get: () => Promise<ContainerImagePushOptions>;
+        set: (value: ContainerImagePushOptions) => Promise<void>;
+    };
+}
+
+// ============================================================================
+// ContainerImagePushOptionsCallbackContextImpl
+// ============================================================================
+
+/**
+ * Type class for ContainerImagePushOptionsCallbackContext.
+ */
+class ContainerImagePushOptionsCallbackContextImpl implements ContainerImagePushOptionsCallbackContext {
+    constructor(private _handle: ContainerImagePushOptionsCallbackContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Gets the Resource property */
+    resource = {
+        get: async (): Promise<Resource> => {
+            const handle = await this._client.invokeCapability<IResourceHandle>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.resource',
+                { context: this._handle }
+            );
+            return new ResourceImpl(handle, this._client);
+        },
+        set: async (value: CSharpAppResource | ComputeResource | ConnectionStringResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setResource',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+    /** Gets the CancellationToken property */
+    cancellationToken = {
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.cancellationToken',
+                { context: this._handle }
+            );
+            return CancellationToken.fromValue(result);
+        },
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setCancellationToken',
+                { context: this._handle, value: CancellationToken.fromValue(value) }
+            );
+        }
+    };
+
+    /** Gets the Options property */
+    options = {
+        get: async (): Promise<ContainerImagePushOptions> => {
+            const handle = await this._client.invokeCapability<ContainerImagePushOptionsHandle>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.options',
+                { context: this._handle }
+            );
+            return new ContainerImagePushOptionsImpl(handle, this._client);
+        },
+        set: async (value: ContainerImagePushOptions): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerImagePushOptionsCallbackContext.setOptions',
+                { context: this._handle, value }
+            );
+        }
     };
 
 }
@@ -8693,6 +8848,7 @@ export interface ContainerResource {
     withIconName(iconName: string, options?: WithIconNameOptions): ContainerResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ContainerResourcePromise;
     excludeFromMcp(): ContainerResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise;
     withRemoteImageName(remoteImageName: string): ContainerResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ContainerResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ContainerResourcePromise;
@@ -8803,6 +8959,7 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
     withIconName(iconName: string, options?: WithIconNameOptions): ContainerResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ContainerResourcePromise;
     excludeFromMcp(): ContainerResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise;
     withRemoteImageName(remoteImageName: string): ContainerResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ContainerResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ContainerResourcePromise;
@@ -10108,6 +10265,26 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     }
 
     /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ContainerResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new ContainerResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+    }
+
+    /** @internal */
     private async _withRemoteImageNameInternal(remoteImageName: string): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
@@ -11100,6 +11277,11 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.excludeFromMcp()), this._client);
     }
 
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+    }
+
     /** Sets the remote image name for publishing */
     withRemoteImageName(remoteImageName: string): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)), this._client);
@@ -11341,6 +11523,7 @@ export interface CSharpAppResource {
     withIconName(iconName: string, options?: WithIconNameOptions): CSharpAppResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): CSharpAppResourcePromise;
     excludeFromMcp(): CSharpAppResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise;
     withRemoteImageName(remoteImageName: string): CSharpAppResourcePromise;
     withRemoteImageTag(remoteImageTag: string): CSharpAppResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): CSharpAppResourcePromise;
@@ -11436,6 +11619,7 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
     withIconName(iconName: string, options?: WithIconNameOptions): CSharpAppResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): CSharpAppResourcePromise;
     excludeFromMcp(): CSharpAppResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise;
     withRemoteImageName(remoteImageName: string): CSharpAppResourcePromise;
     withRemoteImageTag(remoteImageTag: string): CSharpAppResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): CSharpAppResourcePromise;
@@ -12522,6 +12706,26 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     }
 
     /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<CSharpAppResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new CSharpAppResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+    }
+
+    /** @internal */
     private async _withRemoteImageNameInternal(remoteImageName: string): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
@@ -13425,6 +13629,11 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.excludeFromMcp()), this._client);
     }
 
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+    }
+
     /** Sets the remote image name for publishing */
     withRemoteImageName(remoteImageName: string): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)), this._client);
@@ -13667,6 +13876,7 @@ export interface DotnetToolResource {
     withIconName(iconName: string, options?: WithIconNameOptions): DotnetToolResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): DotnetToolResourcePromise;
     excludeFromMcp(): DotnetToolResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise;
     withRemoteImageName(remoteImageName: string): DotnetToolResourcePromise;
     withRemoteImageTag(remoteImageTag: string): DotnetToolResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): DotnetToolResourcePromise;
@@ -13768,6 +13978,7 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
     withIconName(iconName: string, options?: WithIconNameOptions): DotnetToolResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): DotnetToolResourcePromise;
     excludeFromMcp(): DotnetToolResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise;
     withRemoteImageName(remoteImageName: string): DotnetToolResourcePromise;
     withRemoteImageTag(remoteImageTag: string): DotnetToolResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): DotnetToolResourcePromise;
@@ -14941,6 +15152,26 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     }
 
     /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<DotnetToolResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new DotnetToolResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+    }
+
+    /** @internal */
     private async _withRemoteImageNameInternal(remoteImageName: string): Promise<DotnetToolResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
@@ -15874,6 +16105,11 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.excludeFromMcp()), this._client);
     }
 
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+    }
+
     /** Sets the remote image name for publishing */
     withRemoteImageName(remoteImageName: string): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)), this._client);
@@ -16110,6 +16346,7 @@ export interface ExecutableResource {
     withIconName(iconName: string, options?: WithIconNameOptions): ExecutableResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ExecutableResourcePromise;
     excludeFromMcp(): ExecutableResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise;
     withRemoteImageName(remoteImageName: string): ExecutableResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ExecutableResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ExecutableResourcePromise;
@@ -16205,6 +16442,7 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
     withIconName(iconName: string, options?: WithIconNameOptions): ExecutableResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ExecutableResourcePromise;
     excludeFromMcp(): ExecutableResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise;
     withRemoteImageName(remoteImageName: string): ExecutableResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ExecutableResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ExecutableResourcePromise;
@@ -17288,6 +17526,26 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     }
 
     /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ExecutableResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new ExecutableResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+    }
+
+    /** @internal */
     private async _withRemoteImageNameInternal(remoteImageName: string): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
@@ -18189,6 +18447,11 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.excludeFromMcp()), this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
     /** Sets the remote image name for publishing */
@@ -20729,6 +20992,7 @@ export interface ProjectResource {
     withIconName(iconName: string, options?: WithIconNameOptions): ProjectResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ProjectResourcePromise;
     excludeFromMcp(): ProjectResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise;
     withRemoteImageName(remoteImageName: string): ProjectResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ProjectResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ProjectResourcePromise;
@@ -20824,6 +21088,7 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
     withIconName(iconName: string, options?: WithIconNameOptions): ProjectResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ProjectResourcePromise;
     excludeFromMcp(): ProjectResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise;
     withRemoteImageName(remoteImageName: string): ProjectResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ProjectResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ProjectResourcePromise;
@@ -21910,6 +22175,26 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     }
 
     /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ProjectResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new ProjectResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+    }
+
+    /** @internal */
     private async _withRemoteImageNameInternal(remoteImageName: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
@@ -22813,6 +23098,11 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.excludeFromMcp()), this._client);
     }
 
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+    }
+
     /** Sets the remote image name for publishing */
     withRemoteImageName(remoteImageName: string): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)), this._client);
@@ -23063,6 +23353,7 @@ export interface TestDatabaseResource {
     withIconName(iconName: string, options?: WithIconNameOptions): TestDatabaseResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestDatabaseResourcePromise;
     excludeFromMcp(): TestDatabaseResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
     withRemoteImageName(remoteImageName: string): TestDatabaseResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestDatabaseResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestDatabaseResourcePromise;
@@ -23173,6 +23464,7 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
     withIconName(iconName: string, options?: WithIconNameOptions): TestDatabaseResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestDatabaseResourcePromise;
     excludeFromMcp(): TestDatabaseResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
     withRemoteImageName(remoteImageName: string): TestDatabaseResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestDatabaseResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestDatabaseResourcePromise;
@@ -24478,6 +24770,26 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     }
 
     /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestDatabaseResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new TestDatabaseResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+    }
+
+    /** @internal */
     private async _withRemoteImageNameInternal(remoteImageName: string): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
@@ -25470,6 +25782,11 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.excludeFromMcp()), this._client);
     }
 
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+    }
+
     /** Sets the remote image name for publishing */
     withRemoteImageName(remoteImageName: string): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)), this._client);
@@ -25728,6 +26045,7 @@ export interface TestRedisResource {
     withIconName(iconName: string, options?: WithIconNameOptions): TestRedisResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestRedisResourcePromise;
     excludeFromMcp(): TestRedisResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise;
     withRemoteImageName(remoteImageName: string): TestRedisResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestRedisResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestRedisResourcePromise;
@@ -25854,6 +26172,7 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
     withIconName(iconName: string, options?: WithIconNameOptions): TestRedisResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestRedisResourcePromise;
     excludeFromMcp(): TestRedisResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise;
     withRemoteImageName(remoteImageName: string): TestRedisResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestRedisResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestRedisResourcePromise;
@@ -27211,6 +27530,26 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     }
 
     /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestRedisResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new TestRedisResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+    }
+
+    /** @internal */
     private async _withRemoteImageNameInternal(remoteImageName: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
@@ -28407,6 +28746,11 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.excludeFromMcp()), this._client);
     }
 
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+    }
+
     /** Sets the remote image name for publishing */
     withRemoteImageName(remoteImageName: string): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)), this._client);
@@ -28727,6 +29071,7 @@ export interface TestVaultResource {
     withIconName(iconName: string, options?: WithIconNameOptions): TestVaultResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestVaultResourcePromise;
     excludeFromMcp(): TestVaultResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise;
     withRemoteImageName(remoteImageName: string): TestVaultResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestVaultResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestVaultResourcePromise;
@@ -28838,6 +29183,7 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
     withIconName(iconName: string, options?: WithIconNameOptions): TestVaultResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestVaultResourcePromise;
     excludeFromMcp(): TestVaultResourcePromise;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise;
     withRemoteImageName(remoteImageName: string): TestVaultResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestVaultResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestVaultResourcePromise;
@@ -30144,6 +30490,26 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     }
 
     /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestVaultResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new TestVaultResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
+    }
+
+    /** @internal */
     private async _withRemoteImageNameInternal(remoteImageName: string): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
@@ -31151,6 +31517,11 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.excludeFromMcp()), this._client);
     }
 
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
+    }
+
     /** Sets the remote image name for publishing */
     withRemoteImageName(remoteImageName: string): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)), this._client);
@@ -31339,11 +31710,13 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
 
 export interface ComputeResource {
     toJSON(): MarshalledHandle;
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise;
     withRemoteImageName(remoteImageName: string): ComputeResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ComputeResourcePromise;
 }
 
 export interface ComputeResourcePromise extends PromiseLike<ComputeResource> {
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise;
     withRemoteImageName(remoteImageName: string): ComputeResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ComputeResourcePromise;
 }
@@ -31355,6 +31728,26 @@ export interface ComputeResourcePromise extends PromiseLike<ComputeResource> {
 class ComputeResourceImpl extends ResourceBuilderBase<IComputeResourceHandle> implements ComputeResource {
     constructor(handle: IComputeResourceHandle, client: AspireClientRpc) {
         super(handle, client);
+    }
+
+    /** @internal */
+    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ComputeResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
+            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<IComputeResourceHandle>(
+            'Aspire.Hosting/withImagePushOptions',
+            rpcArgs
+        );
+        return new ComputeResourceImpl(result, this._client);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {
+        return new ComputeResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
     /** @internal */
@@ -31404,6 +31797,11 @@ class ComputeResourcePromiseImpl implements ComputeResourcePromise {
         onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
     ): PromiseLike<TResult1 | TResult2> {
         return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Sets image push options via callback */
+    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {
+        return new ComputeResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
     /** Sets the remote image name for publishing */
@@ -34217,6 +34615,8 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeReso
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeStartEvent', (handle, client) => new BeforeStartEventImpl(handle as BeforeStartEventHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext', (handle, client) => new CommandLineArgsCallbackContextImpl(handle as CommandLineArgsCallbackContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent', (handle, client) => new ConnectionStringAvailableEventImpl(handle as ConnectionStringAvailableEventHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions', (handle, client) => new ContainerImagePushOptionsImpl(handle as ContainerImagePushOptionsHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext', (handle, client) => new ContainerImagePushOptionsCallbackContextImpl(handle as ContainerImagePushOptionsCallbackContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.DistributedApplication', (handle, client) => new DistributedApplicationImpl(handle as DistributedApplicationHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.DistributedApplicationExecutionContext', (handle, client) => new DistributedApplicationExecutionContextImpl(handle as DistributedApplicationExecutionContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.DistributedApplicationModel', (handle, client) => new DistributedApplicationModelImpl(handle as DistributedApplicationModelHandle, client));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -8848,7 +8848,7 @@ export interface ContainerResource {
     withIconName(iconName: string, options?: WithIconNameOptions): ContainerResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ContainerResourcePromise;
     excludeFromMcp(): ContainerResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise;
     withRemoteImageName(remoteImageName: string): ContainerResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ContainerResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ContainerResourcePromise;
@@ -8959,7 +8959,7 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
     withIconName(iconName: string, options?: WithIconNameOptions): ContainerResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ContainerResourcePromise;
     excludeFromMcp(): ContainerResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise;
     withRemoteImageName(remoteImageName: string): ContainerResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ContainerResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ContainerResourcePromise;
@@ -10265,11 +10265,11 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ContainerResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ContainerResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
@@ -10280,7 +10280,7 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -11278,7 +11278,7 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
@@ -11523,7 +11523,7 @@ export interface CSharpAppResource {
     withIconName(iconName: string, options?: WithIconNameOptions): CSharpAppResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): CSharpAppResourcePromise;
     excludeFromMcp(): CSharpAppResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise;
     withRemoteImageName(remoteImageName: string): CSharpAppResourcePromise;
     withRemoteImageTag(remoteImageTag: string): CSharpAppResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): CSharpAppResourcePromise;
@@ -11619,7 +11619,7 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
     withIconName(iconName: string, options?: WithIconNameOptions): CSharpAppResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): CSharpAppResourcePromise;
     excludeFromMcp(): CSharpAppResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise;
     withRemoteImageName(remoteImageName: string): CSharpAppResourcePromise;
     withRemoteImageTag(remoteImageTag: string): CSharpAppResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): CSharpAppResourcePromise;
@@ -12706,11 +12706,11 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<CSharpAppResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<CSharpAppResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
@@ -12721,7 +12721,7 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -13630,7 +13630,7 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
@@ -13876,7 +13876,7 @@ export interface DotnetToolResource {
     withIconName(iconName: string, options?: WithIconNameOptions): DotnetToolResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): DotnetToolResourcePromise;
     excludeFromMcp(): DotnetToolResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise;
     withRemoteImageName(remoteImageName: string): DotnetToolResourcePromise;
     withRemoteImageTag(remoteImageTag: string): DotnetToolResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): DotnetToolResourcePromise;
@@ -13978,7 +13978,7 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
     withIconName(iconName: string, options?: WithIconNameOptions): DotnetToolResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): DotnetToolResourcePromise;
     excludeFromMcp(): DotnetToolResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise;
     withRemoteImageName(remoteImageName: string): DotnetToolResourcePromise;
     withRemoteImageTag(remoteImageTag: string): DotnetToolResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): DotnetToolResourcePromise;
@@ -15152,11 +15152,11 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<DotnetToolResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<DotnetToolResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
@@ -15167,7 +15167,7 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -16106,7 +16106,7 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
@@ -16346,7 +16346,7 @@ export interface ExecutableResource {
     withIconName(iconName: string, options?: WithIconNameOptions): ExecutableResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ExecutableResourcePromise;
     excludeFromMcp(): ExecutableResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise;
     withRemoteImageName(remoteImageName: string): ExecutableResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ExecutableResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ExecutableResourcePromise;
@@ -16442,7 +16442,7 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
     withIconName(iconName: string, options?: WithIconNameOptions): ExecutableResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ExecutableResourcePromise;
     excludeFromMcp(): ExecutableResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise;
     withRemoteImageName(remoteImageName: string): ExecutableResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ExecutableResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ExecutableResourcePromise;
@@ -17526,11 +17526,11 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ExecutableResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ExecutableResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
@@ -17541,7 +17541,7 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -18450,7 +18450,7 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
@@ -20992,7 +20992,7 @@ export interface ProjectResource {
     withIconName(iconName: string, options?: WithIconNameOptions): ProjectResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ProjectResourcePromise;
     excludeFromMcp(): ProjectResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise;
     withRemoteImageName(remoteImageName: string): ProjectResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ProjectResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ProjectResourcePromise;
@@ -21088,7 +21088,7 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
     withIconName(iconName: string, options?: WithIconNameOptions): ProjectResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ProjectResourcePromise;
     excludeFromMcp(): ProjectResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise;
     withRemoteImageName(remoteImageName: string): ProjectResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ProjectResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): ProjectResourcePromise;
@@ -22175,11 +22175,11 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ProjectResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ProjectResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
@@ -22190,7 +22190,7 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -23099,7 +23099,7 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
@@ -23353,7 +23353,7 @@ export interface TestDatabaseResource {
     withIconName(iconName: string, options?: WithIconNameOptions): TestDatabaseResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestDatabaseResourcePromise;
     excludeFromMcp(): TestDatabaseResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
     withRemoteImageName(remoteImageName: string): TestDatabaseResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestDatabaseResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestDatabaseResourcePromise;
@@ -23464,7 +23464,7 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
     withIconName(iconName: string, options?: WithIconNameOptions): TestDatabaseResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestDatabaseResourcePromise;
     excludeFromMcp(): TestDatabaseResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
     withRemoteImageName(remoteImageName: string): TestDatabaseResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestDatabaseResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestDatabaseResourcePromise;
@@ -24770,11 +24770,11 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestDatabaseResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestDatabaseResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
@@ -24785,7 +24785,7 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -25783,7 +25783,7 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
@@ -26045,7 +26045,7 @@ export interface TestRedisResource {
     withIconName(iconName: string, options?: WithIconNameOptions): TestRedisResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestRedisResourcePromise;
     excludeFromMcp(): TestRedisResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise;
     withRemoteImageName(remoteImageName: string): TestRedisResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestRedisResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestRedisResourcePromise;
@@ -26172,7 +26172,7 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
     withIconName(iconName: string, options?: WithIconNameOptions): TestRedisResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestRedisResourcePromise;
     excludeFromMcp(): TestRedisResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise;
     withRemoteImageName(remoteImageName: string): TestRedisResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestRedisResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestRedisResourcePromise;
@@ -27530,11 +27530,11 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestRedisResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestRedisResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
@@ -27545,7 +27545,7 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -28747,7 +28747,7 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
@@ -29071,7 +29071,7 @@ export interface TestVaultResource {
     withIconName(iconName: string, options?: WithIconNameOptions): TestVaultResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestVaultResourcePromise;
     excludeFromMcp(): TestVaultResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise;
     withRemoteImageName(remoteImageName: string): TestVaultResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestVaultResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestVaultResourcePromise;
@@ -29183,7 +29183,7 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
     withIconName(iconName: string, options?: WithIconNameOptions): TestVaultResourcePromise;
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestVaultResourcePromise;
     excludeFromMcp(): TestVaultResourcePromise;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise;
     withRemoteImageName(remoteImageName: string): TestVaultResourcePromise;
     withRemoteImageTag(remoteImageTag: string): TestVaultResourcePromise;
     withPipelineStepFactory(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, options?: WithPipelineStepFactoryOptions): TestVaultResourcePromise;
@@ -30490,11 +30490,11 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestVaultResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<TestVaultResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
@@ -30505,7 +30505,7 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -31518,7 +31518,7 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 
@@ -31710,13 +31710,13 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
 
 export interface ComputeResource {
     toJSON(): MarshalledHandle;
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise;
     withRemoteImageName(remoteImageName: string): ComputeResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ComputeResourcePromise;
 }
 
 export interface ComputeResourcePromise extends PromiseLike<ComputeResource> {
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise;
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise;
     withRemoteImageName(remoteImageName: string): ComputeResourcePromise;
     withRemoteImageTag(remoteImageTag: string): ComputeResourcePromise;
 }
@@ -31731,11 +31731,11 @@ class ComputeResourceImpl extends ResourceBuilderBase<IComputeResourceHandle> im
     }
 
     /** @internal */
-    private async _withImagePushOptionsInternal(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ComputeResource> {
-        const callbackId = registerCallback(async (objData: unknown) => {
-            const objHandle = wrapIfHandle(objData) as ContainerImagePushOptionsCallbackContextHandle;
-            const obj = new ContainerImagePushOptionsCallbackContextImpl(objHandle, this._client);
-            await callback(obj);
+    private async _withImagePushOptionsInternal(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): Promise<ComputeResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerImagePushOptionsCallbackContextHandle;
+            const arg = new ContainerImagePushOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
         const result = await this._client.invokeCapability<IComputeResourceHandle>(
@@ -31746,7 +31746,7 @@ class ComputeResourceImpl extends ResourceBuilderBase<IComputeResourceHandle> im
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {
         return new ComputeResourcePromiseImpl(this._withImagePushOptionsInternal(callback));
     }
 
@@ -31800,7 +31800,7 @@ class ComputeResourcePromiseImpl implements ComputeResourcePromise {
     }
 
     /** Sets image push options via callback */
-    withImagePushOptions(callback: (obj: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {
+    withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {
         return new ComputeResourcePromiseImpl(this._promise.then(obj => obj.withImagePushOptions(callback)));
     }
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -40,6 +40,11 @@ void main() throws Exception {
         container.withHttpProbe(ProbeType.LIVENESS, new WithHttpProbeOptions().path("/health"));
         container.withRemoteImageName("myregistry.azurecr.io/myapp");
         container.withRemoteImageTag("latest");
+        container.withImagePushOptions((context) -> {
+            var options = context.options();
+            options.setRemoteImageName("myregistry.azurecr.io/myapp");
+            options.setRemoteImageTag("latest");
+        });
         container.withMcpServer(new WithMcpServerOptions().path("/mcp"));
         container.withRequiredCommand("docker");
         tool.withToolIgnoreExistingFeeds();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -115,6 +115,13 @@ with create_builder() as builder:
     container.with_remote_image_name()
     # withRemoteImageTag
     container.with_remote_image_tag()
+    # withImagePushOptions
+    def configure_image_push_options(context):
+        options = context.options
+        options.remote_image_name = "myregistry.azurecr.io/myapp"
+        options.remote_image_tag = "latest"
+
+    container.with_image_push_options(configure_image_push_options)
     # withMcpServer
     container.with_mcp_server()
     # withRequiredCommand

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
@@ -187,6 +187,13 @@ await container.withRemoteImageName("myregistry.azurecr.io/myapp");
 // withRemoteImageTag
 await container.withRemoteImageTag("latest");
 
+// withImagePushOptions
+await container.withImagePushOptions(async (context) => {
+    const options = await context.options.get();
+    await options.remoteImageName.set("myregistry.azurecr.io/myapp");
+    await options.remoteImageTag.set("latest");
+});
+
 // withMcpServer
 await container.withMcpServer({ path: "/mcp" });
 

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -116,6 +116,7 @@ internal static class Hex1bAutomatorTestHelpers
                         }
 
                         firstOutputMatched = firstOutputLine.Contains(desiredOutput, StringComparison.Ordinal);
+                        sawPrompt = IsPromptVisible(snapshot, expectedPromptSequence);
                         return true;
                     }
 

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -136,18 +136,13 @@ internal static class Hex1bAutomatorTestHelpers
 
             if (!sawPrompt)
             {
-                remaining = effectiveTimeout - stopwatch.Elapsed;
-                if (remaining <= TimeSpan.Zero)
-                {
-                    break;
-                }
-
+                var promptGrace = TimeSpan.FromSeconds(1);
                 try
                 {
-                    await auto.WaitForAnyPromptAsync(counter, remaining);
+                    await auto.WaitForAnyPromptAsync(counter, promptGrace);
                     sawPrompt = true;
                 }
-                catch (TimeoutException) when (stopwatch.Elapsed < effectiveTimeout)
+                catch (TimeoutException) when (stopwatch.Elapsed < effectiveTimeout + promptGrace)
                 {
                     continue;
                 }


### PR DESCRIPTION
## Description

Issue #15705 asks for TypeScript AppHost parity for `WithImagePushOptions` so polyglot app hosts can customize image push settings without falling back to narrower helpers. This keeps the change scoped to the existing generated callback model rather than introducing a new TypeScript-specific API shape.

This PR exports a single `withImagePushOptions` overload for polyglot hosts, marks `ContainerImagePushOptionsCallbackContext` and `ContainerImagePushOptions` for ATS property exposure, and updates the generated snapshots that prove the surface across TypeScript, Java, and Python. It also moves coverage to the shared polyglot apphost fixtures in those languages and removes stale comments that said the API was unavailable in polyglot hosts.

Dependencies: N/A

Fixes #15705

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No