### PR TITLE
Add CLI logs output channel logging for describe process lifecycle, reduce aspire describe calls, other performance improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "dotnet.solution.autoOpen": "./Aspire.slnx",
     "dotnet.preview.enableSupportForSlnx": true,
     "dotnet.testWindow.useTestingPlatformProtocol": true,
-    "aspire.enableSettingsFileCreationPromptOnStartup": false
+    "aspire.enableSettingsFileCreationPromptOnStartup": false,
+    "aspire.enableAutoRestore": false
 }

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -25,6 +25,9 @@
     <trans-unit id="aspire-vscode.strings.aspireOutputChannelName">
       <source xml:lang="en">Aspire Extension</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.aspireCliLogsChannelName">
+      <source xml:lang="en">Aspire Extension - CLI Logs</source>
+    </trans-unit>
     <trans-unit id="aspire-vscode.strings.aspireHostingSdkVersion">
       <source xml:lang="en">Aspire Hosting SDK Version: {0}.</source>
     </trans-unit>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -63,6 +63,7 @@
 	"aspire-vscode.strings.aspireTerminalName": "Aspire terminal",
 	"aspire-vscode.strings.rpcServerError": "RPC server error: {0}.",
 	"aspire-vscode.strings.aspireOutputChannelName": "Aspire Extension",
+	"aspire-vscode.strings.aspireCliLogsChannelName": "Aspire Extension - CLI Logs",
 	"aspire-vscode.strings.fieldRequired": "This field is required.",
   "aspire-vscode.strings.runProject": "Run {0}",
 	"aspire-vscode.strings.debugProject": "Debug {0}",

--- a/extension/src/debugger/languages/cli.ts
+++ b/extension/src/debugger/languages/cli.ts
@@ -20,6 +20,24 @@ export interface SpawnProcessOptions {
     logToCliOutputChannel?: boolean;
 }
 
+export function withCliLogOutputChannelArgs(args: readonly string[] = []): string[] {
+    const delimiterIndex = args.indexOf('--');
+    const insertionIndex = delimiterIndex === -1 ? args.length : delimiterIndex;
+    const cliArgs = args.slice(0, insertionIndex);
+    const forwardedArgs = args.slice(insertionIndex);
+    const updatedArgs = [...cliArgs];
+
+    if (!cliArgs.includes('--debug')) {
+        updatedArgs.push('--debug');
+    }
+
+    if (!cliArgs.includes('--no-log-file')) {
+        updatedArgs.push('--no-log-file');
+    }
+
+    return [...updatedArgs, ...forwardedArgs];
+}
+
 export function spawnCliProcess(terminalProvider: AspireTerminalProvider, command: string, args?: string[], options?: SpawnProcessOptions): ChildProcessWithoutNullStreams {
     const workingDirectory = options?.workingDirectory ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd();
     const env = {};
@@ -29,7 +47,7 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
         Object.assign(env, Object.fromEntries(options.env.map(e => [e.name, e.value])));
     }
     if (options?.logToCliOutputChannel) {
-        args = [...(args ?? []), '--debug', '--no-log-file'];
+        args = withCliLogOutputChannelArgs(args);
         cliLogsOutputChannel.appendLine(`Spawning CLI process with command: ${command} ${args.join(' ')} in directory: ${workingDirectory}`);
     }
 

--- a/extension/src/debugger/languages/cli.ts
+++ b/extension/src/debugger/languages/cli.ts
@@ -1,6 +1,6 @@
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { EnvVar } from "../../dcp/types";
-import { extensionLogOutputChannel } from "../../utils/logging";
+import { extensionLogOutputChannel, cliLogsOutputChannel } from "../../utils/logging";
 import { AspireTerminalProvider } from "../../utils/AspireTerminalProvider";
 import * as readline from 'readline';
 import * as vscode from 'vscode';
