### PR TITLE
Detect system-assigned managed identities in AzureCredentialHelper

### DIFF
--- a/src/Shared/AzureCredentialHelper.cs
+++ b/src/Shared/AzureCredentialHelper.cs
@@ -18,13 +18,20 @@ internal static class AzureCredentialHelper
             return new DefaultAzureCredential(DefaultAzureCredential.DefaultEnvironmentVariableName);
         }
 
-        if (Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") is not null)
+        if (Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") is string azureClientId)
         {
             // When we don't see DefaultEnvironmentVariableName, but we do see AZURE_CLIENT_ID,
             // we just use ManagedIdentityCredential because that's the only credential type that
             // Aspire Hosting enables by default.
+            // This is also used to support user assigned managed identities in Azure App Service and Azure Functions.
             // If this doesn't work for applications, they can override the TokenCredential in their settings.
-            return new ManagedIdentityCredential(new ManagedIdentityCredentialOptions());
+            return new ManagedIdentityCredential(new ManagedIdentityCredentialOptions(ManagedIdentityId.FromUserAssignedClientId(azureClientId)));
+        }
+        else if (Environment.GetEnvironmentVariable("IDENTITY_ENDPOINT") is not null)
+        {
+            // When we see IDENTITY_ENDPOINT, but not AZURE_CLIENT_ID, we assume we're in an Azure
+            // environment with a system assigned managed identity such as Azure App Service or Azure Functions.
+            return new ManagedIdentityCredential(new ManagedIdentityCredentialOptions(ManagedIdentityId.SystemAssigned));
         }
 
         // when we can't detect a known Azure environment, fall back to the development credential


### PR DESCRIPTION
## Description
This should restore support for system-assigned managed identities.

When system-assigned managed identities are enabled the `IDENTITY_ENDPOINT` and `IDENTITY_HEADER` environment variables are defined. It should be enough to detect the endpoint variable for this purpose.

`AZURE_CLIENT_ID` is still used by user-managed identities.

Reference:
https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp#rest-endpoint-reference

Fixes #15879

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
