### PR TITLE
Create project output subfolder in VS Code extension mode

### DIFF
--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -616,7 +616,18 @@ internal class DotNetTemplateFactory(
             outputPath = await prompter.PromptForOutputPath(pathDeriver(projectName), cancellationToken);
         }
 
-        return Path.GetFullPath(outputPath);
+        outputPath = Path.GetFullPath(outputPath);
+
+        // When running in extension mode (VS Code), the folder picker returns the parent
+        // directory the user selected. Append the project name as a subdirectory so the
+        // project gets its own clean folder, matching the git-clone convention.
+        if (ExtensionHelper.IsExtensionHost(interactionService, out _, out _)
+            && !string.Equals(Path.GetFileName(outputPath), projectName, StringComparison.OrdinalIgnoreCase))
+        {
+            outputPath = Path.Combine(outputPath, projectName);
+        }
+
+        return outputPath;
     }
 
     private async Task<(NuGetPackage Package, PackageChannel Channel)> GetProjectTemplatesVersionAsync(TemplateInputs inputs, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -622,9 +622,19 @@ internal class DotNetTemplateFactory(
         // directory the user selected. Append the project name as a subdirectory so the
         // project gets its own clean folder, matching the git-clone convention.
         if (ExtensionHelper.IsExtensionHost(interactionService, out _, out _)
-            && !string.Equals(Path.GetFileName(outputPath), projectName, StringComparison.OrdinalIgnoreCase))
+            && !projectName.Equals(".", StringComparison.Ordinal)
+            && !projectName.Equals("..", StringComparison.Ordinal))
         {
-            outputPath = Path.Combine(outputPath, projectName);
+            var normalizedOutputPath = Path.TrimEndingDirectorySeparator(outputPath);
+
+            if (!string.Equals(Path.GetFileName(normalizedOutputPath), projectName, StringComparison.OrdinalIgnoreCase))
+            {
+                outputPath = Path.Combine(normalizedOutputPath, projectName);
+            }
+            else
+            {
+                outputPath = normalizedOutputPath;
+            }
         }
 
         return outputPath;

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1664,6 +1664,206 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.NotEqual(0, exitCode);
         Assert.NotNull(testInteractionService);
     }
+
+    [Fact]
+    public async Task NewCommandInExtensionModeAppendsProjectNameToOutputPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedOutputPath = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
+            {
+                HasCapabilityAsyncCallback = (c, _) => Task.FromResult(c is "baseline.v1"),
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForProjectNameCallback = (_) => "MyFirstApp";
+
+                // Simulate the user picking a parent folder (not named after the project)
+                prompter.PromptForOutputPathCallback = (_) =>
+                    Path.Combine(workspace.WorkspaceRoot.FullName, "source");
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+                    return (0, new NuGetPackage[] { package });
+                };
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                {
+                    return (0, version);
+                };
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    capturedOutputPath = outputPath;
+                    return 0;
+                };
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedOutputPath);
+
+        // Output path should have the project name appended as a subdirectory
+        var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, "source", "MyFirstApp");
+        Assert.Equal(expectedPath, capturedOutputPath);
+    }
+
+    [Fact]
+    public async Task NewCommandInExtensionModeDoesNotDoubleAppendProjectName()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedOutputPath = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
+            {
+                HasCapabilityAsyncCallback = (c, _) => Task.FromResult(c is "baseline.v1"),
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForProjectNameCallback = (_) => "MyFirstApp";
+
+                // Simulate the user picking a folder already named after the project
+                prompter.PromptForOutputPathCallback = (_) =>
+                    Path.Combine(workspace.WorkspaceRoot.FullName, "source", "MyFirstApp");
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+                    return (0, new NuGetPackage[] { package });
+                };
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                {
+                    return (0, version);
+                };
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    capturedOutputPath = outputPath;
+                    return 0;
+                };
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedOutputPath);
+
+        // Output path should NOT have the project name double-appended
+        var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, "source", "MyFirstApp");
+        Assert.Equal(expectedPath, capturedOutputPath);
+    }
+
+    [Fact]
+    public async Task NewCommandInConsoleModeDoesNotAppendProjectName()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedOutputPath = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            // Default InteractionServiceFactory creates ConsoleInteractionService (not extension mode)
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForProjectNameCallback = (_) => "MyFirstApp";
+
+                // Simulate user accepting default path or selecting parent folder
+                prompter.PromptForOutputPathCallback = (_) =>
+                    Path.Combine(workspace.WorkspaceRoot.FullName, "source");
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+                    return (0, new NuGetPackage[] { package });
+                };
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                {
+                    return (0, version);
+                };
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    capturedOutputPath = outputPath;
+                    return 0;
+                };
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedOutputPath);
+
+        // In console mode, the output path should NOT have project name appended
+        var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, "source");
+        Assert.Equal(expectedPath, capturedOutputPath);
+    }
 }
 
 internal sealed class TestNewCommandPrompter(IInteractionService interactionService) : NewCommandPrompter(interactionService)

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1864,6 +1864,85 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, "source");
         Assert.Equal(expectedPath, capturedOutputPath);
     }
