### PR TITLE
Fail CI jobs when test runner times out (hangdump detection)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -338,7 +338,6 @@ jobs:
             --report-trx --report-trx-filename "${{ inputs.testShortName }}.trx" \
             --crashdump \
             --hangdump \
-            --hangdump-filename ${{ github.workspace }}/testresults/${{ inputs.testShortName }}.hangdump \
             --hangdump-timeout ${{ inputs.testHangTimeout }} \
             --results-directory ${{ github.workspace }}/testresults \
             --filter-not-trait "category=failing" \
@@ -386,6 +385,8 @@ jobs:
               --ignore-exit-code 8 `
               --report-trx --report-trx-filename "${{ inputs.testShortName }}.trx" `
               --crashdump `
+              --hangdump `
+              --hangdump-timeout ${{ inputs.testHangTimeout }} `
               --results-directory ${{ github.workspace }}/testresults `
               --filter-not-trait "category=failing" `
               --timeout ${{ inputs.testSessionTimeout }} `
@@ -435,6 +436,8 @@ jobs:
             --ignore-exit-code 8 \
             --report-trx \
             --crashdump \
+            --hangdump \
+            --hangdump-timeout ${{ inputs.testHangTimeout }} \
             --results-directory ${{ github.workspace }}/testresults \
             --timeout ${{ inputs.testSessionTimeout }} \
             ${{ inputs.extraTestArgs }} \
@@ -488,6 +491,8 @@ jobs:
               --ignore-exit-code 8 `
               --report-trx `
               --crashdump `
+              --hangdump `
+              --hangdump-timeout ${{ inputs.testHangTimeout }} `
               --results-directory ${{ github.workspace }}/testresults `
               --timeout ${{ inputs.testSessionTimeout }} `
               ${{ inputs.extraTestArgs }}

--- a/.github/workflows/specialized-test-runner.yml
+++ b/.github/workflows/specialized-test-runner.yml
@@ -132,6 +132,8 @@ jobs:
       requiresNugets: ${{ matrix.tests.requiresNugets == true }}
       requiresTestSdk: ${{ matrix.tests.requiresTestSdk == true }}
       os: ${{ matrix.tests.os }}
+      testSessionTimeout: ${{ matrix.tests.testSessionTimeout }}
+      testHangTimeout: ${{ matrix.tests.testHangTimeout }}
       enablePlaywrightInstall: ${{ inputs.enablePlaywrightInstall }}
       extraTestArgs: ${{ inputs.extraTestArgs }}
       ignoreTestFailures: ${{ inputs.ignoreTestFailures }}
@@ -198,6 +200,23 @@ jobs:
           --
           ${{ github.workspace }}/testresults
           --combined
+
+      - name: Fail if test runner crashed or timed out
+        if: steps.check_tests.outputs.tests_run == 'true'
+        shell: pwsh
+        run: |
+          $logDirectory = "${{ github.workspace }}/artifacts/all-logs"
+
+          # Check for dump files (.dmp) in any of the collected test artifacts.
+          # A .dmp file indicates a crash (--crashdump) or timeout (--hangdump).
+          $dumpFiles = Get-ChildItem -Path $logDirectory -Filter *.dmp -Recurse -ErrorAction SilentlyContinue
+          if ($dumpFiles.Count -gt 0) {
+            Write-Host "::error::Dump file(s) detected — the test runner crashed or timed out in one or more jobs:"
+            foreach ($df in $dumpFiles) { Write-Host "  - $($df.FullName)" }
+            exit 1
+          }
+
+          Write-Host "✓ No dump files detected"
 
       - name: Fail if any dependency failed
         # 'skipped' can be when a transitive dependency fails and the dependent job gets 'skipped'.


### PR DESCRIPTION
## Description

When a test runner crashes or times out (e.g., Cli.EndToEnd in [quarantine run #24057803347](https://github.com/microsoft/aspire/actions/runs/24057803347/attempts/1)), it produces a `.trx` file with zero test results. Previously this went undetected — the job passed green — because:
- `ignoreTestFailures` swallows the exit code with `|| true`
- The `.trx` validation only checked XML structure, not that tests actually ran
- Zero-test `.trx` files are legitimate for specialized tests on certain OSes, so we can't reject them outright

**Changes:**

1. **`run-tests.yml`**: Add `--hangdump` and `--hangdump-timeout` to all 4 test runner steps. Previously only the Linux nuget-dependent step had hangdump configured. This ensures all runner paths generate a hangdump file when the test runner times out.

2. **`run-tests.yml`**: Align default `testSessionTimeout` (15m → 20m) and `testHangTimeout` (7m → 10m) to match `Testing.props`. The `specialized-test-runner.yml` doesn't pass these inputs, so quarantine/outerloop tests were silently getting tighter timeouts than regular tests.

3. **`specialized-test-runner.yml`**: The Final Results job now scans all collected artifacts for `.hangdump` files and fails the workflow if any are detected. This is the most precise signal — a hangdump file proves the test runner timed out, vs legitimate zero-test runs which complete in seconds.

The hangdump check is only in the Final Results job (not individual run-tests jobs) because for regular tests, a non-zero exit code already fails the job naturally; for specialized tests with `ignoreTestFailures`, the Final Results job is the right aggregation point.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