@@ -16,6 +16,8 @@ export interface SpawnProcessOptions {
     debugSessionId?: string,
     noDebug?: boolean;
     noExtensionVariables?: boolean;
+    /** When true, passes --debug --no-log-file to redirect CLI logs to the CLI output channel instead of a file. */
+    logToCliOutputChannel?: boolean;
 }
 
 export function spawnCliProcess(terminalProvider: AspireTerminalProvider, command: string, args?: string[], options?: SpawnProcessOptions): ChildProcessWithoutNullStreams {
@@ -25,6 +27,10 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
     Object.assign(env, terminalProvider.createEnvironment(options?.debugSessionId, options?.noDebug, options?.noExtensionVariables));
     if (options?.env) {
         Object.assign(env, Object.fromEntries(options.env.map(e => [e.name, e.value])));
+    }
+    if (options?.logToCliOutputChannel) {
+        args = [...(args ?? []), '--debug', '--no-log-file'];
+        cliLogsOutputChannel.appendLine(`Spawning CLI process with command: ${command} ${args.join(' ')} in directory: ${workingDirectory}`);
     }
 
     const child = spawn(command, args ?? [], {
@@ -45,14 +51,24 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
     });
 
     child.stderr.on("data", (data) => {
-        options?.stderrCallback?.(new String(data).toString());
+        const text = new String(data).toString();
+        options?.stderrCallback?.(text);
+        if (options?.logToCliOutputChannel) {
+            cliLogsOutputChannel.append(text);
+        }
     });
 
     child.on('error', (error) => {
+        if (options?.logToCliOutputChannel) {
+            cliLogsOutputChannel.appendLine(`CLI process error: ${error.message} (command: ${command} ${(args ?? []).join(' ')})`);
+        }
         options?.errorCallback?.(error);
     });
 
     child.on("close", (code) => {
+        if (options?.logToCliOutputChannel) {
+            cliLogsOutputChannel.appendLine(`CLI process exited with code ${code} (command: ${command} ${(args ?? []).join(' ')})`);
+        }
         options?.exitCallback?.(code);
     });
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -32,8 +32,9 @@ import { installCliStableCommand, installCliDailyCommand, verifyCliInstalledComm
 import { AspireMcpServerDefinitionProvider } from './mcp/AspireMcpServerDefinitionProvider';
 import { AspireCodeLensProvider } from './editor/AspireCodeLensProvider';
 import { AspireGutterDecorationProvider } from './editor/AspireGutterDecorationProvider';
-import { getSupportedLanguageIds } from './editor/parsers/AppHostResourceParser';
+import { getSupportedLanguageIds, getParserForDocument } from './editor/parsers/AppHostResourceParser';
 import { readGitCommitSha } from './utils/versionInfo';
+import { clearCliPathCache } from './utils/cliPath';
 
 let aspireExtensionContext = new AspireExtensionContext();
 
@@ -95,6 +96,14 @@ export async function activate(context: vscode.ExtensionContext) {
     dataRepository.setPanelVisible(e.visible);
   });
 
+  // Describe watch is also started when an apphost file is visible in an editor
+  const updateAppHostEditorVisible = () => {
+    const hasAppHostEditor = vscode.window.visibleTextEditors.some(editor => getParserForDocument(editor.document) !== undefined);
+    dataRepository.setAppHostEditorVisible(hasAppHostEditor);
+  };
+  updateAppHostEditorVisible();
+  context.subscriptions.push(vscode.window.onDidChangeVisibleTextEditors(() => updateAppHostEditorVisible()));
+
   const refreshRunningAppHostsRegistration = vscode.commands.registerCommand('aspire-vscode.refreshRunningAppHosts', () => dataRepository.refresh());
   const switchToGlobalViewRegistration = vscode.commands.registerCommand('aspire-vscode.switchToGlobalView', () => dataRepository.setViewMode('global'));
   const switchToWorkspaceViewRegistration = vscode.commands.registerCommand('aspire-vscode.switchToWorkspaceView', () => dataRepository.setViewMode('workspace'));
@@ -118,8 +127,15 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.commands.executeCommand('setContext', 'aspire.noRunningAppHosts', true);
   vscode.commands.executeCommand('setContext', 'aspire.loading', true);
 
-  // Activate the data repository (starts workspace describe --follow; global polling begins when the panel is visible)
+  // Activate the data repository (describe --follow starts when panel or apphost editor is visible; global polling begins when the panel is visible)
   dataRepository.activate();
+
+  // Clear cached CLI path when the user changes the setting
+  context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
+    if (e.affectsConfiguration('aspire.aspireCliExecutablePath')) {
+      clearCliPathCache();
+    }
+  }));
 
   context.subscriptions.push(appHostTreeView, refreshRunningAppHostsRegistration, switchToGlobalViewRegistration, switchToWorkspaceViewRegistration, openDashboardRegistration, openAppHostSourceRegistration, stopAppHostRegistration, stopResourceRegistration, startResourceRegistration, restartResourceRegistration, viewResourceLogsRegistration, executeResourceCommandRegistration, copyEndpointUrlRegistration, openInExternalBrowserRegistration, openInIntegratedBrowserRegistration, copyResourceNameRegistration, copyPidRegistration, copyAppHostPathRegistration, expandAllRegistration, { dispose: () => { appHostTreeProvider.dispose(); dataRepository.dispose(); } });
 

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -21,6 +21,7 @@ export const aspireCliVersion = (version: string) => vscode.l10n.t('Aspire CLI V
 export const requiredCapability = (capability: string) => vscode.l10n.t('Required capability: {0}.', capability);
 export const aspireTerminalName = vscode.l10n.t('Aspire terminal');
 export const aspireOutputChannelName = vscode.l10n.t('Aspire Extension');
+export const aspireCliLogsChannelName = vscode.l10n.t('Aspire Extension - CLI Logs');
 export const fieldRequired = vscode.l10n.t('This field is required.');
 export const runProject = (projectName: string) => vscode.l10n.t('Run {0}', projectName);
 export const debugProject = (projectName: string) => vscode.l10n.t('Debug {0}', projectName);

--- a/extension/src/test/cli.test.ts
+++ b/extension/src/test/cli.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+import { withCliLogOutputChannelArgs } from '../debugger/languages/cli';
+
+suite('debugger/languages/cli tests', () => {
+    test('adds logging args when none are provided', () => {
+        assert.deepStrictEqual(withCliLogOutputChannelArgs(), ['--debug', '--no-log-file']);
+    });
+
+    test('inserts logging args before the forwarded app args delimiter', () => {
+        const args = ['run', '--apphost', '/repo/AppHost.csproj', '--', '--applicationArg'];
+
+        assert.deepStrictEqual(withCliLogOutputChannelArgs(args), ['run', '--apphost', '/repo/AppHost.csproj', '--debug', '--no-log-file', '--', '--applicationArg']);
+    });
+
+    test('does not duplicate logging args that are already present before the delimiter', () => {
+        const args = ['run', '--debug', '--no-log-file', '--', '--applicationArg'];
+
+        assert.deepStrictEqual(withCliLogOutputChannelArgs(args), args);
+    });
+
+    test('adds only the missing logging arg before the delimiter', () => {
+        const args = ['run', '--debug', '--', '--applicationArg'];
+
+        assert.deepStrictEqual(withCliLogOutputChannelArgs(args), ['run', '--debug', '--no-log-file', '--', '--applicationArg']);
+    });
+});

--- a/extension/src/test/cliPath.test.ts
+++ b/extension/src/test/cliPath.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as os from 'os';
 import * as path from 'path';
-import { getDefaultCliInstallPaths, resolveCliPath, CliPathDependencies } from '../utils/cliPath';
+import { getDefaultCliInstallPaths, resolveCliPath, clearCliPathCache, CliPathDependencies } from '../utils/cliPath';
 
 const bundlePath = '/home/user/.aspire/bin/aspire';
 const globalToolPath = '/home/user/.dotnet/tools/aspire';
@@ -206,6 +206,65 @@ suite('utils/cliPath tests', () => {
             assert.strictEqual(result.source, 'default-install');
             assert.ok(setConfiguredPath.notCalled, 'should not re-set the path if it already matches');
         });
+
+        test('does not cache results when custom deps are provided', async () => {
+            const tryExecute = sinon.stub().resolves(false);
+            const isOnPath = sinon.stub().resolves(true);
+
+            const deps = createMockDeps({
+                isOnPath,
+                tryExecute,
+            });
+
+            const result1 = await resolveCliPath(deps);
+            assert.strictEqual(result1.source, 'path');
+
+            // Change behavior — second call should re-probe since custom deps are not cached
+            isOnPath.resolves(false);
+            const deps2 = createMockDeps({
+                isOnPath,
+                findAtDefaultPath: async () => bundlePath,
+                setConfiguredPath: sinon.stub().resolves(),
+            });
+
+            const result2 = await resolveCliPath(deps2);
+            assert.strictEqual(result2.source, 'default-install', 'should re-probe with new deps, not return cached result');
+        });
+
+        test('clearCliPathCache does not throw', () => {
+            clearCliPathCache();
+        });
+
+        test('coalesces concurrent resolutions for the same dependency set', async () => {
+            let releaseIsOnPath: (() => void) | undefined;
+            let signalIsOnPathStarted: (() => void) | undefined;
+            const isOnPathStarted = new Promise<void>(resolve => {
+                signalIsOnPathStarted = resolve;
+            });
+
+            const isOnPath = sinon.stub().callsFake(async () => {
+                signalIsOnPathStarted?.();
+                await new Promise<void>(resolveRelease => {
+                    releaseIsOnPath = resolveRelease;
+                });
+                return true;
+            });
+
+            const deps = createMockDeps({
+                isOnPath,
+            });
+
+            const firstResolution = resolveCliPath(deps);
+            await isOnPathStarted;
+            const secondResolution = resolveCliPath(deps);
+
+            assert.strictEqual(isOnPath.callCount, 1, 'should only run PATH probe once');
+            assert.ok(releaseIsOnPath, 'expected first resolution to be in progress');
+
+            releaseIsOnPath();
+
+            const [firstResult, secondResult] = await Promise.all([firstResolution, secondResolution]);
+            assert.deepStrictEqual(firstResult, secondResult);
+        });
     });
 });
-

