### PR TITLE
Fix aspire start failing in VS Code integrated terminal

### DIFF
--- a/extension/src/utils/AspirePackageRestoreProvider.ts
+++ b/extension/src/utils/AspirePackageRestoreProvider.ts
@@ -64,10 +64,14 @@ export class AspirePackageRestoreProvider implements vscode.Disposable {
     async retryRestore(): Promise<void> {
         this._failedDirs.clear();
         this._showProgress();
-        await this._restoreAll();
+        await this._restoreAll(true);
     }
 
-    private async _restoreAll(): Promise<void> {
+    private async _restoreAll(force = false): Promise<void> {
+        if (!force && !getEnableAutoRestore()) {
+            extensionLogOutputChannel.info('Auto-restore is disabled, skipping restore');
+            return;
+        }
         const allConfigs = await findAspireSettingsFiles();
         const configs = allConfigs.filter(uri => uri.fsPath.endsWith(aspireConfigFileName));
         if (configs.length === 0) {
@@ -122,6 +126,10 @@ export class AspirePackageRestoreProvider implements vscode.Disposable {
     }
 
     private async _restoreIfChanged(uri: vscode.Uri, isInitial: boolean): Promise<void> {
+        if (!getEnableAutoRestore()) {
+            return;
+        }
+
         let content: string;
         try {
             content = (await vscode.workspace.fs.readFile(uri)).toString();

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -214,13 +214,11 @@ internal sealed class AppHostLauncher(
     }
 
     /// <summary>
-    /// Extension-related environment variable names that must be removed from
-    /// the detached child process. When the parent CLI runs inside the VS Code
-    /// Aspire terminal, these vars are set — but the child must not see them
-    /// because it would incorrectly detect extension mode and delegate back to
-    /// the extension instead of launching the AppHost.
+    /// Environment variable names that make a detached child CLI run in extension-host mode.
+    /// Keep the DEBUG_SESSION_* and DCP session variables intact because the launched AppHost
+    /// still relies on them for IDE execution and dashboard integration.
     /// </summary>
-    private static readonly HashSet<string> s_extensionEnvironmentVariables = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> s_extensionHostEnvironmentVariables = new(StringComparer.OrdinalIgnoreCase)
     {
         KnownConfigNames.ExtensionEndpoint,
         KnownConfigNames.ExtensionToken,
@@ -229,13 +227,12 @@ internal sealed class AppHostLauncher(
         KnownConfigNames.ExtensionDebugSessionId,
         KnownConfigNames.ExtensionDebugRunMode,
         KnownConfigNames.ExtensionCapabilities,
-        KnownConfigNames.DebugSessionInfo,
-        KnownConfigNames.DebugSessionRunMode,
-        KnownConfigNames.DebugSessionPort,
-        KnownConfigNames.DebugSessionToken,
-        KnownConfigNames.DebugSessionServerCertificate,
-        KnownConfigNames.DcpInstanceIdPrefix,
     };
+
+    /// <summary>
+    /// Gets the environment variables removed from detached child CLI processes.
+    /// </summary>
+    internal static IReadOnlySet<string> DetachedChildEnvironmentVariablesToRemove => s_extensionHostEnvironmentVariables;
 
     private record LaunchResult(Process? ChildProcess, IAppHostAuxiliaryBackchannel? Backchannel, DashboardUrlsState? DashboardUrls, bool ChildExitedEarly, int ChildExitCode);
 
@@ -253,7 +250,7 @@ internal sealed class AppHostLauncher(
                 executablePath,
                 childArgs,
                 executionContext.WorkingDirectory.FullName,
-                s_extensionEnvironmentVariables);
+                s_extensionHostEnvironmentVariables);
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -11,7 +11,6 @@ using Aspire.Cli.Processes;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
-using Aspire.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Commands;
@@ -214,25 +213,20 @@ internal sealed class AppHostLauncher(
     }
 
     /// <summary>
-    /// Environment variable names that make a detached child CLI run in extension-host mode.
+    /// Prefix for environment variables that configure extension-host mode.
+    /// Any environment variable starting with this prefix is removed from
+    /// detached child processes to prevent them from entering extension mode.
     /// Keep the DEBUG_SESSION_* and DCP session variables intact because the launched AppHost
     /// still relies on them for IDE execution and dashboard integration.
     /// </summary>
-    private static readonly HashSet<string> s_extensionHostEnvironmentVariables = new(StringComparer.OrdinalIgnoreCase)
-    {
-        KnownConfigNames.ExtensionEndpoint,
-        KnownConfigNames.ExtensionToken,
-        KnownConfigNames.ExtensionCert,
-        KnownConfigNames.ExtensionPromptEnabled,
-        KnownConfigNames.ExtensionDebugSessionId,
-        KnownConfigNames.ExtensionDebugRunMode,
-        KnownConfigNames.ExtensionCapabilities,
-    };
+    internal const string ExtensionEnvironmentVariablePrefix = "ASPIRE_EXTENSION_";
 
     /// <summary>
-    /// Gets the environment variables removed from detached child CLI processes.
+    /// Returns <see langword="true"/> if the specified environment variable name
+    /// should be removed from detached child CLI processes.
     /// </summary>
-    internal static IReadOnlySet<string> DetachedChildEnvironmentVariablesToRemove => s_extensionHostEnvironmentVariables;
+    internal static bool IsExtensionEnvironmentVariable(string name) =>
+        name.StartsWith(ExtensionEnvironmentVariablePrefix, StringComparison.OrdinalIgnoreCase);
 
     private record LaunchResult(Process? ChildProcess, IAppHostAuxiliaryBackchannel? Backchannel, DashboardUrlsState? DashboardUrls, bool ChildExitedEarly, int ChildExitCode);
 
@@ -250,7 +244,7 @@ internal sealed class AppHostLauncher(
                 executablePath,
                 childArgs,
                 executionContext.WorkingDirectory.FullName,
-                s_extensionHostEnvironmentVariables);
+                IsExtensionEnvironmentVariable);
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Processes;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Commands;
@@ -212,6 +213,30 @@ internal sealed class AppHostLauncher(
         return (dotnetPath, childArgs);
     }
 
+    /// <summary>
+    /// Extension-related environment variable names that must be removed from
+    /// the detached child process. When the parent CLI runs inside the VS Code
+    /// Aspire terminal, these vars are set — but the child must not see them
+    /// because it would incorrectly detect extension mode and delegate back to
+    /// the extension instead of launching the AppHost.
+    /// </summary>
+    private static readonly HashSet<string> s_extensionEnvironmentVariables = new(StringComparer.OrdinalIgnoreCase)
+    {
+        KnownConfigNames.ExtensionEndpoint,
+        KnownConfigNames.ExtensionToken,
+        KnownConfigNames.ExtensionCert,
+        KnownConfigNames.ExtensionPromptEnabled,
+        KnownConfigNames.ExtensionDebugSessionId,
+        KnownConfigNames.ExtensionDebugRunMode,
+        KnownConfigNames.ExtensionCapabilities,
+        KnownConfigNames.DebugSessionInfo,
+        KnownConfigNames.DebugSessionRunMode,
+        KnownConfigNames.DebugSessionPort,
+        KnownConfigNames.DebugSessionToken,
+        KnownConfigNames.DebugSessionServerCertificate,
+        KnownConfigNames.DcpInstanceIdPrefix,
+    };
+
     private record LaunchResult(Process? ChildProcess, IAppHostAuxiliaryBackchannel? Backchannel, DashboardUrlsState? DashboardUrls, bool ChildExitedEarly, int ChildExitCode);
 
     private async Task<LaunchResult> LaunchAndWaitForBackchannelAsync(
@@ -227,7 +252,8 @@ internal sealed class AppHostLauncher(
             childProcess = DetachedProcessLauncher.Start(
                 executablePath,
                 childArgs,
-                executionContext.WorkingDirectory.FullName);
+                executionContext.WorkingDirectory.FullName,
+                s_extensionEnvironmentVariables);
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -165,8 +165,12 @@ internal sealed class RunCommand : BaseCommand
         }
 
         // A user may run `aspire run` in an Aspire terminal in VS Code. In this case, intercept and prompt
-        // VS Code to start a debug session using the current directory
-        if (ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _)
+        // VS Code to start a debug session using the current directory.
+        // Skip this when running in non-interactive mode (e.g. as a child of `aspire start`)
+        // to avoid delegating back to the extension instead of launching the AppHost directly.
+        var nonInteractive = parseResult.GetValue(RootCommand.NonInteractiveOption);
+        if (!nonInteractive
+            && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _)
             && string.IsNullOrEmpty(_configuration[KnownConfigNames.ExtensionDebugSessionId]))
         {
             extensionInteractionService.DisplayConsolePlainText(RunCommandStrings.StartingDebugSessionInExtension);
@@ -463,8 +467,12 @@ internal sealed class RunCommand : BaseCommand
         var logsLabel = RunCommandStrings.Logs;
         var pidLabel = RunCommandStrings.ProcessId;
 
-        // Calculate column width based on all possible labels
-        var labels = new List<string> { appHostLabel, dashboardLabel, logsLabel };
+        // Calculate column width based on labels that will actually be displayed
+        var labels = new List<string> { appHostLabel, logsLabel };
+        if (!isExtensionHost)
+        {
+            labels.Add(dashboardLabel);
+        }
         if (pid.HasValue)
         {
             labels.Add(pidLabel);

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Commands;
 

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -48,7 +48,9 @@ internal sealed class StartCommand : BaseCommand
         var isolated = parseResult.GetValue(AppHostLauncher.s_isolatedOption);
 
         var noBuild = parseResult.GetValue(s_noBuildOption);
-        var isExtensionHost = ExtensionHelper.IsExtensionHost(_interactionService, out _, out _);
+        // `aspire start` is always user-initiated, so we never suppress dashboard URLs
+        // in the summary — even when running inside the VS Code extension terminal.
+        var isExtensionHost = false;
         var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
         var globalArgs = RootCommand.GetChildProcessArgs(parseResult);
         var additionalArgs = parseResult.UnmatchedTokens.ToList();

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -46,8 +46,9 @@ internal sealed class StartCommand : BaseCommand
         var isolated = parseResult.GetValue(AppHostLauncher.s_isolatedOption);
 
         var noBuild = parseResult.GetValue(s_noBuildOption);
-        // `aspire start` is always user-initiated, so we never suppress dashboard URLs
-        // in the summary — even when running inside the VS Code extension terminal.
+        // `aspire start` is always user-initiated — the VS Code extension only invokes
+        // `aspire run`, never `aspire start`. So we hardcode isExtensionHost to false
+        // to ensure dashboard URLs always appear in the summary output.
         var isExtensionHost = false;
         var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
         var globalArgs = RootCommand.GetChildProcessArgs(parseResult);

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -15,7 +15,6 @@ internal sealed class StartCommand : BaseCommand
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
     private readonly AppHostLauncher _appHostLauncher;
-    private readonly IInteractionService _interactionService;
 
     private static readonly Option<bool> s_noBuildOption = new("--no-build")
     {
@@ -32,7 +31,6 @@ internal sealed class StartCommand : BaseCommand
         : base("start", StartCommandStrings.Description,
                features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        _interactionService = interactionService;
         _appHostLauncher = appHostLauncher;
 
         Options.Add(s_noBuildOption);

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -6,7 +6,6 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
-using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Commands;
 

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
@@ -15,7 +15,7 @@ internal static partial class DetachedProcessLauncher
     /// pipe has no reader and writes produce EPIPE (harmless). The key difference from
     /// Windows is that on Unix, only fds 0/1/2 survive exec — no extra handle leakage.
     /// </summary>
-    private static Process StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory, IReadOnlySet<string>? environmentVariablesToRemove)
+    private static Process StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -35,11 +35,20 @@ internal static partial class DetachedProcessLauncher
 
         // Remove specified environment variables from the child process.
         // Accessing startInfo.Environment auto-populates from the current process.
-        if (environmentVariablesToRemove is { Count: > 0 })
+        if (shouldRemoveEnvironmentVariable is not null)
         {
-            foreach (var varName in environmentVariablesToRemove)
+            var keysToRemove = new List<string>();
+            foreach (var key in startInfo.Environment.Keys)
             {
-                startInfo.Environment.Remove(varName);
+                if (shouldRemoveEnvironmentVariable(key))
+                {
+                    keysToRemove.Add(key);
+                }
+            }
+
+            foreach (var key in keysToRemove)
+            {
+                startInfo.Environment.Remove(key);
             }
         }
 

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
@@ -15,7 +15,7 @@ internal static partial class DetachedProcessLauncher
     /// pipe has no reader and writes produce EPIPE (harmless). The key difference from
     /// Windows is that on Unix, only fds 0/1/2 survive exec — no extra handle leakage.
     /// </summary>
-    private static Process StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    private static Process StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory, IReadOnlySet<string>? environmentVariablesToRemove)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -31,6 +31,16 @@ internal static partial class DetachedProcessLauncher
         foreach (var arg in arguments)
         {
             startInfo.ArgumentList.Add(arg);
+        }
+
+        // Remove specified environment variables from the child process.
+        // Accessing startInfo.Environment auto-populates from the current process.
+        if (environmentVariablesToRemove is { Count: > 0 })
+        {
+            foreach (var varName in environmentVariablesToRemove)
+            {
+                startInfo.Environment.Remove(varName);
+            }
         }
 
         var process = Process.Start(startInfo)

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -17,7 +17,7 @@ internal static partial class DetachedProcessLauncher
     /// PROC_THREAD_ATTRIBUTE_HANDLE_LIST to prevent handle inheritance to grandchildren.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    private static Process StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory, IReadOnlySet<string>? environmentVariablesToRemove)
+    private static Process StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable)
     {
         // Open NUL device for stdout/stderr — child writes go nowhere
         using var nulHandle = CreateFileW(
@@ -94,9 +94,9 @@ internal static partial class DetachedProcessLauncher
                     var envBlockHandle = nint.Zero;
                     try
                     {
-                        if (environmentVariablesToRemove is { Count: > 0 })
+                        if (shouldRemoveEnvironmentVariable is not null)
                         {
-                            envBlockHandle = BuildFilteredEnvironmentBlock(environmentVariablesToRemove);
+                            envBlockHandle = BuildFilteredEnvironmentBlock(shouldRemoveEnvironmentVariable);
                         }
 
                         if (!CreateProcessW(
@@ -242,14 +242,14 @@ internal static partial class DetachedProcessLauncher
     /// and double-null-terminated. The caller must free the returned pointer with Marshal.FreeHGlobal.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    private static nint BuildFilteredEnvironmentBlock(IReadOnlySet<string> variablesToRemove)
+    private static nint BuildFilteredEnvironmentBlock(Func<string, bool> shouldRemove)
     {
         // Collect current environment variables, excluding the ones to remove.
         var envVars = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
         {
             var key = (string)entry.Key;
-            if (!variablesToRemove.Contains(key))
+            if (!shouldRemove(key))
             {
                 envVars[key] = (string?)entry.Value ?? string.Empty;
             }

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -265,6 +265,12 @@ internal static partial class DetachedProcessLauncher
             blockBuilder.Append(kvp.Value);
             blockBuilder.Append('\0');
         }
+
+        if (envVars.Count == 0)
+        {
+            blockBuilder.Append('\0');
+        }
+
         blockBuilder.Append('\0'); // Final terminator
 
         var blockString = blockBuilder.ToString();

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -17,7 +17,7 @@ internal static partial class DetachedProcessLauncher
     /// PROC_THREAD_ATTRIBUTE_HANDLE_LIST to prevent handle inheritance to grandchildren.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    private static Process StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    private static Process StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory, IReadOnlySet<string>? environmentVariablesToRemove)
     {
         // Open NUL device for stdout/stderr — child writes go nowhere
         using var nulHandle = CreateFileW(
@@ -88,34 +88,53 @@ internal static partial class DetachedProcessLauncher
 
                     var flags = CreateUnicodeEnvironment | ExtendedStartupInfoPresent | CreateNoWindow;
 
-                    if (!CreateProcessW(
-                        null,
-                        commandLine,
-                        nint.Zero,
-                        nint.Zero,
-                        bInheritHandles: true, // TRUE but HANDLE_LIST restricts what's actually inherited
-                        flags,
-                        nint.Zero,
-                        workingDirectory,
-                        ref si,
-                        out var pi))
-                    {
-                        throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create detached process");
-                    }
-
-                    Process detachedProcess;
+                    // Build a filtered environment block if variables need to be removed.
+                    // CreateProcessW with lpEnvironment=nint.Zero inherits the parent's
+                    // environment, so we only build a custom block when filtering is needed.
+                    var envBlockHandle = nint.Zero;
                     try
                     {
-                        detachedProcess = Process.GetProcessById(pi.dwProcessId);
+                        if (environmentVariablesToRemove is { Count: > 0 })
+                        {
+                            envBlockHandle = BuildFilteredEnvironmentBlock(environmentVariablesToRemove);
+                        }
+
+                        if (!CreateProcessW(
+                            null,
+                            commandLine,
+                            nint.Zero,
+                            nint.Zero,
+                            bInheritHandles: true, // TRUE but HANDLE_LIST restricts what's actually inherited
+                            flags,
+                            envBlockHandle,
+                            workingDirectory,
+                            ref si,
+                            out var pi))
+                        {
+                            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create detached process");
+                        }
+
+                        Process detachedProcess;
+                        try
+                        {
+                            detachedProcess = Process.GetProcessById(pi.dwProcessId);
+                        }
+                        finally
+                        {
+                            // Close the process and thread handles returned by CreateProcess.
+                            CloseHandle(pi.hProcess);
+                            CloseHandle(pi.hThread);
+                        }
+
+                        return detachedProcess;
                     }
                     finally
                     {
-                        // Close the process and thread handles returned by CreateProcess.
-                        CloseHandle(pi.hProcess);
-                        CloseHandle(pi.hThread);
+                        if (envBlockHandle != nint.Zero)
+                        {
+                            Marshal.FreeHGlobal(envBlockHandle);
+                        }
                     }
-
-                    return detachedProcess;
                 }
                 finally
                 {
@@ -215,6 +234,51 @@ internal static partial class DetachedProcessLauncher
         }
 
         sb.Append('"');
+    }
+
+    /// <summary>
+    /// Builds a Unicode environment block for CreateProcessW with specified variables removed.
+    /// The block is sorted by variable name (case-insensitive, as required by Windows)
+    /// and double-null-terminated. The caller must free the returned pointer with Marshal.FreeHGlobal.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static nint BuildFilteredEnvironmentBlock(IReadOnlySet<string> variablesToRemove)
+    {
+        // Collect current environment variables, excluding the ones to remove.
+        var envVars = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            var key = (string)entry.Key;
+            if (!variablesToRemove.Contains(key))
+            {
+                envVars[key] = (string?)entry.Value ?? string.Empty;
+            }
+        }
+
+        // Build the double-null-terminated Unicode environment block:
+        // KEY1=VALUE1\0KEY2=VALUE2\0...\0\0
+        var blockBuilder = new StringBuilder();
+        foreach (var kvp in envVars)
+        {
+            blockBuilder.Append(kvp.Key);
+            blockBuilder.Append('=');
+            blockBuilder.Append(kvp.Value);
+            blockBuilder.Append('\0');
+        }
+        blockBuilder.Append('\0'); // Final terminator
+
+        var blockString = blockBuilder.ToString();
+        var byteCount = Encoding.Unicode.GetByteCount(blockString);
+        var ptr = Marshal.AllocHGlobal(byteCount);
+        unsafe
+        {
+            fixed (char* pStr = blockString)
+            {
+                Encoding.Unicode.GetBytes(pStr, blockString.Length, (byte*)ptr, byteCount);
+            }
+        }
+
+        return ptr;
     }
 
     // --- Constants ---

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
@@ -67,15 +67,15 @@ internal static partial class DetachedProcessLauncher
     /// <param name="fileName">The executable path (e.g. dotnet or the native CLI).</param>
     /// <param name="arguments">The command-line arguments for the child process.</param>
     /// <param name="workingDirectory">The working directory for the child process.</param>
-    /// <param name="environmentVariablesToRemove">Optional set of environment variable names to remove from the child process.</param>
+    /// <param name="shouldRemoveEnvironmentVariable">Optional predicate that returns <see langword="true" /> for environment variable names that should be removed from the child process.</param>
     /// <returns>A <see cref="Process"/> object representing the launched child.</returns>
-    public static Process Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory, IReadOnlySet<string>? environmentVariablesToRemove = null)
+    public static Process Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable = null)
     {
         if (OperatingSystem.IsWindows())
         {
-            return StartWindows(fileName, arguments, workingDirectory, environmentVariablesToRemove);
+            return StartWindows(fileName, arguments, workingDirectory, shouldRemoveEnvironmentVariable);
         }
 
-        return StartUnix(fileName, arguments, workingDirectory, environmentVariablesToRemove);
+        return StartUnix(fileName, arguments, workingDirectory, shouldRemoveEnvironmentVariable);
     }
 }

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
@@ -67,14 +67,15 @@ internal static partial class DetachedProcessLauncher
     /// <param name="fileName">The executable path (e.g. dotnet or the native CLI).</param>
     /// <param name="arguments">The command-line arguments for the child process.</param>
     /// <param name="workingDirectory">The working directory for the child process.</param>
+    /// <param name="environmentVariablesToRemove">Optional set of environment variable names to remove from the child process.</param>
     /// <returns>A <see cref="Process"/> object representing the launched child.</returns>
-    public static Process Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    public static Process Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory, IReadOnlySet<string>? environmentVariablesToRemove = null)
     {
         if (OperatingSystem.IsWindows())
         {
-            return StartWindows(fileName, arguments, workingDirectory);
+            return StartWindows(fileName, arguments, workingDirectory, environmentVariablesToRemove);
         }
 
-        return StartUnix(fileName, arguments, workingDirectory);
+        return StartUnix(fileName, arguments, workingDirectory, environmentVariablesToRemove);
     }
 }

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -47,6 +47,8 @@ internal static class KnownConfigNames
     public const string ExtensionToken = "ASPIRE_EXTENSION_TOKEN";
     public const string ExtensionCert = "ASPIRE_EXTENSION_CERT";
     public const string ExtensionDebugSessionId = "ASPIRE_EXTENSION_DEBUG_SESSION_ID";
+    public const string ExtensionDebugRunMode = "ASPIRE_EXTENSION_DEBUG_RUN_MODE";
+    public const string ExtensionCapabilities = "ASPIRE_EXTENSION_CAPABILITIES";
 
     public const string DeveloperCertificateDefaultTrust = "ASPIRE_DEVELOPER_CERTIFICATE_DEFAULT_TRUST";
     public const string DeveloperCertificateDefaultHttpsTermination = "ASPIRE_DEVELOPER_CERTIFICATE_DEFAULT_HTTPS_TERMINATION";
@@ -54,6 +56,10 @@ internal static class KnownConfigNames
 
     public const string DebugSessionInfo = "DEBUG_SESSION_INFO";
     public const string DebugSessionRunMode = "DEBUG_SESSION_RUN_MODE";
+    public const string DebugSessionPort = "DEBUG_SESSION_PORT";
+    public const string DebugSessionToken = "DEBUG_SESSION_TOKEN";
+    public const string DebugSessionServerCertificate = "DEBUG_SESSION_SERVER_CERTIFICATE";
+    public const string DcpInstanceIdPrefix = "DCP_INSTANCE_ID_PREFIX";
 
     public static class Legacy
     {

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Aspire.Shared.UserSecrets;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -1634,6 +1635,21 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(startDebugSessionCalled, "StartDebugSessionAsync should not be called in non-interactive mode.");
+    }
+
+    [Fact]
+    public void DetachedChildEnvironmentFilter_PreservesDebugSessionVariables()
+    {
+        var filteredVariables = AppHostLauncher.DetachedChildEnvironmentVariablesToRemove;
+
+        Assert.Contains(KnownConfigNames.ExtensionEndpoint, filteredVariables);
+        Assert.Contains(KnownConfigNames.ExtensionDebugSessionId, filteredVariables);
+        Assert.DoesNotContain(KnownConfigNames.DebugSessionInfo, filteredVariables);
+        Assert.DoesNotContain(KnownConfigNames.DebugSessionRunMode, filteredVariables);
+        Assert.DoesNotContain(KnownConfigNames.DebugSessionPort, filteredVariables);
+        Assert.DoesNotContain(KnownConfigNames.DebugSessionToken, filteredVariables);
+        Assert.DoesNotContain(KnownConfigNames.DebugSessionServerCertificate, filteredVariables);
+        Assert.DoesNotContain(KnownConfigNames.DcpInstanceIdPrefix, filteredVariables);
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1640,16 +1640,17 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void DetachedChildEnvironmentFilter_PreservesDebugSessionVariables()
     {
-        var filteredVariables = AppHostLauncher.DetachedChildEnvironmentVariablesToRemove;
+        // Extension variables use the ASPIRE_EXTENSION_ prefix and should be filtered
+        Assert.True(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.ExtensionEndpoint));
+        Assert.True(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.ExtensionDebugSessionId));
 
-        Assert.Contains(KnownConfigNames.ExtensionEndpoint, filteredVariables);
-        Assert.Contains(KnownConfigNames.ExtensionDebugSessionId, filteredVariables);
-        Assert.DoesNotContain(KnownConfigNames.DebugSessionInfo, filteredVariables);
-        Assert.DoesNotContain(KnownConfigNames.DebugSessionRunMode, filteredVariables);
-        Assert.DoesNotContain(KnownConfigNames.DebugSessionPort, filteredVariables);
-        Assert.DoesNotContain(KnownConfigNames.DebugSessionToken, filteredVariables);
-        Assert.DoesNotContain(KnownConfigNames.DebugSessionServerCertificate, filteredVariables);
-        Assert.DoesNotContain(KnownConfigNames.DcpInstanceIdPrefix, filteredVariables);
+        // DEBUG_SESSION variables should NOT be filtered
+        Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DebugSessionInfo));
+        Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DebugSessionRunMode));
+        Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DebugSessionPort));
+        Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DebugSessionToken));
+        Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DebugSessionServerCertificate));
+        Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DcpInstanceIdPrefix));
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1559,4 +1559,81 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         }
     }
 
