### PR TITLE
Clear terminal input buffer before sending Aspire commands

### DIFF
--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -97,6 +97,12 @@ export class AspireTerminalProvider implements vscode.Disposable {
 
         const aspireTerminal = this.getAspireTerminal();
         extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${command}`);
+
+        // Clear any pre-existing text in the terminal input buffer before sending the command.
+        // Ctrl+U clears the current line in bash/zsh; Escape clears it in PowerShell.
+        const clearSequence = process.platform === 'win32' ? '\x1b' : '\x15';
+        aspireTerminal.terminal.sendText(clearSequence, false);
+
         aspireTerminal.terminal.sendText(command);
         if (showTerminal) {
             aspireTerminal.terminal.show();

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -99,8 +99,9 @@ export class AspireTerminalProvider implements vscode.Disposable {
         extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${command}`);
 
         // Clear any pre-existing text in the terminal input buffer before sending the command.
-        // Ctrl+U clears the current line in bash/zsh; Escape clears it in PowerShell.
-        const clearSequence = process.platform === 'win32' ? '\x1b' : '\x15';
+        // Use Ctrl+U to clear the current line without sending an ESC prefix that can alter
+        // how the following command text is interpreted by Windows line editors.
+        const clearSequence = '\x15';
         aspireTerminal.terminal.sendText(clearSequence, false);
 
         aspireTerminal.terminal.sendText(command);

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -99,9 +99,11 @@ export class AspireTerminalProvider implements vscode.Disposable {
         extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${command}`);
 
         // Clear any pre-existing text in the terminal input buffer before sending the command.
-        // Use Ctrl+U to clear the current line without sending an ESC prefix that can alter
-        // how the following command text is interpreted by Windows line editors.
-        const clearSequence = '\x15';
+        // Unix (bash/zsh): Ctrl+U (\x15) clears the current line via unix-line-discard.
+        // Windows (PowerShell): Escape (\x1b) clears the current line in PSReadLine's default Windows edit mode.
+        // Sending \x1b alone (without a trailing bracket sequence) via a separate sendText call is safe —
+        // PSReadLine's escape-sequence timeout ensures it is processed as a standalone Escape keypress.
+        const clearSequence = process.platform === 'win32' ? '\x1b' : '\x15';
         aspireTerminal.terminal.sendText(clearSequence, false);
 
         aspireTerminal.terminal.sendText(command);


### PR DESCRIPTION
## Description

When the Aspire terminal has pre-existing text in its input buffer (e.g., a partially typed command), clicking **Stop**, **Restart**, or **Start** on a code lens or tree view appends the Aspire CLI command to the existing text, producing an invalid command that fails.

This fix sends a line-clearing control sequence before each command:
- **Unix (bash/zsh):** `Ctrl+U` (`\x15`) — clears the current input line
- **Windows (PowerShell):** `Escape` (`\x1b`) — clears the current input line

Fixes #15587

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
