### PR TITLE
Allow CLI E2E tests to run in quarantine and outerloop workflows

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
@@ -8,7 +8,7 @@
     <IsTestProject>true</IsTestProject>
     <IsUnitTestProject>true</IsUnitTestProject>
     <OutputType>Exe</OutputType>
-    <SkipTests Condition="'$(IsGitHubActionsRunner)' == 'true' and '$(IsGithubPullRequest)' != 'true'">true</SkipTests>
+    <SkipTests Condition="'$(IsGitHubActionsRunner)' == 'true' and '$(IsGithubPullRequest)' != 'true' and '$(RunQuarantinedTests)' != 'true' and '$(RunOuterloopTests)' != 'true'">true</SkipTests>
 
     <SplitTestsOnCI>true</SplitTestsOnCI>
     <RequiresNugets>true</RequiresNugets>


### PR DESCRIPTION
## Summary

The quarantine workflow (`tests-quarantine.yml`) and outerloop workflow (`tests-outerloop.yml`) were not running any CLI E2E tests, silently skipping 5 quarantined and 3 outerloop tests.

## Root Cause

The `SkipTests` condition in `Aspire.Cli.EndToEnd.Tests.csproj` was:
```xml
<SkipTests Condition="'$(IsGitHubActionsRunner)' == 'true' and '$(IsGithubPullRequest)' != 'true'">true</SkipTests>
```

This skips tests on **all** non-PR GitHub Actions runs. Since the quarantine and outerloop workflows run on `schedule`, `SkipTests` was set to `true` and the specialized runsheet builder skipped test enumeration for this project.

## Fix

Added exceptions for `RunQuarantinedTests` and `RunOuterloopTests` properties (which are already passed by the respective workflows via `extraRunSheetBuilderArgs`).

## Affected tests

**Quarantined (5):**
- `WaitCommandTests` (#14993)
- `ProjectReferenceTests` (#15831)

**Outerloop (3):**
- `McpDocsE2ETests`
- `ConfigMigrationTests`
- `PlaywrightCliInstallTests`

Fixes #15835