### PR TITLE
Add ConfigureEnvFile support to polyglot Docker app hosts

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Java/Resources/Base.java
+++ b/src/Aspire.Hosting.CodeGeneration.Java/Resources/Base.java
@@ -329,6 +329,49 @@ class AspireDict<K, V> extends HandleWrapperBase {
         }
         return resolvedHandle;
     }
+
+    public int size() {
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.count", Map.of("dict", ensureHandle().toJson()));
+        return ((Number) result).intValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    public V get(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        return (V) getClient().invokeCapability("Aspire.Hosting/Dict.get", args);
+    }
+
+    public void put(K key, V value) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        args.put("value", AspireClient.serializeValue(value));
+        getClient().invokeCapability("Aspire.Hosting/Dict.set", args);
+    }
+
+    public boolean remove(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.remove", args);
+        return Boolean.TRUE.equals(result);
+    }
+
+    public boolean containsKey(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.has", args);
+        return Boolean.TRUE.equals(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<K> keys() {
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.keys", Map.of("dict", ensureHandle().toJson()));
+        return (List<K>) result;
+    }
 }
 
 /**

--- a/src/Aspire.Hosting.CodeGeneration.Java/Resources/Base.java
+++ b/src/Aspire.Hosting.CodeGeneration.Java/Resources/Base.java
@@ -339,14 +339,14 @@ class AspireDict<K, V> extends HandleWrapperBase {
     public V get(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         return (V) getClient().invokeCapability("Aspire.Hosting/Dict.get", args);
     }
 
     public void put(K key, V value) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         args.put("value", AspireClient.serializeValue(value));
         getClient().invokeCapability("Aspire.Hosting/Dict.set", args);
     }
@@ -354,7 +354,7 @@ class AspireDict<K, V> extends HandleWrapperBase {
     public boolean remove(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         Object result = getClient().invokeCapability("Aspire.Hosting/Dict.remove", args);
         return Boolean.TRUE.equals(result);
     }
@@ -362,7 +362,7 @@ class AspireDict<K, V> extends HandleWrapperBase {
     public boolean containsKey(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         Object result = getClient().invokeCapability("Aspire.Hosting/Dict.has", args);
         return Boolean.TRUE.equals(result);
     }

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -143,12 +143,6 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     private string GetPublicPromiseInterfaceName(string typeId) => GetPromiseInterfaceName(GetConcreteClassName(typeId));
 
     /// <summary>
-    /// Checks if an AtsTypeRef represents a handle type.
-    /// </summary>
-    private static bool IsHandleType(AtsTypeRef? typeRef) =>
-        typeRef != null && typeRef.Category == AtsTypeCategory.Handle;
-
-    /// <summary>
     /// Maps an AtsTypeRef to a TypeScript type using category-based dispatch.
     /// This is the preferred method - uses type metadata rather than string parsing.
     /// </summary>
@@ -615,34 +609,11 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         // Exclude DTO types - they have their own interfaces, not handle aliases
         var dtoTypeIds = new HashSet<string>(dtoTypes.Select(d => d.TypeId));
         var typeIds = new HashSet<string>();
-        foreach (var cap in capabilities)
+        foreach (var typeId in CollectAllReferencedTypes(capabilities).Keys)
         {
-            if (!string.IsNullOrEmpty(cap.TargetTypeId) && !dtoTypeIds.Contains(cap.TargetTypeId))
+            if (!dtoTypeIds.Contains(typeId))
             {
-                typeIds.Add(cap.TargetTypeId);
-            }
-            if (IsHandleType(cap.ReturnType) && !dtoTypeIds.Contains(cap.ReturnType!.TypeId))
-            {
-                typeIds.Add(GetReturnTypeId(cap)!);
-            }
-            // Add parameter type IDs (for types like IResourceBuilder<IResource>)
-            foreach (var param in cap.Parameters)
-            {
-                if (IsHandleType(param.Type) && !dtoTypeIds.Contains(param.Type!.TypeId))
-                {
-                    typeIds.Add(param.Type!.TypeId);
-                }
-                // Also collect callback parameter types
-                if (param.IsCallback && param.CallbackParameters != null)
-                {
-                    foreach (var cbParam in param.CallbackParameters)
-                    {
-                        if (IsHandleType(cbParam.Type) && !dtoTypeIds.Contains(cbParam.Type.TypeId))
-                        {
-                            typeIds.Add(cbParam.Type.TypeId);
-                        }
-                    }
-                }
+                typeIds.Add(typeId);
             }
         }
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -2186,25 +2186,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         {
             // Single parameter callback
             var cbParam = callbackParameters[0];
-            var tsType = MapTypeRefToTypeScript(cbParam.Type);
-            var cbTypeId = cbParam.Type.TypeId;
-
-            if (cbTypeId == AtsConstants.CancellationToken)
-            {
-                WriteLine($"{bodyIndent}const {cbParam.Name} = CancellationToken.fromValue({cbParam.Name}Data);");
-            }
-            else if (_wrapperClassNames.TryGetValue(cbTypeId, out var wrapperClassName))
-            {
-                // For types with wrapper classes, create an instance of the wrapper
-                var handleType = GetHandleTypeName(cbTypeId);
-                WriteLine($"{bodyIndent}const {cbParam.Name}Handle = wrapIfHandle({cbParam.Name}Data) as {handleType};");
-                WriteLine($"{bodyIndent}const {cbParam.Name} = new {GetImplementationClassName(wrapperClassName)}({cbParam.Name}Handle, this._client);");
-            }
-            else
-            {
-                // For raw handle types, just wrap and cast
-                WriteLine($"{bodyIndent}const {cbParam.Name} = wrapIfHandle({cbParam.Name}Data) as {tsType};");
-            }
+            GenerateCallbackParameterConversion(cbParam, $"{cbParam.Name}Data");
 
             WriteLine($"{bodyIndent}{returnPrefix}await {callbackName}({cbParam.Name});");
         }
@@ -2214,30 +2196,43 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             for (var i = 0; i < callbackParameters.Count; i++)
             {
                 var cbParam = callbackParameters[i];
-                var tsType = MapTypeRefToTypeScript(cbParam.Type);
-                var cbTypeId = cbParam.Type.TypeId;
                 var callbackArgName = $"{cbParam.Name}Data";
 
-                if (cbTypeId == AtsConstants.CancellationToken)
-                {
-                    WriteLine($"{bodyIndent}const {cbParam.Name} = CancellationToken.fromValue({callbackArgName});");
-                }
-                else if (_wrapperClassNames.TryGetValue(cbTypeId, out var wrapperClassName))
-                {
-                    // For types with wrapper classes, create an instance of the wrapper
-                    var handleType = GetHandleTypeName(cbTypeId);
-                    WriteLine($"{bodyIndent}const {cbParam.Name}Handle = wrapIfHandle({callbackArgName}) as {handleType};");
-                    WriteLine($"{bodyIndent}const {cbParam.Name} = new {GetImplementationClassName(wrapperClassName)}({cbParam.Name}Handle, this._client);");
-                }
-                else
-                {
-                    // For raw handle types, just wrap and cast
-                    WriteLine($"{bodyIndent}const {cbParam.Name} = wrapIfHandle({callbackArgName}) as {tsType};");
-                }
+                GenerateCallbackParameterConversion(cbParam, callbackArgName);
                 callArgs.Add(cbParam.Name);
             }
 
             WriteLine($"{bodyIndent}{returnPrefix}await {callbackName}({string.Join(", ", callArgs)});");
+        }
+    }
+
+    private void GenerateCallbackParameterConversion(AtsCallbackParameterInfo callbackParameter, string callbackArgName)
+    {
+        var tsType = MapTypeRefToTypeScript(callbackParameter.Type);
+        var cbTypeId = callbackParameter.Type.TypeId;
+
+        if (cbTypeId == AtsConstants.CancellationToken)
+        {
+            WriteLine($"            const {callbackParameter.Name} = CancellationToken.fromValue({callbackArgName});");
+        }
+        else if (IsDictionaryType(callbackParameter.Type) && !callbackParameter.Type.IsReadOnly)
+        {
+            var keyType = MapTypeRefToTypeScript(callbackParameter.Type.KeyType);
+            var valueType = MapTypeRefToTypeScript(callbackParameter.Type.ValueType);
+            var handleType = GetHandleTypeName(cbTypeId);
+
+            WriteLine($"            const {callbackParameter.Name}Handle = wrapIfHandle({callbackArgName}) as {handleType};");
+            WriteLine($"            const {callbackParameter.Name} = new AspireDict<{keyType}, {valueType}>({callbackParameter.Name}Handle, this._client, '{cbTypeId}');");
+        }
+        else if (_wrapperClassNames.TryGetValue(cbTypeId, out var wrapperClassName))
+        {
+            var handleType = GetHandleTypeName(cbTypeId);
+            WriteLine($"            const {callbackParameter.Name}Handle = wrapIfHandle({callbackArgName}) as {handleType};");
+            WriteLine($"            const {callbackParameter.Name} = new {GetImplementationClassName(wrapperClassName)}({callbackParameter.Name}Handle, this._client);");
+        }
+        else
+        {
+            WriteLine($"            const {callbackParameter.Name} = wrapIfHandle({callbackArgName}) as {tsType};");
         }
     }
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -142,6 +142,9 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
     private string GetPublicPromiseInterfaceName(string typeId) => GetPromiseInterfaceName(GetConcreteClassName(typeId));
 
+    private static bool IsHandleType(AtsTypeRef? typeRef) =>
+        typeRef is { Category: AtsTypeCategory.Handle };
+
     /// <summary>
     /// Maps an AtsTypeRef to a TypeScript type using category-based dispatch.
     /// This is the preferred method - uses type metadata rather than string parsing.

--- a/src/Aspire.Hosting.Docker/CapturedEnvironmentVariable.cs
+++ b/src/Aspire.Hosting.Docker/CapturedEnvironmentVariable.cs
@@ -9,11 +9,13 @@ namespace Aspire.Hosting.Docker;
 /// Represents a captured environment variable that will be written to the .env file 
 /// adjacent to the Docker Compose file.
 /// </summary>
+[AspireExport(ExposeProperties = true)]
 public sealed class CapturedEnvironmentVariable
 {
     /// <summary>
     /// Gets the name of the environment variable.
     /// </summary>
+    [AspireExportIgnore(Reason = "The dictionary key already identifies the captured environment variable in polyglot callbacks.")]
     public required string Name { get; init; }
 
     /// <summary>
@@ -31,6 +33,7 @@ public sealed class CapturedEnvironmentVariable
     /// This could be a <see cref="ParameterResource"/>,
     /// <see cref="ContainerMountAnnotation"/>, or other source types.
     /// </summary>
+    [AspireExportIgnore(Reason = "Source projection is out of scope for the Docker Compose env file callback polyglot surface.")]
     public object? Source { get; set; }
 
     /// <summary>
@@ -38,5 +41,6 @@ public sealed class CapturedEnvironmentVariable
     /// This is useful when the source is an annotation on a resource, allowing you to 
     /// identify which resource this environment variable is related to.
     /// </summary>
+    [AspireExportIgnore(Reason = "Resource projection is out of scope for the Docker Compose env file callback polyglot surface.")]
     public IResource? Resource { get; set; }
 }

--- a/src/Aspire.Hosting.Docker/CapturedEnvironmentVariable.cs
+++ b/src/Aspire.Hosting.Docker/CapturedEnvironmentVariable.cs
@@ -33,7 +33,7 @@ public sealed class CapturedEnvironmentVariable
     /// This could be a <see cref="ParameterResource"/>,
     /// <see cref="ContainerMountAnnotation"/>, or other source types.
     /// </summary>
-    [AspireExportIgnore(Reason = "Source projection is out of scope for the Docker Compose env file callback polyglot surface.")]
+    [AspireExportIgnore(Reason = "Source can be arbitrary provenance data (ParameterResource, ContainerMountAnnotation, etc.); exporting it here would require projecting a much broader heterogeneous source surface that configureEnvFile does not need.")]
     public object? Source { get; set; }
 
     /// <summary>
@@ -41,6 +41,6 @@ public sealed class CapturedEnvironmentVariable
     /// This is useful when the source is an annotation on a resource, allowing you to 
     /// identify which resource this environment variable is related to.
     /// </summary>
-    [AspireExportIgnore(Reason = "Resource projection is out of scope for the Docker Compose env file callback polyglot surface.")]
+    [AspireExportIgnore(Reason = "Resource is provenance metadata only; exporting it here would pull the broader IResource surface into the callback even though polyglot configureEnvFile only needs to mutate Description and DefaultValue.")]
     public IResource? Resource { get; set; }
 }

--- a/src/Aspire.Hosting.Docker/CapturedEnvironmentVariable.cs
+++ b/src/Aspire.Hosting.Docker/CapturedEnvironmentVariable.cs
@@ -31,9 +31,10 @@ public sealed class CapturedEnvironmentVariable
     /// <summary>
     /// Gets or sets the source object that originated this environment variable.
     /// This could be a <see cref="ParameterResource"/>,
-    /// <see cref="ContainerMountAnnotation"/>, or other source types.
+    /// <see cref="ContainerMountAnnotation"/>, <see cref="ContainerImageReference"/>,
+    /// or <see cref="ContainerPortReference"/>.
     /// </summary>
-    [AspireExportIgnore(Reason = "Source can be arbitrary provenance data (ParameterResource, ContainerMountAnnotation, etc.); exporting it here would require projecting a much broader heterogeneous source surface that configureEnvFile does not need.")]
+    [AspireUnion(typeof(ParameterResource), typeof(ContainerMountAnnotation), typeof(ContainerImageReference), typeof(ContainerPortReference))]
     public object? Source { get; set; }
 
     /// <summary>

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -97,13 +97,12 @@ public static class DockerComposeEnvironmentExtensions
     /// <param name="configure">A method that can be used for customizing the captured environment variables.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
-    /// This method is not available in polyglot app hosts.
     /// <para>
     /// This callback is invoked during the prepare phase, allowing programmatic modification of the environment variables
-    /// that will be written to the .env file adjacent to the Docker Compose file.
+    /// that will be written to the environment-specific <c>.env</c> file adjacent to the Docker Compose file.
     /// </para>
     /// </remarks>
-    [AspireExportIgnore(Reason = "Action<IDictionary<string, CapturedEnvironmentVariable>> callbacks are not ATS-compatible.")]
+    [AspireExport("configureEnvFile", Description = "Configures the captured environment variables written to the Docker Compose .env file")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> ConfigureEnvFile(this IResourceBuilder<DockerComposeEnvironmentResource> builder, Action<IDictionary<string, CapturedEnvironmentVariable>> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -102,7 +102,7 @@ public static class DockerComposeEnvironmentExtensions
     /// that will be written to the environment-specific <c>.env</c> file adjacent to the Docker Compose file.
     /// </para>
     /// </remarks>
-    [AspireExport("configureEnvFile", Description = "Configures the captured environment variables written to the Docker Compose .env file")]
+    [AspireExport(Description = "Configures the captured environment variables written to the Docker Compose .env file")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> ConfigureEnvFile(this IResourceBuilder<DockerComposeEnvironmentResource> builder, Action<IDictionary<string, CapturedEnvironmentVariable>> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -1306,9 +1306,19 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol? aspireExportAttribute,
         HashSet<ITypeSymbol>? currentAssemblyExportedTypes)
     {
-        if (type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
+        if (type is not INamedTypeSymbol namedType)
         {
             return false;
+        }
+
+        if (!namedType.IsGenericType)
+        {
+            return namedType is
+            {
+                ContainingNamespace.Name: "Collections",
+                ContainingNamespace.ContainingNamespace.Name: "System",
+                Name: "IDictionary" or "IList"
+            };
         }
 
         // Dictionary<K,V> and IDictionary<K,V>

--- a/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Xml.Linq;
@@ -1807,6 +1808,16 @@ public static class AtsCapabilityScanner
             return AtsConstants.Any;
         }
 
+        if (type == typeof(IDictionary))
+        {
+            return AtsConstants.DictTypeId(AtsConstants.String, AtsConstants.Any);
+        }
+
+        if (type == typeof(IList))
+        {
+            return AtsConstants.ListTypeId(AtsConstants.Any);
+        }
+
         // Handle enum types
         if (type.IsEnum)
         {
@@ -2072,6 +2083,30 @@ public static class AtsCapabilityScanner
         if (type == typeof(object))
         {
             return new AtsTypeRef { TypeId = AtsConstants.Any, ClrType = type, Category = AtsTypeCategory.Primitive };
+        }
+
+        if (type == typeof(IDictionary))
+        {
+            return new AtsTypeRef
+            {
+                TypeId = AtsConstants.DictTypeId(AtsConstants.String, AtsConstants.Any),
+                ClrType = type,
+                Category = AtsTypeCategory.Dict,
+                KeyType = new AtsTypeRef { TypeId = AtsConstants.String, ClrType = typeof(string), Category = AtsTypeCategory.Primitive },
+                ValueType = new AtsTypeRef { TypeId = AtsConstants.Any, ClrType = typeof(object), Category = AtsTypeCategory.Primitive },
+                IsReadOnly = false
+            };
+        }
+
+        if (type == typeof(IList))
+        {
+            return new AtsTypeRef
+            {
+                TypeId = AtsConstants.ListTypeId(AtsConstants.Any),
+                ClrType = type,
+                Category = AtsTypeCategory.List,
+                ElementType = new AtsTypeRef { TypeId = AtsConstants.Any, ClrType = typeof(object), Category = AtsTypeCategory.Primitive }
+            };
         }
 
         // Handle enum types

--- a/src/Aspire.Hosting/ApplicationModel/ContainerImageReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerImageReference.cs
@@ -32,6 +32,7 @@ public class ContainerImageReference : IManifestExpressionProvider, IValueWithRe
     public string ValueExpression => $"{{{Resource.Name}.containerImage}}";
 
     /// <inheritdoc/>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Reference enumeration is not needed in the ATS surface for container image provenance.")]
     public IEnumerable<object> References => [Resource];
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting/ApplicationModel/ContainerPortReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerPortReference.cs
@@ -20,6 +20,7 @@ public class ContainerPortReference(IResource resource) : IManifestExpressionPro
     public string ValueExpression => $"{{{Resource.Name}.containerPort}}";
 
     /// <inheritdoc/>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Reference enumeration is not needed in the ATS surface for container port provenance.")]
     public IEnumerable<object> References => [Resource];
 
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Ats/AtsTypeMappings.cs
+++ b/src/Aspire.Hosting/Ats/AtsTypeMappings.cs
@@ -44,6 +44,9 @@ using Microsoft.Extensions.Logging;
 [assembly: AspireExport(typeof(ExecutableResource))]
 [assembly: AspireExport(typeof(ProjectResource))]
 [assembly: AspireExport(typeof(ParameterResource))]
+[assembly: AspireExport(typeof(ContainerMountAnnotation), ExposeProperties = true)]
+[assembly: AspireExport(typeof(ContainerImageReference), ExposeProperties = true)]
+[assembly: AspireExport(typeof(ContainerPortReference), ExposeProperties = true)]
 
 // Service types
 [assembly: AspireExport(typeof(IServiceProvider))]

--- a/src/Aspire.Hosting/Ats/CollectionExports.cs
+++ b/src/Aspire.Hosting/Ats/CollectionExports.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+
 namespace Aspire.Hosting.Ats;
 
 /// <summary>
@@ -31,8 +33,8 @@ internal static class CollectionExports
     /// <param name="key">The key to look up.</param>
     /// <returns>The value, or null if not found.</returns>
     [AspireExport("Dict.get", Description = "Gets a value from a dictionary")]
-    public static object? DictGet(this IDictionary<string, object> dict, string key)
-        => dict.TryGetValue(key, out var value) ? value : null;
+    public static object? DictGet(this IDictionary dict, string key)
+        => dict.Contains(key) ? dict[key] : null;
 
     /// <summary>
     /// Sets a value in a dictionary.
@@ -41,7 +43,7 @@ internal static class CollectionExports
     /// <param name="key">The key to set.</param>
     /// <param name="value">The value to set.</param>
     [AspireExport("Dict.set", Description = "Sets a value in a dictionary")]
-    public static void DictSet(this IDictionary<string, object> dict, string key, object value)
+    public static void DictSet(this IDictionary dict, string key, object value)
         => dict[key] = value;
 
     /// <summary>
@@ -51,8 +53,16 @@ internal static class CollectionExports
     /// <param name="key">The key to remove.</param>
     /// <returns>True if the key was removed, false if not found.</returns>
     [AspireExport("Dict.remove", Description = "Removes a key from a dictionary")]
-    public static bool DictRemove(this IDictionary<string, object> dict, string key)
-        => dict.Remove(key);
+    public static bool DictRemove(this IDictionary dict, string key)
+    {
+        if (!dict.Contains(key))
+        {
+            return false;
+        }
+
+        dict.Remove(key);
+        return true;
+    }
 
     /// <summary>
     /// Gets all keys from a dictionary.
@@ -60,8 +70,8 @@ internal static class CollectionExports
     /// <param name="dict">The dictionary handle.</param>
     /// <returns>An array of all keys.</returns>
     [AspireExport("Dict.keys", Description = "Gets all keys from a dictionary")]
-    public static string[] DictKeys(this IDictionary<string, object> dict)
-        => [.. dict.Keys];
+    public static string[] DictKeys(this IDictionary dict)
+        => [.. dict.Keys.Cast<string>()];
 
     /// <summary>
     /// Checks if a dictionary contains a key.
@@ -70,8 +80,8 @@ internal static class CollectionExports
     /// <param name="key">The key to check.</param>
     /// <returns>True if the key exists.</returns>
     [AspireExport("Dict.has", Description = "Checks if a dictionary contains a key")]
-    public static bool DictHas(this IDictionary<string, object> dict, string key)
-        => dict.ContainsKey(key);
+    public static bool DictHas(this IDictionary dict, string key)
+        => dict.Contains(key);
 
     /// <summary>
     /// Gets the number of entries in a dictionary.
@@ -79,7 +89,7 @@ internal static class CollectionExports
     /// <param name="dict">The dictionary handle.</param>
     /// <returns>The number of key-value pairs.</returns>
     [AspireExport("Dict.count", Description = "Gets the number of entries in a dictionary")]
-    public static int DictCount(this IDictionary<string, object> dict)
+    public static int DictCount(this IDictionary dict)
         => dict.Count;
 
     /// <summary>
@@ -87,7 +97,7 @@ internal static class CollectionExports
     /// </summary>
     /// <param name="dict">The dictionary handle.</param>
     [AspireExport("Dict.clear", Description = "Clears all entries from a dictionary")]
-    public static void DictClear(this IDictionary<string, object> dict)
+    public static void DictClear(this IDictionary dict)
         => dict.Clear();
 
     /// <summary>
@@ -96,8 +106,8 @@ internal static class CollectionExports
     /// <param name="dict">The dictionary handle.</param>
     /// <returns>An array of all values.</returns>
     [AspireExport("Dict.values", Description = "Gets all values from a dictionary")]
-    public static object[] DictValues(this IDictionary<string, object> dict)
-        => [.. dict.Values];
+    public static object?[] DictValues(this IDictionary dict)
+        => [.. dict.Values.Cast<object?>()];
 
     /// <summary>
     /// Converts the dictionary to a plain object (creates a copy).
@@ -105,8 +115,8 @@ internal static class CollectionExports
     /// <param name="dict">The dictionary handle.</param>
     /// <returns>A copy of the dictionary as an object.</returns>
     [AspireExport("Dict.toObject", Description = "Converts a dictionary to a plain object")]
-    public static Dictionary<string, object> DictToObject(this IDictionary<string, object> dict)
-        => new(dict);
+    public static Dictionary<string, object?> DictToObject(this IDictionary dict)
+        => dict.Cast<DictionaryEntry>().ToDictionary(entry => (string)entry.Key, entry => entry.Value);
 
     #endregion
 
@@ -119,7 +129,7 @@ internal static class CollectionExports
     /// <param name="index">The zero-based index.</param>
     /// <returns>The item at the specified index.</returns>
     [AspireExport("List.get", Description = "Gets an item from a list by index")]
-    public static object? ListGet(this IList<object> list, int index)
+    public static object? ListGet(this IList list, int index)
         => index >= 0 && index < list.Count ? list[index] : null;
 
     /// <summary>
@@ -129,7 +139,7 @@ internal static class CollectionExports
     /// <param name="index">The zero-based index.</param>
     /// <param name="value">The value to set.</param>
     [AspireExport("List.set", Description = "Sets an item in a list at a specific index")]
-    public static void ListSet(this IList<object> list, int index, object value)
+    public static void ListSet(this IList list, int index, object value)
     {
         if (index >= 0 && index < list.Count)
         {
@@ -143,7 +153,7 @@ internal static class CollectionExports
     /// <param name="list">The list handle.</param>
     /// <param name="item">The item to add.</param>
     [AspireExport("List.add", Description = "Adds an item to the end of a list")]
-    public static void ListAdd(this IList<object> list, object item)
+    public static void ListAdd(this IList list, object item)
         => list.Add(item);
 
     /// <summary>
@@ -153,7 +163,7 @@ internal static class CollectionExports
     /// <param name="index">The zero-based index of the item to remove.</param>
     /// <returns>True if the item was removed.</returns>
     [AspireExport("List.removeAt", Description = "Removes an item at a specific index from a list")]
-    public static bool ListRemoveAt(this IList<object> list, int index)
+    public static bool ListRemoveAt(this IList list, int index)
     {
         if (index >= 0 && index < list.Count)
         {
@@ -169,7 +179,7 @@ internal static class CollectionExports
     /// <param name="list">The list handle.</param>
     /// <returns>The number of items.</returns>
     [AspireExport("List.length", Description = "Gets the number of items in a list")]
-    public static int ListLength(this IList<object> list)
+    public static int ListLength(this IList list)
         => list.Count;
 
     /// <summary>
@@ -177,7 +187,7 @@ internal static class CollectionExports
     /// </summary>
     /// <param name="list">The list handle.</param>
     [AspireExport("List.clear", Description = "Clears all items from a list")]
-    public static void ListClear(this IList<object> list)
+    public static void ListClear(this IList list)
         => list.Clear();
 
     /// <summary>
@@ -187,7 +197,7 @@ internal static class CollectionExports
     /// <param name="index">The zero-based index at which to insert.</param>
     /// <param name="item">The item to insert.</param>
     [AspireExport("List.insert", Description = "Inserts an item at a specific index in a list")]
-    public static void ListInsert(this IList<object> list, int index, object item)
+    public static void ListInsert(this IList list, int index, object item)
     {
         if (index >= 0 && index <= list.Count)
         {
@@ -202,7 +212,7 @@ internal static class CollectionExports
     /// <param name="item">The item to find.</param>
     /// <returns>The zero-based index, or -1 if not found.</returns>
     [AspireExport("List.indexOf", Description = "Gets the index of an item in a list")]
-    public static int ListIndexOf(this IList<object> list, object item)
+    public static int ListIndexOf(this IList list, object item)
         => list.IndexOf(item);
 
     /// <summary>
@@ -211,8 +221,8 @@ internal static class CollectionExports
     /// <param name="list">The list handle.</param>
     /// <returns>An array containing all items.</returns>
     [AspireExport("List.toArray", Description = "Converts a list to an array")]
-    public static object[] ListToArray(this IList<object> list)
-        => [.. list];
+    public static object?[] ListToArray(this IList list)
+        => [.. list.Cast<object?>()];
 
     #endregion
 }

--- a/src/Aspire.Hosting/Ats/CollectionExports.cs
+++ b/src/Aspire.Hosting/Ats/CollectionExports.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Globalization;
 
 namespace Aspire.Hosting.Ats;
 
@@ -33,8 +34,11 @@ internal static class CollectionExports
     /// <param name="key">The key to look up.</param>
     /// <returns>The value, or null if not found.</returns>
     [AspireExport("Dict.get", Description = "Gets a value from a dictionary")]
-    public static object? DictGet(this IDictionary dict, string key)
-        => dict.Contains(key) ? dict[key] : null;
+    public static object? DictGet(this IDictionary dict, object key)
+    {
+        var normalizedKey = NormalizeDictionaryKey(dict, key);
+        return dict.Contains(normalizedKey) ? dict[normalizedKey] : null;
+    }
 
     /// <summary>
     /// Sets a value in a dictionary.
@@ -43,8 +47,8 @@ internal static class CollectionExports
     /// <param name="key">The key to set.</param>
     /// <param name="value">The value to set.</param>
     [AspireExport("Dict.set", Description = "Sets a value in a dictionary")]
-    public static void DictSet(this IDictionary dict, string key, object value)
-        => dict[key] = value;
+    public static void DictSet(this IDictionary dict, object key, object value)
+        => dict[NormalizeDictionaryKey(dict, key)] = value;
 
     /// <summary>
     /// Removes a key from a dictionary.
@@ -53,14 +57,15 @@ internal static class CollectionExports
     /// <param name="key">The key to remove.</param>
     /// <returns>True if the key was removed, false if not found.</returns>
     [AspireExport("Dict.remove", Description = "Removes a key from a dictionary")]
-    public static bool DictRemove(this IDictionary dict, string key)
+    public static bool DictRemove(this IDictionary dict, object key)
     {
-        if (!dict.Contains(key))
+        var normalizedKey = NormalizeDictionaryKey(dict, key);
+        if (!dict.Contains(normalizedKey))
         {
             return false;
         }
 
-        dict.Remove(key);
+        dict.Remove(normalizedKey);
         return true;
     }
 
@@ -70,8 +75,8 @@ internal static class CollectionExports
     /// <param name="dict">The dictionary handle.</param>
     /// <returns>An array of all keys.</returns>
     [AspireExport("Dict.keys", Description = "Gets all keys from a dictionary")]
-    public static string[] DictKeys(this IDictionary dict)
-        => [.. dict.Keys.Cast<string>()];
+    public static object?[] DictKeys(this IDictionary dict)
+        => [.. dict.Keys.Cast<object?>()];
 
     /// <summary>
     /// Checks if a dictionary contains a key.
@@ -80,8 +85,8 @@ internal static class CollectionExports
     /// <param name="key">The key to check.</param>
     /// <returns>True if the key exists.</returns>
     [AspireExport("Dict.has", Description = "Checks if a dictionary contains a key")]
-    public static bool DictHas(this IDictionary dict, string key)
-        => dict.Contains(key);
+    public static bool DictHas(this IDictionary dict, object key)
+        => dict.Contains(NormalizeDictionaryKey(dict, key));
 
     /// <summary>
     /// Gets the number of entries in a dictionary.
@@ -116,7 +121,83 @@ internal static class CollectionExports
     /// <returns>A copy of the dictionary as an object.</returns>
     [AspireExport("Dict.toObject", Description = "Converts a dictionary to a plain object")]
     public static Dictionary<string, object?> DictToObject(this IDictionary dict)
-        => dict.Cast<DictionaryEntry>().ToDictionary(entry => (string)entry.Key, entry => entry.Value);
+    {
+        var result = new Dictionary<string, object?>(dict.Count);
+        foreach (var key in dict.Keys)
+        {
+            result[GetStringKey(key)] = dict[key];
+        }
+
+        return result;
+    }
+
+    private static object NormalizeDictionaryKey(IDictionary dict, object key)
+    {
+        var keyType = GetDictionaryKeyType(dict.GetType());
+        if (keyType is null)
+        {
+            return key;
+        }
+
+        var normalizedKeyType = Nullable.GetUnderlyingType(keyType) ?? keyType;
+        if (normalizedKeyType.IsInstanceOfType(key))
+        {
+            return key;
+        }
+
+        if (normalizedKeyType == typeof(string))
+        {
+            return key.ToString()!;
+        }
+
+        try
+        {
+            if (normalizedKeyType.IsEnum)
+            {
+                return key switch
+                {
+                    string enumName => Enum.Parse(normalizedKeyType, enumName, ignoreCase: true),
+                    IConvertible convertible => Enum.ToObject(normalizedKeyType, Convert.ChangeType(convertible, Enum.GetUnderlyingType(normalizedKeyType), CultureInfo.InvariantCulture)!),
+                    _ => key
+                };
+            }
+
+            if (normalizedKeyType == typeof(Guid) && key is string guidText && Guid.TryParse(guidText, out var guid))
+            {
+                return guid;
+            }
+
+            if (key is IConvertible)
+            {
+                return Convert.ChangeType(key, normalizedKeyType, CultureInfo.InvariantCulture)!;
+            }
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException or ArgumentException)
+        {
+        }
+
+        return key;
+    }
+
+    private static Type? GetDictionaryKeyType(Type type)
+    {
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+        {
+            return type.GetGenericArguments()[0];
+        }
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+        {
+            return type.GetGenericArguments()[0];
+        }
+
+        return type.GetInterfaces()
+            .FirstOrDefault(static iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+            ?.GetGenericArguments()[0];
+    }
+
+    private static string GetStringKey(object? key)
+        => key as string ?? throw new InvalidOperationException($"Aspire.Hosting/Dict.toObject only supports string-key dictionaries, but found key type '{key?.GetType().FullName ?? "null"}'.");
 
     #endregion
 

--- a/src/Aspire.Hosting/Ats/CollectionExports.cs
+++ b/src/Aspire.Hosting/Ats/CollectionExports.cs
@@ -174,6 +174,8 @@ internal static class CollectionExports
         }
         catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException or ArgumentException)
         {
+            // Fall back to the original key when best-effort conversion fails so callers see
+            // the same "missing key" behavior as an unconvertible lookup against the underlying dictionary.
         }
 
         return key;

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
@@ -99,4 +99,90 @@ public sealed class TypeScriptPublishTests(ITestOutputHelper output)
 
         await pendingRun;
     }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task PublishWithConfigureEnvFileUpdatesEnvOutput()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+
+        if (installMode == CliE2ETestHelpers.DockerInstallMode.GaRelease)
+        {
+            Assert.Skip("This test exercises unreleased TypeScript AppHost SDK surface. Build a local Aspire CLI bundle or run in CI so the test uses current PR bits instead of the GA CLI.");
+        }
+
+        using var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, variant: CliE2ETestHelpers.DockerfileVariant.Polyglot, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        await auto.EnablePolyglotSupportAsync(counter);
+
+        await auto.TypeAsync("aspire init --language typescript --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.Docker");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("The package Aspire.Hosting.", timeout: TimeSpan.FromMinutes(2));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire restore");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts");
+        var newContent = """
+            import { createBuilder } from './.modules/aspire.js';
+
+            const builder = await createBuilder();
+
+            const compose = await builder.addDockerComposeEnvironment("compose");
+            await compose.withDashboard(false);
+
+            const container = await builder.addContainer("my-container", "nginx:alpine");
+            await container.withBindMount("/host/path/data", "/container/data");
+
+            await compose.configureEnvFile(async (envVars) => {
+                const bindMount = await envVars.get("MY_CONTAINER_BINDMOUNT_0");
+                await bindMount.description.set("Customized bind mount source");
+                await bindMount.defaultValue.set("./data");
+            });
+
+            await builder.build().run();
+            """;
+
+        File.WriteAllText(appHostPath, newContent);
+
+        await auto.TypeAsync("unset ASPIRE_PLAYGROUND");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire publish -o artifacts --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, timeout: TimeSpan.FromMinutes(5));
+
+        var envFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "artifacts", ".env");
+        Assert.True(File.Exists(envFilePath), $"Expected env file at {envFilePath}");
+
+        var envFileContent = await File.ReadAllTextAsync(envFilePath);
+        Assert.Contains("# Customized bind mount source", envFileContent);
+        Assert.DoesNotContain("# Bind mount source for my-container:/container/data", envFileContent);
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
 }

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -805,10 +805,10 @@ public class AspireExportAnalyzerTests
 
             public static class TestExports
             {
-                [AspireExport("dictMethod")]
+                [AspireExport]
                 public static object? DictMethod(this IDictionary dict, string key) => dict[key];
 
-                [AspireExport("listMethod")]
+                [AspireExport]
                 public static object? ListMethod(this IList list, int index) => list[index];
             }
             """, []);

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -795,6 +795,28 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
+    public async Task NonGenericCollectionTypes_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System.Collections;
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                [AspireExport("dictMethod")]
+                public static object? DictMethod(this IDictionary dict, string key) => dict[key];
+
+                [AspireExport("listMethod")]
+                public static object? ListMethod(this IList list, int index) => list[index];
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task InvalidCollectionElementType_ReportsASPIREEXPORT004()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_parameterTypeMustBeAtsCompatible;

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -2894,6 +2894,42 @@ func (s *ConnectionStringResource) WithMergeRouteMiddleware(path string, method 
 	return result.(*IResource), nil
 }
 
+// ContainerImageReference wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference.
+type ContainerImageReference struct {
+	HandleWrapperBase
+}
+
+// NewContainerImageReference creates a new ContainerImageReference.
+func NewContainerImageReference(handle *Handle, client *AspireClient) *ContainerImageReference {
+	return &ContainerImageReference{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// ContainerMountAnnotation wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation.
+type ContainerMountAnnotation struct {
+	HandleWrapperBase
+}
+
+// NewContainerMountAnnotation creates a new ContainerMountAnnotation.
+func NewContainerMountAnnotation(handle *Handle, client *AspireClient) *ContainerMountAnnotation {
+	return &ContainerMountAnnotation{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// ContainerPortReference wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference.
+type ContainerPortReference struct {
+	HandleWrapperBase
+}
+
+// NewContainerPortReference creates a new ContainerPortReference.
+func NewContainerPortReference(handle *Handle, client *AspireClient) *ContainerPortReference {
+	return &ContainerPortReference{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
 // ContainerRegistryResource wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerRegistryResource.
 type ContainerRegistryResource struct {
 	ResourceBuilderBase
@@ -19297,6 +19333,15 @@ func init() {
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource", func(h *Handle, c *AspireClient) any {
 		return NewParameterResource(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation", func(h *Handle, c *AspireClient) any {
+		return NewContainerMountAnnotation(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference", func(h *Handle, c *AspireClient) any {
+		return NewContainerImageReference(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference", func(h *Handle, c *AspireClient) any {
+		return NewContainerPortReference(h, c)
 	})
 	RegisterHandleWrapper("System.ComponentModel/System.IServiceProvider", func(h *Handle, c *AspireClient) any {
 		return NewIServiceProvider(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
@@ -1,4 +1,4 @@
-// ===== Aspire.java =====
+﻿// ===== Aspire.java =====
 // Aspire.java - GENERATED CODE - DO NOT EDIT
 
 package aspire;
@@ -840,14 +840,14 @@ public class AspireDict<K, V> extends HandleWrapperBase {
     public V get(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         return (V) getClient().invokeCapability("Aspire.Hosting/Dict.get", args);
     }
 
     public void put(K key, V value) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         args.put("value", AspireClient.serializeValue(value));
         getClient().invokeCapability("Aspire.Hosting/Dict.set", args);
     }
@@ -855,7 +855,7 @@ public class AspireDict<K, V> extends HandleWrapperBase {
     public boolean remove(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         Object result = getClient().invokeCapability("Aspire.Hosting/Dict.remove", args);
         return Boolean.TRUE.equals(result);
     }
@@ -863,7 +863,7 @@ public class AspireDict<K, V> extends HandleWrapperBase {
     public boolean containsKey(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         Object result = getClient().invokeCapability("Aspire.Hosting/Dict.has", args);
         return Boolean.TRUE.equals(result);
     }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
@@ -830,6 +830,49 @@ public class AspireDict<K, V> extends HandleWrapperBase {
         }
         return resolvedHandle;
     }
+
+    public int size() {
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.count", Map.of("dict", ensureHandle().toJson()));
+        return ((Number) result).intValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    public V get(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        return (V) getClient().invokeCapability("Aspire.Hosting/Dict.get", args);
+    }
+
+    public void put(K key, V value) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        args.put("value", AspireClient.serializeValue(value));
+        getClient().invokeCapability("Aspire.Hosting/Dict.set", args);
+    }
+
+    public boolean remove(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.remove", args);
+        return Boolean.TRUE.equals(result);
+    }
+
+    public boolean containsKey(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.has", args);
+        return Boolean.TRUE.equals(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<K> keys() {
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.keys", Map.of("dict", ensureHandle().toJson()));
+        return (List<K>) result;
+    }
 }
 
 // ===== AspireFunc0.java =====

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
@@ -1,4 +1,4 @@
-﻿// ===== Aspire.java =====
+// ===== Aspire.java =====
 // Aspire.java - GENERATED CODE - DO NOT EDIT
 
 package aspire;

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1170,6 +1170,9 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource", (h, c) -> new ExecutableResource(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ProjectResource", (h, c) -> new ProjectResource(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource", (h, c) -> new ParameterResource(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation", (h, c) -> new ContainerMountAnnotation(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference", (h, c) -> new ContainerImageReference(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference", (h, c) -> new ContainerPortReference(h, c));
         AspireClient.registerHandleWrapper("System.ComponentModel/System.IServiceProvider", (h, c) -> new IServiceProvider(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceNotificationService", (h, c) -> new ResourceNotificationService(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceLoggerService", (h, c) -> new ResourceLoggerService(h, c));
@@ -4032,6 +4035,22 @@ public class ConnectionStringResource extends ResourceBuilderBase {
 
 }
 
+// ===== ContainerImageReference.java =====
+// ContainerImageReference.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference. */
+public class ContainerImageReference extends HandleWrapperBase {
+    ContainerImageReference(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+}
+
 // ===== ContainerLifetime.java =====
 // ContainerLifetime.java - GENERATED CODE - DO NOT EDIT
 
@@ -4059,6 +4078,38 @@ public enum ContainerLifetime implements WireValueEnum {
         }
         throw new IllegalArgumentException("Unknown value: " + value);
     }
+}
+
+// ===== ContainerMountAnnotation.java =====
+// ContainerMountAnnotation.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation. */
+public class ContainerMountAnnotation extends HandleWrapperBase {
+    ContainerMountAnnotation(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+}
+
+// ===== ContainerPortReference.java =====
+// ContainerPortReference.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference. */
+public class ContainerPortReference extends HandleWrapperBase {
+    ContainerPortReference(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
 }
 
 // ===== ContainerRegistryResource.java =====
@@ -21735,7 +21786,10 @@ public final class WithVolumeOptions {
 .modules/CompleteTaskOptions.java
 .modules/ConnectionStringAvailableEvent.java
 .modules/ConnectionStringResource.java
+.modules/ContainerImageReference.java
 .modules/ContainerLifetime.java
+.modules/ContainerMountAnnotation.java
+.modules/ContainerPortReference.java
 .modules/ContainerRegistryResource.java
 .modules/ContainerResource.java
 .modules/CreateBuilderOptions.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1004,14 +1004,14 @@ public class AspireDict<K, V> extends HandleWrapperBase {
     public V get(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         return (V) getClient().invokeCapability("Aspire.Hosting/Dict.get", args);
     }
 
     public void put(K key, V value) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         args.put("value", AspireClient.serializeValue(value));
         getClient().invokeCapability("Aspire.Hosting/Dict.set", args);
     }
@@ -1019,7 +1019,7 @@ public class AspireDict<K, V> extends HandleWrapperBase {
     public boolean remove(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         Object result = getClient().invokeCapability("Aspire.Hosting/Dict.remove", args);
         return Boolean.TRUE.equals(result);
     }
@@ -1027,7 +1027,7 @@ public class AspireDict<K, V> extends HandleWrapperBase {
     public boolean containsKey(K key) {
         Map<String, Object> args = new HashMap<>();
         args.put("dict", ensureHandle().toJson());
-        args.put("key", key);
+        args.put("key", AspireClient.serializeValue(key));
         Object result = getClient().invokeCapability("Aspire.Hosting/Dict.has", args);
         return Boolean.TRUE.equals(result);
     }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -994,6 +994,49 @@ public class AspireDict<K, V> extends HandleWrapperBase {
         }
         return resolvedHandle;
     }
+
+    public int size() {
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.count", Map.of("dict", ensureHandle().toJson()));
+        return ((Number) result).intValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    public V get(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        return (V) getClient().invokeCapability("Aspire.Hosting/Dict.get", args);
+    }
+
+    public void put(K key, V value) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        args.put("value", AspireClient.serializeValue(value));
+        getClient().invokeCapability("Aspire.Hosting/Dict.set", args);
+    }
+
+    public boolean remove(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.remove", args);
+        return Boolean.TRUE.equals(result);
+    }
+
+    public boolean containsKey(K key) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("dict", ensureHandle().toJson());
+        args.put("key", key);
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.has", args);
+        return Boolean.TRUE.equals(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<K> keys() {
+        Object result = getClient().invokeCapability("Aspire.Hosting/Dict.keys", Map.of("dict", ensureHandle().toJson()));
+        return (List<K>) result;
+    }
 }
 
 // ===== AspireFunc0.java =====

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -2825,6 +2825,84 @@ impl ConnectionStringResource {
     }
 }
 
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference
+pub struct ContainerImageReference {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerImageReference {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerImageReference {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerMountAnnotation
+pub struct ContainerMountAnnotation {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerMountAnnotation {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerMountAnnotation {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference
+pub struct ContainerPortReference {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerPortReference {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerPortReference {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
 /// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerRegistryResource
 pub struct ContainerRegistryResource {
     handle: Handle,

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -109,6 +109,9 @@ type IComputeResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationM
 /** Handle to IContainerFilesDestinationResource */
 type IContainerFilesDestinationResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource'>;
 
+/** Handle to IExpressionValue */
+type IExpressionValueHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExpressionValue'>;
+
 /** Handle to InitializeResourceEvent */
 type InitializeResourceEventHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent'>;
 
@@ -220,12 +223,6 @@ type PipelineSummaryHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Pipelines.Pip
 /** Handle to ProjectResourceOptions */
 type ProjectResourceOptionsHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions'>;
 
-/** Handle to Dict<string,any> */
-type DictstringanyHandle = Handle<'Aspire.Hosting/Dict<string,any>'>;
-
-/** Handle to List<any> */
-type ListanyHandle = Handle<'Aspire.Hosting/List<any>'>;
-
 /** Handle to IConfiguration */
 type IConfigurationHandle = Handle<'Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfiguration'>;
 
@@ -240,9 +237,6 @@ type ILoggerHandle = Handle<'Microsoft.Extensions.Logging.Abstractions/Microsoft
 
 /** Handle to ILoggerFactory */
 type ILoggerFactoryHandle = Handle<'Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory'>;
-
-/** Handle to string[] */
-type stringArrayHandle = Handle<'string[]'>;
 
 /** Handle to IServiceProvider */
 type IServiceProviderHandle = Handle<'System.ComponentModel/System.IServiceProvider'>;

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Reflection;
 using System.Reflection.Emit;
 using Aspire.Hosting.ApplicationModel;
@@ -127,6 +128,22 @@ public class AtsCapabilityScannerTests
 
         // System.Object maps to 'any'
         Assert.Equal("any", result);
+    }
+
+    [Fact]
+    public void MapToAtsTypeId_NonGenericIDictionary_ReturnsStringAnyDict()
+    {
+        var result = AtsCapabilityScanner.MapToAtsTypeId(typeof(IDictionary));
+
+        Assert.Equal("Aspire.Hosting/Dict<string,any>", result);
+    }
+
+    [Fact]
+    public void MapToAtsTypeId_NonGenericIList_ReturnsAnyList()
+    {
+        var result = AtsCapabilityScanner.MapToAtsTypeId(typeof(IList));
+
+        Assert.Equal("Aspire.Hosting/List<any>", result);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -940,6 +940,28 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
+    public void Invoke_ListGet_ReturnsItemFromTypedList()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestTypeCategoryCapabilities).Assembly, typeof(AspireExportAttribute).Assembly]);
+
+        var listResult = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/returnTypedMutableList", null);
+        var listHandle = (listResult as JsonObject)?["$handle"]?.GetValue<string>();
+        Assert.NotNull(listHandle);
+
+        var args = new JsonObject
+        {
+            ["list"] = new JsonObject { ["$handle"] = listHandle },
+            ["index"] = 1
+        };
+
+        var result = dispatcher.Invoke("Aspire.Hosting/List.get", args);
+
+        Assert.NotNull(result);
+        Assert.Equal(20, result.GetValue<int>());
+    }
+
+    [Fact]
     public void Invoke_ListRemoveAt_RemovesItem()
     {
         var handles = new HandleRegistry();
@@ -1061,6 +1083,28 @@ public class CapabilityDispatcherTests
 
         Assert.NotNull(result);
         Assert.Equal("value1", result.GetValue<string>());
+    }
+
+    [Fact]
+    public void Invoke_DictGet_ReturnsValueFromTypedDictionary()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestTypeCategoryCapabilities).Assembly, typeof(AspireExportAttribute).Assembly]);
+
+        var dictResult = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/returnTypedMutableDict", null);
+        var dictHandle = (dictResult as JsonObject)?["$handle"]?.GetValue<string>();
+        Assert.NotNull(dictHandle);
+
+        var args = new JsonObject
+        {
+            ["dict"] = new JsonObject { ["$handle"] = dictHandle },
+            ["key"] = "key1"
+        };
+
+        var result = dispatcher.Invoke("Aspire.Hosting/Dict.get", args);
+
+        Assert.NotNull(result);
+        Assert.Equal(10, result.GetValue<int>());
     }
 
     [Fact]
@@ -2016,13 +2060,29 @@ internal static class TestTypeCategoryCapabilities
         return ["first", "second", "third"];
     }
 
-    [AspireExport(Description = "Returns a mutable Dictionary<string, object>")]
+    [AspireExport("returnTypedMutableList", Description = "Returns a mutable List<int>")]
+    public static List<int> ReturnTypedMutableList()
+    {
+        return [10, 20, 30];
+    }
+
+    [AspireExport("returnMutableDict", Description = "Returns a mutable Dictionary<string, object>")]
     public static Dictionary<string, object> ReturnMutableDict()
     {
         return new Dictionary<string, object>
         {
             ["key1"] = "value1",
             ["key2"] = 42
+        };
+    }
+
+    [AspireExport("returnTypedMutableDict", Description = "Returns a mutable Dictionary<string, int>")]
+    public static Dictionary<string, int> ReturnTypedMutableDict()
+    {
+        return new Dictionary<string, int>
+        {
+            ["key1"] = 10,
+            ["key2"] = 20
         };
     }
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -1108,6 +1108,28 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
+    public void Invoke_DictGet_ReturnsValueFromIntKeyDictionary()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestTypeCategoryCapabilities).Assembly, typeof(AspireExportAttribute).Assembly]);
+
+        var dictResult = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/returnIntKeyMutableDict", null);
+        var dictHandle = (dictResult as JsonObject)?["$handle"]?.GetValue<string>();
+        Assert.NotNull(dictHandle);
+
+        var args = new JsonObject
+        {
+            ["dict"] = new JsonObject { ["$handle"] = dictHandle },
+            ["key"] = 1
+        };
+
+        var result = dispatcher.Invoke("Aspire.Hosting/Dict.get", args);
+
+        Assert.NotNull(result);
+        Assert.Equal("one", result.GetValue<string>());
+    }
+
+    [Fact]
     public void Invoke_DictRemove_RemovesKey()
     {
         var handles = new HandleRegistry();
@@ -1198,6 +1220,49 @@ public class CapabilityDispatcherTests
         Assert.Equal(2, keysArray.Count);
         Assert.Contains("key1", keysArray.Select(k => k?.GetValue<string>()));
         Assert.Contains("key2", keysArray.Select(k => k?.GetValue<string>()));
+    }
+
+    [Fact]
+    public void Invoke_DictKeys_ReturnsAllIntKeys()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestTypeCategoryCapabilities).Assembly, typeof(AspireExportAttribute).Assembly]);
+
+        var dictResult = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/returnIntKeyMutableDict", null);
+        var dictHandle = (dictResult as JsonObject)?["$handle"]?.GetValue<string>();
+        Assert.NotNull(dictHandle);
+
+        var args = new JsonObject
+        {
+            ["dict"] = new JsonObject { ["$handle"] = dictHandle }
+        };
+
+        var result = dispatcher.Invoke("Aspire.Hosting/Dict.keys", args);
+
+        Assert.NotNull(result);
+        var keysArray = Assert.IsType<JsonArray>(result);
+        Assert.Equal(2, keysArray.Count);
+        Assert.Contains(1, keysArray.Select(k => k?.GetValue<int>()));
+        Assert.Contains(2, keysArray.Select(k => k?.GetValue<int>()));
+    }
+
+    [Fact]
+    public void Invoke_DictToObject_ThrowsForNonStringKeyDictionary()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestTypeCategoryCapabilities).Assembly, typeof(AspireExportAttribute).Assembly]);
+
+        var dictResult = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/returnIntKeyMutableDict", null);
+        var dictHandle = (dictResult as JsonObject)?["$handle"]?.GetValue<string>();
+        Assert.NotNull(dictHandle);
+
+        var args = new JsonObject
+        {
+            ["dict"] = new JsonObject { ["$handle"] = dictHandle }
+        };
+
+        var ex = Assert.Throws<CapabilityException>(() => dispatcher.Invoke("Aspire.Hosting/Dict.toObject", args));
+        Assert.Contains("only supports string-key dictionaries", ex.Message);
     }
 
     [Fact]
