### PR TITLE
Use deny list for non-linkable endpoint URLs in extension

### DIFF
--- a/extension/src/test/urlSchemes.test.ts
+++ b/extension/src/test/urlSchemes.test.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import { isLinkableUrl } from '../utils/urlSchemes';
+
+suite('isLinkableUrl', () => {
+    test('http URLs are linkable', () => {
+        assert.strictEqual(isLinkableUrl('http://localhost:5000'), true);
+    });
+
+    test('https URLs are linkable', () => {
+        assert.strictEqual(isLinkableUrl('https://example.com'), true);
+    });
+
+    test('vscode:// URLs are linkable (custom scheme)', () => {
+        assert.strictEqual(isLinkableUrl('vscode://extension/id'), true);
+    });
+
+    test('ftp URLs are linkable', () => {
+        assert.strictEqual(isLinkableUrl('ftp://files.example.com'), true);
+    });
+
+    test('tcp URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('tcp://localhost:1433'), false);
+    });
+
+    test('redis URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('redis://localhost:6379'), false);
+    });
+
+    test('rediss URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('rediss://localhost:6380'), false);
+    });
+
+    test('ws URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('ws://localhost:8080'), false);
+    });
+
+    test('wss URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('wss://localhost:8080'), false);
+    });
+
+    test('telnet URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('telnet://localhost:23'), false);
+    });
+
+    test('gopher URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('gopher://example.com'), false);
+    });
+
+    test('news URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('news://news.example.com'), false);
+    });
+
+    test('nntp URLs are not linkable', () => {
+        assert.strictEqual(isLinkableUrl('nntp://news.example.com'), false);
+    });
+
+    test('scheme matching is case-insensitive', () => {
+        assert.strictEqual(isLinkableUrl('TCP://localhost:1433'), false);
+        assert.strictEqual(isLinkableUrl('Redis://localhost:6379'), false);
+        assert.strictEqual(isLinkableUrl('HTTP://localhost:5000'), true);
+        assert.strictEqual(isLinkableUrl('HTTPS://example.com'), true);
+    });
+
+    test('invalid URLs return false', () => {
+        assert.strictEqual(isLinkableUrl('not a url'), false);
+        assert.strictEqual(isLinkableUrl(''), false);
+    });
+});

--- a/extension/src/utils/urlSchemes.ts
+++ b/extension/src/utils/urlSchemes.ts
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/**
+ * URL schemes that terminals and browsers don't support opening as links.
+ * This is a deny list because custom schemes could hand off the link to an app
+ * registered with the OS. For example, vscode://.
+ *
+ * Mirrors the dashboard's KnownUnsupportedUrlSchemes (src/Shared/KnownUnsupportedUrlSchemes.cs).
+ */
+const unsupportedSchemes = new Set([
+    'gopher',
+    'ws',
+    'wss',
+    'news',
+    'nntp',
+    'telnet',
+    'tcp',
+    'redis',
+    'rediss',
+]);
+
+/**
+ * Returns true when the URL scheme is known to be linkable (i.e. not in the unsupported set).
+ */
+export function isLinkableUrl(url: string): boolean {
+    try {
+        const parsed = new URL(url);
+        return !unsupportedSchemes.has(parsed.protocol.replace(/:$/, '').toLowerCase());
+    } catch {
+        return false;
+    }
+}

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -25,6 +25,7 @@ import {
     resourceDescriptionHealth,
     resourceDescriptionExitCode,
 } from '../loc/strings';
+import { isLinkableUrl } from '../utils/urlSchemes';
 import {
     AppHostDataRepository,
     AppHostDisplayInfo,
@@ -94,8 +95,7 @@ class EndpointUrlItem extends vscode.TreeItem {
         this.tooltip = url;
 
         const uri = vscode.Uri.parse(url);
-        const isHttpUrl = uri.scheme.toLowerCase() === 'http' || uri.scheme.toLowerCase() === 'https';
-        if (isHttpUrl) {
+        if (isLinkableUrl(url)) {
             this.iconPath = new vscode.ThemeIcon('link-external');
             this.contextValue = 'endpointUrl';
             this.command = {
@@ -297,7 +297,7 @@ function buildResourceTooltip(resource: ResourceJson): vscode.MarkdownString {
             }
         }
     }
-    const urls = resource.urls?.filter(u => !u.isInternal && typeof u.url === 'string' && (u.url.startsWith('http://') || u.url.startsWith('https://'))) ?? [];
+    const urls = resource.urls?.filter(u => !u.isInternal && typeof u.url === 'string' && isLinkableUrl(u.url)) ?? [];
     if (urls.length > 0) {
         md.appendMarkdown(`**${tooltipEndpoints}**\n\n`);
         for (const url of urls) {

--- a/src/Shared/KnownUnsupportedUrlSchemes.cs
+++ b/src/Shared/KnownUnsupportedUrlSchemes.cs
@@ -11,6 +11,8 @@ namespace Aspire.Shared;
 /// <remarks>
 /// This is a deny list because custom schemes could hand off the link to an app registered with the OS.
 /// For example, vscode://.
+/// These values are mirrored in the VS Code extension at extension/src/utils/urlSchemes.ts.
+/// Both files must be kept in sync.
 /// </remarks>
 internal static class KnownUnsupportedUrlSchemes
 {


### PR DESCRIPTION
## Description

Replace the HTTP/HTTPS allow list with a deny list matching the dashboard's `KnownUnsupportedUrlSchemes` for determining which endpoint URLs are clickable in the VS Code extension tree view and tooltips.

The previous fix (#15514) only made `http://` and `https://` URLs clickable, but as @JamesNK [pointed out](https://github.com/microsoft/aspire/pull/15514#issuecomment-4124105360), custom schemes like `vscode://` should also be clickable since they can hand off to apps registered with the OS. The dashboard uses a deny list approach for this reason.

Changes:
- Added `extension/src/utils/urlSchemes.ts` with a deny list of 9 unsupported schemes (gopher, ws, wss, news, nntp, telnet, tcp, redis, rediss) mirroring `src/Shared/KnownUnsupportedUrlSchemes.cs`
- Updated `EndpointUrlItem` constructor to use `isLinkableUrl()` instead of HTTP-only check
- Updated `buildResourceTooltip` to use `isLinkableUrl()` instead of `startsWith('http')` check
- Added unit tests for the `isLinkableUrl` helper

Fixes #15472

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
