### PR TITLE
Buffer console logs during interactive prompts

### DIFF
--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -45,6 +45,7 @@ internal sealed class RenderCommand : BaseCommand
         ["choice"] = "Selection prompt with formatted choices",
         ["choice-simple"] = "Selection prompt without formatter",
         ["mixed"] = "Mixed interaction service methods",
+        ["buffered-logging"] = "Background logging during interactive prompt (buffer demo)",
         ["markdown-interactive"] = "Render markdown with DisplayMarkdown (interactive)",
         ["markdown-plain"] = "Render markdown as plain text with DisplayRawText (non-interactive)",
         ["markdown-renderable"] = "Render markdown via ConvertToRenderable with ANSI disabled",
@@ -177,6 +178,8 @@ internal sealed class RenderCommand : BaseCommand
                 case "mixed":
                     await TestMixedMethodsAsync(cancellationToken);
                     return CliExitCodes.Success;
+                case "buffered-logging":
+                    return await TestBufferedLoggingAsync(cancellationToken);
                 case "markdown-interactive":
                     return TestMarkdownRenderInteractive();
                 case "markdown-plain":
@@ -387,6 +390,55 @@ internal sealed class RenderCommand : BaseCommand
 
         InteractionService.DisplayEmptyLine();
         InteractionService.DisplayMessage(KnownEmojis.StopSign, "Mixed methods test complete.");
+    }
+
+    private async Task<int> TestBufferedLoggingAsync(CancellationToken cancellationToken)
+    {
+        // Create a dedicated LoggerFactory with SpectreConsoleLoggerProvider so log messages
+        // are always visible on stderr without requiring --debug. Uses the shared buffer
+        // context from DI so buffering during interactive prompts still works.
+        var logBufferContext = _serviceProvider.GetRequiredService<ConsoleLogBufferContext>();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(new SpectreConsoleLoggerProvider(Console.Error, logBufferContext));
+        });
+        var logger = loggerFactory.CreateLogger<RenderCommand>();
+
+        InteractionService.DisplayMessage(KnownEmojis.Information, "This demo fires background log messages while a prompt is active.");
+        InteractionService.DisplayMessage(KnownEmojis.Information, "Logs are buffered and flushed after the prompt completes.");
+        InteractionService.DisplayEmptyLine();
+
+        // Start a background task that writes log messages every 200ms.
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var loggingTask = Task.Run(async () =>
+        {
+            var counter = 0;
+            while (!cts.Token.IsCancellationRequested)
+            {
+                counter++;
+                logger.LogDebug("Background log #{Counter} written while prompt is active", counter);
+                await Task.Delay(200, cts.Token).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            }
+        }, cancellationToken);
+
+        await Task.Delay(500, cancellationToken); // Let a few logs accumulate before starting the prompt
+
+        // Show an interactive prompt — background logs should be buffered during this.
+        var answer = await InteractionService.PromptForStringAsync(
+            "Type something (background logs are buffering)",
+            binding: PromptBinding.CreateDefault<string?>("hello"),
+            cancellationToken: cancellationToken);
+
+        // Stop background logging and let buffered messages flush.
+        cts.Cancel();
+        await loggingTask;
+
+        InteractionService.DisplayEmptyLine();
+        InteractionService.DisplaySuccess($"You entered: {answer}");
+        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Buffered log lines should appear above this message.");
+
+        return CliExitCodes.Success;
     }
 
     private async Task<int> TestLinksAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -239,6 +239,10 @@ internal class ConsoleInteractionService : IInteractionService
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
+        // Buffer console logs while interactive prompts are active so
+        // background debug output doesn't drown the prompt UI.
+        using var promptScope = SpectreConsoleLoggerProvider.BeginInteractivePromptScope();
+
         MessageLogger.LogInformation("Prompt: {PromptText} (default: {DefaultValue}, secret: {IsSecret})", promptText, isSecret ? "****" : defaultValue ?? "(none)", isSecret);
 
         var displayDefaultValue = defaultValue?.EscapeMarkup();
@@ -312,6 +316,10 @@ internal class ConsoleInteractionService : IInteractionService
             throw new EmptyChoicesException(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NoItemsAvailableForSelection, promptText));
         }
 
+        // Buffer console logs while interactive prompts are active so
+        // background debug output doesn't drown the prompt UI.
+        using var promptScope = SpectreConsoleLoggerProvider.BeginInteractivePromptScope();
+
         MessageLogger.LogInformation("Selection prompt: {PromptText}", promptText);
 
         var prompt = new SelectionPrompt<T>()
@@ -370,6 +378,10 @@ internal class ConsoleInteractionService : IInteractionService
         {
             throw new EmptyChoicesException(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NoItemsAvailableForSelection, promptText));
         }
+
+        // Buffer console logs while interactive prompts are active so
+        // background debug output doesn't drown the prompt UI.
+        using var promptScope = SpectreConsoleLoggerProvider.BeginInteractivePromptScope();
 
         var preSelectedSet = preSelected is not null ? new HashSet<T>(preSelected) : null;
 

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -31,6 +31,7 @@ internal class ConsoleInteractionService : IInteractionService
     private readonly ICliHostEnvironment _hostEnvironment;
     private readonly ILogger _stdoutLogger;
     private readonly ILogger _stderrLogger;
+    private readonly ConsoleLogBufferContext _logBufferContext;
     private int _inStatus;
 
     /// <summary>
@@ -57,18 +58,20 @@ internal class ConsoleInteractionService : IInteractionService
 
     public bool SupportsLinks => MessageConsole.Profile.Capabilities.Links;
 