+    [Fact]
+    public async Task RunCommand_NonInteractive_SkipsExtensionDelegation()
+    {
+        // When `aspire start` spawns `aspire run --non-interactive`, the child process
+        // may inherit ASPIRE_EXTENSION_* env vars from the parent terminal. Without the
+        // --non-interactive guard, the child would delegate to the extension via
+        // StartDebugSessionAsync and exit immediately instead of launching the AppHost.
+        var startDebugSessionCalled = false;
+
+        var extensionBackchannel = new TestExtensionBackchannel();
+        extensionBackchannel.GetCapabilitiesAsyncCallback = ct => Task.FromResult(Array.Empty<string>());
+
+        var appHostBackchannel = new TestAppHostBackchannel();
+        appHostBackchannel.GetDashboardUrlsAsyncCallback = (ct) => Task.FromResult(new DashboardUrlsState
+        {
+            DashboardHealthy = true,
+            BaseUrlWithLoginToken = "http://localhost/dashboard",
+            CodespacesUrlWithLoginToken = null
+        });
+        appHostBackchannel.GetAppHostLogEntriesAsyncCallback = ReturnLogEntriesUntilCancelledAsync;
+
+        var backchannelFactory = (IServiceProvider sp) => appHostBackchannel;
+
+        var extensionInteractionServiceFactory = (IServiceProvider sp) =>
+        {
+            var service = new TestExtensionInteractionService(sp);
+            service.StartDebugSessionCallback = (_, _, _) =>
+            {
+                startDebugSessionCalled = true;
+            };
+            return service;
+        };
+
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
+            {
+                var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
+                backchannelCompletionSource!.SetResult(backchannel);
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                return 0;
+            };
+            return runner;
+        };
+
+        var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = projectLocatorFactory;
+            options.AppHostBackchannelFactory = backchannelFactory;
+            options.DotNetCliRunnerFactory = runnerFactory;
+            options.ExtensionBackchannelFactory = _ => extensionBackchannel;
+            options.InteractionServiceFactory = extensionInteractionServiceFactory;
+            // Deliberately NOT setting ASPIRE_EXTENSION_DEBUG_SESSION_ID —
+            // without --non-interactive, this would trigger the early return.
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        // Parse with --non-interactive to simulate the child of `aspire start`
+        var result = command.Parse("run --non-interactive");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+        cts.Cancel();
+
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(startDebugSessionCalled, "StartDebugSessionAsync should not be called in non-interactive mode.");
+    }
+
 }


