### PR TITLE
Fix /unquarantine-test parsing trailing URLs as test names

### DIFF
--- a/.github/workflows/apply-test-attributes.yml
+++ b/.github/workflows/apply-test-attributes.yml
@@ -132,8 +132,12 @@ jobs:
               return;
             }
           } else {
-            // For unquarantine/enable: test names only
-            testNames = parts;
+            // For unquarantine/enable: test names only, ignore any trailing URLs
+            testNames = parts.filter(p => !urlPattern.test(p));
+            if (testNames.length === 0) {
+              failWithError('No test name(s) provided. Only URLs were found in the arguments.');
+              return;
+            }
           }
 
           // Validate target PR URL is from the same repo if provided


### PR DESCRIPTION
## Summary

Fixes a bug in the `/unquarantine-test` (and `/enable-test`) command parser in `apply-test-attributes.yml` where trailing issue URLs were treated as test names.

## Problem

When a user runs:
```
/unquarantine-test Aspire.Hosting.Tests.DistributedApplicationTests.StartResourceForcesStart https://github.com/microsoft/aspire/issues/15777
```

The URL is parsed as a second test name, producing:
- Incorrect PR title: *"Unquarantine 2 tests"* (should be 1)
- The URL listed as a test in the PR body

This happened because the `requiresUrl: false` code path for unquarantine/enable assigned **all** space-separated parts as test names without filtering out URLs.

See the resulting incorrect PR: #15881 (title/description now corrected).

## Fix

In the `else` branch (unquarantine/enable), filter out URL-like arguments using the existing `urlPattern` regex. If only URLs are provided with no actual test names, the command fails with a clear error message.

## Testing

| Command | Before | After |
|---------|--------|-------|
| `/unquarantine-test TestName https://...` | 2 tests (URL as test) | 1 test (URL ignored) |
| `/unquarantine-test TestName` | Works | Works (no change) |
| `/unquarantine-test https://...` | 1 test (URL as test) | Error: no test names |

Related: #15777