### PR TITLE
Fix /create-issue positional test name with flags

### DIFF
--- a/.github/workflows/create-failing-test-issue.js
+++ b/.github/workflows/create-failing-test-issue.js
@@ -57,10 +57,22 @@ function parseCommand(body, defaultSourceUrl = null) {
                     break;
 
                 default:
-                    return {
-                        success: false,
-                        errorMessage: `Unknown argument '${token}'. Supported arguments are --test, --url, --workflow, and --force-new.`,
-                    };
+                    if (token.startsWith('--')) {
+                        return {
+                            success: false,
+                            errorMessage: `Unknown argument '${token}'. Supported arguments are --test, --url, --workflow, and --force-new.`,
+                        };
+                    }
+
+                    if (result.testQuery) {
+                        return {
+                            success: false,
+                            errorMessage: 'Positional input is ambiguous. Use /create-issue --test "<test-name>" [--url <pr|run|job-url>] [--workflow <selector>] [--force-new].',
+                        };
+                    }
+
+                    result.testQuery = token;
+                    break;
             }
         }
 

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -82,6 +82,25 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ParseCommandSupportsPositionalTestNameWithFlags()
+    {
+        var result = await InvokeHarnessAsync<ParseCommandResult>(
+            "parseCommand",
+            new
+            {
+                body = "/create-issue Tests.Namespace.Type.Method --force-new",
+                defaultSourceUrl = "https://github.com/microsoft/aspire/pull/999"
+            });
+
+        Assert.True(result.Success);
+        Assert.Equal("Tests.Namespace.Type.Method", result.TestQuery);
+        Assert.Equal("https://github.com/microsoft/aspire/pull/999", result.SourceUrl);
+        Assert.True(result.ForceNew);
+        Assert.False(result.ListOnly);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task ParseCommandRejectsAmbiguousPositionalSyntax()
     {
         var result = await InvokeHarnessAsync<ParseCommandResult>(


### PR DESCRIPTION
The parser rejected positional test names when any flag was present. For example:

```
/create-issue Aspire.Hosting.Tests.ValueSnapshotTests.IsValueSet_FalseBeforeAnySet --force-new
```

Would fail with: `Unknown argument 'Aspire.Hosting.Tests...'`

This happened because the parser has two modes (flag mode vs positional mode) and entering flag mode (when any `--` token is present) rejected all non-flag tokens.

**Fix**: In flag mode, allow non-`--` tokens as positional test names (same as positional mode), with validation to reject ambiguous cases (multiple positional args).

**Test added**: `ParseCommandSupportsPositionalTestNameWithFlags`

Follow-up to #15973.