### PR TITLE
Fix open redirect vulnerability

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Login.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor.cs
@@ -108,7 +108,7 @@ public partial class Login : IAsyncDisposable, IComponentWithTelemetry
 
     private string GetRedirectUrl()
     {
-        return ReturnUrl ?? DashboardUrls.ResourcesUrl();
+        return UrlValidationHelper.IsSafeRedirectUrl(ReturnUrl) ? ReturnUrl : DashboardUrls.ResourcesUrl();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
+++ b/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
@@ -69,6 +69,8 @@ internal sealed class ValidateTokenMiddleware
 
     private static void RedirectAfterValidation(HttpContext context)
     {
+        // An optional returnurl value must be a valid URL and it must be local.
+        // We don't want an open redirect (the potential to create a URL that redirects to a third-party site).
         if (context.Request.Query.TryGetValue("returnUrl", out var returnUrl)
             && IsLocalUrl(returnUrl.ToString()))
         {

--- a/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
+++ b/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 using System.Web;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Dashboard.Model;
 
@@ -79,13 +80,66 @@ internal sealed class ValidateTokenMiddleware
         }
     }
 
-    private static bool IsLocalUrl(string url)
+    // Copied from ASP.NET Core's IsLocalUrl implementation:
+    // https://github.com/dotnet/aspnetcore/blob/7cbda0e023075490b4365a0754ca410ce6eff59a/src/Shared/ResultsHelpers/SharedUrlHelper.cs#L33
+    internal static bool IsLocalUrl([NotNullWhen(true)] string? url)
     {
-        // Only allow local URLs that start with "/" (but not "//" or "/\" which browsers treat as absolute).
-        // This mirrors the logic in ASP.NET Core's IUrlHelper.IsLocalUrl.
-        return url.Length > 0
-            && url[0] == '/'
-            && (url.Length == 1 || (url[1] != '/' && url[1] != '\\'));
+        if (string.IsNullOrEmpty(url))
+        {
+            return false;
+        }
+
+        // Allows "/" or "/foo" but not "//" or "/\".
+        if (url[0] == '/')
+        {
+            // url is exactly "/"
+            if (url.Length == 1)
+            {
+                return true;
+            }
+
+            // url doesn't start with "//" or "/\"
+            if (url[1] != '/' && url[1] != '\\')
+            {
+                return !HasControlCharacter(url.AsSpan(1));
+            }
+
+            return false;
+        }
+
+        // Allows "~/" or "~/foo" but not "~//" or "~/\".
+        if (url[0] == '~' && url.Length > 1 && url[1] == '/')
+        {
+            // url is exactly "~/"
+            if (url.Length == 2)
+            {
+                return true;
+            }
+
+            // url doesn't start with "~//" or "~/\"
+            if (url[2] != '/' && url[2] != '\\')
+            {
+                return !HasControlCharacter(url.AsSpan(2));
+            }
+
+            return false;
+        }
+
+        return false;
+
+        static bool HasControlCharacter(ReadOnlySpan<char> readOnlySpan)
+        {
+            // URLs may not contain ASCII control characters.
+            for (var i = 0; i < readOnlySpan.Length; i++)
+            {
+                if (char.IsControl(readOnlySpan[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     public static async Task<bool> TryAuthenticateAsync(string incomingBrowserToken, HttpContext httpContext, IOptionsMonitor<DashboardOptions> dashboardOptions)

--- a/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
+++ b/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 using System.Web;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Dashboard.Model;
 
@@ -72,75 +71,13 @@ internal sealed class ValidateTokenMiddleware
         // An optional returnurl value must be a valid URL and it must be local.
         // We don't want an open redirect (the potential to create a URL that redirects to a third-party site).
         if (context.Request.Query.TryGetValue("returnUrl", out var returnUrl)
-            && IsLocalUrl(returnUrl.ToString()))
+            && UrlValidationHelper.IsSafeRedirectUrl(returnUrl.ToString()))
         {
             context.Response.Redirect(returnUrl.ToString());
         }
         else
         {
             context.Response.Redirect(DashboardUrls.ResourcesUrl());
-        }
-    }
-
-    // Copied from ASP.NET Core's IsLocalUrl implementation:
-    // https://github.com/dotnet/aspnetcore/blob/7cbda0e023075490b4365a0754ca410ce6eff59a/src/Shared/ResultsHelpers/SharedUrlHelper.cs#L33
-    internal static bool IsLocalUrl([NotNullWhen(true)] string? url)
-    {
-        if (string.IsNullOrEmpty(url))
-        {
-            return false;
-        }
-
-        // Allows "/" or "/foo" but not "//" or "/\".
-        if (url[0] == '/')
-        {
-            // url is exactly "/"
-            if (url.Length == 1)
-            {
-                return true;
-            }
-
-            // url doesn't start with "//" or "/\"
-            if (url[1] != '/' && url[1] != '\\')
-            {
-                return !HasControlCharacter(url.AsSpan(1));
-            }
-
-            return false;
-        }
-
-        // Allows "~/" or "~/foo" but not "~//" or "~/\".
-        if (url[0] == '~' && url.Length > 1 && url[1] == '/')
-        {
-            // url is exactly "~/"
-            if (url.Length == 2)
-            {
-                return true;
-            }
-
-            // url doesn't start with "~//" or "~/\"
-            if (url[2] != '/' && url[2] != '\\')
-            {
-                return !HasControlCharacter(url.AsSpan(2));
-            }
-
-            return false;
-        }
-
-        return false;
-
-        static bool HasControlCharacter(ReadOnlySpan<char> readOnlySpan)
-        {
-            // URLs may not contain ASCII control characters.
-            for (var i = 0; i < readOnlySpan.Length; i++)
-            {
-                if (char.IsControl(readOnlySpan[i]))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 

--- a/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
+++ b/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
@@ -68,7 +68,8 @@ internal sealed class ValidateTokenMiddleware
 
     private static void RedirectAfterValidation(HttpContext context)
     {
-        if (context.Request.Query.TryGetValue("returnUrl", out var returnUrl))
+        if (context.Request.Query.TryGetValue("returnUrl", out var returnUrl)
+            && IsLocalUrl(returnUrl.ToString()))
         {
             context.Response.Redirect(returnUrl.ToString());
         }
@@ -76,6 +77,15 @@ internal sealed class ValidateTokenMiddleware
         {
             context.Response.Redirect(DashboardUrls.ResourcesUrl());
         }
+    }
+
+    private static bool IsLocalUrl(string url)
+    {
+        // Only allow local URLs that start with "/" (but not "//" or "/\" which browsers treat as absolute).
+        // This mirrors the logic in ASP.NET Core's IUrlHelper.IsLocalUrl.
+        return url.Length > 0
+            && url[0] == '/'
+            && (url.Length == 1 || (url[1] != '/' && url[1] != '\\'));
     }
 
     public static async Task<bool> TryAuthenticateAsync(string incomingBrowserToken, HttpContext httpContext, IOptionsMonitor<DashboardOptions> dashboardOptions)

--- a/src/Aspire.Dashboard/Utils/UrlValidationHelper.cs
+++ b/src/Aspire.Dashboard/Utils/UrlValidationHelper.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Dashboard.Utils;
+
+/// <summary>
+/// Helpers for validating redirect URLs.
+/// </summary>
+internal static class UrlValidationHelper
+{
+    /// <summary>
+    /// Checks whether a URL is safe to use as a redirect target.
+    /// The URL must be a valid URI and a local path (not absolute or protocol-relative).
+    /// </summary>
+    internal static bool IsSafeRedirectUrl([NotNullWhen(true)] string? url)
+    {
+        return Uri.TryCreate(url, UriKind.Relative, out _) && IsLocalUrl(url);
+    }
+
+    // Copied from ASP.NET Core's IsLocalUrl implementation:
+    // https://github.com/dotnet/aspnetcore/blob/7cbda0e023075490b4365a0754ca410ce6eff59a/src/Shared/ResultsHelpers/SharedUrlHelper.cs#L33
+    internal static bool IsLocalUrl([NotNullWhen(true)] string? url)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            return false;
+        }
+
+        // Allows "/" or "/foo" but not "//" or "/\".
+        if (url[0] == '/')
+        {
+            // url is exactly "/"
+            if (url.Length == 1)
+            {
+                return true;
+            }
+
+            // url doesn't start with "//" or "/\"
+            if (url[1] != '/' && url[1] != '\\')
+            {
+                return !HasControlCharacter(url.AsSpan(1));
+            }
+
+            return false;
+        }
+
+        // Allows "~/" or "~/foo" but not "~//" or "~/\".
+        if (url[0] == '~' && url.Length > 1 && url[1] == '/')
+        {
+            // url is exactly "~/"
+            if (url.Length == 2)
+            {
+                return true;
+            }
+
+            // url doesn't start with "~//" or "~/\"
+            if (url[2] != '/' && url[2] != '\\')
+            {
+                return !HasControlCharacter(url.AsSpan(2));
+            }
+
+            return false;
+        }
+
+        return false;
+
+        static bool HasControlCharacter(ReadOnlySpan<char> readOnlySpan)
+        {
+            // URLs may not contain ASCII control characters.
+            for (var i = 0; i < readOnlySpan.Length; i++)
+            {
+                if (char.IsControl(readOnlySpan[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Middleware/ValidateTokenMiddlewareTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Middleware/ValidateTokenMiddlewareTests.cs
@@ -63,6 +63,32 @@ public class ValidateTokenMiddlewareTests
         Assert.Equal("/test", response.Headers.Location?.OriginalString);
     }
 
+    [Theory]
+    [InlineData("https://evil.com")]
+    [InlineData("http://evil.com")]
+    [InlineData("//evil.com")]
+    [InlineData("//evil.com/path")]
+    [InlineData("/\\evil.com")]
+    public async Task ValidateToken_NotBrowserTokenAuth_AbsoluteReturnUrl_RedirectsToHomepage(string returnUrl)
+    {
+        using var host = await SetUpHostAsync(FrontendAuthMode.Unsecured, string.Empty).DefaultTimeout();
+        var response = await host.GetTestClient().GetAsync($"/login?t=test&returnUrl={Uri.EscapeDataString(returnUrl)}").DefaultTimeout();
+        Assert.Equal("/", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData("https://evil.com")]
+    [InlineData("http://evil.com")]
+    [InlineData("//evil.com")]
+    [InlineData("//evil.com/path")]
+    [InlineData("/\\evil.com")]
+    public async Task ValidateToken_BrowserTokenAuth_RightToken_AbsoluteReturnUrl_RedirectsToHomepage(string returnUrl)
+    {
+        using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token").DefaultTimeout();
+        var response = await host.GetTestClient().GetAsync($"/login?t=token&returnUrl={Uri.EscapeDataString(returnUrl)}").DefaultTimeout();
+        Assert.Equal("/", response.Headers.Location?.OriginalString);
+    }
+
     private static async Task<IHost> SetUpHostAsync(FrontendAuthMode authMode, string expectedToken)
     {
         return await new HostBuilder()


### PR DESCRIPTION
## Description

Fix an open redirect vulnerability in `ValidateTokenMiddleware`. The `returnUrl` query parameter was used directly in `Response.Redirect` without validation, allowing an attacker to craft a login URL that redirects users to an external malicious site after authentication.

The fix adds an `IsLocalUrl` check (matching ASP.NET Core's `IUrlHelper.IsLocalUrl` logic) that only allows redirect URLs starting with `/` while rejecting protocol-relative (`//`) and backslash escape (`/\`) patterns. If validation fails, the middleware falls back to the default resources URL.

Unit tests are added covering absolute URLs (`https://evil.com`, `http://evil.com`), protocol-relative URLs (`//evil.com`), and backslash escape URLs (`/\evil.com`) for both Unsecured and BrowserToken auth modes.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