### PR DESCRIPTION
## Description

When `aspire start` runs from the VS Code Aspire terminal, the detached child process (`aspire run --non-interactive`) inherits `ASPIRE_EXTENSION_*` environment variables from the terminal. This causes the child to detect extension mode and delegate back to the extension via `StartDebugSessionAsync` instead of launching the AppHost — resulting in an immediate exit with code 0.

**Root cause:** `DetachedProcessLauncher.Start()` inherits all parent environment variables, including extension backchannel vars. The child's `RunCommand.ExecuteAsync` sees `IsExtensionHost=true` and `ExtensionDebugSessionId=empty`, triggering the early-return delegation path.

**Fix (two layers):**
1. **Strip extension env vars from the detached child process** — `DetachedProcessLauncher.Start()` now accepts an optional set of env var names to remove. On Unix, vars are removed from `ProcessStartInfo.Environment`. On Windows, a filtered Unicode environment block is built for `CreateProcessW`.
2. **Guard `RunCommand` delegation with `--non-interactive`** — When running in non-interactive mode (as the child of `aspire start`), skip the `StartDebugSessionAsync` early return.

**Additional fixes:**
- `StartCommand` now sets `isExtensionHost=false` so the Dashboard URL always appears in `aspire start` output
- `RenderAppHostSummary` column width calculation only includes labels that are actually displayed
- Added missing `KnownConfigNames` constants for 6 extension-related env vars (`ExtensionDebugRunMode`, `ExtensionCapabilities`, `DebugSessionPort`, `DebugSessionToken`, `DebugSessionServerCertificate`, `DcpInstanceIdPrefix`)

Fixes #15786

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
