### PR TITLE
Replace dotnet/actions-create-pull-request with local composite action

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: 'The body of the pull request'
     required: true
   labels:
-    description: 'A comma or newline-separated list of labels'
+    description: 'A newline-separated list of labels'
     required: false
     default: ''
   commit-message:
@@ -42,6 +42,14 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Configure git authentication
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        # Use the provided token for both git and gh operations
+        gh auth setup-git
+
     - name: Commit and push changes
       if: inputs.branch-already-exists != 'true'
       id: commit-and-push
@@ -89,7 +97,7 @@ runs:
           echo "Pull request #$PR_NUMBER already exists: $PR_URL"
           echo "pull-request-number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "pull-request-url=$PR_URL" >> $GITHUB_OUTPUT
-          echo "pull-request-operation=updated" >> $GITHUB_OUTPUT
+          echo "pull-request-operation=none" >> $GITHUB_OUTPUT
         else
           # Build label arguments as a bash array (avoids eval/injection)
           LABEL_ARGS=()
@@ -102,9 +110,10 @@ runs:
             done <<< "$LABELS"
           fi
 
-          # Write body to a temp file to avoid shell quoting issues
+          # Write body to a temp file to avoid shell quoting issues with special characters
           BODY_FILE=$(mktemp)
-          echo "$PR_BODY" > "$BODY_FILE"
+          trap 'rm -f "$BODY_FILE"' EXIT
+          printf '%s\n' "$PR_BODY" > "$BODY_FILE"
 
           # Create the pull request without eval — all args are properly quoted
           PR_URL=$(gh pr create \
@@ -115,6 +124,7 @@ runs:
             "${LABEL_ARGS[@]}")
 
           rm -f "$BODY_FILE"
+          trap - EXIT
 
           PR_NUMBER=$(gh pr view "$BRANCH" --json number --jq '.number')
           echo "Created pull request #$PR_NUMBER: $PR_URL"

