### PR TITLE
Fix apphost path case sensitivity mismatch in VS Code extension

### DIFF
--- a/extension/src/editor/AspireEditorCommandProvider.ts
+++ b/extension/src/editor/AspireEditorCommandProvider.ts
@@ -4,6 +4,7 @@ import { noAppHostInWorkspace } from '../loc/strings';
 import { getResourceDebuggerExtensions } from '../debugger/debuggerExtensions';
 import { AspireCommandType } from '../dcp/types';
 import { aspireConfigFileName, getAppHostPathFromConfig, readJsonFile } from '../utils/cliTypes';
+import { resolveCanonicalPath } from '../utils/io';
 
 export class AspireEditorCommandProvider implements vscode.Disposable {
     private _workspaceAppHostPath: string | null = null;
@@ -187,7 +188,9 @@ export class AspireEditorCommandProvider implements vscode.Disposable {
                 const appHostPath = path.isAbsolute(appHostRelativePath)
                     ? appHostRelativePath
                     : path.join(configDir, appHostRelativePath);
-                onChangeAppHostPath(appHostPath);
+                // Resolve to canonical on-disk casing to prevent case mismatches
+                // when the path is passed to the CLI via --apphost (see #15588)
+                onChangeAppHostPath(resolveCanonicalPath(appHostPath));
             }
             catch {
                 onChangeAppHostPath(null);
@@ -200,7 +203,7 @@ export class AspireEditorCommandProvider implements vscode.Disposable {
      */
     public async getAppHostPath(): Promise<string | null> {
         if (vscode.window.activeTextEditor && await this.isAppHostFile(vscode.window.activeTextEditor.document.uri.fsPath)) {
-            return vscode.window.activeTextEditor.document.uri.fsPath;
+            return resolveCanonicalPath(vscode.window.activeTextEditor.document.uri.fsPath);
         }
 
         return this._workspaceAppHostPath;

--- a/extension/src/test/io.test.ts
+++ b/extension/src/test/io.test.ts
@@ -1,0 +1,132 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveCanonicalPath } from '../utils/io';
+
+suite('utils/io tests', () => {
+
+    test('resolveCanonicalPath returns canonical casing for existing file', () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+
+        // Resolve tmpDir itself first so symlinks (e.g., /var -> /private/var on macOS)
+        // don't interfere with comparisons
+        const canonicalTmpDir = fs.realpathSync.native(tmpDir);
+        const filePath = path.join(canonicalTmpDir, 'MyAppHost.csproj');
+        fs.writeFileSync(filePath, '');
+
+        try {
+            const resolved = resolveCanonicalPath(filePath);
+
+            assert.ok(fs.existsSync(resolved), 'Resolved path should exist');
+            assert.ok(path.isAbsolute(resolved), 'Resolved path should be absolute');
+            assert.strictEqual(resolved, filePath, 'Canonical path should match when input casing is already correct');
+        } finally {
+            fs.unlinkSync(filePath);
+            fs.rmdirSync(canonicalTmpDir);
+        }
+    });
+
+    test('resolveCanonicalPath resolves wrong-cased path on case-insensitive filesystem', function () {
+        // This test is meaningful only on case-insensitive file systems (macOS, Windows)
+        if (process.platform === 'linux') {
+            this.skip();
+            return;
+        }
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+        const canonicalTmpDir = fs.realpathSync.native(tmpDir);
+        const filePath = path.join(canonicalTmpDir, 'MyAppHost.csproj');
+        fs.writeFileSync(filePath, '');
+
+        try {
+            // Pass a wrong-cased version of the path
+            const wrongCased = path.join(canonicalTmpDir, 'myapphost.csproj');
+            const resolved = resolveCanonicalPath(wrongCased);
+
+            // On case-insensitive FS, realpathSync.native returns the actual on-disk casing
+            assert.strictEqual(path.basename(resolved), 'MyAppHost.csproj',
+                `Expected resolved path to have on-disk casing "MyAppHost.csproj", got "${path.basename(resolved)}"`);
+            assert.strictEqual(resolved, filePath, 'Full resolved path should match the on-disk canonical path');
+        } finally {
+            fs.unlinkSync(filePath);
+            fs.rmdirSync(canonicalTmpDir);
+        }
+    });
+
+    test('resolveCanonicalPath returns original path for non-existent file', () => {
+        const fakePath = path.join(os.tmpdir(), 'non-existent-dir-15588', 'DoesNotExist.csproj');
+        const resolved = resolveCanonicalPath(fakePath);
+
+        assert.strictEqual(resolved, fakePath, 'Should return original path when file does not exist');
+    });
+
+    test('resolveCanonicalPath handles symlinks', function () {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+        const canonicalTmpDir = fs.realpathSync.native(tmpDir);
+        const realFile = path.join(canonicalTmpDir, 'RealFile.csproj');
+        const symlink = path.join(canonicalTmpDir, 'SymLink.csproj');
+
+        fs.writeFileSync(realFile, '');
+
+        try {
+            fs.symlinkSync(realFile, symlink);
+        } catch {
+            // Symlinks may not be available (e.g., some Windows configs)
+            this.skip();
+            return;
+        }
+
+        try {
+            const resolved = resolveCanonicalPath(symlink);
+            assert.ok(resolved.endsWith('RealFile.csproj'),
+                `Expected symlink to resolve to "RealFile.csproj", got "${path.basename(resolved)}"`);
+        } finally {
+            fs.unlinkSync(symlink);
+            fs.unlinkSync(realFile);
+            fs.rmdirSync(canonicalTmpDir);
+        }
+    });
+
+    test('resolveCanonicalPath handles directory paths', () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+        const canonicalTmpDir = fs.realpathSync.native(tmpDir);
+
+        try {
+            const resolved = resolveCanonicalPath(canonicalTmpDir);
+            assert.ok(fs.existsSync(resolved), 'Resolved directory path should exist');
+            assert.ok(path.isAbsolute(resolved), 'Resolved directory path should be absolute');
+        } finally {
+            fs.rmdirSync(canonicalTmpDir);
+        }
+    });
+
+    test('resolveCanonicalPath normalizes parent directory casing on case-insensitive filesystem', function () {
+        // Verifies that case normalization works for parent directories too,
+        // not just the filename component
+        if (process.platform === 'linux') {
+            this.skip();
+            return;
+        }
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'AspireTestDir-'));
+        const canonicalTmpDir = fs.realpathSync.native(tmpDir);
+        const subDir = path.join(canonicalTmpDir, 'SubFolder');
+        fs.mkdirSync(subDir);
+        const filePath = path.join(subDir, 'AppHost.csproj');
+        fs.writeFileSync(filePath, '');
+
+        try {
+            // Construct a path with wrong casing in both directory and file name
+            const wrongCased = path.join(canonicalTmpDir, 'subfolder', 'apphost.csproj');
+            const resolved = resolveCanonicalPath(wrongCased);
+
+            assert.ok(resolved.includes('SubFolder'), `Expected "SubFolder" in resolved path, got "${resolved}"`);
+            assert.ok(resolved.endsWith('AppHost.csproj'), `Expected "AppHost.csproj" at end, got "${path.basename(resolved)}"`);
+        } finally {
+            fs.unlinkSync(filePath);
+            fs.rmdirSync(subDir);
+            fs.rmdirSync(canonicalTmpDir);
+        }
+    });
+});

