### PR TITLE
Fix release pipeline source and NuGet service connection

### DIFF
--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -47,7 +47,7 @@ variables:
   - template: /eng/pipelines/common-variables.yml@self
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
   # Variable group containing secrets (VscePublishToken for future use)
-  # Note: NuGet publishing uses service connection 'NuGet.org - microsoft/aspire' instead of API key
+  # Note: NuGet publishing uses service connection 'NuGet.org - dotnet/aspire' instead of API key
   - group: Aspire-Release-Secrets
   # Variable group containing aspire-winget-bot-pat and aspire-homebrew-bot-pat for WinGet and Homebrew publishing
   - group: Aspire-Secrets
@@ -385,7 +385,7 @@ extends:
                     packagesToPush: '$(Pipeline.Workspace)/packages/PackageArtifacts/*.nupkg'
                     packageParentPath: '$(Pipeline.Workspace)/packages/PackageArtifacts'
                     nuGetFeedType: external
-                    publishFeedCredentials: 'NuGet.org - microsoft/aspire'
+                    publishFeedCredentials: 'NuGet.org - dotnet/aspire'
 
               # Skip message when SkipNuGetPublish is true
               - ${{ if eq(parameters.SkipNuGetPublish, true) }}:

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -60,7 +60,7 @@ resources:
       ref: refs/tags/release
   pipelines:
     - pipeline: aspire-build
-      source: dotnet-aspire  # Name of the main build pipeline
+      source: microsoft-aspire  # Name of the main build pipeline
       project: internal      # AzDO project name
       trigger: none          # Manual trigger only - no automatic releases
 

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -71,11 +71,11 @@ extends:
       name: NetCore1ESPool-Internal
       image: windows.vs2026preview.scout.amd64
       os: windows
-    # Required for publishing to external feeds like nuget.org
-    # Pattern from dotnet-workload-versions/official.yml
-    # Note: 'Permissive,CFSClean' blocks NuGet.org - must use just 'Permissive'
+    # Network isolation policy: match main build pipeline for ES4.2.4 CFS compliance.
+    # releaseJob templateContext provides approved network access for external publishing
+    # (NuGet.org, GitHub API for WinGet/Homebrew, Maestro).
     settings:
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2
 
     stages:
       # ===== STAGE 1: PREPARE ARTIFACTS =====


### PR DESCRIPTION
## Summary

These changes are needed to fix the release pipeline.

### Changes

1. **Fix pipeline resource source** - Update the pipeline resource source from `dotnet-aspire` to `microsoft-aspire` to match the renamed main build pipeline.
2. **Fix NuGet service connection** - Update `publishFeedCredentials` from `NuGet.org - microsoft/aspire` to `NuGet.org - dotnet/aspire`.

Cherry-picked from `InternalFork/joperezr/fix-release-pipeline-source`.