--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -1,0 +1,124 @@
+name: 'Create Pull Request'
+description: 'Creates or updates a pull request for changes to the repository'
+inputs:
+  token:
+    description: 'GitHub token for authentication'
+    required: true
+  branch:
+    description: 'The pull request branch name'
+    required: true
+  base:
+    description: 'The base branch for the pull request'
+    required: false
+    default: 'main'
+  title:
+    description: 'The title of the pull request'
+    required: true
+  body:
+    description: 'The body of the pull request'
+    required: true
+  labels:
+    description: 'A comma or newline-separated list of labels'
+    required: false
+    default: ''
+  commit-message:
+    description: 'The commit message to use when committing changes'
+    required: false
+    default: '[create-pull-request] automated change'
+  branch-already-exists:
+    description: 'Set to true if the branch is already pushed remotely (skips commit/push)'
+    required: false
+    default: 'false'
+outputs:
+  pull-request-number:
+    description: 'The pull request number'
+    value: ${{ steps.create-pr.outputs.pull-request-number }}
+  pull-request-url:
+    description: 'The URL of the pull request'
+    value: ${{ steps.create-pr.outputs.pull-request-url }}
+  pull-request-operation:
+    description: 'The pull request operation performed (created, updated, none)'
+    value: ${{ steps.create-pr.outputs.pull-request-operation }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Commit and push changes
+      if: inputs.branch-already-exists != 'true'
+      id: commit-and-push
+      shell: bash
+      env:
+        BRANCH: ${{ inputs.branch }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+      run: |
+        # Check for any changes (staged, unstaged, or untracked)
+        if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+          echo "No changes to commit"
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        echo "has_changes=true" >> $GITHUB_OUTPUT
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        # Create or reset branch
+        git checkout -B "$BRANCH"
+        git add -A
+        git commit -m "$COMMIT_MESSAGE"
+        git push -f origin "$BRANCH"
+
+    - name: Create or update pull request
+      id: create-pr
+      if: inputs.branch-already-exists == 'true' || steps.commit-and-push.outputs.has_changes == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        BRANCH: ${{ inputs.branch }}
+        BASE: ${{ inputs.base }}
+        PR_TITLE: ${{ inputs.title }}
+        PR_BODY: ${{ inputs.body }}
+        LABELS: ${{ inputs.labels }}
+      run: |
+        # Check if a PR already exists for this branch
+        EXISTING_PR=$(gh pr list --head "$BRANCH" --base "$BASE" --json number,url --jq '.[0] // empty')
+
+        if [ -n "$EXISTING_PR" ]; then
+          PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number')
+          PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
+          echo "Pull request #$PR_NUMBER already exists: $PR_URL"
+          echo "pull-request-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pull-request-url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "pull-request-operation=updated" >> $GITHUB_OUTPUT
+        else
+          # Build label arguments as a bash array (avoids eval/injection)
+          LABEL_ARGS=()
+          if [ -n "$LABELS" ]; then
+            while IFS= read -r label; do
+              label=$(echo "$label" | xargs)  # trim whitespace
+              if [ -n "$label" ]; then
+                LABEL_ARGS+=(--label "$label")
+              fi
+            done <<< "$LABELS"
+          fi
+
+          # Write body to a temp file to avoid shell quoting issues
+          BODY_FILE=$(mktemp)
+          echo "$PR_BODY" > "$BODY_FILE"
+
+          # Create the pull request without eval — all args are properly quoted
+          PR_URL=$(gh pr create \
+            --title "$PR_TITLE" \
+            --body-file "$BODY_FILE" \
+            --base "$BASE" \
+            --head "$BRANCH" \
+            "${LABEL_ARGS[@]}")
+
+          rm -f "$BODY_FILE"
+
+          PR_NUMBER=$(gh pr view "$BRANCH" --json number --jq '.number')
+          echo "Created pull request #$PR_NUMBER: $PR_URL"
+          echo "pull-request-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pull-request-url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "pull-request-operation=created" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/generate-api-diffs.yml
+++ b/.github/workflows/generate-api-diffs.yml
@@ -34,7 +34,7 @@ jobs:
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
 
       - name: Create or update pull request
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-api-diffs

--- a/.github/workflows/generate-ats-diffs.yml
+++ b/.github/workflows/generate-ats-diffs.yml
@@ -84,7 +84,7 @@ jobs:
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
 
       - name: Create or update pull request
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-ats-diffs

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -34,7 +34,7 @@ jobs:
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
 
       - name: Create or update pull request
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-manifests

--- a/.github/workflows/refresh-typescript-sdks.yml
+++ b/.github/workflows/refresh-typescript-sdks.yml
@@ -32,7 +32,7 @@ jobs:
           ./eng/refreshTypeScriptSdks.ps1
 
       - name: Create or update pull request
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update-typescript-playground-sdks

--- a/.github/workflows/release-github-tasks.yml
+++ b/.github/workflows/release-github-tasks.yml
@@ -356,7 +356,7 @@ jobs:
 
       - name: Create Merge PR
         if: steps.check-pr.outputs.pr_exists != 'true' && inputs.dry_run != true
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1 # v1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: "Merge ${{ inputs.release_branch }} to main after v${{ inputs.release_version }} release"
@@ -372,6 +372,7 @@ jobs:
             *Created automatically by the release workflow.*
           branch: ${{ inputs.release_branch }}
           base: main
+          branch-already-exists: 'true'
           labels: |
             area-infrastructure
             release-automation
@@ -476,7 +477,7 @@ jobs:
 
       - name: Create Baseline PR
         if: steps.check-pr.outputs.pr_exists != 'true' && inputs.dry_run != true
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1 # v1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: "Update PackageValidationBaselineVersion to ${{ inputs.release_version }}"
@@ -492,6 +493,7 @@ jobs:
             *Created automatically by the release workflow.*
           branch: update-baseline-${{ inputs.release_version }}
           base: main
+          branch-already-exists: 'true'
           labels: |
             area-infrastructure
             release-automation

--- a/.github/workflows/update-ai-foundry-models.yml
+++ b/.github/workflows/update-ai-foundry-models.yml
@@ -31,7 +31,7 @@ jobs:
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
 
       - name: Create or update pull request
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-ai-foundry-models

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-dependencies

--- a/.github/workflows/update-github-models.yml
+++ b/.github/workflows/update-github-models.yml
@@ -32,7 +32,7 @@ jobs:
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
 
       - name: Create or update pull request
-        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
+        uses: ./.github/actions/create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-github-models

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -150,7 +150,7 @@ The pipeline uses the `Aspire-Release-Secrets` variable group. Note that NuGet p
 The workflow uses only pre-approved actions:
 
 - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4)
-- `.github/actions/create-pull-request` (local composite action)
+- `./.github/actions/create-pull-request` (local composite action)
 
 ## Troubleshooting
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -150,7 +150,7 @@ The pipeline uses the `Aspire-Release-Secrets` variable group. Note that NuGet p
 The workflow uses only pre-approved actions:
 
 - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4)
-- `dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1` (v1)
+- `.github/actions/create-pull-request` (local composite action)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

Replace the external `dotnet/actions-create-pull-request` GitHub Action with a local composite action at `.github/actions/create-pull-request/action.yml`.

### Motivation

The `dotnet/actions-create-pull-request` fork is 482 commits behind upstream `peter-evans/create-pull-request`, still declares `node16` in its `action.yml`, and has not incorporated the fix for `actions/checkout@v6` compatibility ([peter-evans#4230](https://github.com/peter-evans/create-pull-request/pull/4230)). This causes all workflows using it to fail with `The process '/usr/bin/git' failed with exit code 128` due to duplicate Authorization headers.

### Changes

- **New**: `.github/actions/create-pull-request/action.yml` — a composite action using `git` and `gh` CLI (pre-installed on all runners). No external dependencies, no Node.js version concerns.
- **Updated 8 workflow files** (9 usages) to reference `./.github/actions/create-pull-request` instead of `dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1`:
  - `generate-api-diffs.yml`
  - `generate-ats-diffs.yml`
  - `refresh-manifests.yml`
  - `refresh-typescript-sdks.yml`
  - `update-ai-foundry-models.yml`
  - `update-dependencies.yml`
  - `update-github-models.yml`
  - `release-github-tasks.yml` (2 usages, using `branch-already-exists: 'true'`)
- **Updated**: `docs/release-process.md` to reflect the new action reference.

### Security

A threat model was performed on the composite action:
- All inputs flow through `env:` variables (never `${{ }}` interpolation in `run:` blocks) to prevent expression injection
- No `eval` — label arguments use bash arrays, PR body uses `--body-file` with a temp file
- Token passed via `GH_TOKEN` env var, never on command lines
- All callers trigger only on `schedule` or `workflow_dispatch` (requires repo write access)
- Eliminates the unmaintained external dependency entirely

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