@@ -2083,6 +2148,16 @@ internal static class TestTypeCategoryCapabilities
         {
             ["key1"] = 10,
             ["key2"] = 20
+        };
+    }
+
+    [AspireExport("returnIntKeyMutableDict", Description = "Returns a mutable Dictionary<int, string>")]
+    public static Dictionary<int, string> ReturnIntKeyMutableDict()
+    {
+        return new Dictionary<int, string>
+        {
+            [1] = "one",
+            [2] = "two"
         };
     }
 }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Java/AppHost.java
@@ -11,6 +11,13 @@ void main() throws Exception {
             var _dashboardEnabled = environment.dashboardEnabled();
             var _environmentName = environment.name();
         });
+        compose.configureEnvFile((envVars) -> {
+            var bindMount = envVars.get("API_BINDMOUNT_0");
+            bindMount.setDescription("Customized bind mount source");
+            var _bindMountDescription = bindMount.description();
+            bindMount.setDefaultValue("./data");
+            var _bindMountDefaultValue = bindMount.defaultValue();
+        });
         compose.withDashboard(false);
         compose.withDashboard();
         compose.configureDashboard((dashboard) -> {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Python/apphost.py
@@ -5,9 +5,29 @@ from aspire_app import create_builder
 
 
 with create_builder() as builder:
-    compose = builder.add_docker_compose_environment("resource")
-    api = builder.add_container("resource", "image")
-    compose.with_properties()
+    compose = builder.add_docker_compose_environment("compose")
+    api = builder.add_container("api", "nginx:alpine")
+    api.with_bind_mount("/host/path/data", "/container/data")
+
+    def configure_environment(environment):
+        environment.default_network_name = "validation-network"
+        _default_network_name = environment.default_network_name
+
+        environment.dashboard_enabled = True
+        _dashboard_enabled = environment.dashboard_enabled
+
+        _environment_name = environment.name
+
+    compose.with_properties(configure_environment)
+
+    def configure_env_file(env_vars):
+        bind_mount = env_vars["API_BINDMOUNT_0"]
+        bind_mount.description = "Customized bind mount source"
+        _bind_mount_description = bind_mount.description
+        bind_mount.default_value = "./data"
+        _bind_mount_default_value = bind_mount.default_value
+
+    compose.configure_env_file(configure_env_file)
     compose.with_dashboard()
     compose.with_dashboard()
     compose.configure_dashboard()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
@@ -4,6 +4,7 @@ const builder = await createBuilder();
 
 const compose = await builder.addDockerComposeEnvironment("compose");
 const api = await builder.addContainer("api", "nginx:alpine");
+await api.withBindMount("/host/path/data", "/container/data");
 
 await compose.withProperties(async (environment) => {
     await environment.defaultNetworkName.set("validation-network");
@@ -13,6 +14,14 @@ await compose.withProperties(async (environment) => {
     const _dashboardEnabled: boolean = await environment.dashboardEnabled.get();
 
     const _environmentName: string = await environment.name.get();
+});
+
+await compose.configureEnvFile(async (envVars) => {
+    const bindMount = await envVars.get("API_BINDMOUNT_0");
+    await bindMount.description.set("Customized bind mount source");
+    const _bindMountDescription: string | null = await bindMount.description.get();
+    await bindMount.defaultValue.set("./data");
+    const _bindMountDefaultValue: string | null = await bindMount.defaultValue.get();
 });
 
 await compose.withDashboard({ enabled: false });


### PR DESCRIPTION
## Description

This adds `ConfigureEnvFile` parity for Docker Compose polyglot AppHosts so generated TypeScript, Python, and Java SDKs can customize captured `.env` entries the same way the C# surface already can. The main goal is to unblock the TypeScript issue path without widening scope into broader Docker Compose projection work.

The change exports `ConfigureEnvFile` to ATS, projects `CapturedEnvironmentVariable` just enough for mutation, and updates the shared ATS/runtime pieces needed for typed `Dict`/`List` handles to flow through callback parameters correctly. On top of that, the Docker polyglot validation AppHosts now exercise the env-file callback in TypeScript, Python, and Java, the Java shared runtime now exposes mutable `AspireDict` accessors needed for that callback shape, and the focused TypeScript publish validation asserts that the generated `artifacts/.env` output changes.

Fixes #15704

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No