--- a/extension/src/utils/AspirePackageRestoreProvider.ts
+++ b/extension/src/utils/AspirePackageRestoreProvider.ts
@@ -14,7 +14,7 @@ import { runningAspireRestore, runningAspireRestoreProgress, aspireRestoreComple
  * (e.g. after a git branch switch).
  */
 export class AspirePackageRestoreProvider implements vscode.Disposable {
-    private static readonly _maxConcurrency = 4;
+    private static readonly _maxConcurrency = 2;
     private static readonly _statusBarHideDelayMs = 5000;
     private static readonly _restoreTimeoutMs = 120_000;
 

--- a/extension/src/utils/AspirePackageRestoreProvider.ts
+++ b/extension/src/utils/AspirePackageRestoreProvider.ts
@@ -181,6 +181,7 @@ export class AspirePackageRestoreProvider implements vscode.Disposable {
                 const proc = spawnCliProcess(this._terminalProvider, cliPath, ['restore'], {
                     workingDirectory: configDir,
                     noExtensionVariables: true,
+                    logToCliOutputChannel: true,
                     exitCallback: code => {
                         if (settled) { return; }
                         settled = true;

--- a/extension/src/utils/cliPath.ts
+++ b/extension/src/utils/cliPath.ts
@@ -10,6 +10,24 @@ const execFileAsync = promisify(execFile);
 const fsAccessAsync = promisify(fs.access);
 
 /**
+ * Cached result from the last successful resolveCliPath call.
+ * Avoids spawning `aspire --version` on every CLI invocation.
+ */
+let cachedCliPathResult: CliPathResolutionResult | undefined;
+
+/**
+ * In-flight resolution promises keyed by dependency set to avoid duplicate
+ * concurrent resolution work.
+ */
+const pendingCliPathResolutions = new WeakMap<CliPathDependencies, Promise<CliPathResolutionResult>>();
+
+/**
+ * Monotonically increasing token used to invalidate stale default-resolution
+ * cache writes when clearCliPathCache is called.
+ */
+let cliPathCacheGeneration = 0;
+
+/**
  * Gets the default installation paths for the Aspire CLI, in priority order.
  *
  * The CLI can be installed in two ways:
@@ -132,6 +150,86 @@ const defaultDependencies: CliPathDependencies = {
 };
 
 /**
+ * Clears the cached CLI path so the next resolveCliPath call re-probes.
+ */
+export function clearCliPathCache(): void {
+    cliPathCacheGeneration++;
+    cachedCliPathResult = undefined;
+    pendingCliPathResolutions.delete(defaultDependencies);
+}
+
+function shouldMutateConfiguration(useCache: boolean, cacheGeneration: number): boolean {
+    return !useCache || cacheGeneration === cliPathCacheGeneration;
+}
+
+function setCachedResultIfCurrent(
+    result: CliPathResolutionResult,
+    useCache: boolean,
+    cacheGeneration: number): CliPathResolutionResult {
+    if (useCache && cacheGeneration === cliPathCacheGeneration) {
+        cachedCliPathResult = result;
+    }
+
+    return result;
+}
+
+async function resolveCliPathCore(
+    deps: CliPathDependencies,
+    useCache: boolean,
+    cacheGeneration: number): Promise<CliPathResolutionResult> {
+    const configuredPath = deps.getConfiguredPath();
+    const defaultPaths = deps.getDefaultPaths();
+
+    // 1. Check if user has configured a custom path (not one of the defaults)
+    if (configuredPath && !defaultPaths.includes(configuredPath)) {
+        const isValid = await deps.tryExecute(configuredPath);
+        if (isValid) {
+            return setCachedResultIfCurrent(
+                { cliPath: configuredPath, available: true, source: 'configured' },
+                useCache,
+                cacheGeneration);
+        }
+
+        extensionLogOutputChannel.warn(`Configured CLI path is invalid: ${configuredPath}`);
+        // Continue to check other locations
+    }
+
+    // 2. Check if CLI is on PATH
+    const onPath = await deps.isOnPath();
+    if (onPath) {
+        // If we previously auto-set the path to a default install location, clear it
+        // since PATH is now working
+        if (defaultPaths.includes(configuredPath) && shouldMutateConfiguration(useCache, cacheGeneration)) {
+            extensionLogOutputChannel.info('Clearing aspireCliExecutablePath setting since CLI is on PATH');
+            await deps.setConfiguredPath('');
+        }
+
+        return setCachedResultIfCurrent(
+            { cliPath: 'aspire', available: true, source: 'path' },
+            useCache,
+            cacheGeneration);
+    }
+
+    // 3. Check default installation paths (~/.aspire/bin first, then ~/.dotnet/tools)
+    const foundPath = await deps.findAtDefaultPath();
+    if (foundPath) {
+        // Update the setting so future invocations use this path
+        if (configuredPath !== foundPath && shouldMutateConfiguration(useCache, cacheGeneration)) {
+            extensionLogOutputChannel.info('Updating aspireCliExecutablePath setting to use default install location');
+            await deps.setConfiguredPath(foundPath);
+        }
+
+        return setCachedResultIfCurrent(
+            { cliPath: foundPath, available: true, source: 'default-install' },
+            useCache,
+            cacheGeneration);
+    }
+
+    // 4. CLI not found anywhere — don't cache so we re-probe next time
+    return { cliPath: 'aspire', available: false, source: 'not-found' };
+}
+
+/**
  * Resolves the Aspire CLI path, checking multiple locations in order:
  * 1. User-configured path in VS Code settings
  * 2. System PATH
@@ -144,45 +242,31 @@ const defaultDependencies: CliPathDependencies = {
  * the setting is cleared to prefer PATH.
  */
 export async function resolveCliPath(deps: CliPathDependencies = defaultDependencies): Promise<CliPathResolutionResult> {
-    const configuredPath = deps.getConfiguredPath();
-    const defaultPaths = deps.getDefaultPaths();
+    const useCache = deps === defaultDependencies;
+    const cacheGeneration = cliPathCacheGeneration;
 
-    // 1. Check if user has configured a custom path (not one of the defaults)
-    if (configuredPath && !defaultPaths.includes(configuredPath)) {
-        const isValid = await deps.tryExecute(configuredPath);
-        if (isValid) {
-            return { cliPath: configuredPath, available: true, source: 'configured' };
-        }
-
-        extensionLogOutputChannel.warn(`Configured CLI path is invalid: ${configuredPath}`);
-        // Continue to check other locations
+    // Return cached result when available — avoids spawning `aspire --version` on
+    // every CLI invocation.  The cache is cleared when the user changes the
+    // aspire.aspireCliExecutablePath setting (see clearCliPathCache).
+    if (useCache && cachedCliPathResult) {
+        return cachedCliPathResult;
     }
 
-    // 2. Check if CLI is on PATH
-    const onPath = await deps.isOnPath();
-    if (onPath) {
-        // If we previously auto-set the path to a default install location, clear it
-        // since PATH is now working
-        if (defaultPaths.includes(configuredPath)) {
-            extensionLogOutputChannel.info('Clearing aspireCliExecutablePath setting since CLI is on PATH');
-            await deps.setConfiguredPath('');
-        }
-
-        return { cliPath: 'aspire', available: true, source: 'path' };
+    const pendingResolution = pendingCliPathResolutions.get(deps);
+    if (pendingResolution) {
+        return pendingResolution;
     }
 
-    // 3. Check default installation paths (~/.aspire/bin first, then ~/.dotnet/tools)
-    const foundPath = await deps.findAtDefaultPath();
-    if (foundPath) {
-        // Update the setting so future invocations use this path
-        if (configuredPath !== foundPath) {
-            extensionLogOutputChannel.info('Updating aspireCliExecutablePath setting to use default install location');
-            await deps.setConfiguredPath(foundPath);
+    const resolution = resolveCliPathCore(deps, useCache, cacheGeneration);
+    pendingCliPathResolutions.set(deps, resolution);
+
+    const clearPending = () => {
+        if (pendingCliPathResolutions.get(deps) === resolution) {
+            pendingCliPathResolutions.delete(deps);
         }
+    };
 
-        return { cliPath: foundPath, available: true, source: 'default-install' };
-    }
+    void resolution.then(clearPending, clearPending);
 
-    // 4. CLI not found anywhere
-    return { cliPath: 'aspire', available: false, source: 'not-found' };
+    return resolution;
 }

--- a/extension/src/utils/configInfoProvider.ts
+++ b/extension/src/utils/configInfoProvider.ts
@@ -45,7 +45,8 @@ export async function getConfigInfo(terminalProvider: AspireTerminalProvider): P
                 vscode.window.showErrorMessage(strings.errorGettingConfigInfo(error));
                 resolve(null);
             },
-            noExtensionVariables: true
+            noExtensionVariables: true,
+            logToCliOutputChannel: true
         });
     });
 }

--- a/extension/src/utils/logging.ts
+++ b/extension/src/utils/logging.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
-import { aspireOutputChannelName } from '../loc/strings';
+import { aspireOutputChannelName, aspireCliLogsChannelName } from '../loc/strings';
 
 export const extensionLogOutputChannel: vscode.LogOutputChannel = vscode.window.createOutputChannel(aspireOutputChannelName, { log: true });
+export const cliLogsOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(aspireCliLogsChannelName);
 
 export async function logAsyncOperation<T>(beforeMessage: string, afterMessage: (result: T) => string, operation: () => Promise<T>): Promise<T> {
     extensionLogOutputChannel.info( beforeMessage);

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -204,6 +204,7 @@ export async function checkForExistingAppHostPathInWorkspace(terminalProvider: A
                 }
             },
             noExtensionVariables: true,
+            logToCliOutputChannel: true,
             workingDirectory: rootFolder.uri.fsPath
         });
     })

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -71,7 +71,6 @@ export class AppHostDataRepository {
     // ── Workspace mode state (describe --follow) ──
     private _workspaceResources: Map<string, ResourceJson> = new Map();
     private _describeProcess: ChildProcessWithoutNullStreams | undefined;
-    private _describeRestarting = false;
     private _describeRestartDelay = 5000;
     private _describeRestartTimer: ReturnType<typeof setTimeout> | undefined;
     private _describeReceivedData = false;
@@ -204,7 +203,6 @@ export class AppHostDataRepository {
             return;
         }
         if (this._shouldDescribe) {
-            extensionLogOutputChannel.info(`_syncDescribeWatch: starting describe watch (panelVisible=${this._panelVisible}, appHostEditorVisible=${this._appHostEditorVisible})`);
             this._startDescribeWatch();
         } else {
             this._stopDescribeWatch();
@@ -289,21 +287,21 @@ export class AppHostDataRepository {
     // ── Workspace mode: describe --follow ──
 
     private _startDescribeWatch(): void {
-        if (this._describeProcess || this._disposed) {
+        if (this._describeProcess || this._disposed || !this._shouldDescribe) {
             return;
         }
 
         this._terminalProvider.getAspireCliExecutablePath().then(cliPath => {
-            if (this._disposed) {
+            if (this._describeProcess || this._disposed || !this._shouldDescribe) {
                 return;
             }
 
             const args = ['describe', '--follow', '--format', 'json'];
 
-            extensionLogOutputChannel.info('Starting aspire describe --follow for workspace resources');
+            extensionLogOutputChannel.info(`Starting aspire describe --follow for workspace resources (panelVisible=${this._panelVisible}, appHostEditorVisible=${this._appHostEditorVisible})`);
 
             this._describeReceivedData = false;
-            this._describeProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
+            const describeProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                 noExtensionVariables: true,
                 logToCliOutputChannel: true,
                 lineCallback: (line) => {
@@ -311,9 +309,13 @@ export class AppHostDataRepository {
                 },
                 exitCallback: (code) => {
                     extensionLogOutputChannel.info(`aspire describe --follow exited with code ${code}`);
+                    if (this._describeProcess !== describeProcess) {
+                        return;
+                    }
+
                     this._describeProcess = undefined;
 
-                    if (!this._disposed && !this._describeRestarting) {
+                    if (!this._disposed && this._shouldDescribe) {
                         if (!this._describeReceivedData) {
                             // The process exited without ever producing valid data.
                             // This is expected when no apphost is running. Don't restart —
@@ -339,18 +341,23 @@ export class AppHostDataRepository {
                             }, delay);
                         }
                     }
-                    this._describeRestarting = false;
                 },
                 errorCallback: (error) => {
                     extensionLogOutputChannel.warn(`aspire describe --follow error: ${error.message}`);
+                    if (this._describeProcess !== describeProcess) {
+                        return;
+                    }
+
                     this._describeProcess = undefined;
-                    if (!this._disposed && !this._describeRestarting) {
+
+                    if (!this._disposed && this._shouldDescribe) {
                         this._loadingWorkspace = false;
                         this._updateLoadingContext();
                         this._setError(errorFetchingAppHosts(error.message));
                     }
                 }
             });
+            this._describeProcess = describeProcess;
         }).catch(error => {
             extensionLogOutputChannel.warn(`Failed to start describe watch: ${error}`);
             this._loadingWorkspace = false;
@@ -366,9 +373,9 @@ export class AppHostDataRepository {
         }
         if (this._describeProcess) {
             cliLogsOutputChannel.appendLine('Stopping aspire describe --follow process');
-            this._describeRestarting = true;
-            this._describeProcess.kill();
+            const describeProcess = this._describeProcess;
             this._describeProcess = undefined;
+            describeProcess.kill();
         }
     }
 

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ChildProcessWithoutNullStreams } from 'child_process';
 import { spawnCliProcess } from '../debugger/languages/cli';
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
-import { extensionLogOutputChannel } from '../utils/logging';
+import { extensionLogOutputChannel, cliLogsOutputChannel } from '../utils/logging';
 import { EnvironmentVariables } from '../utils/environment';
 import { errorFetchingAppHosts } from '../loc/strings';
 
@@ -53,8 +53,8 @@ export type ViewMode = 'workspace' | 'global';
  *
  * Owns two independent data sources:
  *  - `aspire describe --follow` (workspace mode) — streams resource updates
- *    via NDJSON.  Runs unconditionally from activation so workspace data is
- *    available across the extension.
+ *    via NDJSON.  Only active while the Aspire panel or an app-host editor
+ *    is visible.
  *  - `aspire ps` polling (global mode) — periodically fetches all running
  *    app hosts.  Only active while the tree-view panel is visible **and**
  *    global mode is selected.
@@ -66,6 +66,7 @@ export class AppHostDataRepository {
     // ── Mode / panel state ──
     private _viewMode: ViewMode = 'workspace';
     private _panelVisible = false;
+    private _appHostEditorVisible = false;
 
     // ── Workspace mode state (describe --follow) ──
     private _workspaceResources: Map<string, ResourceJson> = new Map();
@@ -155,6 +156,15 @@ export class AppHostDataRepository {
         }
         this._panelVisible = visible;
         this._syncPolling();
+        this._syncDescribeWatch();
+    }
+
+    setAppHostEditorVisible(visible: boolean): void {
+        if (this._appHostEditorVisible === visible) {
+            return;
+        }
+        this._appHostEditorVisible = visible;
+        this._syncDescribeWatch();
     }
 
     refresh(): void {
@@ -171,7 +181,7 @@ export class AppHostDataRepository {
 
     activate(): void {
         vscode.commands.executeCommand('setContext', 'aspire.viewMode', this._viewMode);
-        this._startDescribeWatch();
+        this._syncDescribeWatch();
     }
 
     dispose(): void {
@@ -181,6 +191,24 @@ export class AppHostDataRepository {
         this._getAppHostsProcess?.kill();
         this._configChangeDisposable.dispose();
         this._onDidChangeData.dispose();
+    }
+
+    // ── Describe watch lifecycle ──
+
+    private get _shouldDescribe(): boolean {
+        return this._panelVisible || this._appHostEditorVisible;
+    }
+
+    private _syncDescribeWatch(): void {
+        if (this._disposed) {
+            return;
+        }
+        if (this._shouldDescribe) {
+            extensionLogOutputChannel.info(`_syncDescribeWatch: starting describe watch (panelVisible=${this._panelVisible}, appHostEditorVisible=${this._appHostEditorVisible})`);
+            this._startDescribeWatch();
+        } else {
+            this._stopDescribeWatch();
+        }
     }
 
     // ── PS polling lifecycle ──
@@ -223,6 +251,7 @@ export class AppHostDataRepository {
 
             this._getAppHostsProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                 noExtensionVariables: true,
+                logToCliOutputChannel: true,
                 workingDirectory: rootFolder.uri.fsPath,
                 lineCallback: (line) => {
                     try {
@@ -276,6 +305,7 @@ export class AppHostDataRepository {
             this._describeReceivedData = false;
             this._describeProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                 noExtensionVariables: true,
+                logToCliOutputChannel: true,
                 lineCallback: (line) => {
                     this._handleDescribeLine(line);
                 },
@@ -284,11 +314,11 @@ export class AppHostDataRepository {
                     this._describeProcess = undefined;
 
                     if (!this._disposed && !this._describeRestarting) {
-                        if (!this._describeReceivedData && code !== 0) {
-                            // The process exited with a non-zero code without ever producing valid data.
-                            // This is expected when no apphost is running. Don't set the error state
-                            // since that would show the "CLI not supported" banner; instead just show
-                            // the normal "no running apphost" welcome.
+                        if (!this._describeReceivedData) {
+                            // The process exited without ever producing valid data.
+                            // This is expected when no apphost is running. Don't restart —
+                            // the user can trigger a refresh manually or the extension will
+                            // start watching again when a debug session begins.
                             extensionLogOutputChannel.warn('aspire describe --follow exited without producing data; no running apphost or CLI may not support this feature.');
                             this._workspaceResources.clear();
                             this._updateWorkspaceContext();
@@ -335,6 +365,7 @@ export class AppHostDataRepository {
             this._describeRestartTimer = undefined;
         }
         if (this._describeProcess) {
+            cliLogsOutputChannel.appendLine('Stopping aspire describe --follow process');
             this._describeRestarting = true;
             this._describeProcess.kill();
             this._describeProcess = undefined;
@@ -481,6 +512,7 @@ export class AppHostDataRepository {
 
         spawnCliProcess(this._terminalProvider, cliPath, args, {
             noExtensionVariables: true,
+            logToCliOutputChannel: true,
             stdoutCallback: (data) => { stdout += data; },
             stderrCallback: (data) => { stderr += data; },
             exitCallback: (code) => {

--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -5,7 +5,7 @@ using System.CommandLine;
 
 namespace Aspire.Cli;
 
-internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null)
+internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string? logFilePath, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null)
 {
     public DirectoryInfo WorkingDirectory { get; } = workingDirectory;
     public DirectoryInfo HivesDirectory { get; } = hivesDirectory;
@@ -24,9 +24,9 @@ internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, Direct
     public DirectoryInfo LogsDirectory { get; } = logsDirectory;
 
     /// <summary>
-    /// Gets the path to the current session's log file.
+    /// Gets the path to the current session's log file, or null when file logging is disabled.
     /// </summary>
-    public string LogFilePath { get; } = logFilePath;
+    public string? LogFilePath { get; } = logFilePath;
 
     public DirectoryInfo HomeDirectory { get; } = homeDirectory ?? new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
     public bool DebugMode { get; } = debugMode;

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -290,7 +290,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         };
     }
 
-    private void RenderDashboardSummary(DashboardInfo info, string logFilePath)
+    private void RenderDashboardSummary(DashboardInfo info, string? logFilePath)
     {
         _interactionService.DisplayEmptyLine();
         var grid = new Grid();
@@ -327,9 +327,12 @@ internal sealed class DashboardRunCommand : BaseCommand
         grid.AddRow(Text.Empty, Text.Empty);
 
         // Logs row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(logFilePath));
+        if (logFilePath is not null)
+        {
+            grid.AddRow(
+                new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
+                new Text(logFilePath));
+        }
 
         var padder = new Padder(grid, new Padding(3, 0));
         _interactionService.DisplayRenderable(padder);
@@ -348,7 +351,7 @@ internal sealed class DashboardRunCommand : BaseCommand
             {
                 outputCollector.AppendOutput(line);
 
-                // The dashboard writes "Now listening on: {urls}" when it's ready to accept requests. 
+                // The dashboard writes "Now listening on: {urls}" when it's ready to accept requests.
                 // Wait for that message before showing the dashboard URL to the user.
                 // This message isn't localized, so we can reliably look for it in the output regardless of the user's language/locale.
                 if (line.Contains("Now listening on:", StringComparison.OrdinalIgnoreCase))

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -68,6 +68,14 @@ internal sealed class RootCommand : BaseRootCommand
         DefaultValueFactory = _ => false
     };
 
+    public static readonly Option<bool> NoLogFileOption = new(CommonOptionNames.NoLogFile)
+    {
+        Description = RootCommandStrings.NoLogFileArgumentDescription,
+        Recursive = true,
+        Hidden = true,
+        DefaultValueFactory = _ => false
+    };
+
     /// <summary>
     /// Global options that should be passed through to child CLI processes when spawning.
     /// Add new global options here to ensure they are forwarded during detached mode execution.
@@ -180,6 +188,7 @@ internal sealed class RootCommand : BaseRootCommand
         Options.Add(BannerOption);
         Options.Add(WaitForDebuggerOption);
         Options.Add(CliWaitForDebuggerOption);
+        Options.Add(NoLogFileOption);
 
         // Handle standalone 'aspire' or 'aspire --banner' (no subcommand)
         this.SetAction((context, cancellationToken) =>

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -79,6 +79,8 @@ internal sealed class RootCommand : BaseRootCommand
     /// <summary>
     /// Global options that should be passed through to child CLI processes when spawning.
     /// Add new global options here to ensure they are forwarded during detached mode execution.
+    /// Options like <c>--no-log-file</c> are intentionally excluded because detached launches
+    /// always provision an explicit child log file for startup diagnostics.
     /// </summary>
     private static readonly (Option Option, Func<ParseResult, string[]?> GetArgs)[] s_childProcessOptions =
     [

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -440,7 +440,7 @@ internal sealed class RunCommand : BaseCommand
     /// <param name="appHostRelativePath">The relative path to the AppHost file.</param>
     /// <param name="dashboardUrl">The dashboard URL with login token, or null if not available.</param>
     /// <param name="codespacesUrl">The codespaces URL with login token, or null if not in codespaces.</param>
-    /// <param name="logFilePath">The full path to the log file.</param>
+    /// <param name="logFilePath">The full path to the log file, or <see langword="null"/> to omit the logs row.</param>
     /// <param name="pid">The process ID to display, or null to omit the PID row.</param>
     /// <param name="isExtensionHost">Whether the AppHost is running in the Aspire extension.</param>
     /// <returns>The column width used, for subsequent grid additions.</returns>

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -449,7 +449,7 @@ internal sealed class RunCommand : BaseCommand
         string appHostRelativePath,
         string? dashboardUrl,
         string? codespacesUrl,
-        string logFilePath,
+        string? logFilePath,
         bool isExtensionHost,
         int? pid = null)
     {
@@ -504,9 +504,12 @@ internal sealed class RunCommand : BaseCommand
         }
 
         // Logs row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(logFilePath));
+        if (logFilePath is not null)
+        {
+            grid.AddRow(
+                new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
+                new Text(logFilePath));
+        }
 
         // PID row (if provided)
         if (pid.HasValue)

--- a/src/Aspire.Cli/CommonOptionNames.cs
+++ b/src/Aspire.Cli/CommonOptionNames.cs
@@ -20,6 +20,7 @@ internal static class CommonOptionNames
     public const string NonInteractive = "--non-interactive";
     public const string WaitForDebugger = "--wait-for-debugger";
     public const string CliWaitForDebugger = "--cli-wait-for-debugger";
+    public const string NoLogFile = "--no-log-file";
 
     /// <summary>
     /// Options that represent informational commands (e.g. --version, --help) which should

--- a/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
+++ b/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
@@ -19,16 +19,36 @@ internal sealed class FileLoggerProvider : ILoggerProvider
 {
     private const int MaxQueuedMessages = 1024;
 
-    private readonly string _logFilePath;
+    private readonly string? _logFilePath;
     private readonly StreamWriter? _writer;
     private readonly Channel<string>? _channel;
     private readonly Task? _writerTask;
     private bool _disposed;
 
     /// <summary>
-    /// Gets the path to the log file.
+    /// Gets the path to the log file, or null when file logging is disabled.
     /// </summary>
-    public string LogFilePath => _logFilePath;
+    public string? LogFilePath => _logFilePath;
+
+    /// <summary>
+    /// Creates a no-op <see cref="FileLoggerProvider"/> that does not create or write to
+    /// any file. Used when the <c>--no-log-file</c> flag is passed
+    /// (e.g. by the VS Code extension for background CLI invocations).
+    /// </summary>
+    internal static FileLoggerProvider CreateNull()
+    {
+        return new FileLoggerProvider();
+    }
+
+    /// <summary>
+    /// Private constructor for the no-op case (no file I/O).
+    /// </summary>
+    private FileLoggerProvider()
+    {
+        _logFilePath = null;
+        _writer = null;
+        _channel = null;
+    }
 
     /// <summary>
     /// Generates a unique, chronologically-sortable log file name.

--- a/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
+++ b/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
@@ -58,12 +58,12 @@ internal sealed class StartupErrorWriter : IStartupErrorWriter
 
     public void Dispose()
     {
-        if (!_hasOutput || !File.Exists(_logFilePath))
+        if (!_hasOutput || _logFilePath is null || !File.Exists(_logFilePath))
         {
             return;
         }
 
         var prefix = ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.PageFacingUp, _errorConsole);
-        _errorConsole.MarkupLine(prefix + string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _logFilePath!.EscapeMarkup()));
+        _errorConsole.MarkupLine(prefix + string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _logFilePath.EscapeMarkup()));
     }
 }

--- a/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
+++ b/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
@@ -32,10 +32,10 @@ internal interface IStartupErrorWriter : IDisposable
 internal sealed class StartupErrorWriter : IStartupErrorWriter
 {
     private readonly IAnsiConsole _errorConsole;
-    private readonly string _logFilePath;
+    private readonly string? _logFilePath;
     private bool _hasOutput;
 
-    public StartupErrorWriter(string logFilePath)
+    public StartupErrorWriter(string? logFilePath)
     {
         _logFilePath = logFilePath;
         _errorConsole = AnsiConsole.Create(new AnsiConsoleSettings
@@ -64,6 +64,6 @@ internal sealed class StartupErrorWriter : IStartupErrorWriter
         }
 
         var prefix = ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.PageFacingUp, _errorConsole);
-        _errorConsole.MarkupLine(prefix + string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _logFilePath.EscapeMarkup()));
+        _errorConsole.MarkupLine(prefix + string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _logFilePath!.EscapeMarkup()));
     }
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -120,7 +120,7 @@ public class Program
         }
 
         var logsDirectory = Path.Combine(GetUsersAspirePath(), "logs");
-        var noLogFile = args?.Any(a => a == CommonOptionNames.NoLogFile) ?? false;
+        var noLogFile = HasNoLogFileOption(args);
         var logFilePath = noLogFile
             ? null
             : ParseLogFileOption(args) ?? FileLoggerProvider.GenerateLogFilePath(logsDirectory, TimeProvider.System);
@@ -153,6 +153,32 @@ public class Program
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Returns whether <c>--no-log-file</c> appears before the command delimiter (<c>--</c>).
+    /// </summary>
+    private static bool HasNoLogFileOption(string[]? args)
+    {
+        if (args is null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--")
+            {
+                break;
+            }
+
+            if (args[i] == CommonOptionNames.NoLogFile)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string GetGlobalSettingsPath(ILogger logger)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -62,8 +62,9 @@ public class Program
     /// <param name="ConsoleLogLevel">The console log level if specified via --log-level or --debug.</param>
     /// <param name="DebugMode">Whether --debug or -d was specified.</param>
     /// <param name="LogsDirectory">The directory where log files are stored.</param>
-    /// <param name="LogFilePath">The full path to the current session's log file.</param>
-    internal record CliLoggingOptions(LogLevel? ConsoleLogLevel, bool DebugMode, string LogsDirectory, string LogFilePath);
+    /// <param name="LogFilePath">The full path to the current session's log file, or null when file logging is disabled.</param>
+    /// <param name="NoLogFile">Whether --no-log-file was specified to disable file logging.</param>
+    internal record CliLoggingOptions(LogLevel? ConsoleLogLevel, bool DebugMode, string LogsDirectory, string? LogFilePath, bool NoLogFile);
 
     /// <summary>
     /// Holds the objects created during early CLI startup, before DI is available.
@@ -119,9 +120,12 @@ public class Program
         }
 
         var logsDirectory = Path.Combine(GetUsersAspirePath(), "logs");
-        var logFilePath = ParseLogFileOption(args) ?? FileLoggerProvider.GenerateLogFilePath(logsDirectory, TimeProvider.System);
+        var noLogFile = args?.Any(a => a == CommonOptionNames.NoLogFile) ?? false;
+        var logFilePath = noLogFile
+            ? null
+            : ParseLogFileOption(args) ?? FileLoggerProvider.GenerateLogFilePath(logsDirectory, TimeProvider.System);
 
-        return new CliLoggingOptions(logLevel, debugMode, logsDirectory, logFilePath);
+        return new CliLoggingOptions(logLevel, debugMode, logsDirectory, logFilePath, noLogFile);
     }
 
     /// <summary>
@@ -194,8 +198,12 @@ public class Program
 
         var extensionEndpoint = Environment.GetEnvironmentVariable(KnownConfigNames.ExtensionEndpoint);
 
-        // Create file logger provider from pre-computed path info
-        var fileLoggerProvider = new FileLoggerProvider(loggingOptions.LogFilePath, errorWriter);
+        // When --no-log-file is passed (e.g. by the VS Code extension for background
+        // invocations), skip creating a log file. Use --debug --no-log-file together
+        // to redirect logs to stderr instead of a file.
+        var fileLoggerProvider = loggingOptions.NoLogFile
+            ? FileLoggerProvider.CreateNull()
+            : new FileLoggerProvider(loggingOptions.LogFilePath!, errorWriter);
 
         var factory = LoggerFactory.Create(builder =>
         {
@@ -525,7 +533,7 @@ public class Program
         return new DirectoryInfo(sdksPath);
     }
 
-    private static CliExecutionContext BuildCliExecutionContext(bool debugMode, string logsDirectory, string logFilePath)
+    private static CliExecutionContext BuildCliExecutionContext(bool debugMode, string logsDirectory, string? logFilePath)
     {
         var workingDirectory = new DirectoryInfo(Environment.CurrentDirectory);
         var hivesDirectory = GetHivesDirectory();

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -227,9 +227,12 @@ public class Program
         // When --no-log-file is passed (e.g. by the VS Code extension for background
         // invocations), skip creating a log file. Use --debug --no-log-file together
         // to redirect logs to stderr instead of a file.
-        var fileLoggerProvider = loggingOptions.NoLogFile
-            ? FileLoggerProvider.CreateNull()
-            : new FileLoggerProvider(loggingOptions.LogFilePath!, errorWriter);
+        var fileLoggerProvider = loggingOptions switch
+        {
+            { NoLogFile: true } => FileLoggerProvider.CreateNull(),
+            { LogFilePath: { } logFilePath } => new FileLoggerProvider(logFilePath, errorWriter),
+            _ => throw new InvalidOperationException("A log file path is required when file logging is enabled.")
+        };
 
         var factory = LoggerFactory.Create(builder =>
         {

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -157,6 +157,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string ProjectCouldNotBeAnalyzedWithoutLogFile
+        {
+            get
+            {
+                return ResourceManager.GetString("ProjectCouldNotBeAnalyzedWithoutLogFile", resourceCulture);
+            }
+        }
+
         public static string ProjectIsNotAppHost
         {
             get

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -159,6 +159,9 @@
   <data name="ProjectCouldNotBeAnalyzed" xml:space="preserve">
     <value>The project could not be analyzed due to a build error. See logs at {0}</value>
   </data>
+  <data name="ProjectCouldNotBeAnalyzedWithoutLogFile" xml:space="preserve">
+    <value>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</value>
+  </data>
   <data name="ProjectIsNotAppHost" xml:space="preserve">
     <value>The project does not contain an Aspire AppHost.</value>
   </data>

--- a/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
@@ -106,6 +106,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Disable writing logs to a file..
+        /// </summary>
+        public static string NoLogFileArgumentDescription {
+            get {
+                return ResourceManager.GetString("NoLogFileArgumentDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The Aspire CLI can be used to create, run, and publish Aspire-based applications..
         /// </summary>
         public static string Description {

--- a/src/Aspire.Cli/Resources/RootCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.resx
@@ -132,6 +132,9 @@
   <data name="DebugArgumentDescription" xml:space="preserve">
     <value>Enable debug logging to the console</value>
   </data>
+  <data name="NoLogFileArgumentDescription" xml:space="preserve">
+    <value>Disable writing logs to a file</value>
+  </data>
   <data name="DebugLevelArgumentDescription" xml:space="preserve">
     <value>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical)</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Projekt se nepodařilo analyzovat kvůli chybě sestavení. Protokoly najdete na {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Soubor projektu neexistuje.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Das Projekt konnte aufgrund eines Buildfehlers nicht analysiert werden. Protokolle unter {0} anzeigen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Die Projektdatei ist nicht vorhanden.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -147,6 +147,11 @@
         <target state="translated">No se pudo analizar el proyecto debido a un error de compilación. Consulte los registros en {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">El archivo de proyecto no existe.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Impossible d’analyser le projet en raison d’une erreur de build. Consultez les journaux à l’emplacement {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Le fichier projet de bot n’existe pas.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Non è possibile analizzare il progetto a causa di un errore di compilazione. Consultare i log in {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Il file di progetto non esiste.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -147,6 +147,11 @@
         <target state="translated">ビルド エラーのため、プロジェクトを分析できませんでした。{0} でログを表示する</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">プロジェクト ファイルが存在しません。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -147,6 +147,11 @@
         <target state="translated">빌드 오류로 인해 프로젝트를 분석할 수 없습니다. {0}에서 로그 보기</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">프로젝트 파일이 없습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Nie można przeanalizować projektu z powodu błędu kompilacji. Zobacz dzienniki pod adresem {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Plik projektu nie istnieje.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Não foi possível analisar o projeto devido a um erro de compilação. Ver logs em {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">O arquivo de projeto não existe.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Не удалось проанализировать проект из-за ошибки сборки. См. журналы по адресу {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Файл проекта не существует.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Proje bir derleme hatası nedeniyle analiz edilemedi. {0} adresinde günlüklere bakın</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Proje dosyası mevcut değil.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -147,6 +147,11 @@
         <target state="translated">由于生成错误，无法分析项目。请参阅 {0} 处的日志</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">项目文件不存在。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -147,6 +147,11 @@
         <target state="translated">因為組建錯誤，無法分析專案。請參閱 {0} 中的記錄</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</source>
+        <target state="new">The project could not be analyzed due to a build error. Re-run with file logging enabled to capture the build output.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">專案檔案不存在。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Umožňuje potlačit banner spuštění a oznámení o telemetrii.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Unterdrücken Sie das Startupbanner und den Telemetriehinweis.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Suprima el banner de inicio y el aviso de telemetría.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Supprimer la bannière de démarrage et la notification de télémétrie.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Consente di disabilitare il banner di avvio e l'avviso di telemetria.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">スタートアップ バナーとテレメトリ通知を非表示にします。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">시작 배너 및 원격 분석 알림을 표시하지 않습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Wstrzymaj baner startowy i powiadomienie o telemetrii.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Suprima a faixa de inicialização e o aviso de telemetria.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Отключить баннер запуска и уведомление о телеметрии.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Başlangıç başlığını ve telemetri bildirimini gizle.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">抑制显示启动横幅和遥测通知。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing logs to a file</source>
+        <target state="new">Disable writing logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">抑制啟動橫幅與遙測通知。</target>

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.Utils;
 
 internal static class AppHostHelper
 {
-    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, string logFilePath, CancellationToken cancellationToken)
+    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, string? logFilePath, CancellationToken cancellationToken)
     {
         var appHostInformation = await GetAppHostInformationAsync(runner, interactionService, projectFile, telemetry, workingDirectory, cancellationToken);
 

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -14,13 +14,20 @@ namespace Aspire.Cli.Utils;
 
 internal static class AppHostHelper
 {
+    internal static string GetProjectCouldNotBeAnalyzedMessage(string? logFilePath)
+    {
+        return logFilePath is { Length: > 0 }
+            ? string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectCouldNotBeAnalyzed, logFilePath)
+            : ErrorStrings.ProjectCouldNotBeAnalyzedWithoutLogFile;
+    }
+
     internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, string? logFilePath, CancellationToken cancellationToken)
     {
         var appHostInformation = await GetAppHostInformationAsync(runner, interactionService, projectFile, telemetry, workingDirectory, cancellationToken);
 
         if (appHostInformation.ExitCode != 0)
         {
-            interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectCouldNotBeAnalyzed, logFilePath));
+            interactionService.DisplayError(GetProjectCouldNotBeAnalyzedMessage(logFilePath));
             return (false, false, null);
         }
 

--- a/tests/Aspire.Cli.Tests/ProgramTests.cs
+++ b/tests/Aspire.Cli.Tests/ProgramTests.cs
@@ -62,6 +62,15 @@ public class ProgramTests
     }
 
     [Fact]
+    public void ParseLoggingOptions_IgnoresNoLogFileAfterDelimiter()
+    {
+        var options = Program.ParseLoggingOptions(["run", "--", "--no-log-file"]);
+
+        Assert.False(options.NoLogFile);
+        Assert.NotNull(options.LogFilePath);
+    }
+
+    [Fact]
     public void FileLoggerProvider_CreateNull_DoesNotCreateFile()
     {
         using var provider = FileLoggerProvider.CreateNull();
@@ -81,5 +90,12 @@ public class ProgramTests
 
         // Logger reports enabled (filter is separate from file existence)
         Assert.True(logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Information));
+    }
+
+    [Fact]
+    public void StartupErrorWriter_Dispose_DoesNotThrowWhenLogFileIsDisabled()
+    {
+        using var writer = new StartupErrorWriter(logFilePath: null);
+        writer.WriteLine("example startup error");
     }
 }

--- a/tests/Aspire.Cli.Tests/ProgramTests.cs
+++ b/tests/Aspire.Cli.Tests/ProgramTests.cs
@@ -98,4 +98,15 @@ public class ProgramTests
         using var writer = new StartupErrorWriter(logFilePath: null);
         writer.WriteLine("example startup error");
     }
+
+    [Fact]
+    public void CreateLoggerFactory_ThrowsWhenFileLoggingEnabledWithoutLogFilePath()
+    {
+        var loggingOptions = new Program.CliLoggingOptions(ConsoleLogLevel: null, DebugMode: false, LogsDirectory: Path.GetTempPath(), LogFilePath: null, NoLogFile: false);
+        using var writer = new StartupErrorWriter(logFilePath: null);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => Program.CreateLoggerFactory([], loggingOptions, writer));
+
+        Assert.Equal("A log file path is required when file logging is enabled.", exception.Message);
+    }
 }

--- a/tests/Aspire.Cli.Tests/ProgramTests.cs
+++ b/tests/Aspire.Cli.Tests/ProgramTests.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Diagnostics;
+using Microsoft.Extensions.Logging;
+
 namespace Aspire.Cli.Tests;
 
 public class ProgramTests
@@ -27,5 +30,56 @@ public class ProgramTests
         var result = Program.ParseLogFileOption(["run", "--", "--log-file", "app.log"]);
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseLoggingOptions_NoLogFile_SetsFlag()
+    {
+        var options = Program.ParseLoggingOptions(["describe", "--no-log-file"]);
+
+        Assert.True(options.NoLogFile);
+        Assert.Null(options.LogFilePath);
+    }
+
+    [Fact]
+    public void ParseLoggingOptions_WithoutNoLogFile_GeneratesLogFilePath()
+    {
+        var options = Program.ParseLoggingOptions(["describe"]);
+
+        Assert.False(options.NoLogFile);
+        Assert.NotNull(options.LogFilePath);
+        Assert.EndsWith(".log", options.LogFilePath);
+    }
+
+    [Fact]
+    public void ParseLoggingOptions_NoLogFileWithDebug_SetsBothFlags()
+    {
+        var options = Program.ParseLoggingOptions(["describe", "--debug", "--no-log-file"]);
+
+        Assert.True(options.NoLogFile);
+        Assert.True(options.DebugMode);
+        Assert.Null(options.LogFilePath);
+    }
+
+    [Fact]
+    public void FileLoggerProvider_CreateNull_DoesNotCreateFile()
+    {
+        using var provider = FileLoggerProvider.CreateNull();
+
+        Assert.Null(provider.LogFilePath);
+
+        // Writing should be a no-op (no exception)
+        var logger = provider.CreateLogger("Test");
+        logger.LogInformation("This should not throw");
+    }
+
+    [Fact]
+    public void FileLoggerProvider_CreateNull_LoggerIsEnabled()
+    {
+        using var provider = FileLoggerProvider.CreateNull();
+        var logger = provider.CreateLogger("Aspire.Cli.Test");
+
+        // Logger reports enabled (filter is separate from file existence)
+        Assert.True(logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Information));
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Tests.Utils;
@@ -25,6 +27,22 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var dir = Path.GetDirectoryName(socketPrefix);
         Assert.NotNull(dir);
         Assert.EndsWith("backchannels", dir);
+    }
+
+    [Fact]
+    public void GetProjectCouldNotBeAnalyzedMessage_UsesLogPathWhenAvailable()
+    {
+        var message = AppHostHelper.GetProjectCouldNotBeAnalyzedMessage("/tmp/cli.log");
+
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectCouldNotBeAnalyzed, "/tmp/cli.log"), message);
+    }
+
+    [Fact]
+    public void GetProjectCouldNotBeAnalyzedMessage_UsesNoLogFileMessageWhenLogPathMissing()
+    {
+        var message = AppHostHelper.GetProjectCouldNotBeAnalyzedMessage(null);
+
+        Assert.Equal(ErrorStrings.ProjectCouldNotBeAnalyzedWithoutLogFile, message);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -84,7 +84,7 @@ internal static class CliTestHelper
         var testLogsDirectory = Path.Combine(options.WorkingDirectory.FullName, ".aspire", "logs");
         var testLogFilePath = FileLoggerProvider.GenerateLogFilePath(testLogsDirectory, TimeProvider.System);
         services.AddSingleton(new FileLoggerProvider(testLogFilePath, new TestStartupErrorWriter()));
-        services.AddSingleton(new Program.CliLoggingOptions(ConsoleLogLevel: null, DebugMode: false, LogsDirectory: testLogsDirectory, LogFilePath: testLogFilePath));
+        services.AddSingleton(new Program.CliLoggingOptions(ConsoleLogLevel: null, DebugMode: false, LogsDirectory: testLogsDirectory, LogFilePath: testLogFilePath, NoLogFile: false));
 
         services.AddMemoryCache();
 


### PR DESCRIPTION
## Description

- In spawned CLI processes (outside of an aspire terminal), changed so that debug output is logged to the new cli output channel and NOT a file.
- Reduces aspire restore parallelization from 4 to 2.
- Adds `--no-log-file` to the CLI to complement `--log-file` to avoid logging entirely.
- Adds an aspire cli availability cache, including coalescing concurrent resolutions and invalidation when `aspire.aspireCliExecutablePath` changes.
- Only calls `aspire describe` when an apphost file is open or the panel is open, and tightens the describe-watch lifecycle so stale async starts do not spawn duplicate watchers.
- Sets the repo `.vscode` default `aspire.enableAutoRestore: false` to avoid auto-restoring across very large workspaces.

CC @jamesnk

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `` and `<code/>` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
