### PR TITLE
Implement health checks for Azure Key Vault CertificateClient and KeyClient

### DIFF
--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultCertificatesComponent.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultCertificatesComponent.cs
@@ -20,11 +20,8 @@ internal sealed class AzureKeyVaultCertificatesComponent : AbstractAzureKeyVault
     internal override CertificateClient CreateComponentClient(Uri vaultUri, CertificateClientOptions options, TokenCredential cred)
         => new(vaultUri, cred, options);
 
-    protected override bool GetHealthCheckEnabled(AzureSecurityKeyVaultSettings settings)
-        => false;
-
     protected override IHealthCheck CreateHealthCheck(CertificateClient client, AzureSecurityKeyVaultSettings settings)
-        => throw new NotImplementedException();
+        => new AzureKeyVaultCertificatesHealthCheck(client);
 
     protected override void BindClientOptionsToConfiguration(IAzureClientBuilder<CertificateClient, CertificateClientOptions> clientBuilder, IConfiguration configuration)
 #pragma warning disable IDE0200 // Remove unnecessary lambda expression - needed so the ConfigBinder Source Generator works

--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultCertificatesHealthCheck.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultCertificatesHealthCheck.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Security.KeyVault.Certificates;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Aspire.Azure.Security.KeyVault;
+
+internal sealed class AzureKeyVaultCertificatesHealthCheck : IHealthCheck
+{
+    private readonly CertificateClient _client;
+
+    public AzureKeyVaultCertificatesHealthCheck(CertificateClient client)
+        => _client = client;
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await foreach (var _ in _client.GetPropertiesOfCertificatesAsync(cancellationToken: cancellationToken).AsPages(pageSizeHint: 1).WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                break;
+            }
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+        }
+    }
+}

--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultKeysComponent.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultKeysComponent.cs
@@ -13,11 +13,8 @@ namespace Microsoft.Extensions.Hosting;
 
 internal sealed class AzureKeyVaultKeysComponent : AbstractAzureKeyVaultComponent<KeyClient, KeyClientOptions>
 {
-    protected override bool GetHealthCheckEnabled(AzureSecurityKeyVaultSettings settings)
-        => false;
-
     protected override IHealthCheck CreateHealthCheck(KeyClient client, AzureSecurityKeyVaultSettings settings)
-        => throw new NotImplementedException();
+        => new AzureKeyVaultKeysHealthCheck(client);
 
     internal override KeyClient CreateComponentClient(Uri vaultUri, KeyClientOptions options, TokenCredential cred)
         => new(vaultUri, cred, options);

--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultKeysHealthCheck.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultKeysHealthCheck.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Security.KeyVault.Keys;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Aspire.Azure.Security.KeyVault;
+
+internal sealed class AzureKeyVaultKeysHealthCheck : IHealthCheck
+{
+    private readonly KeyClient _client;
+
+    public AzureKeyVaultKeysHealthCheck(KeyClient client)
+        => _client = client;
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await foreach (var _ in _client.GetPropertiesOfKeysAsync(cancellationToken).AsPages(pageSizeHint: 1).WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                break;
+            }
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+        }
+    }
+}

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/CertificateClientConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/CertificateClientConformanceTests.cs
@@ -88,9 +88,7 @@ public class CertificateClientConformanceTests : ConformanceTests<CertificateCli
     }
 
     protected override void SetHealthCheck(AzureSecurityKeyVaultSettings options, bool enabled)
-    // Disable Key Vault health check tests until https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/2279 is fixed
-    //    => options.DisableHealthChecks = !enabled;
-        => throw new NotImplementedException();
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetMetrics(AzureSecurityKeyVaultSettings options, bool enabled)
         => throw new NotImplementedException();

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/KeyClientConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/KeyClientConformanceTests.cs
@@ -90,9 +90,7 @@ public class KeyClientConformanceTests : ConformanceTests<KeyClient, AzureSecuri
     }
 
     protected override void SetHealthCheck(AzureSecurityKeyVaultSettings options, bool enabled)
-    // Disable Key Vault health check tests until https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/2279 is fixed
-    //    => options.DisableHealthChecks = !enabled;
-        => throw new NotImplementedException();
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetMetrics(AzureSecurityKeyVaultSettings options, bool enabled)
         => throw new NotImplementedException();


### PR DESCRIPTION
**Description**

`CertificateClient` and `KeyClient` registrations had `GetHealthCheckEnabled` hardcoded to `false` and `CreateHealthCheck` throwing `NotImplementedException`, meaning health checks were silently disabled for these two Key Vault client types regardless of the `DisableHealthChecks` setting.

This PR adds `AzureKeyVaultCertificatesHealthCheck` and `AzureKeyVaultKeysHealthCheck` — lightweight `IHealthCheck` implementations that use the already-registered SDK clients to enumerate the first page of properties (one read-only API call), verifying vault connectivity. No new NuGet dependencies are introduced since no equivalent split packages exist in `AspNetCore.Diagnostics.HealthChecks` for Certificates or Keys (only Secrets has one). The conformance test `SetHealthCheck` overrides for both client types are also enabled.

Fixes # (issue) — N/A, addressing existing `NotImplementedException` / hardcoded `false`

---

**Checklist**

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes — `SetHealthCheck` conformance tests enabled for `CertificateClientConformanceTests` and `KeyClientConformanceTests`
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No