### PR TITLE
Fix pr-docs safe outputs checkout path

### DIFF
--- a/.github/workflows/pr-docs-check.lock.yml
+++ b/.github/workflows/pr-docs-check.lock.yml
@@ -1312,9 +1312,11 @@ jobs:
           ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
           token: ${{ steps.safe-outputs-app-token.outputs.token }}
           persist-credentials: false
+          path: aspire.dev
           fetch-depth: 1
       - name: Configure Git credentials
         if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
+        working-directory: aspire.dev
         env:
           REPO_NAME: "microsoft/aspire.dev"
           SERVER_URL: ${{ github.server_url }}


### PR DESCRIPTION
## Description

Follow-up to the `pr-docs-check` workflow after the `v0.67.2` regeneration work.

### Root cause

Run https://github.com/microsoft/aspire/actions/runs/24118533263 completed the agent phase and produced the docs changes, but `create_pull_request` still fell back to an issue-style comment on https://github.com/microsoft/aspire/pull/15906#issuecomment-4203977632.

The safe-outputs handler error was:

```text
Repository 'microsoft/aspire.dev' not found in workspace. Make sure it's checked out using actions/checkout with a path.
```

So this was no longer a token/permission problem. The generated `safe_outputs` job was checking out `microsoft/aspire.dev` at the workspace root, but the cross-repo PR creation handler expects that target repo checkout to live under an explicit `path`.

### What this changes

- Updates the generated `safe_outputs` job to check out `microsoft/aspire.dev` with `path: aspire.dev`.
- Runs the git remote configuration from that checkout via `working-directory: aspire.dev`.

### Why this should work

The agent already had access to the docs repo and produced a valid `create_pull_request` output. This change aligns the follow-up safe-output job with the handler's workspace discovery requirement so it can actually open the draft PR instead of falling back to the explanatory comment.