-    public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
+    public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, ILoggerFactory loggerFactory, ConsoleLogBufferContext logBufferContext)
     {
         ArgumentNullException.ThrowIfNull(consoleEnvironment);
         ArgumentNullException.ThrowIfNull(executionContext);
         ArgumentNullException.ThrowIfNull(hostEnvironment);
         ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentNullException.ThrowIfNull(logBufferContext);
         _outConsole = consoleEnvironment.Out;
         _errorConsole = consoleEnvironment.Error;
         _executionContext = executionContext;
         _hostEnvironment = hostEnvironment;
         _stdoutLogger = loggerFactory.CreateLogger($"Aspire.Cli.Console.{CliLogFormat.Categories.Stdout}");
         _stderrLogger = loggerFactory.CreateLogger($"Aspire.Cli.Console.{CliLogFormat.Categories.Stderr}");
+        _logBufferContext = logBufferContext;
     }
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
@@ -241,7 +244,7 @@ internal class ConsoleInteractionService : IInteractionService
 
         // Buffer console logs while interactive prompts are active so
         // background debug output doesn't drown the prompt UI.
-        using var promptScope = SpectreConsoleLoggerProvider.BeginInteractivePromptScope();
+        using var promptScope = _logBufferContext.BeginInteractivePromptScope();
 
         MessageLogger.LogInformation("Prompt: {PromptText} (default: {DefaultValue}, secret: {IsSecret})", promptText, isSecret ? "****" : defaultValue ?? "(none)", isSecret);
 
@@ -318,7 +321,7 @@ internal class ConsoleInteractionService : IInteractionService
 
         // Buffer console logs while interactive prompts are active so
         // background debug output doesn't drown the prompt UI.
-        using var promptScope = SpectreConsoleLoggerProvider.BeginInteractivePromptScope();
+        using var promptScope = _logBufferContext.BeginInteractivePromptScope();
 
         MessageLogger.LogInformation("Selection prompt: {PromptText}", promptText);
 
@@ -381,7 +384,7 @@ internal class ConsoleInteractionService : IInteractionService
 
         // Buffer console logs while interactive prompts are active so
         // background debug output doesn't drown the prompt UI.
-        using var promptScope = SpectreConsoleLoggerProvider.BeginInteractivePromptScope();
+        using var promptScope = _logBufferContext.BeginInteractivePromptScope();
 
         var preSelectedSet = preSelected is not null ? new HashSet<T>(preSelected) : null;
 
@@ -638,6 +641,10 @@ internal class ConsoleInteractionService : IInteractionService
 
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
+
+        // Buffer console logs while interactive prompts are active so
+        // background debug output doesn't drown the prompt UI.
+        using var promptScope = _logBufferContext.BeginInteractivePromptScope();
 
         // When no binding is provided, default to true (matching the historical behavior
         // where the old ConfirmAsync signature had defaultValue = true).

--- a/src/Aspire.Cli/Interaction/ConsoleLogBufferContext.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleLogBufferContext.cs
@@ -71,7 +71,11 @@ internal sealed class ConsoleLogBufferContext
         // Flush may need to loop because new messages can arrive during the drain.
         // The decrement must only happen once per scope close, so track it separately
         // from the loop iterations to avoid stealing depth from a concurrently opened scope.
+        // Cap iterations to prevent unbounded looping if messages arrive faster than
+        // we can drain (e.g., a very chatty logger on another thread).
+        const int maxFlushIterations = 3;
         var decremented = false;
+        var remainingIterations = maxFlushIterations;
         while (true)
         {
             List<(TextWriter Writer, string Message)> messagesToFlush;
@@ -104,12 +108,25 @@ internal sealed class ConsoleLogBufferContext
                 {
                     messagesToFlush.Add(_bufferedMessages.Dequeue());
                 }
+
+                // On the final iteration, clear flushing state before writing so new
+                // messages arriving during the last write go directly to output (the
+                // prompt is over). This prevents the loop from running indefinitely.
+                if (--remainingIterations <= 0)
+                {
+                    _isFlushing = false;
+                }
             }
 
             // Write outside the lock to avoid holding it during I/O.
             foreach (var (writer, msg) in messagesToFlush)
             {
                 writer.WriteLine(msg);
+            }
+
+            if (remainingIterations <= 0)
+            {
+                return;
             }
 
             // Loop back to check whether new messages arrived while we were writing.

