### PR TITLE
Use PR-specific version for dogfood VS Code extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       skip_workflow: ${{ (steps.check_for_changes.outputs.no_changes == 'true' || steps.check_for_changes.outputs.only_changed == 'true') && 'true' || 'false' }}
       VERSION_SUFFIX_OVERRIDE: ${{ steps.compute_version_suffix.outputs.VERSION_SUFFIX_OVERRIDE }}
+      EXTENSION_VERSION_OVERRIDE: ${{ steps.compute_version_suffix.outputs.EXTENSION_VERSION_OVERRIDE }}
 
     steps:
       - name: Checkout code
@@ -58,6 +59,10 @@ jobs:
           Write-Host "Computed VERSION_SUFFIX_OVERRIDE=$VERSION_SUFFIX"
           "VERSION_SUFFIX_OVERRIDE=$VERSION_SUFFIX" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
 
+          $EXTENSION_VERSION = "0.0.$($Env:PR_NUMBER)"
+          Write-Host "Computed EXTENSION_VERSION_OVERRIDE=$EXTENSION_VERSION"
+          "EXTENSION_VERSION_OVERRIDE=$EXTENSION_VERSION" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+
   tests:
     uses: ./.github/workflows/tests.yml
     name: Tests
@@ -65,6 +70,7 @@ jobs:
     if: ${{ github.repository_owner == 'microsoft' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
     with:
       versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
+      extensionVersionOverride: ${{ needs.prepare_for_ci.outputs.EXTENSION_VERSION_OVERRIDE }}
 
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           Write-Host "Computed VERSION_SUFFIX_OVERRIDE=$VERSION_SUFFIX"
           "VERSION_SUFFIX_OVERRIDE=$VERSION_SUFFIX" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
 
-          $EXTENSION_VERSION = "0.0.$($Env:PR_NUMBER)"
+          $EXTENSION_VERSION = "99.0.$($Env:PR_NUMBER)"
           Write-Host "Computed EXTENSION_VERSION_OVERRIDE=$EXTENSION_VERSION"
           "EXTENSION_VERSION_OVERRIDE=$EXTENSION_VERSION" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
       versionOverrideArg:
         required: false
         type: string
+      extensionVersionOverride:
+        required: false
+        type: string
 
 jobs:
   setup_for_tests:
@@ -295,7 +298,7 @@ jobs:
       - name: Run tests
         run: npm test
       - name: Package VSIX
-        run: npm exec @vscode/vsce -- package --pre-release -o out/aspire-extension.vsix
+        run: npm exec @vscode/vsce -- package --pre-release ${{ inputs.extensionVersionOverride && format('--version {0}', inputs.extensionVersionOverride) || '' }} -o out/aspire-extension.vsix
       - name: Upload VSIX
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -297,8 +297,11 @@ jobs:
         run: npm install
       - name: Run tests
         run: npm test
+      - name: Override extension version for PR builds
+        if: ${{ inputs.extensionVersionOverride != '' }}
+        run: npm version "${{ inputs.extensionVersionOverride }}" --no-git-tag-version
       - name: Package VSIX
-        run: npm exec @vscode/vsce -- package ${{ inputs.extensionVersionOverride || '' }} --pre-release -o out/aspire-extension.vsix
+        run: npm exec @vscode/vsce -- package --pre-release -o out/aspire-extension.vsix
       - name: Upload VSIX
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -299,7 +299,9 @@ jobs:
         run: npm test
       - name: Override extension version for PR builds
         if: ${{ inputs.extensionVersionOverride != '' }}
-        run: npm version "${{ inputs.extensionVersionOverride }}" --no-git-tag-version
+        env:
+          EXTENSION_VERSION: ${{ inputs.extensionVersionOverride }}
+        run: npm version "$EXTENSION_VERSION" --no-git-tag-version
       - name: Package VSIX
         run: npm exec @vscode/vsce -- package --pre-release -o out/aspire-extension.vsix
       - name: Upload VSIX

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Run tests
         run: npm test
       - name: Package VSIX
-        run: npm exec @vscode/vsce -- package --pre-release ${{ inputs.extensionVersionOverride && format('--version {0}', inputs.extensionVersionOverride) || '' }} -o out/aspire-extension.vsix
+        run: npm exec @vscode/vsce -- package ${{ inputs.extensionVersionOverride || '' }} --pre-release -o out/aspire-extension.vsix
       - name: Upload VSIX
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/extension/Extension.proj
+++ b/extension/Extension.proj
@@ -25,9 +25,12 @@
       <_VscodeOutputDir>$(ArtifactsPackagesDir)vscode</_VscodeOutputDir>
       <_VsixPath>$(_VscodeOutputDir)\aspire-vscode-$(_EffectiveVersion).vsix</_VsixPath>
       <_ManifestPath>$(_VscodeOutputDir)\aspire-vscode-$(_EffectiveVersion).manifest</_ManifestPath>
-      <_VersionArg Condition="'$(ExtensionVersionOverride)' != ''">$(ExtensionVersionOverride)</_VersionArg>
-      <_VersionArg Condition="'$(ExtensionVersionOverride)' == ''"></_VersionArg>
     </PropertyGroup>
+
+    <!-- Override package.json version if ExtensionVersionOverride is set -->
+    <Exec Command="node -e &quot;const p=require('./package.json');p.version='$(ExtensionVersionOverride)';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n')&quot;"
+          Condition="'$(ExtensionVersionOverride)' != ''"
+          WorkingDirectory="$(ExtensionSrcDir)" />
 
     <!-- Install dependencies and compile -->
     <Exec Command="yarn install" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
@@ -37,11 +40,11 @@
     <MakeDir Directories="$(_VscodeOutputDir)" />
 
     <!-- Package extension -->
-    <Exec Command="vsce package $(_VersionArg) --out $(_VsixPath)"
+    <Exec Command="vsce package --out $(_VsixPath)"
           IgnoreStandardErrorWarningFormat="true"
           WorkingDirectory="$(ExtensionSrcDir)" />
 
-    <!-- 
+    <!--
       VS Code extension signing for marketplace verification:
       Generate manifest from the VSIX using vsce. The signing project (signing/signVsix.proj)
       will copy this to .signature.p7s and sign it with the VSCodePublisher certificate.

--- a/extension/Extension.proj
+++ b/extension/Extension.proj
@@ -11,10 +11,11 @@
 
     <Error Text="$(_PackageJsonPath) not found. Cannot package the extension." Condition="!Exists('$(_PackageJsonPath)')" />
 
-    <!-- Extract version from package.json using Node.js -->
+    <!-- Extract version from package.json using Node.js (skip when override is provided) -->
     <Exec Command="node -p &quot;require('./package.json').version&quot;"
           ConsoleToMSBuild="true"
           IgnoreStandardErrorWarningFormat="true"
+          Condition="'$(ExtensionVersionOverride)' == ''"
           WorkingDirectory="$(ExtensionSrcDir)">
       <Output TaskParameter="ConsoleOutput" PropertyName="_ExtractedVersion" />
     </Exec>
@@ -27,8 +28,10 @@
       <_ManifestPath>$(_VscodeOutputDir)\aspire-vscode-$(_EffectiveVersion).manifest</_ManifestPath>
     </PropertyGroup>
 
-    <!-- Override package.json version if ExtensionVersionOverride is set -->
-    <Exec Command="node -e &quot;const p=require('./package.json');p.version='$(ExtensionVersionOverride)';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n')&quot;"
+    <!-- Override package.json version if ExtensionVersionOverride is set, saving original first -->
+    <Copy SourceFiles="$(_PackageJsonPath)" DestinationFiles="$(_PackageJsonPath).bak"
+          Condition="'$(ExtensionVersionOverride)' != ''" />
+    <Exec Command="npm version &quot;$(ExtensionVersionOverride)&quot; --no-git-tag-version"
           Condition="'$(ExtensionVersionOverride)' != ''"
           WorkingDirectory="$(ExtensionSrcDir)" />
 
@@ -53,6 +56,10 @@
     <Exec Command="vsce generate-manifest -i $(_VsixPath) -o $(_ManifestPath)"
           IgnoreStandardErrorWarningFormat="true"
           WorkingDirectory="$(ExtensionSrcDir)" />
+
+    <!-- Restore original package.json if it was overridden -->
+    <Move SourceFiles="$(_PackageJsonPath).bak" DestinationFiles="$(_PackageJsonPath)"
+          Condition="Exists('$(_PackageJsonPath).bak')" />
 
     <Message Importance="high" Text="VS Code extension artifacts created in $(_VscodeOutputDir):" />
     <Message Importance="high" Text="  VSIX: $(_VsixPath)" />

--- a/extension/Extension.proj
+++ b/extension/Extension.proj
@@ -20,9 +20,13 @@
     </Exec>
 
     <PropertyGroup>
+      <_EffectiveVersion Condition="'$(ExtensionVersionOverride)' != ''">$(ExtensionVersionOverride)</_EffectiveVersion>
+      <_EffectiveVersion Condition="'$(ExtensionVersionOverride)' == ''">$(_ExtractedVersion)</_EffectiveVersion>
       <_VscodeOutputDir>$(ArtifactsPackagesDir)vscode</_VscodeOutputDir>
-      <_VsixPath>$(_VscodeOutputDir)\aspire-vscode-$(_ExtractedVersion).vsix</_VsixPath>
-      <_ManifestPath>$(_VscodeOutputDir)\aspire-vscode-$(_ExtractedVersion).manifest</_ManifestPath>
+      <_VsixPath>$(_VscodeOutputDir)\aspire-vscode-$(_EffectiveVersion).vsix</_VsixPath>
+      <_ManifestPath>$(_VscodeOutputDir)\aspire-vscode-$(_EffectiveVersion).manifest</_ManifestPath>
+      <_VersionArg Condition="'$(ExtensionVersionOverride)' != ''">--version $(ExtensionVersionOverride)</_VersionArg>
+      <_VersionArg Condition="'$(ExtensionVersionOverride)' == ''"></_VersionArg>
     </PropertyGroup>
 
     <!-- Install dependencies and compile -->
@@ -33,7 +37,7 @@
     <MakeDir Directories="$(_VscodeOutputDir)" />
 
     <!-- Package extension -->
-    <Exec Command="vsce package --out $(_VsixPath)"
+    <Exec Command="vsce package $(_VersionArg) --out $(_VsixPath)"
           IgnoreStandardErrorWarningFormat="true"
           WorkingDirectory="$(ExtensionSrcDir)" />
 

--- a/extension/Extension.proj
+++ b/extension/Extension.proj
@@ -25,7 +25,7 @@
       <_VscodeOutputDir>$(ArtifactsPackagesDir)vscode</_VscodeOutputDir>
       <_VsixPath>$(_VscodeOutputDir)\aspire-vscode-$(_EffectiveVersion).vsix</_VsixPath>
       <_ManifestPath>$(_VscodeOutputDir)\aspire-vscode-$(_EffectiveVersion).manifest</_ManifestPath>
-      <_VersionArg Condition="'$(ExtensionVersionOverride)' != ''">--version $(ExtensionVersionOverride)</_VersionArg>
+      <_VersionArg Condition="'$(ExtensionVersionOverride)' != ''">$(ExtensionVersionOverride)</_VersionArg>
       <_VersionArg Condition="'$(ExtensionVersionOverride)' == ''"></_VersionArg>
     </PropertyGroup>
 


### PR DESCRIPTION
## Description

When installing the VS Code extension from a PR dogfood build, the version is always the same as the marketplace release (currently `1.0.7` from `package.json`), making it impossible to distinguish a dogfooded extension from a released one.

This PR sets the extension VSIX version to `0.0.<PR_NUMBER>` for PR builds, so dogfooded extensions are clearly distinguishable from marketplace releases. The version `0.0.X` was chosen because:
- VS Code extensions don't support semver pre-release labels in version strings
- `0.0.X` is obviously non-release (major=minor=0)
- The PR number identifies which PR the extension came from

### Changes

1. **`ci.yml`**: Compute `EXTENSION_VERSION_OVERRIDE=0.0.<PR_NUMBER>` alongside the existing `VERSION_SUFFIX_OVERRIDE` and pass it to `tests.yml`
2. **`tests.yml`**: Accept `extensionVersionOverride` input and pass `--version` to `vsce package` when set
3. **`Extension.proj`**: Support `ExtensionVersionOverride` MSBuild property for local builds (`dotnet build Extension.proj /p:ExtensionVersionOverride=0.0.99`)

Non-PR builds (push to main/release) continue using the version from `package.json`.

Fixes #15589

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No