### PR TITLE
Restore extension/.npmrc and add registry to .yarnrc to fix internal build

### DIFF
--- a/extension/.npmrc
+++ b/extension/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/

--- a/extension/.yarnrc
+++ b/extension/.yarnrc
@@ -1,1 +1,2 @@
 --ignore-engines true
+registry "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/"


### PR DESCRIPTION
## Summary

Restores `extension/.npmrc` and adds an explicit registry to `extension/.yarnrc` to fix the internal AzDO build failure during `yarn install`.

## Root Cause

The internal AzDO build was failing with:
```
error Error: connect EACCES 192.0.2.15:443
```

This happened because `extension/.npmrc` (which configured the internal npm registry) was deleted in commit 9504185 when GH Actions switched from yarn to npm.

**Yarn v1 doesn't walk up parent directories for `.npmrc`** like npm does. Without `extension/.npmrc`, yarn fell back to `registry.yarnpkg.com`, which is DNS-sinkholed to `192.0.2.15` under the CFS network isolation policy (`Permissive,CFSClean,CFSClean2`).

## Changes

1. **`extension/.npmrc`** (new) — Restores the registry pointing to `dotnet-public-npm` Azure DevOps feed. This is the primary mechanism yarn v1 uses to find the registry.
2. **`extension/.yarnrc`** (modified) — Adds an explicit `registry` line for belt-and-suspenders coverage.

Both point to:
```
https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
```

This is the same URL used in the root `.npmrc` and throughout `extension/yarn.lock` resolved URLs. The feed is publicly readable (no auth needed for local dev) and is approved by the CFS policy.

## Verification

- `yarn config get registry` in `extension/` returns the correct `dotnet-public-npm` URL
- `yarn install` succeeds locally
- `npm install` also succeeds (GH Actions compatibility)
- No changes to `yarn.lock`, `package-lock.json`, `Extension.proj`, or pipeline YAML needed

Fixes #15807