--- a/src/Aspire.Cli/Interaction/ConsoleLogBufferContext.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleLogBufferContext.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Interaction;
+
+/// <summary>
+/// Shared context that buffers console log output while interactive prompts are active.
+/// Registered as a singleton so the logger provider and interaction service share the same state.
+/// </summary>
+internal sealed class ConsoleLogBufferContext
+{
+    // Cap the buffer to prevent unbounded memory growth when a prompt stays open
+    // during heavy logging. Once the cap is reached, oldest messages are dropped.
+    internal const int MaxBufferedMessages = 1000;
+
+    // Guards prompt depth, buffer state, and direct writes. Holding the lock during
+    // I/O is acceptable because Console.Error is already internally serialized and
+    // each write is a single short log line (sub-millisecond).
+    private readonly object _logBufferLock = new();
+    private readonly Queue<(TextWriter Writer, string Message)> _bufferedMessages = new();
+    private int _interactivePromptDepth;
+
+    // When true, the buffer is being flushed. New writes arriving during flush are
+    // still buffered so they don't interleave with the drain or appear before it.
+    private bool _isFlushing;
+
+    /// <summary>
+    /// Begins an interactive prompt scope. Logs are buffered until the outermost scope ends.
+    /// </summary>
+    internal IDisposable BeginInteractivePromptScope()
+    {
+        lock (_logBufferLock)
+        {
+            _interactivePromptDepth++;
+        }
+
+        return new InteractivePromptScope(this);
+    }
+
+    /// <summary>
+    /// Writes the message immediately if no prompt scope is active, otherwise buffers it.
+    /// The decision and write are performed atomically under the same lock so no log line
+    /// can slip into an active prompt window.
+    /// </summary>
+    internal void WriteOrBuffer(TextWriter output, string message)
+    {
+        lock (_logBufferLock)
+        {
+            // During an active prompt or an ongoing flush, queue log lines instead of
+            // writing immediately so output ordering is preserved.
+            if (_interactivePromptDepth > 0 || _isFlushing)
+            {
+                if (_bufferedMessages.Count >= MaxBufferedMessages)
+                {
+                    // Drop the oldest message to stay within the cap.
+                    _bufferedMessages.Dequeue();
+                }
+
+                _bufferedMessages.Enqueue((output, message));
+                return;
+            }
+
+            // No prompt active and not flushing — write directly under lock so the
+            // decision and I/O are atomic with respect to prompt scope changes.
+            output.WriteLine(message);
+        }
+    }
+
+    private void EndInteractivePromptScope()
+    {
+        // Flush may need to loop because new messages can arrive during the drain.
+        // The decrement must only happen once per scope close, so track it separately
+        // from the loop iterations to avoid stealing depth from a concurrently opened scope.
+        var decremented = false;
+        while (true)
+        {
+            List<(TextWriter Writer, string Message)> messagesToFlush;
+
+            lock (_logBufferLock)
+            {
+                if (!decremented && _interactivePromptDepth > 0)
+                {
+                    _interactivePromptDepth--;
+                    decremented = true;
+                }
+
+                if (_interactivePromptDepth > 0)
+                {
+                    return;
+                }
+
+                if (_bufferedMessages.Count == 0)
+                {
+                    _isFlushing = false;
+                    return;
+                }
+
+                // Enter flushing state so concurrent WriteOrBuffer calls still buffer.
+                _isFlushing = true;
+
+                // Drain current buffer under lock to preserve ordering.
+                messagesToFlush = new List<(TextWriter, string)>(_bufferedMessages.Count);
+                while (_bufferedMessages.Count > 0)
+                {
+                    messagesToFlush.Add(_bufferedMessages.Dequeue());
+                }
+            }
+
+            // Write outside the lock to avoid holding it during I/O.
+            foreach (var (writer, msg) in messagesToFlush)
+            {
+                writer.WriteLine(msg);
+            }
+
+            // Loop back to check whether new messages arrived while we were writing.
+        }
+    }
+
+    private sealed class InteractivePromptScope(ConsoleLogBufferContext context) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            // Ensure scope close is applied only once for idempotent disposal.
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                context.EndInteractivePromptScope();
+            }
+        }
+    }
+}

--- a/src/Aspire.Cli/Interaction/ConsoleLogBufferContext.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleLogBufferContext.cs
@@ -20,10 +20,6 @@ internal sealed class ConsoleLogBufferContext
     private readonly Queue<(TextWriter Writer, string Message)> _bufferedMessages = new();
     private int _interactivePromptDepth;
 
-    // When true, the buffer is being flushed. New writes arriving during flush are
-    // still buffered so they don't interleave with the drain or appear before it.
-    private bool _isFlushing;
-
     /// <summary>
     /// Begins an interactive prompt scope. Logs are buffered until the outermost scope ends.
     /// </summary>
