### PR TITLE
Fix Hosting-1 Windows runner crash by disabling test parallelization

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -257,6 +257,8 @@ jobs:
       # Workaround for bug in Azure Functions Worker SDK. See https://github.com/Azure/azure-functions-dotnet-worker/issues/2969.
       - name: Rebuild for Azure Functions project
         if: inputs.testShortName == 'Playground'
+        env:
+          UseSharedCompilation: ${{ runner.os == 'Windows' && 'false' || '' }}
         run: |
           ${{ env.DOTNET_SCRIPT }} build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
 
@@ -300,6 +302,15 @@ jobs:
       - name: Unlock macOS keychain for certificate tests
         if: runner.os == 'macOS'
         uses: ./.github/actions/unlock-macos-keychain
+
+      # Shut down the Roslyn compiler server before running tests. On resource-constrained
+      # runners (e.g. 2-core windows-latest), VBCSCompiler stays resident and consumes
+      # ~150% CPU / 700MB RAM, starving the runner agent and causing "lost communication"
+      # crashes. This is fast and idempotent (no-op if no server is running).
+      # See https://github.com/microsoft/aspire/issues/15832
+      - name: Shutdown build server
+        if: runner.os == 'Windows'
+        run: ${{ env.DOTNET_SCRIPT }} build-server shutdown
 
       - name: Run nuget dependent tests (Linux/macOS)
         if: ${{ inputs.requiresNugets && runner.os != 'Windows' }}
@@ -354,14 +365,17 @@ jobs:
           TEST_LOG_PATH: ${{ github.workspace }}/artifacts/log/test-logs
           TestsRunningOutsideOfRepo: true
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
+          # Prevent VBCSCompiler from starting during tests. See #15832
+          UseSharedCompilation: false
           # PR metadata and token for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ inputs.requiresCliArchive && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ inputs.requiresCliArchive && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ inputs.requiresCliArchive && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (output goes to console directly)
+          # Use 60s interval on Windows to reduce overhead on constrained 2-core runners
           $heartbeatProcess = Start-Process -FilePath "dotnet" `
-            -ArgumentList "${{ github.workspace }}\tools\scripts\Heartbeat.cs" `
+            -ArgumentList "${{ github.workspace }}\tools\scripts\Heartbeat.cs 60" `
             -NoNewWindow -PassThru
 
           try {
@@ -442,14 +456,21 @@ jobs:
           NUGET_PACKAGES: ${{ github.workspace }}/.packages
           PLAYWRIGHT_INSTALLED: ${{ !inputs.enablePlaywrightInstall && 'false' || 'true' }}
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
+          # Prevent the Roslyn compiler server (VBCSCompiler) from starting during tests.
+          # On 2-core runners, VBCSCompiler consumes ~150% CPU / 700MB RAM and starves the
+          # runner agent, causing "lost communication" crashes. Projects are already pre-built,
+          # so any rebuild triggered by DCP's "dotnet run" should be minimal.
+          # See https://github.com/microsoft/aspire/issues/15832
+          UseSharedCompilation: false
           # PR metadata and token for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ inputs.requiresCliArchive && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ inputs.requiresCliArchive && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ inputs.requiresCliArchive && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (output goes to console directly)
+          # Use 60s interval on Windows to reduce overhead on constrained 2-core runners
           $heartbeatProcess = Start-Process -FilePath "${{ env.DOTNET_SCRIPT }}" `
-            -ArgumentList "${{ github.workspace }}\tools\scripts\Heartbeat.cs" `
+            -ArgumentList "${{ github.workspace }}\tools\scripts\Heartbeat.cs 60" `
             -NoNewWindow -PassThru
 
           try {


### PR DESCRIPTION
## Description

Fixes the Hosting-1 (windows-latest) CI job repeatedly hanging and crashing the GitHub Actions runner ("lost communication" errors). See #15832.

### Root Cause

On 2-core `windows-latest` runners, multiple CPU-intensive processes compete for limited resources during tests:

1. **xUnit test parallelization** — multiple DCP instances run concurrently within a single test partition, each spawning child processes
2. **VBCSCompiler** (Roslyn compiler server) — stays resident after build, consuming ~150% CPU / 700MB RAM
3. **Heartbeat monitor** — spawns 5 PowerShell processes per cycle at the default 5s interval

Total CPU demand reaches 400-600% on a 200% capacity machine. The Runner.Worker agent starves, can't send heartbeats to GitHub, and the job is killed.

### Changes

1. **Disable test parallelization on Windows CI** — Pass `/p:DisableTestParallelization=true` on Windows build steps, which triggers an xunit.runner.json swap (via `tests/Directory.Build.targets`) to a config with `parallelizeTestCollections: false`
2. **Suppress VBCSCompiler** — Set `UseSharedCompilation=false` env var on Windows test steps and add `dotnet build-server shutdown` before tests
3. **Increase heartbeat interval on Windows** — From default 5s to 60s to reduce PowerShell process spawn overhead (each cycle spawns 5 `powershell.exe` processes for metrics collection)

### Validation

Tested with `reproduce-flaky-tests.yml` workflow (Hosting partition 1, 8 runners × windows-latest):

| Configuration | Heartbeat | Result |
|--------------|-----------|--------|
| Main branch (no fix) | 5s (default) | **~0/9** ❌ |
| All fixes applied | No heartbeat | **16/16** ✅ |
| All fixes applied | 60s interval | **14/16** ✅ |

The remaining ~12% with heartbeat is from PowerShell overhead — filed #15887 to replace with .NET APIs.

Fixes #15832

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
