### PR TITLE
Switch extension build from yarn to npm to fix internal build

### DIFF
--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -180,15 +180,6 @@ extends:
                   script: Write-Host "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Build.SourcesDirectory)\.npmrc"
 
               - task: PowerShell@2
-                displayName: 🟣Install yarn
-                inputs:
-                  targetType: 'inline'
-                  script: |
-                    npm install -g yarn@1.22.22
-                    yarn --version
-                  workingDirectory: '$(Build.SourcesDirectory)'
-
-              - task: PowerShell@2
                 displayName: 🟣Install vsce
                 inputs:
                   targetType: 'inline'

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -262,15 +262,6 @@ extends:
                   script: Write-Host "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Build.SourcesDirectory)\.npmrc"
 
               - task: PowerShell@2
-                displayName: 🟣Install yarn
-                inputs:
-                  targetType: 'inline'
-                  script: |
-                    npm install -g yarn@1.22.22
-                    yarn --version
-                  workingDirectory: '$(Build.SourcesDirectory)'
-
-              - task: PowerShell@2
                 displayName: 🟣Install vsce
                 inputs:
                   targetType: 'inline'

--- a/extension/Extension.proj
+++ b/extension/Extension.proj
@@ -4,7 +4,7 @@
     <ExtensionSrcDir>$(MSBuildThisFileDirectory)</ExtensionSrcDir>
   </PropertyGroup>
 
-  <Target Name="BuildAndPackageExtension" BeforeTargets="Build" DependsOnTargets="CheckYarnInstalled;CheckVsceInstalled">
+  <Target Name="BuildAndPackageExtension" BeforeTargets="Build" DependsOnTargets="CheckVsceInstalled">
     <PropertyGroup>
       <_PackageJsonPath>$([MSBuild]::NormalizePath($(ExtensionSrcDir), 'package.json'))</_PackageJsonPath>
     </PropertyGroup>
@@ -26,8 +26,8 @@
     </PropertyGroup>
 
     <!-- Install dependencies and compile -->
-    <Exec Command="yarn install" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
-    <Exec Command="yarn compile" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command="npm install" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command="npm run compile" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
 
     <!-- Make extension directory -->
     <MakeDir Directories="$(_VscodeOutputDir)" />
@@ -51,17 +51,6 @@
     <Message Importance="high" Text="  VSIX: $(_VsixPath)" />
     <Message Importance="high" Text="  Manifest: $(_ManifestPath)" />
     <Message Importance="high" Text="  (Signature will be created by signing/signVsix.proj during signing phase)" />
-  </Target>
-
-  <Target Name="CheckYarnInstalled">
-    <Exec Command="yarn --version" ContinueOnError="true" ConsoleToMSBuild="true" IgnoreStandardErrorWarningFormat="true">
-      <Output TaskParameter="ExitCode" PropertyName="YarnExitCode" />
-      <Output TaskParameter="ConsoleOutput" PropertyName="YarnVersion" />
-    </Exec>
-
-    <Error Condition="'$(YarnExitCode)' != '0'" Text="yarn is not installed or not available in PATH. To build the extension, install yarn: https://yarnpkg.com/getting-started/install" />
-
-    <Message Importance="high" Text="yarn version: $(YarnVersion)" />
   </Target>
 
   <Target Name="CheckVsceInstalled">

--- a/extension/Extension.proj
+++ b/extension/Extension.proj
@@ -33,7 +33,7 @@
     <MakeDir Directories="$(_VscodeOutputDir)" />
 
     <!-- Package extension -->
-    <Exec Command="vsce package --out $(_VsixPath)"
+    <Exec Command="vsce package --no-yarn --out $(_VsixPath)"
           IgnoreStandardErrorWarningFormat="true"
           WorkingDirectory="$(ExtensionSrcDir)" />
 

--- a/extension/build.ps1
+++ b/extension/build.ps1
@@ -16,13 +16,6 @@ if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
     exit 1
 }
 
