### PR TITLE
Add *.lscache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,8 @@ Session.vim
 config.ps1
 **/IISApplications
 
+# Language server cache files
+*.lscache
 
 # Node.js modules
 node_modules/


### PR DESCRIPTION
Add `*.lscache` (language server cache) files to the root `.gitignore` to prevent them from being accidentally committed.