### PR TITLE
Fix quarantine/outerloop workflow failures from empty timeout arguments

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,11 +16,11 @@ on:
       testSessionTimeout:
         required: false
         type: string
-        default: "15m"
+        default: "20m"
       testHangTimeout:
         required: false
         type: string
-        default: "7m"
+        default: "10m"
       extraTestArgs:
         required: false
         type: string
@@ -67,6 +67,11 @@ jobs:
     name: ${{ inputs.testShortName }} (${{ inputs.os }})
     env:
       DOTNET_ROOT: ${{ github.workspace }}/.dotnet
+      # Resolve once so the fallback isn't duplicated across all four test-runner steps.
+      # The '|| default' is needed because GitHub Actions passes empty strings for
+      # unset workflow_call inputs, bypassing the input-level default: values.
+      EFFECTIVE_TEST_SESSION_TIMEOUT: ${{ inputs.testSessionTimeout || '20m' }}
+      EFFECTIVE_TEST_HANG_TIMEOUT: ${{ inputs.testHangTimeout || '10m' }}
     steps:
       - name: Validate arguments
         shell: pwsh
@@ -338,10 +343,10 @@ jobs:
             --report-trx --report-trx-filename "${{ inputs.testShortName }}.trx" \
             --crashdump \
             --hangdump \
-            --hangdump-timeout ${{ inputs.testHangTimeout }} \
+            --hangdump-timeout ${{ env.EFFECTIVE_TEST_HANG_TIMEOUT }} \
             --results-directory ${{ github.workspace }}/testresults \
             --filter-not-trait "category=failing" \
-            --timeout ${{ inputs.testSessionTimeout }} \
+            --timeout ${{ env.EFFECTIVE_TEST_SESSION_TIMEOUT }} \
             ${{ inputs.extraTestArgs }} \
             ${{ inputs.ignoreTestFailures && '|| true' || '' }}
           TEST_EXIT_CODE=$?
@@ -386,10 +391,10 @@ jobs:
               --report-trx --report-trx-filename "${{ inputs.testShortName }}.trx" `
               --crashdump `
               --hangdump `
-              --hangdump-timeout ${{ inputs.testHangTimeout }} `
+              --hangdump-timeout ${{ env.EFFECTIVE_TEST_HANG_TIMEOUT }} `
               --results-directory ${{ github.workspace }}/testresults `
               --filter-not-trait "category=failing" `
-              --timeout ${{ inputs.testSessionTimeout }} `
+              --timeout ${{ env.EFFECTIVE_TEST_SESSION_TIMEOUT }} `
               ${{ inputs.extraTestArgs }}
             $testExitCode = $LASTEXITCODE
           }
@@ -437,9 +442,9 @@ jobs:
             --report-trx \
             --crashdump \
             --hangdump \
-            --hangdump-timeout ${{ inputs.testHangTimeout }} \
+            --hangdump-timeout ${{ env.EFFECTIVE_TEST_HANG_TIMEOUT }} \
             --results-directory ${{ github.workspace }}/testresults \
-            --timeout ${{ inputs.testSessionTimeout }} \
+            --timeout ${{ env.EFFECTIVE_TEST_SESSION_TIMEOUT }} \
             ${{ inputs.extraTestArgs }} \
             ${{ inputs.ignoreTestFailures && '|| true' || '' }}
           TEST_EXIT_CODE=$?
@@ -492,9 +497,9 @@ jobs:
               --report-trx `
               --crashdump `
               --hangdump `
