### PR TITLE
Add zizmor GitHub Actions security analysis workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -29,5 +29,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install zizmor
+        run: pip install zizmor
+
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        run: zizmor --format sarif .github/workflows/ > results.sarif
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,33 @@
+name: Zizmor workflow security analysis
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - '.github/workflows/**'
+      - '.github/zizmor.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/zizmor.yml'
+  schedule:
+    # Daily scan at 06:30 UTC to catch drift
+    - cron: '30 6 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# zizmor configuration for microsoft/aspire
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  dangerous-triggers:
+    ignore:
+      # These workflows use workflow_run / pull_request_target intentionally
+      # and have explicit fork validation guards in place.
+      - auto-rerun-transient-ci-failures.yml
+      - cli-e2e-recording-comment.yml
+      - dogfood-comment.yml
+      - labeler-predict-pulls.yml


### PR DESCRIPTION
## Summary

Adds [zizmor](https://docs.zizmor.sh/) — a static analysis tool for GitHub Actions workflow security — to the CI pipeline.

## What's included

### `.github/workflows/zizmor.yml`
- **Non-blocking** integration using SARIF upload to GitHub Code Scanning
- Runs on PRs and pushes to `main` when workflow files change
- Daily scheduled scan (06:30 UTC) to catch drift
- Uses the official [`zizmorcore/zizmor-action`](https://github.com/zizmorcore/zizmor-action) (pinned to SHA)
- Results appear in the **Security → Code Scanning** tab and as PR annotations

### `.github/zizmor.yml`
- Configuration file that suppresses `dangerous-triggers` findings on 4 workflows that intentionally use `workflow_run`/`pull_request_target` with explicit fork validation guards

## Baseline scan

The initial scan found **236 findings** (after suppression) across 33 of 39 workflows:

| Severity | Rule | Count | Notes |
|---|---|---|---|
| error | template-injection | 83 | Mostly `inputs.*`, `env.*`, `matrix.*` in `run:` — not externally controllable |
| warning | template-injection | 40 | Same pattern |
| warning | artipacked | 39 | Missing `persist-credentials: false` — auto-fixable |
| warning | excessive-permissions | 28 | Intentional write permissions for PR comments, checks, etc. |
| note | template-injection | 38 | Low confidence |
| error | excessive-permissions | 8 | Workflow-level write perms on backport/release workflows |

These findings are informational and do **not** block CI. They'll be visible in the Security tab for gradual triage and improvement.

## References
- [zizmor docs](https://docs.zizmor.sh/)
- [microsoft/linux-package-repositories](https://github.com/microsoft/linux-package-repositories/blob/main/.github/workflows/zizmor.yml) — similar integration in another Microsoft repo
- [dotnet/maui](https://github.com/dotnet/maui) — uses inline zizmor ignore comments
