### PR TITLE
Update DCP to 0.23.0

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.22.11">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.23.0">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>c118c398e1c069496ee986cc8bd601234e0acafa</Sha>
+      <Sha>1add83daefbe714c85eab1a057876c1c416b35c8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.22.11">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.23.0">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>c118c398e1c069496ee986cc8bd601234e0acafa</Sha>
+      <Sha>1add83daefbe714c85eab1a057876c1c416b35c8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.22.11">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.23.0">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>c118c398e1c069496ee986cc8bd601234e0acafa</Sha>
+      <Sha>1add83daefbe714c85eab1a057876c1c416b35c8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.22.11">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.23.0">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>c118c398e1c069496ee986cc8bd601234e0acafa</Sha>
+      <Sha>1add83daefbe714c85eab1a057876c1c416b35c8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.22.11">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.23.0">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>c118c398e1c069496ee986cc8bd601234e0acafa</Sha>
+      <Sha>1add83daefbe714c85eab1a057876c1c416b35c8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.22.11">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.23.0">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>c118c398e1c069496ee986cc8bd601234e0acafa</Sha>
+      <Sha>1add83daefbe714c85eab1a057876c1c416b35c8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.22.11">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.23.0">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>c118c398e1c069496ee986cc8bd601234e0acafa</Sha>
+      <Sha>1add83daefbe714c85eab1a057876c1c416b35c8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="10.2.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,13 +28,13 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.22.11</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.22.11</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.22.11</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.22.11</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.22.11</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.22.11</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.22.11</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.23.0</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.23.0</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.23.0</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.23.0</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.23.0</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.23.0</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.23.0</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25610.3</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25610.3</MicrosoftDotNetXUnitV3ExtensionsVersion>


### PR DESCRIPTION
Updates the inserted version of DCP to 0.23.0

https://github.com/microsoft/dcp/releases/tag/v0.23.0