--- a/extension/src/utils/io.ts
+++ b/extension/src/utils/io.ts
@@ -6,7 +6,8 @@ import { access, stat } from 'fs/promises';
  * On case-insensitive file systems (macOS, Windows), this returns the path with
  * the actual casing stored on disk, preventing case mismatches when paths are
  * compared or hashed by other tools (e.g., the Aspire CLI backchannel socket lookup).
- * Falls back to the original path if the file does not exist.
+ * Falls back to the original path if the native realpath call fails for any reason
+ * (e.g., the file does not exist).
  */
 export function resolveCanonicalPath(p: string): string {
     try {

--- a/extension/src/utils/io.ts
+++ b/extension/src/utils/io.ts
@@ -1,4 +1,20 @@
+import { realpathSync } from 'fs';
 import { access, stat } from 'fs/promises';
+
+/**
+ * Resolves a file path to its canonical on-disk casing using the native OS realpath.
+ * On case-insensitive file systems (macOS, Windows), this returns the path with
+ * the actual casing stored on disk, preventing case mismatches when paths are
+ * compared or hashed by other tools (e.g., the Aspire CLI backchannel socket lookup).
+ * Falls back to the original path if the file does not exist.
+ */
+export function resolveCanonicalPath(p: string): string {
+    try {
+        return realpathSync.native(p);
+    } catch {
+        return p;
+    }
+}
 
 export async function doesFileExist(filePath: string): Promise<boolean> {
     try {

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -5,6 +5,7 @@ import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import { extensionLogOutputChannel } from '../utils/logging';
 import { EnvironmentVariables } from '../utils/environment';
 import { errorFetchingAppHosts } from '../loc/strings';
+import { resolveCanonicalPath } from '../utils/io';
 
 export interface ResourceUrlJson {
     name: string | null;
@@ -231,7 +232,9 @@ export class AppHostDataRepository {
                             const appHostPath = parsed.selected_project_file
                                 ?? (parsed.all_project_file_candidates.length === 1 ? parsed.all_project_file_candidates[0] : null);
                             if (appHostPath) {
-                                this._workspaceAppHostPath = appHostPath;
+                                // Resolve to canonical on-disk casing to prevent case mismatches
+                                // when the path is passed to the CLI via --apphost (see #15588)
+                                this._workspaceAppHostPath = resolveCanonicalPath(appHostPath);
                                 this._workspaceAppHostName = shortenPath(appHostPath);
                                 extensionLogOutputChannel.info(`Workspace apphost resolved: ${appHostPath}`);
                                 this._onDidChangeData.fire();

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -234,9 +234,10 @@ export class AppHostDataRepository {
                             if (appHostPath) {
                                 // Resolve to canonical on-disk casing to prevent case mismatches
                                 // when the path is passed to the CLI via --apphost (see #15588)
-                                this._workspaceAppHostPath = resolveCanonicalPath(appHostPath);
-                                this._workspaceAppHostName = shortenPath(appHostPath);
-                                extensionLogOutputChannel.info(`Workspace apphost resolved: ${appHostPath}`);
+                                const canonicalAppHostPath = resolveCanonicalPath(appHostPath);
+                                this._workspaceAppHostPath = canonicalAppHostPath;
+                                this._workspaceAppHostName = shortenPath(canonicalAppHostPath);
+                                extensionLogOutputChannel.info(`Workspace apphost resolved: ${canonicalAppHostPath}`);
                                 this._onDidChangeData.fire();
                             }
                         }


### PR DESCRIPTION
## Description

Fix apphost path case sensitivity mismatch in the VS Code extension that prevents resource commands (restart, stop, logs) from finding running AppHosts on case-insensitive file systems (macOS, Windows).

### Root Cause

The extension obtains the apphost path from multiple sources (config files, CLI output, active editor) that can produce different casing for the same file path. On macOS (case-insensitive APFS), VS Code's `Uri.fsPath` preserves the workspace URI's casing rather than the canonical on-disk casing. When this differs from the casing the running AppHost used, the CLI's hash-based socket lookup fails because different casing produces different hashes.

### Fix

Use `fs.realpathSync.native()` to resolve all apphost paths to their canonical on-disk casing before storing or passing them to the CLI via `--apphost`. The native variant (unlike the default `realpathSync`) uses the OS's native `realpath(3)` which returns the actual on-disk casing on case-insensitive file systems.

Three normalization points:
- `AspireEditorCommandProvider.ts` — config-file based path resolution
- `AspireEditorCommandProvider.ts` — `getAppHostPath()` active editor path
- `AppHostDataRepository.ts` — CLI-based path from `aspire extension get-apphosts`

Falls back to the original path if the file doesn't exist yet (e.g., during initial project setup).

Fixes #15588

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