@@ -46,9 +42,7 @@ internal sealed class ConsoleLogBufferContext
     {
         lock (_logBufferLock)
         {
-            // During an active prompt or an ongoing flush, queue log lines instead of
-            // writing immediately so output ordering is preserved.
-            if (_interactivePromptDepth > 0 || _isFlushing)
+            if (_interactivePromptDepth > 0)
             {
                 if (_bufferedMessages.Count >= MaxBufferedMessages)
                 {
@@ -60,76 +54,33 @@ internal sealed class ConsoleLogBufferContext
                 return;
             }
 
-            // No prompt active and not flushing — write directly under lock so the
-            // decision and I/O are atomic with respect to prompt scope changes.
             output.WriteLine(message);
         }
     }
 
     private void EndInteractivePromptScope()
     {
-        // Flush may need to loop because new messages can arrive during the drain.
-        // The decrement must only happen once per scope close, so track it separately
-        // from the loop iterations to avoid stealing depth from a concurrently opened scope.
-        // Cap iterations to prevent unbounded looping if messages arrive faster than
-        // we can drain (e.g., a very chatty logger on another thread).
-        const int maxFlushIterations = 3;
-        var decremented = false;
-        var remainingIterations = maxFlushIterations;
-        while (true)
+        lock (_logBufferLock)
         {
-            List<(TextWriter Writer, string Message)> messagesToFlush;
-
-            lock (_logBufferLock)
+            if (_interactivePromptDepth > 0)
             {
-                if (!decremented && _interactivePromptDepth > 0)
-                {
-                    _interactivePromptDepth--;
-                    decremented = true;
-                }
-
-                if (_interactivePromptDepth > 0)
-                {
-                    return;
-                }
-
-                if (_bufferedMessages.Count == 0)
-                {
-                    _isFlushing = false;
-                    return;
-                }
-
-                // Enter flushing state so concurrent WriteOrBuffer calls still buffer.
-                _isFlushing = true;
-
-                // Drain current buffer under lock to preserve ordering.
-                messagesToFlush = new List<(TextWriter, string)>(_bufferedMessages.Count);
-                while (_bufferedMessages.Count > 0)
-                {
-                    messagesToFlush.Add(_bufferedMessages.Dequeue());
-                }
-
-                // On the final iteration, clear flushing state before writing so new
-                // messages arriving during the last write go directly to output (the
-                // prompt is over). This prevents the loop from running indefinitely.
-                if (--remainingIterations <= 0)
-                {
-                    _isFlushing = false;
-                }
+                _interactivePromptDepth--;
             }
 
-            // Write outside the lock to avoid holding it during I/O.
-            foreach (var (writer, msg) in messagesToFlush)
-            {
-                writer.WriteLine(msg);
-            }
-
-            if (remainingIterations <= 0)
+            if (_interactivePromptDepth > 0)
             {
                 return;
             }
 
-            // Loop back to check whether new messages arrived while we were writing.
+            // Flush all buffered messages under the lock. This is acceptable because
+            // each message is a single short log line (sub-millisecond write) and
+            // Console.Error is already internally serialized. Writing under lock
+            // eliminates the need for a flush loop or _isFlushing flag entirely.
+            while (_bufferedMessages.Count > 0)
+            {
+                var (writer, msg) = _bufferedMessages.Dequeue();
+                writer.WriteLine(msg);
+            }
         }
     }
 

--- a/src/Aspire.Cli/Interaction/SpectreConsoleLoggerProvider.cs
+++ b/src/Aspire.Cli/Interaction/SpectreConsoleLoggerProvider.cs
@@ -9,6 +9,11 @@ namespace Aspire.Cli.Interaction;
 
 internal class SpectreConsoleLoggerProvider : ILoggerProvider
 {
+    // Shared buffering state for console logs emitted while interactive prompts are active.
+    private static readonly object s_logBufferLock = new();
+    private static readonly Queue<(TextWriter Writer, string Message)> s_bufferedMessages = new();
+    private static int s_interactivePromptDepth;
+
     private readonly TextWriter _output;
 
     /// <summary>
@@ -18,6 +23,76 @@ internal class SpectreConsoleLoggerProvider : ILoggerProvider
     public SpectreConsoleLoggerProvider(TextWriter output)
     {
         _output = output;
+    }
+
+    // Depth-based scope to support nested prompts. Logs flush when the outermost scope ends.
+    internal static IDisposable BeginInteractivePromptScope()
+    {
+        lock (s_logBufferLock)
+        {
+            s_interactivePromptDepth++;
+        }
+
+        return new InteractivePromptScope();
+    }
+
+    internal static void WriteOrBuffer(TextWriter output, string message)
+    {
+        lock (s_logBufferLock)
+        {
+            // During an active prompt, queue log lines instead of writing immediately.
+            if (s_interactivePromptDepth > 0)
+            {
+                s_bufferedMessages.Enqueue((output, message));
+                return;
+            }
+        }
+
+        output.WriteLine(message);
+    }
+
+    private static void EndInteractivePromptScope()
+    {
+        List<(TextWriter Writer, string Message)> messagesToFlush = [];
+
+        lock (s_logBufferLock)
+        {
+            if (s_interactivePromptDepth > 0)
+            {
+                s_interactivePromptDepth--;
+            }
+
+            if (s_interactivePromptDepth > 0)
+            {
+                return;
+            }
+
+            // Drain under lock to preserve ordering across concurrent writers.
+            while (s_bufferedMessages.Count > 0)
+            {
+                messagesToFlush.Add(s_bufferedMessages.Dequeue());
+            }
+        }
+
+        // Write outside the lock to avoid holding the global lock during I/O.
+        foreach (var (writer, message) in messagesToFlush)
+        {
+            writer.WriteLine(message);
+        }
+    }
+
+    private sealed class InteractivePromptScope : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            // Ensure scope close is applied only once for idempotent disposal.
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                EndInteractivePromptScope();
+            }
+        }
     }
 
     public ILogger CreateLogger(string categoryName)
@@ -62,7 +137,7 @@ internal class SpectreConsoleLogger(TextWriter output, string categoryName) : IL
         var logMessage = $"[{timestamp}] [{GetLogLevelString(logLevel)}] {shortCategoryName}: {formattedMessage}";
 
         // Write to the configured output (stderr by default)
-        output.WriteLine(logMessage);
+        SpectreConsoleLoggerProvider.WriteOrBuffer(output, logMessage);
     }
 
     private static string GetLogLevelString(LogLevel logLevel) => CliLogFormat.GetConsoleLevelToken(logLevel);

--- a/src/Aspire.Cli/Interaction/SpectreConsoleLoggerProvider.cs
+++ b/src/Aspire.Cli/Interaction/SpectreConsoleLoggerProvider.cs
@@ -9,95 +9,23 @@ namespace Aspire.Cli.Interaction;
 
 internal class SpectreConsoleLoggerProvider : ILoggerProvider
 {
-    // Shared buffering state for console logs emitted while interactive prompts are active.
-    private static readonly object s_logBufferLock = new();
-    private static readonly Queue<(TextWriter Writer, string Message)> s_bufferedMessages = new();
-    private static int s_interactivePromptDepth;
-
     private readonly TextWriter _output;
+    private readonly ConsoleLogBufferContext _bufferContext;
 
     /// <summary>
     /// Creates a logger provider that writes to the specified output.
     /// </summary>
     /// <param name="output">The text writer to write log messages to.</param>
-    public SpectreConsoleLoggerProvider(TextWriter output)
+    /// <param name="bufferContext">Shared buffer context for pausing logs during interactive prompts.</param>
+    public SpectreConsoleLoggerProvider(TextWriter output, ConsoleLogBufferContext bufferContext)
     {
         _output = output;
-    }
-
-    // Depth-based scope to support nested prompts. Logs flush when the outermost scope ends.
-    internal static IDisposable BeginInteractivePromptScope()
-    {
-        lock (s_logBufferLock)
-        {
-            s_interactivePromptDepth++;
-        }
-
-        return new InteractivePromptScope();
-    }
-
-    internal static void WriteOrBuffer(TextWriter output, string message)
-    {
-        lock (s_logBufferLock)
-        {
-            // During an active prompt, queue log lines instead of writing immediately.
-            if (s_interactivePromptDepth > 0)
-            {
-                s_bufferedMessages.Enqueue((output, message));
-                return;
-            }
-        }
-
-        output.WriteLine(message);
-    }
-
-    private static void EndInteractivePromptScope()
-    {
-        List<(TextWriter Writer, string Message)> messagesToFlush = [];
-
-        lock (s_logBufferLock)
-        {
-            if (s_interactivePromptDepth > 0)
-            {
-                s_interactivePromptDepth--;
-            }
-
-            if (s_interactivePromptDepth > 0)
-            {
-                return;
-            }
-
-            // Drain under lock to preserve ordering across concurrent writers.
-            while (s_bufferedMessages.Count > 0)
-            {
-                messagesToFlush.Add(s_bufferedMessages.Dequeue());
-            }
-        }
-
-        // Write outside the lock to avoid holding the global lock during I/O.
-        foreach (var (writer, message) in messagesToFlush)
-        {
-            writer.WriteLine(message);
-        }
-    }
-
-    private sealed class InteractivePromptScope : IDisposable
-    {
-        private int _disposed;
-
-        public void Dispose()
-        {
-            // Ensure scope close is applied only once for idempotent disposal.
-            if (Interlocked.Exchange(ref _disposed, 1) == 0)
-            {
-                EndInteractivePromptScope();
-            }
-        }
+        _bufferContext = bufferContext;
     }
 
     public ILogger CreateLogger(string categoryName)
     {
-        return new SpectreConsoleLogger(_output, categoryName);
+        return new SpectreConsoleLogger(_output, categoryName, _bufferContext);
     }
 
     public void Dispose()
@@ -105,7 +33,7 @@ internal class SpectreConsoleLoggerProvider : ILoggerProvider
     }
 }
 
