### PR TITLE
Fix `main` build

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -54,7 +54,7 @@ public static class ContainerAppExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("configureCustomDomain", Description = "Configures the custom domain for the container app")]
+    [AspireExport(Description = "Configures the custom domain for the container app")]
     [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static void ConfigureCustomDomain(this ContainerApp app, IResourceBuilder<ParameterResource> customDomain, IResourceBuilder<ParameterResource> certificateName)
     {


### PR DESCRIPTION
## Remove redundant export ID from ConfigureCustomDomain attribute

The explicit ID `"configureCustomDomain"` on the `[AspireExport]` attribute matches the convention-derived name, triggering `ASPIREEXPORT011`. Remove it to fix the main build.

Fixes: https://github.com/microsoft/aspire/actions/runs/23966941995/job/69908651195

cc @sebastienros