### PR TITLE
Add polyglot ACA custom domain support

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -36,7 +36,7 @@ public static class ContainerAppExtensions
     /// certificate. Once the certificate is successfully provisioned, subsequent deployments of the application can use this certificate name when the
     /// <paramref name="certificateName"/> is prompted.</para>
     /// <para>For deployments triggered locally by the Azure Developer CLI the <c>config.json</c> file in the <c>.azure/{environment name}</c> path
-    /// can by modified with the certificate name since Azure Developer CLI will not prompt again for the value.</para>
+    /// can be modified with the certificate name since Azure Developer CLI will not prompt again for the value.</para>
     /// <example>
     /// This example shows declaring two parameters to capture the custom domain and certificate name and
     /// passing them to the <see cref="ConfigureCustomDomain(ContainerApp, IResourceBuilder{ParameterResource}, IResourceBuilder{ParameterResource})"/>
@@ -53,9 +53,9 @@ public static class ContainerAppExtensions
     ///        });
     /// </code>
     /// </example>
-    /// <para>This method is not available in polyglot app hosts.</para>
+    /// <para>In TypeScript app hosts this method is available as <c>app.configureCustomDomain(...)</c> inside the publish callback.</para>
     /// </remarks>
-    [AspireExportIgnore(Reason = "Extends ContainerApp (Azure.Provisioning type) which is not an IResourceBuilder<T> target, so the ATS codegen cannot generate a wrapper class for it.")]
+    [AspireExport("configureCustomDomain", Description = "Configures the custom domain for the container app")]
     [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static void ConfigureCustomDomain(this ContainerApp app, IResourceBuilder<ParameterResource> customDomain, IResourceBuilder<ParameterResource> certificateName)
     {

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -53,7 +53,6 @@ public static class ContainerAppExtensions
     ///        });
     /// </code>
     /// </example>
-    /// <para>In TypeScript app hosts this method is available as <c>app.configureCustomDomain(...)</c> inside the publish callback.</para>
     /// </remarks>
     [AspireExport("configureCustomDomain", Description = "Configures the custom domain for the container app")]
     [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppContainers/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppContainers/Java/AppHost.java
@@ -23,11 +23,13 @@ void main() throws Exception {
         var laws = builder.addAzureLogAnalyticsWorkspace("laws");
         var env3 = builder.addAzureContainerAppEnvironment("myenv3");
         env3.withAzureLogAnalyticsWorkspace(laws);
+        var customDomain = builder.addParameter("customDomain");
+        var certificateName = builder.addParameter("certificateName");
         // === PublishAsAzureContainerApp ===
         // Test publishAsAzureContainerApp on a container resource with callback
         var web = builder.addContainer("web", "myregistry/web:latest");
         web.publishAsAzureContainerApp((infrastructure, app) -> {
-            // Configure container app via callback
+            app.configureCustomDomain(customDomain, certificateName);
         });
         // Test publishAsAzureContainerAppJob on an executable resource
         var api = builder.addExecutable("api", "dotnet", ".", new String[] { "run" });

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppContainers/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppContainers/Python/apphost.py
@@ -15,7 +15,7 @@ with create_builder() as builder:
     # Test withAzureLogAnalyticsWorkspace with a Log Analytics Workspace resource
     laws = builder.add_azure_log_analytics_workspace("resource")
     env3 = builder.add_azure_container_app_environment("resource")
-    env3.with_azure_log_analytics_workspace()
+    env3.with_azure_log_analytics_workspace(laws)
     custom_domain = builder.add_parameter("parameter")
     certificate_name = builder.add_parameter("parameter")
     # Test publishAsAzureContainerApp on a container resource with callback

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppContainers/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppContainers/Python/apphost.py
@@ -16,9 +16,13 @@ with create_builder() as builder:
     laws = builder.add_azure_log_analytics_workspace("resource")
     env3 = builder.add_azure_container_app_environment("resource")
     env3.with_azure_log_analytics_workspace()
+    custom_domain = builder.add_parameter("parameter")
+    certificate_name = builder.add_parameter("parameter")
     # Test publishAsAzureContainerApp on a container resource with callback
     web = builder.add_container("resource", "image")
-    web.publish_as_azure_container_app()
+    web.publish_as_azure_container_app(
+        lambda infrastructure, app: app.configure_custom_domain(custom_domain, certificate_name)
+    )
     # Test publishAsAzureContainerAppJob on an executable resource
     api = builder.add_executable("resource", "echo", ".", [])
     api.publish_as_azure_container_app_job()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppContainers/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppContainers/TypeScript/apphost.ts
@@ -28,12 +28,14 @@ await env2.withHttpsUpgrade();
 const laws = await builder.addAzureLogAnalyticsWorkspace("laws");
 const env3 = builder.addAzureContainerAppEnvironment("myenv3");
 await env3.withAzureLogAnalyticsWorkspace(laws);
+const customDomain = await builder.addParameter("customDomain");
+const certificateName = await builder.addParameter("certificateName");
 
 // === PublishAsAzureContainerApp ===
 // Test publishAsAzureContainerApp on a container resource with callback
 const web = builder.addContainer("web", "myregistry/web:latest");
 await web.publishAsAzureContainerApp(async (infrastructure, app) => {
-    // Configure container app via callback
+    await app.configureCustomDomain(customDomain, certificateName);
 });
 
 // Test publishAsAzureContainerAppJob on an executable resource


### PR DESCRIPTION
## Description

Fixes #15706

`ConfigureCustomDomain` already exists for Azure Container Apps in C#, but the polyglot AppHost surfaces did not expose it. This change exports the existing API through ATS so the generated callback surface can configure custom domains from polyglot AppHosts on `ContainerApp`, and updates the Azure AppContainers Java, Python, and TypeScript validation AppHosts to exercise that generated API.

This stays narrowly scoped to the existing callback shape rather than introducing a new free-function model, and it removes the stale XML doc text that said polyglot AppHosts were unsupported. No new runtime dependencies were added.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No