-internal class SpectreConsoleLogger(TextWriter output, string categoryName) : ILogger
+internal class SpectreConsoleLogger(TextWriter output, string categoryName, ConsoleLogBufferContext bufferContext) : ILogger
 {
     public bool IsEnabled(LogLevel logLevel) =>
         logLevel >= LogLevel.Debug &&
@@ -137,7 +65,7 @@ internal class SpectreConsoleLogger(TextWriter output, string categoryName) : IL
         var logMessage = $"[{timestamp}] [{GetLogLevelString(logLevel)}] {shortCategoryName}: {formattedMessage}";
 
         // Write to the configured output (stderr by default)
-        SpectreConsoleLoggerProvider.WriteOrBuffer(output, logMessage);
+        bufferContext.WriteOrBuffer(output, logMessage);
     }
 
     private static string GetLogLevelString(LogLevel logLevel) => CliLogFormat.GetConsoleLevelToken(logLevel);

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -79,6 +79,7 @@ public class Program
         IStartupErrorWriter ErrorWriter,
         ILoggerFactory LoggerFactory,
         FileLoggerProvider FileLoggerProvider,
+        ConsoleLogBufferContext LogBufferContext,
         ILogger Logger) : IDisposable
     {
         public void Dispose()
@@ -210,7 +211,7 @@ public class Program
     /// and MCP console logging based on command-line arguments.
     /// </summary>
     /// <returns>A tuple containing the configured <see cref="ILoggerFactory"/> and the <see cref="FileLoggerProvider"/> used for file logging.</returns>
-    internal static (ILoggerFactory LoggerFactory, FileLoggerProvider FileLoggerProvider) CreateLoggerFactory(string[] args, CliLoggingOptions loggingOptions, IStartupErrorWriter errorWriter)
+    internal static (ILoggerFactory LoggerFactory, FileLoggerProvider FileLoggerProvider) CreateLoggerFactory(string[] args, CliLoggingOptions loggingOptions, IStartupErrorWriter errorWriter, ConsoleLogBufferContext logBufferContext)
     {
         var consoleLogLevel = loggingOptions.ConsoleLogLevel;
 
@@ -255,7 +256,7 @@ public class Program
             if (consoleLogLevel is not null && !isMcpStartCommand && extensionEndpoint is null)
             {
                 // Use custom Spectre Console logger for clean debug output to stderr
-                builder.AddProvider(new SpectreConsoleLoggerProvider(Console.Error));
+                builder.AddProvider(new SpectreConsoleLoggerProvider(Console.Error, logBufferContext));
             }
 
             // For MCP start command, configure console logger to route all logs to stderr
@@ -320,6 +321,9 @@ public class Program
 
         // Register file logger provider for components that write directly to the log file
         builder.Services.AddSingleton(startupContext.FileLoggerProvider);
+
+        // Register the log buffer context so the interaction service can pause logging during prompts
+        builder.Services.AddSingleton(startupContext.LogBufferContext);
 
         // Register logging options so components can read the user's chosen log level
         builder.Services.AddSingleton(startupContext.LoggingOptions);
@@ -786,9 +790,10 @@ public class Program
 
         var loggingOptions = ParseLoggingOptions(args);
         var errorWriter = new StartupErrorWriter(loggingOptions.LogFilePath);
-        var (loggerFactory, fileLoggerProvider) = CreateLoggerFactory(args, loggingOptions, errorWriter);
+        var logBufferContext = new ConsoleLogBufferContext();
+        var (loggerFactory, fileLoggerProvider) = CreateLoggerFactory(args, loggingOptions, errorWriter, logBufferContext);
         var logger = loggerFactory.CreateLogger(RootLoggerName);
-        using var startupContext = new CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logger);
+        using var startupContext = new CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, logger);
 
         logger.LogInformation("Aspire CLI version: {Version}", AspireCliTelemetry.GetCliVersion());
         logger.LogInformation("Aspire CLI build ID: {BuildId}", AspireCliTelemetry.GetCliBuildId());
@@ -994,7 +999,8 @@ public class Program
                 var executionContext = provider.GetRequiredService<CliExecutionContext>();
                 var hostEnvironment = provider.GetRequiredService<ICliHostEnvironment>();
                 var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                var consoleInteractionService = new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory);
+                var logBufferCtx = provider.GetRequiredService<ConsoleLogBufferContext>();
+                var consoleInteractionService = new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory, logBufferCtx);
                 return new ExtensionInteractionService(consoleInteractionService,
                     provider.GetRequiredService<IExtensionBackchannel>(),
                     extensionPromptEnabled);