-# Check for yarn
-if (-not (Get-Command yarn -ErrorAction SilentlyContinue)) {
-    Write-Error "Error: yarn is not installed. Please install yarn first."
-    Write-Host "You can install yarn by running: npm install -g yarn"
-    exit 1
-}
-
 # Check for VS Code or VS Code Insiders
 $hasVSCode = Get-Command code -ErrorAction SilentlyContinue
 $hasVSCodeInsiders = Get-Command code-insiders -ErrorAction SilentlyContinue
@@ -42,20 +35,20 @@ if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
 
 Write-Host "All prerequisites satisfied."
 Write-Host ""
-Write-Host "Running yarn install..."
-yarn install
+Write-Host "Running npm install..."
+npm install
 
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "yarn install failed with exit code $LASTEXITCODE"
+    Write-Error "npm install failed with exit code $LASTEXITCODE"
     exit $LASTEXITCODE
 }
 
 Write-Host ""
-Write-Host "Running yarn compile..."
-yarn compile
+Write-Host "Running npm run compile..."
+npm run compile
 
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "yarn compile failed with exit code $LASTEXITCODE"
+    Write-Error "npm run compile failed with exit code $LASTEXITCODE"
     exit $LASTEXITCODE
 }
 

--- a/extension/build.sh
+++ b/extension/build.sh
@@ -15,13 +15,6 @@ if ! command -v npm &> /dev/null; then
     exit 1
 fi
 
-# Check for yarn
-if ! command -v yarn &> /dev/null; then
-    echo "Error: yarn is not installed. Please install yarn first."
-    echo "You can install yarn by running: npm install -g yarn"
-    exit 1
-fi
-
 # Check for VS Code or VS Code Insiders
 if ! command -v code &> /dev/null && ! command -v code-insiders &> /dev/null; then
     echo "Error: VS Code or VS Code Insiders is not installed or not in PATH."
@@ -38,12 +31,12 @@ fi
 
 echo "All prerequisites satisfied."
 echo ""
-echo "Running yarn install..."
-yarn install
+echo "Running npm install..."
+npm install
 
 echo ""
-echo "Running yarn compile..."
-yarn compile
+echo "Running npm run compile..."
+npm run compile
 
 echo ""
 echo "Building Aspire CLI..."


### PR DESCRIPTION
## Description

Fix the internal AzDO build which has been consistently failing during `yarn install` with:
```
error Error: connect EACCES 192.0.2.15:443
```

### Root cause

When the GH Actions workflow moved from yarn to npm (commit `9504185f67`, PR #13663), `extension/.npmrc` was deleted. However, the internal AzDO pipeline (`Extension.proj`) still used `yarn install`.

Yarn v1 doesn't walk up parent directories for `.npmrc` like npm does — it only checks the project directory and user home. Without `extension/.npmrc`, yarn fell back to its default registry (`registry.yarnpkg.com`), which is DNS-sinkholed to `192.0.2.15` (a TEST-NET-1 address per RFC 5737) in the internal build network, causing `EACCES`.

### Changes

1. **Switched extension build from yarn to npm** in `Extension.proj`, both pipeline YAMLs, and the extension build scripts — aligning with what GH Actions already does
2. **Added `--no-yarn` to `vsce package`** — vsce auto-detects `yarn.lock` and tries to use yarn for packaging; `--no-yarn` overrides this

npm properly reads the root `.npmrc` (with the internal registry URL) via the `NPM_CONFIG_USERCONFIG` environment variable already set in the pipeline.

### Validation

- Internal pipeline build [2942510](https://dev.azure.com/dnceng/internal/_build/results?buildId=2942510): `🟣Build` task **succeeded** ✅
- Compare with original failing build [2942296](https://dev.azure.com/dnceng/internal/_build/results?buildId=2942296): failed at `yarn install` in Extension.proj

Fixes #15807

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
