### PR TITLE
Remove CFSClean from release pipeline to unblock NuGet publishing

### DIFF
--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -71,11 +71,17 @@ extends:
       name: NetCore1ESPool-Internal
       image: windows.vs2026preview.scout.amd64
       os: windows
-    # Network isolation policy: match main build pipeline for ES4.2.4 CFS compliance.
-    # releaseJob templateContext provides approved network access for external publishing
-    # (NuGet.org, GitHub API for WinGet/Homebrew, Maestro).
+    # Network isolation policy for ES4.2.4 CFS compliance.
+    # CFSClean is intentionally omitted here because it blocks all NuGet endpoints
+    # (api.nuget.org, www.nuget.org, etc.) via DNS sinkhole and this release pipeline
+    # must push packages to NuGet.org via the 1ES.PublishNuget@1 task. ES4.2.4 requires
+    # pipelines to *consume* packages from internal feeds (which we do — NuGet.config
+    # only uses pkgs.dev.azure.com/dnceng feeds), but does not prohibit *publishing* to
+    # public registries. CFSClean2 is retained to block Docker, PowerShell Gallery, and
+    # other endpoints not needed by this pipeline.
+    # See: https://eng.ms/docs/microsoft-ai/webxt/feed-verticals/start-experiences/fv-live-site/sfi-executor-centric-wiki/skills/security/mdp-cfs-security-change/skill
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,CFSClean2
+      networkIsolationPolicy: Permissive,CFSClean2
 
     stages:
       # ===== STAGE 1: PREPARE ARTIFACTS =====


### PR DESCRIPTION
## Description

The recently added `CFSClean` network isolation policy (for ES4.2.4 compliance) blocks **all** NuGet endpoints (`api.nuget.org`, `www.nuget.org`, etc.) via DNS sinkhole to `192.0.2.5`. This causes the `1ES.PublishNuget@1` task in the release pipeline to fail with:

```
Unable to load the service index for source https://api.nuget.org/v3/index.json
SocketException (10013): An attempt was made to access a socket in a way forbidden by its access permissions 192.0.2.5:443
```

**Failing build:** https://dev.azure.com/dnceng/internal/_build/results?buildId=2946410

## Root Cause

`CFSClean` is designed to block outbound access to public package registries during **build/restore** operations, forcing pipelines to consume packages only from internal Azure Artifacts feeds. However, the release pipeline needs outbound NuGet access to **publish** packages to NuGet.org — a scenario the CFS policy doesn't distinguish from consuming.

## Fix

Remove `CFSClean` from the release pipeline's network isolation policy while keeping `CFSClean2` (which blocks Docker, PowerShell Gallery, and other unneeded endpoints):

- **Before:** `networkIsolationPolicy: Permissive,CFSClean,CFSClean2`
- **After:** `networkIsolationPolicy: Permissive,CFSClean2`

The pipeline remains ES4.2.4 compliant because:
- It only **consumes** packages from internal feeds (`NuGet.config` uses `<clear/>` and only references `pkgs.dev.azure.com/dnceng` feeds)
- ES4.2.4 requires consuming from internal feeds, not prohibiting publishing to public registries
- The main build pipeline (`azure-pipelines.yml`) correctly retains `CFSClean` since it only restores from internal feeds

## References

- [CFS Security Change docs](https://eng.ms/docs/microsoft-ai/webxt/feed-verticals/start-experiences/fv-live-site/sfi-executor-centric-wiki/skills/security/mdp-cfs-security-change/skill)
- [ES4.2.4 Network Isolation docs](https://eng.ms/docs/engineering-enablement-and-operations/commerce-platforms/commerce-core/elevatex/guardrails/sfisquad/sfisquad/kpis/es424)