@@ -1008,7 +1014,8 @@ public class Program
                 var executionContext = provider.GetRequiredService<CliExecutionContext>();
                 var hostEnvironment = provider.GetRequiredService<ICliHostEnvironment>();
                 var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory);
+                var logBufferCtx = provider.GetRequiredService<ConsoleLogBufferContext>();
+                return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory, logBufferCtx);
             });
         }
     }

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using Aspire.Cli.Acquisition;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,8 +26,9 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
     {
         var loggingOptions = Program.ParseLoggingOptions([]);
         var errorWriter = new TestStartupErrorWriter();
-        var (loggerFactory, fileLoggerProvider) = Program.CreateLoggerFactory([], loggingOptions, errorWriter);
-        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, loggerFactory.CreateLogger(Program.RootLoggerName));
+        var logBufferContext = new ConsoleLogBufferContext();
+        var (loggerFactory, fileLoggerProvider) = Program.CreateLoggerFactory([], loggingOptions, errorWriter, logBufferContext);
+        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, loggerFactory.CreateLogger(Program.RootLoggerName));
         return await Program.BuildApplicationAsync([], startupContext);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -490,7 +490,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
             new ConsoleEnvironment(console, console),
             executionContext,
             TestHelpers.CreateInteractiveHostEnvironment(),
-            NullLoggerFactory.Instance);
+            NullLoggerFactory.Instance,
+            new ConsoleLogBufferContext());
 
         var dashboardInfo = new DashboardRunCommand.DashboardInfo(
             DashboardUrl: "http://localhost:18888",

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1260,7 +1260,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             new ConsoleEnvironment(console, console),
             executionContext,
             TestHelpers.CreateInteractiveHostEnvironment(),
-            NullLoggerFactory.Instance);
+            NullLoggerFactory.Instance,
+            new ConsoleLogBufferContext());
 
         RunCommand.RenderAppHostSummary(
             interactionService,

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -28,7 +28,7 @@ public class ConsoleInteractionServiceTests
     {
         executionContext ??= CreateExecutionContext();
         var consoleEnvironment = new ConsoleEnvironment(console, console);
-        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment ?? TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance);
+        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment ?? TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance, new ConsoleLogBufferContext());
     }
 
     [Fact]
@@ -694,7 +694,7 @@ public class ConsoleInteractionServiceTests
 
         var executionContext = CreateExecutionContext();
         var consoleEnvironment = new ConsoleEnvironment(stdoutConsole, stderrConsole);
-        var interactionService = new ConsoleInteractionService(consoleEnvironment, executionContext, TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance);
+        var interactionService = new ConsoleInteractionService(consoleEnvironment, executionContext, TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance, new ConsoleLogBufferContext());
 
         // Console defaults to Standard (stdout), but errors should still go to stderr
         interactionService.DisplayError("Something went wrong");
@@ -723,7 +723,7 @@ public class ConsoleInteractionServiceTests
 
         var executionContext = CreateExecutionContext();
         var consoleEnvironment = new ConsoleEnvironment(stdoutConsole, stderrConsole);
-        var interactionService = new ConsoleInteractionService(consoleEnvironment, executionContext, TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance);
+        var interactionService = new ConsoleInteractionService(consoleEnvironment, executionContext, TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance, new ConsoleLogBufferContext());
 
         interactionService.DisplayMessage(KnownEmojis.Information, "Status update");
 

--- a/tests/Aspire.Cli.Tests/Interaction/SpectreConsoleLoggerProviderTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/SpectreConsoleLoggerProviderTests.cs
@@ -101,4 +101,52 @@ public class SpectreConsoleLoggerProviderTests
         // The format should be: [HH:mm:ss] [dbug] Test: Test debug message
         Assert.Matches(@"\[\d{2}:\d{2}:\d{2}\] \[dbug\] Test: Test debug message", outputString);
     }
+
+    [Fact]
+    public void SpectreConsoleLogger_Log_BuffersWhileInteractivePromptScopeIsActive()
+    {
+        // Arrange
+        var output = new StringWriter();
+        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test");
+
+        // Act
+        using (SpectreConsoleLoggerProvider.BeginInteractivePromptScope())
+        {
+            logger.LogInformation("buffered while prompting");
+
+            // Assert
+            Assert.DoesNotContain("buffered while prompting", output.ToString());
+        }
+
+        // Assert
+        Assert.Contains("[info] Test: buffered while prompting", output.ToString());
+    }
+
+    [Fact]
+    public void SpectreConsoleLogger_Log_FlushesOnlyAfterOuterPromptScopeEnds()
+    {
+        // Arrange
+        var output = new StringWriter();
+        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test");
+
+        // Act
+        using (SpectreConsoleLoggerProvider.BeginInteractivePromptScope())
+        {
+            logger.LogInformation("first");
+
+            using (SpectreConsoleLoggerProvider.BeginInteractivePromptScope())
+            {
+                logger.LogInformation("second");
+            }
+
+            Assert.DoesNotContain("first", output.ToString());
+            Assert.DoesNotContain("second", output.ToString());
+        }
+
+        // Assert
+        var flushedOutput = output.ToString();
+        Assert.Contains("[info] Test: first", flushedOutput);
+        Assert.Contains("[info] Test: second", flushedOutput);
+        Assert.True(flushedOutput.IndexOf("first", StringComparison.Ordinal) < flushedOutput.IndexOf("second", StringComparison.Ordinal));
+    }
 }

