### PR TITLE
Trigger Policy Service re-sync after org transfer

### DIFF
--- a/.github/policies/scheduledSearch.markNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.markNoRecentActivity.yml
@@ -1,6 +1,8 @@
 id: scheduledSearch.markNoRecentActivity
 name: No Recent Activity Monitor
-description: Adds no-recent-activity label to issues and PRs that have not been updated in a while
+description: Adds no-recent-activity label to issues and PRs that have not been updated in a while.
+
+# Trigger re-sync of GitHub Policy Service after repo transfer from dotnet/aspire to microsoft/aspire
 owner:
 resource: repository
 disabled: false


### PR DESCRIPTION
## Description

The **Microsoft GitHub Policy Service** (GitOps bot) stopped processing policies after the repository was transferred from `dotnet/aspire` to `microsoft/aspire`.

This is a no-op change to a policy file that triggers a webhook, which should cause the Policy Service to re-sync and start processing policies for `microsoft/aspire`.

## Changes

- Added a period to the description field in `scheduledSearch.markNoRecentActivity.yml`
- Added a comment explaining the purpose of the change

## Context

The Policy Service is a pre-installed core GitHub App (*Microsoft GitHub Policy Service*) on the `microsoft` org. After a repo transfer between orgs, the service may need a policy file change to trigger re-registration of the webhook and reconciliation of the repo's policies.

If this doesn't resolve the issue, next step is to file a support ticket at [microsoft/github-operations](https://github.com/microsoft/github-operations/issues/new/choose).