### PR TITLE
Add shared test dependencies guidance to test review guidelines

### DIFF
--- a/.github/instructions/test-review-guidelines.instructions.md
+++ b/.github/instructions/test-review-guidelines.instructions.md
@@ -29,4 +29,4 @@ When reviewing PRs that add or modify tests, check for:
 
 ## Shared Test Dependencies
 
-When writing tests, prefer using shared test service implementations from a common location (e.g., `Aspire.Cli.Tests/TestServices`) rather than creating private implementation classes within individual test files. Reusing existing test fakes and helpers keeps tests consistent, reduces duplication, and makes maintenance easier. Do not create private test classes when a shared one already exists or can be extended.
+When writing tests, prefer using shared test service implementations (e.g., project-level `TestServices/` or `Helpers/` directories, or the cross-project `tests/Shared/` folder) rather than creating private implementation classes within individual test files. Reusing existing test fakes and helpers keeps tests consistent, reduces duplication, and makes maintenance easier. Do not create private test classes when a shared one already exists or can be extended.

--- a/.github/instructions/test-review-guidelines.instructions.md
+++ b/.github/instructions/test-review-guidelines.instructions.md
@@ -26,3 +26,7 @@ When reviewing PRs that add or modify tests, check for:
 - [ ] **Port randomization**: Is `randomizePorts: true` used (or is the default relied upon)?
 - [ ] **Test isolation**: Does the test clean up all shared state? No static mutations without restoration?
 - [ ] **Platform considerations**: Will this test work on Windows, Linux, and macOS? Watch for path separators, file locking, and encoding differences.
+
+## Shared Test Dependencies
+
+When writing tests, prefer using shared test service implementations from a common location (e.g., `Aspire.Cli.Tests/TestServices`) rather than creating private implementation classes within individual test files. Reusing existing test fakes and helpers keeps tests consistent, reduces duplication, and makes maintenance easier. Do not create private test classes when a shared one already exists or can be extended.


### PR DESCRIPTION
## Description

Add guidance to the test review guidelines instructing agents to prefer shared test service implementations (e.g., `Aspire.Cli.Tests/TestServices`) instead of creating private implementation classes within individual test files. This reduces duplication and keeps test fakes consistent.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