--- a/tests/Aspire.Cli.Tests/Interaction/SpectreConsoleLoggerProviderTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/SpectreConsoleLoggerProviderTests.cs
@@ -13,7 +13,7 @@ public class SpectreConsoleLoggerProviderTests
     {
         // Arrange
         var output = new StringWriter();
-        var provider = new SpectreConsoleLoggerProvider(output);
+        var provider = new SpectreConsoleLoggerProvider(output, new ConsoleLogBufferContext());
 
         // Act
         var logger = provider.CreateLogger("Test.Category");
@@ -28,8 +28,9 @@ public class SpectreConsoleLoggerProviderTests
     {
         // Arrange
         var output = new StringWriter();
-        var aspireLogger = new SpectreConsoleLogger(output, "Aspire.Cli.Test");
-        var systemLogger = new SpectreConsoleLogger(output, "System.Test");
+        var bufferContext = new ConsoleLogBufferContext();
+        var aspireLogger = new SpectreConsoleLogger(output, "Aspire.Cli.Test", bufferContext);
+        var systemLogger = new SpectreConsoleLogger(output, "System.Test", bufferContext);
 
         // Act & Assert
         Assert.True(aspireLogger.IsEnabled(LogLevel.Debug));
@@ -46,7 +47,7 @@ public class SpectreConsoleLoggerProviderTests
     {
         // Arrange
         var output = new StringWriter();
-        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test");
+        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test", new ConsoleLogBufferContext());
 
         // Act
         logger.LogDebug("Test debug message");
@@ -69,7 +70,7 @@ public class SpectreConsoleLoggerProviderTests
     {
         // Arrange
         var output = new StringWriter();
-        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.NuGet.NuGetPackageCache");
+        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.NuGet.NuGetPackageCache", new ConsoleLogBufferContext());
 
         // Act
         logger.LogDebug("Getting integrations from NuGet");
@@ -89,7 +90,7 @@ public class SpectreConsoleLoggerProviderTests
     {
         // Arrange
         var output = new StringWriter();
-        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test");
+        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test", new ConsoleLogBufferContext());
 
         // Act
         logger.LogDebug("Test debug message");
@@ -107,10 +108,11 @@ public class SpectreConsoleLoggerProviderTests
     {
         // Arrange
         var output = new StringWriter();
-        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test");
+        var bufferContext = new ConsoleLogBufferContext();
+        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test", bufferContext);
 
         // Act
-        using (SpectreConsoleLoggerProvider.BeginInteractivePromptScope())
+        using (bufferContext.BeginInteractivePromptScope())
         {
             logger.LogInformation("buffered while prompting");
 
@@ -127,14 +129,15 @@ public class SpectreConsoleLoggerProviderTests
     {
         // Arrange
         var output = new StringWriter();
-        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test");
+        var bufferContext = new ConsoleLogBufferContext();
+        var logger = new SpectreConsoleLogger(output, "Aspire.Cli.Test", bufferContext);
 
         // Act
-        using (SpectreConsoleLoggerProvider.BeginInteractivePromptScope())
+        using (bufferContext.BeginInteractivePromptScope())
         {
             logger.LogInformation("first");
 
-            using (SpectreConsoleLoggerProvider.BeginInteractivePromptScope())
+            using (bufferContext.BeginInteractivePromptScope())
             {
                 logger.LogInformation("second");
             }
@@ -148,5 +151,183 @@ public class SpectreConsoleLoggerProviderTests
         Assert.Contains("[info] Test: first", flushedOutput);
         Assert.Contains("[info] Test: second", flushedOutput);
         Assert.True(flushedOutput.IndexOf("first", StringComparison.Ordinal) < flushedOutput.IndexOf("second", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task WriteOrBuffer_IsAtomic_NoLogSlipsDuringPromptStart()
+    {
+        // Verify that a write started without a prompt active cannot appear after a
+        // prompt scope is opened on another thread — the decision and I/O are atomic.
+        var output = new StringWriter();
+        var bufferContext = new ConsoleLogBufferContext();
+
+        var barrier = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var promptStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Start a prompt scope on another thread, signaling when it's active.
+        var promptTask = Task.Run(async () =>
+        {
+            await barrier.Task;
+            using var scope = bufferContext.BeginInteractivePromptScope();
+            promptStarted.SetResult();
+            // Hold the scope open long enough for the write attempt.
+            await Task.Delay(200);
+        });
+
+        // Signal the prompt thread and wait until it's active.
+        barrier.SetResult();
+        await promptStarted.Task;
+
+        // Any write after the prompt is active must be buffered.
+        bufferContext.WriteOrBuffer(output, "should-be-buffered");
+
+        await promptTask;
+
+        // After prompt ends the message is flushed.
+        var lines = output.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Single(lines);
+        Assert.Equal("should-be-buffered", lines[0]);
+    }
+
+    [Fact]
+    public void EndScope_FlushingState_BuffersNewWritesDuringDrain()
+    {
+        // Messages written during the flush of a prior scope must not appear before
+        // the buffered messages — they should be appended after.
+        var output = new StringWriter();
+        var bufferContext = new ConsoleLogBufferContext();
+
+        // Use a custom TextWriter that writes another message via the buffer context
+        // the first time it's used during flush, simulating a concurrent log arriving
+        // while drain is in progress.
+        var interceptWriter = new FlushInterceptingWriter(output, bufferContext);
+
+        using (bufferContext.BeginInteractivePromptScope())
+        {
+            // This will be flushed first; during its flush the interceptWriter triggers
+            // another WriteOrBuffer call.
+            bufferContext.WriteOrBuffer(interceptWriter, "original");
+        }
+
+        var lines = output.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.Equal("original", lines[0]);
+        Assert.Equal("injected-during-flush", lines[1]);
+    }
+
+    [Fact]
+    public void WriteOrBuffer_DropsOldestWhenBufferCapReached()
+    {
+        var output = new StringWriter();
+        var bufferContext = new ConsoleLogBufferContext();
+
+        using (bufferContext.BeginInteractivePromptScope())
+        {
+            // Fill the buffer beyond the cap.
+            for (var i = 0; i < ConsoleLogBufferContext.MaxBufferedMessages + 50; i++)
+            {
+                bufferContext.WriteOrBuffer(output, $"msg-{i}");
+            }
+        }
+
+        var lines = output.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        // Only the last MaxBufferedMessages should remain; the first 50 were dropped.
+        Assert.Equal(ConsoleLogBufferContext.MaxBufferedMessages, lines.Length);
+        Assert.Equal("msg-50", lines[0]);
+        Assert.Equal($"msg-{ConsoleLogBufferContext.MaxBufferedMessages + 49}", lines[^1]);
+    }
+
+    [Fact]
+    public void WriteOrBuffer_WritesDirectlyWhenNoPromptActive()
+    {
+        var output = new StringWriter();
+        var bufferContext = new ConsoleLogBufferContext();
+
+        bufferContext.WriteOrBuffer(output, "direct-write");
+
+        var lines = output.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Single(lines);
+        Assert.Equal("direct-write", lines[0]);
+    }
+
+    [Fact]
+    public async Task EndScope_DoesNotStealDepthFromConcurrentNewScope()
+    {
+        // Validates that the flush loop of a closing scope does not decrement
+        // _interactivePromptDepth for a scope opened on another thread mid-flush.
+        var output = new StringWriter();
+        var bufferContext = new ConsoleLogBufferContext();
+
+        // Use a writer that opens a new scope during the flush of the first scope,
+        // simulating a concurrent prompt starting while the previous prompt's buffered
+        // messages are being drained.
+        var scopeOpenedDuringFlush = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scopeWriter = new ScopeOpeningWriter(output, bufferContext, scopeOpenedDuringFlush);
+
+        using (bufferContext.BeginInteractivePromptScope())
+        {
+            bufferContext.WriteOrBuffer(scopeWriter, "from-first-scope");
+        }
+
+        // The ScopeOpeningWriter opened a new scope during flush. Messages written
+        // while that scope is active should be buffered.
+        await scopeOpenedDuringFlush.Task;
+        bufferContext.WriteOrBuffer(output, "during-second-scope");
+
+        // End the second scope — this should flush "during-second-scope".
+        scopeWriter.SecondScope!.Dispose();
+
+        var lines = output.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.Equal("from-first-scope", lines[0]);
+        Assert.Equal("during-second-scope", lines[1]);
+    }
+
+    /// <summary>
+    /// A TextWriter wrapper that injects a message via the buffer context the first time
+    /// <see cref="WriteLine(string)"/> is called, simulating a concurrent log during flush.
+    /// </summary>
+    private sealed class FlushInterceptingWriter(StringWriter inner, ConsoleLogBufferContext context) : TextWriter
+    {
+        private int _intercepted;
+
+        public override System.Text.Encoding Encoding => inner.Encoding;
+
+        public override void WriteLine(string? value)
+        {
+            inner.WriteLine(value);
+
+            // On the first flush write, inject another message into the buffer context.
+            if (Interlocked.Exchange(ref _intercepted, 1) == 0)
+            {
+                context.WriteOrBuffer(inner, "injected-during-flush");
+            }
+        }
+    }
+
+    /// <summary>
+    /// A TextWriter that opens a new interactive prompt scope during flush, simulating
+    /// a concurrent prompt starting while a previous scope's buffer is being drained.
+    /// </summary>
+    private sealed class ScopeOpeningWriter(StringWriter inner, ConsoleLogBufferContext context, TaskCompletionSource scopeOpened) : TextWriter
+    {
+        private int _intercepted;
+
+        public IDisposable? SecondScope { get; private set; }
+
+        public override System.Text.Encoding Encoding => inner.Encoding;
+
+        public override void WriteLine(string? value)
+        {
+            inner.WriteLine(value);
+
+            // On the first flush write, open a new scope to simulate a concurrent prompt.
+            if (Interlocked.Exchange(ref _intercepted, 1) == 0)
+            {
+                SecondScope = context.BeginInteractivePromptScope();
+                scopeOpened.SetResult();
+            }
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Configuration;
@@ -20,8 +21,9 @@ public class TelemetryConfigurationTests
     {
         var loggingOptions = Program.ParseLoggingOptions([]);
         var errorWriter = new TestStartupErrorWriter();
-        var (loggerFactory, fileLoggerProvider) = Program.CreateLoggerFactory([], loggingOptions, errorWriter);
-        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, loggerFactory.CreateLogger(Program.RootLoggerName));
+        var logBufferContext = new ConsoleLogBufferContext();
+        var (loggerFactory, fileLoggerProvider) = Program.CreateLoggerFactory([], loggingOptions, errorWriter, logBufferContext);
+        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, loggerFactory.CreateLogger(Program.RootLoggerName));
         return await Program.BuildApplicationAsync([], startupContext, config);
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -99,6 +99,7 @@ internal static class CliTestHelper
 
         services.AddMemoryCache();
 
+        services.AddSingleton<ConsoleLogBufferContext>();
         services.AddSingleton(options.ConsoleEnvironmentFactory);
         services.AddSingleton(sp => sp.GetRequiredService<ConsoleEnvironment>().Out);
         services.AddSingleton(options.TimeProvider);
@@ -449,7 +450,8 @@ internal sealed class CliServiceCollectionTestOptions
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory);
+        var logBufferContext = serviceProvider.GetRequiredService<ConsoleLogBufferContext>();
+        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory, logBufferContext);
     };
 
     public Func<IServiceProvider, ICertificateToolRunner> CertificateToolRunnerFactory { get; set; } = (IServiceProvider _) =>


### PR DESCRIPTION
## Description

Pause terminal debug logging while interactive prompts are active so prompt UI stays readable, then replay buffered lines when the prompt completes. Apply prompt scopes to all ConsoleInteractionService prompt methods and add tests covering buffering and nested scope flush behavior.

Fixes #15936 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
