### PR TITLE
Document cross-assembly ATS exports

### DIFF
--- a/docs/specs/polyglot-apphost.md
+++ b/docs/specs/polyglot-apphost.md
@@ -342,6 +342,8 @@ public class RedisResource : ContainerResource { }
 // Type ID = Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder
 ```
 
+Assembly-level exports are the mechanism for exposing framework or third-party types that live in a different assembly than the capabilities that use them. Even in that case, the ATS type ID still comes from the exported CLR type's assembly and full type name, not from the assembly that declares the attribute.
+
 ### Type Categories
 
 ATS categorizes types for serialization and code generation using `AtsTypeCategory`:
@@ -397,6 +399,25 @@ public static class ResourceExtensions
 ```
 
 Because `RedisResource` implements `IResourceWithEnvironment` (via `ContainerResource`), the scanner adds `withEnvironment` to `RedisResource`'s capability list.
+
+#### Cross-Assembly Type Exports
+
+Use `[assembly: AspireExport(typeof(T))]` when a capability assembly needs to expose a type defined in another assembly:
+
+```csharp
+// In Aspire.Hosting/Ats/AtsTypeMappings.cs
+[assembly: AspireExport(typeof(IConfiguration))]
+[assembly: AspireExport(typeof(IHostEnvironment), ExposeProperties = true)]
+```
+
+At startup, the remote host creates one ATS context by scanning all loaded assemblies together. That shared scan is what lets one assembly export a type while another assembly contributes capabilities that consume or return it.
+
+- **Type identity still comes from the exported CLR type.** For example, `[assembly: AspireExport(typeof(IConfiguration))]` produces the ATS type ID `Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfiguration`, even though the attribute is declared in `Aspire.Hosting`.
+- **Exported handle types are merged by ATS type ID across the full scan.** Re-exporting the same type from multiple assemblies does not create multiple ATS handle types.
+- **Capabilities are merged from all scanned assemblies, but capability IDs must remain unique.** If two assemblies export the same capability ID, scanning emits a diagnostic error.
+- **Cross-assembly resolution is scan-order independent.** If one assembly exports a type and another references it, the scanner resolves it after collecting the complete type universe from every scanned assembly.
+
+This is how Aspire's core hosting assembly exports framework types such as `IConfiguration`, `IConfigurationSection`, and `IHostEnvironment` while keeping them in the same flattened capability model as types exported directly from integration packages.
 
 #### Flattening in Action
 

--- a/src/Aspire.Hosting/Ats/ThirdPartyAtsAttributes.md
+++ b/src/Aspire.Hosting/Ats/ThirdPartyAtsAttributes.md
@@ -40,7 +40,7 @@ public sealed class AspireExportAttribute : Attribute
     }
 
     /// <summary>
-    /// Type export (parameterless). The type ID is derived as {AssemblyName}/{TypeName}.
+    /// Type export (parameterless). The type ID is derived as {AssemblyName}/{FullTypeName}.
     /// </summary>
     public AspireExportAttribute()
     {
@@ -189,5 +189,6 @@ public sealed class AddMyDatabaseOptions
 - **Constructor signatures must match by arity and argument type**: `()`, `(string)`, `(Type)` for `AspireExportAttribute`; `(params Type[])` for `AspireUnionAttribute`. Parameter names can differ.
 - **Property names must match exactly**: `Type`, `Description`, `MethodName`, `ExposeProperties`, `ExposeMethods`, `Reason`, `DtoTypeId`, `Types`.
 - **Namespaces must match exactly**: copied attributes need to be declared in the `Aspire.Hosting` namespace so their full names match the built-in ATS attributes.
+- For end-to-end behavior of assembly-level exports across multiple assemblies, see [Cross-Assembly Type Exports](../../../docs/specs/polyglot-apphost.md#cross-assembly-type-exports).
 - If you later add a reference to `Aspire.Hosting` and both your custom attribute and the official one are applied to the same member, both will be detected (the scanner takes the first match).
 - The scanner uses `CustomAttributeData` which reads metadata without instantiating the attribute, so your attribute types don't need to be loadable at scan time — only the full name and supported members must match.


### PR DESCRIPTION
## Description

This documents the cross-assembly ATS export behavior behind polyglot AppHost type generation so issue #14884 has a concrete explanation in the existing ATS spec. Reviewers were missing guidance on what happens when one assembly exports a type and another assembly contributes capabilities that use it.

The update keeps the change scoped to the existing spec by expanding `docs/specs/polyglot-apphost.md` with a focused cross-assembly exports subsection and by adding a small related cleanup in `ThirdPartyAtsAttributes.md`. The new text explains when to use assembly-level `AspireExport(typeof(T))`, how ATS type IDs are derived from the exported CLR type, how multi-assembly scanning merges exported types and capabilities, and why duplicate capability IDs are still errors.

Fixes #14884

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No