+
+    [Fact]
+    public async Task NewCommandInExtensionModeHandlesTrailingDirectorySeparator()
+    {
+        const string projectName = "MyFirstApp";
+
+        async Task AssertOutputPathAsync(Func<string, string> selectedPathFactory, Func<string, string> expectedPathFactory)
+        {
+            using var workspace = TemporaryWorkspace.Create(outputHelper);
+            string? capturedOutputPath = null;
+
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            {
+                options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
+                options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
+                {
+                    HasCapabilityAsyncCallback = (c, _) => Task.FromResult(c is "baseline.v1"),
+                };
+
+                options.NewCommandPrompterFactory = (sp) =>
+                {
+                    var interactionService = sp.GetRequiredService<IInteractionService>();
+                    var prompter = new TestNewCommandPrompter(interactionService);
+
+                    prompter.PromptForProjectNameCallback = (_) => projectName;
+
+                    prompter.PromptForOutputPathCallback = (_) =>
+                        selectedPathFactory(workspace.WorkspaceRoot.FullName);
+
+                    return prompter;
+                };
+
+                options.DotNetCliRunnerFactory = (sp) =>
+                {
+                    var runner = new TestDotNetCliRunner();
+                    runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                    {
+                        var package = new NuGetPackage()
+                        {
+                            Id = "Aspire.ProjectTemplates",
+                            Source = "nuget",
+                            Version = "9.2.0"
+                        };
+                        return (0, new NuGetPackage[] { package });
+                    };
+                    runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                    {
+                        return (0, version);
+                    };
+                    runner.NewProjectAsyncCallback = (templateName, pName, outputPath, invocationOptions, ct) =>
+                    {
+                        capturedOutputPath = outputPath;
+                        return 0;
+                    };
+                    return runner;
+                };
+            });
+            var provider = services.BuildServiceProvider();
+
+            var command = provider.GetRequiredService<RootCommand>();
+            var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(0, exitCode);
+            Assert.NotNull(capturedOutputPath);
+            Assert.Equal(expectedPathFactory(workspace.WorkspaceRoot.FullName), capturedOutputPath);
+        }
+
+        // Trailing separator on a parent folder should still append the project name once.
+        await AssertOutputPathAsync(
+            workspaceRoot => Path.Combine(workspaceRoot, "source") + Path.DirectorySeparatorChar,
+            workspaceRoot => Path.Combine(workspaceRoot, "source", projectName));
+
+        // Trailing separator on a folder already named after the project should not double-append.
+        await AssertOutputPathAsync(
+            workspaceRoot => Path.Combine(workspaceRoot, projectName) + Path.DirectorySeparatorChar,
+            workspaceRoot => Path.Combine(workspaceRoot, projectName));
+    }
 }
 
 internal sealed class TestNewCommandPrompter(IInteractionService interactionService) : NewCommandPrompter(interactionService)


### PR DESCRIPTION
## Description

When creating a new project via the VS Code extension walkthrough, the user selects a root folder (e.g., `C:\users\username\source`) as the output path. Previously, the template files were placed directly in that folder. This change appends the project name as a subdirectory (e.g., `C:\users\username\source\MyFirstApp`), matching the `git clone` experience.

The fix is in `DotNetTemplateFactory.GetOutputPathAsync()` — when running in extension mode, if the selected output folder doesn't already end with the project name, it's appended as a subdirectory. Console/terminal mode behavior is unchanged.

cc @BethMassi

Fixes #15737

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
