### PR TITLE
Update QuarantinedTest URLs for CLI E2E tests

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
@@ -19,7 +19,7 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
     private const string ProjectName = "AspireDockerDeployTest";
 
     [Fact]
-    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15511")]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15882")]
     public async Task CreateAndDeployToDockerCompose()
     {
         using var workspace = TemporaryWorkspace.Create(output);
@@ -141,7 +141,7 @@ builder.Build().Run();
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15511")]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15871")]
     public async Task CreateAndDeployToDockerComposeInteractive()
     {
         using var workspace = TemporaryWorkspace.Create(output);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
@@ -27,7 +27,7 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
         $"{ClusterNamePrefix}-{Guid.NewGuid():N}"[..32]; // KinD cluster names max 32 chars
 
     [Fact]
-    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15511")]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15870")]
     public async Task CreateAndPublishToKubernetes()
     {
         using var workspace = TemporaryWorkspace.Create(output);


### PR DESCRIPTION
The old issue https://github.com/microsoft/aspire/issues/15511 was closed, so the quarantine URLs for the CLI E2E tests need to be updated to point to the new, specific tracking issues:

- `CreateAndDeployToDockerCompose` → https://github.com/microsoft/aspire/issues/15882
- `CreateAndDeployToDockerComposeInteractive` → https://github.com/microsoft/aspire/issues/15871
- `CreateAndPublishToKubernetes` → https://github.com/microsoft/aspire/issues/15870