-              --hangdump-timeout ${{ inputs.testHangTimeout }} `
+              --hangdump-timeout ${{ env.EFFECTIVE_TEST_HANG_TIMEOUT }} `
               --results-directory ${{ github.workspace }}/testresults `
-              --timeout ${{ inputs.testSessionTimeout }} `
+              --timeout ${{ env.EFFECTIVE_TEST_SESSION_TIMEOUT }} `
               ${{ inputs.extraTestArgs }}
             $testExitCode = $LASTEXITCODE
           }

--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -1,8 +1,9 @@
 # Executes outerloop tests
 #
 # COPILOT INSTRUCTIONS:
-# - Keep the 'paths:' list in sync across tests-outerloop.yml and
-#   tests-quarantine.yml
+# - Keep the shared 'paths:' entries (specialized-test-runner.yml,
+#   run-tests.yml) in sync across tests-outerloop.yml and
+#   tests-quarantine.yml.  Each workflow also lists itself.
 # - Validate that each path exists in the repository before adding or
 #   updating the list
 # - No external YAML file is used—only the workflow YAMLs themselves
@@ -16,15 +17,17 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 02:00 UTC
 
-  # TEMPORARILY DISABLED pull_request trigger due to #12143 (disk space issues): https://github.com/microsoft/aspire/issues/12143
-  # pull_request:
-  #   paths:
-  #     - '.github/actions/**'
-  #     - '.github/workflows/**'
-  #     - 'eng/**'
-  #     - '!eng/pipelines/**'
-  #     - '!eng/scripts/**'
-  #     - '!eng/*pack/**'
+  # Re-enabled with narrow paths filter scoped to key workflow files that
+  # orchestrate this pipeline. Changes to downstream workflows (e.g.
+  # build-packages.yml) are validated by the regular CI and don't need to
+  # re-trigger the full quarantine/outerloop run.
+  # Previously disabled (#12143) due to broad paths filter causing disk
+  # space issues on every CI/eng change.
+  pull_request:
+    paths:
+      - '.github/workflows/tests-outerloop.yml'
+      - '.github/workflows/specialized-test-runner.yml'
+      - '.github/workflows/run-tests.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests-quarantine.yml
+++ b/.github/workflows/tests-quarantine.yml
@@ -1,8 +1,9 @@
 # Executes quarantined tests
 #
 # COPILOT INSTRUCTIONS:
-# - Keep the 'paths:' list in sync across tests-outerloop.yml and
-#   tests-quarantine.yml
+# - Keep the shared 'paths:' entries (specialized-test-runner.yml,
+#   run-tests.yml) in sync across tests-outerloop.yml and
+#   tests-quarantine.yml.  Each workflow also lists itself.
 # - Validate that each path exists in the repository before adding or
 #   updating the list
 # - No external YAML file is used—only the workflow YAMLs themselves
@@ -17,15 +18,17 @@ on:
     # Run every 2 hours. Quarantined tests are run frequently to catch flaky tests with a low failure rate.
     - cron: '0 */2 * * *'
 
-  # TEMPORARILY DISABLED pull_request trigger due to #12143 (disk space issues): https://github.com/microsoft/aspire/issues/12143
-  # pull_request:
-  #   paths:
-  #     - '.github/actions/**'
-  #     - '.github/workflows/**'
-  #     - 'eng/**'
-  #     - '!eng/pipelines/**'
-  #     - '!eng/scripts/**'
-  #     - '!eng/*pack/**'
+  # Re-enabled with narrow paths filter scoped to key workflow files that
+  # orchestrate this pipeline. Changes to downstream workflows (e.g.
+  # build-packages.yml) are validated by the regular CI and don't need to
+  # re-trigger the full quarantine/outerloop run.
+  # Previously disabled (#12143) due to broad paths filter causing disk
+  # space issues on every CI/eng change.
+  pull_request:
+    paths:
+      - '.github/workflows/tests-quarantine.yml'
+      - '.github/workflows/specialized-test-runner.yml'
+      - '.github/workflows/run-tests.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,7 @@ These switches can be repeated to run tests on multiple classes or methods at on
 - **`ci.yml`**: Main CI workflow triggered on PRs and pushes to main/release branches
 - **Build validation**: Includes package generation, API compatibility checks, template validation
 - **Workflow matcher maintenance**: When changing CI workflow job or step names that are referenced by automation or tests, update the corresponding workflow helpers, behavior tests, and docs together. For the transient rerun workflow, keep `.github/workflows/auto-rerun-transient-ci-failures.js`, `tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs`, and `docs/ci/auto-rerun-transient-ci-failures.md` aligned with the live workflow YAML.
+- **⚠️ Quarantine and outerloop tests are easily broken** because they primarily run on schedule, not on most PRs. Changes to `tests-quarantine.yml`, `tests-outerloop.yml`, `specialized-test-runner.yml`, or `run-tests.yml` will automatically trigger the affected workflow(s) on the PR via `paths:` filters. Verify the triggered runs pass before merging.
 
 #### Azure DevOps (secondary, does NOT run tests on PRs)
 - **`eng/pipelines/azure-pipelines-public.yml`**: Weekly scheduled pipeline (Monday midnight UTC) that builds and runs tests on Helix


### PR DESCRIPTION
## Description

PR #15917 added `testSessionTimeout` and `testHangTimeout` pass-through from `specialized-test-runner.yml` to `run-tests.yml`. When runsheet entries don't define these values, GitHub Actions passes empty strings to the `workflow_call` inputs — which **bypasses** the callee's `default:` values. This caused `--hangdump-timeout` and `--timeout` to receive empty arguments, making the MTP test runner print its help text and exit without running any tests.

All 6 test jobs in the quarantine workflow failed: https://github.com/microsoft/aspire/actions/runs/24064788789

### Changes

**1. Fix empty timeout arguments in `run-tests.yml`** (`600339ab`)
- Added `|| 'default'` fallbacks at all 8 usage sites (4 test runner steps × 2 timeout args each)
- Corrected input defaults from 15m/7m to 20m/10m to match the canonical values in `eng/Testing.props`

**2. Auto-trigger quarantine/outerloop workflows on PR** (`e0f21436`)
- Re-enabled `pull_request` triggers on `tests-quarantine.yml` and `tests-outerloop.yml` with narrow `paths:` filters scoped to just the workflow files that affect them
- Previously disabled in #12143 due to overly broad path filters causing disk space issues
- This adds PR validation for the quarantine and outerloop workflows: any PR that touches `run-tests.yml`, `specialized-test-runner.yml`, `tests-quarantine.yml`, or `tests-outerloop.yml` will automatically trigger these workflows, preventing regressions like this one from going undetected

**3. AGENTS.md guidance** (`cc95ec1e`)
- Added a note that changes to quarantine/outerloop workflow files auto-trigger validation

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No — CI workflow fix, validated by the workflows themselves
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No