### PR TITLE
Fix /create-issue workflow

### DIFF
--- a/.github/workflows/create-failing-test-issue.js
+++ b/.github/workflows/create-failing-test-issue.js
@@ -126,7 +126,8 @@ function formatListResponse(resolverOutcome, resultJson) {
         return {
             error: false,
             message: '**Failed tests found on this PR:**\n\n'
-                + tests.map(name => `/create-issue ${name}`).join('\n'),
+                + tests.map(name => `- \`/create-issue ${name}\``).join('\n')
+                + '\n\n',
             tests,
         };
     }
@@ -138,7 +139,7 @@ function formatListResponse(resolverOutcome, resultJson) {
         return { error: true, message: detail ?? 'The failing-test resolver failed to run.' };
     }
 
-    return { error: false, message: 'No test failures were found. Use `--url` to point to a specific workflow run.' };
+    return { error: false, message: 'No test failures were found. Use `--url` to point to a specific workflow run.\n\n' };
 }
 
 function buildIssueSearchQuery(owner, repo, metadataMarker) {

--- a/.github/workflows/create-failing-test-issue.js
+++ b/.github/workflows/create-failing-test-issue.js
@@ -33,6 +33,13 @@ function parseCommand(body, defaultSourceUrl = null) {
                         return { success: false, errorMessage: 'Missing value for --test.' };
                     }
 
+                    if (result.testQuery) {
+                        return {
+                            success: false,
+                            errorMessage: 'Positional input is ambiguous. Use /create-issue --test "<test-name>" [--url <pr|run|job-url>] [--workflow <selector>] [--force-new].',
+                        };
+                    }
+
                     result.testQuery = tokens[++index];
                     break;
 
@@ -57,10 +64,22 @@ function parseCommand(body, defaultSourceUrl = null) {
                     break;
 
                 default:
-                    return {
-                        success: false,
-                        errorMessage: `Unknown argument '${token}'. Supported arguments are --test, --url, --workflow, and --force-new.`,
-                    };
+                    if (token.startsWith('--')) {
+                        return {
+                            success: false,
+                            errorMessage: `Unknown argument '${token}'. Supported arguments are --test, --url, --workflow, and --force-new.`,
+                        };
+                    }
+
+                    if (result.testQuery) {
+                        return {
+                            success: false,
+                            errorMessage: 'Positional input is ambiguous. Use /create-issue --test "<test-name>" [--url <pr|run|job-url>] [--workflow <selector>] [--force-new].',
+                        };
+                    }
+
+                    result.testQuery = token;
+                    break;
             }
         }
 

--- a/.github/workflows/create-failing-test-issue.js
+++ b/.github/workflows/create-failing-test-issue.js
@@ -113,6 +113,27 @@ function parseCommand(body, defaultSourceUrl = null) {
     };
 }
 
+function formatListResponse(resolverOutcome, resultJson) {
+    if (resolverOutcome === 'failure' && !resultJson) {
+        return { error: true, message: 'The failing-test resolver failed to run.' };
+    }
+
+    const tests = resultJson?.allFailures?.tests?.map(t => t.canonicalTestName ?? t.displayTestName)
+        ?? resultJson?.diagnostics?.availableFailedTests
+        ?? [];
+
+    if (tests.length > 0) {
+        return {
+            error: false,
+            message: '**Failed tests found on this PR:**\n\n'
+                + tests.map(name => `/create-issue ${name}`).join('\n'),
+            tests,
+        };
+    }
+
+    return { error: false, message: 'No test failures were found. Use `--url` to point to a specific workflow run.' };
+}
+
 function buildIssueSearchQuery(owner, repo, metadataMarker) {
     const escapedMarker = String(metadataMarker ?? '').replaceAll('"', '\\"');
     return `repo:${owner}/${repo} is:issue label:failing-test in:body "${escapedMarker}"`;
@@ -130,6 +151,7 @@ function isSupportedSourceUrl(value) {
 
 module.exports = {
     buildIssueSearchQuery,
+    formatListResponse,
     isSupportedSourceUrl,
     parseCommand,
 };

--- a/.github/workflows/create-failing-test-issue.js
+++ b/.github/workflows/create-failing-test-issue.js
@@ -131,6 +131,13 @@ function formatListResponse(resolverOutcome, resultJson) {
         };
     }
 
+    // The C# tool writes JSON even on failure (exits non-zero). Surface
+    // the error instead of a misleading "no failures found" message.
+    if (resolverOutcome === 'failure' || resultJson?.success === false) {
+        const detail = resultJson?.errorMessage;
+        return { error: true, message: detail ?? 'The failing-test resolver failed to run.' };
+    }
+
     return { error: false, message: 'No test failures were found. Use `--url` to point to a specific workflow run.' };
 }
 

--- a/.github/workflows/create-failing-test-issue.yml
+++ b/.github/workflows/create-failing-test-issue.yml
@@ -149,7 +149,7 @@ jobs:
 
     - name: Setup .NET SDK
       if: success()
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
         global-json-file: global.json
 
@@ -247,14 +247,7 @@ jobs:
               return;
             }
 
-            // Format test names as clickable commands in list mode
-            let body = listResult.tests?.length > 0
-              ? '**Failed tests found on this PR:**\n\n'
-                + listResult.tests.map(name => `- \`/create-issue ${name}\``).join('\n')
-                + '\n\n'
-              : listResult.message + '\n\n';
-
-            await postComment(`${body}${helpBlock}`);
+            await postComment(`${listResult.message}${helpBlock}`);
             return;
           }
 

--- a/.github/workflows/create-failing-test-issue.yml
+++ b/.github/workflows/create-failing-test-issue.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Verify user has write access
       if: github.event_name == 'issue_comment'
       id: verify-permission
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           const commentUser = context.payload.comment.user.login;
@@ -91,7 +91,7 @@ jobs:
     - name: Extract command
       if: success()
       id: extract-command
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           if (context.eventName === 'workflow_dispatch') {
@@ -137,7 +137,7 @@ jobs:
 
     - name: Add processing reaction
       if: success() && github.event_name == 'issue_comment'
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           await github.rest.reactions.createForIssueComment({
@@ -147,9 +147,11 @@ jobs:
             content: 'eyes'
           });
 
-    - name: Restore SDK
+    - name: Setup .NET SDK
       if: success()
-      run: ./restore.sh
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+      with:
+        global-json-file: global.json
 
     - name: Resolve failing test details
       if: success()
@@ -179,7 +181,7 @@ jobs:
 
     - name: Create or update failing-test issue
       if: steps.resolve-failure.outcome != 'skipped'
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         RESULT_PATH: ${{ runner.temp }}/failing-test-result.json
         FORCE_NEW: ${{ steps.extract-command.outputs.force_new }}
@@ -351,7 +353,7 @@ jobs:
 
     - name: Post failure comment on unexpected error
       if: failure() && steps.extract-command.outcome == 'success' && (steps.verify-permission.outcome == 'success' || steps.verify-permission.outcome == 'skipped')
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         PR_NUMBER: ${{ steps.extract-command.outputs.pr_number }}
       with:

--- a/.github/workflows/create-failing-test-issue.yml
+++ b/.github/workflows/create-failing-test-issue.yml
@@ -234,24 +234,25 @@ jobs:
 
           // List-only mode: show available failures + help when no --test was given
           if (process.env.LIST_ONLY === 'true') {
-            let body = '';
+            const resultJson = hasResultFile
+              ? JSON.parse(fs.readFileSync(process.env.RESULT_PATH, 'utf8'))
+              : null;
+            const listResult = helper.formatListResponse(process.env.RESOLVE_OUTCOME, resultJson);
 
-            if (hasResultFile) {
-              const result = JSON.parse(fs.readFileSync(process.env.RESULT_PATH, 'utf8'));
-              const tests = result.allFailures?.tests?.map(t => t.canonicalTestName ?? t.displayTestName)
-                ?? result.diagnostics?.availableFailedTests
-                ?? [];
-
-              if (tests.length > 0) {
-                body = '**Failed tests found on this PR:**\n\n'
-                  + tests.map(name => `- \`/create-issue ${name}\``).join('\n')
-                  + '\n\n';
-              }
+            if (listResult.error) {
+              const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              const message = `❌ ${listResult.message} See the [workflow run](${runUrl}) for details.`;
+              await postComment(message);
+              core.setFailed(message);
+              return;
             }
 
-            if (!body) {
-              body = 'No test failures were found. Use `--url` to point to a specific workflow run.\n\n';
-            }
+            // Format test names as clickable commands in list mode
+            let body = listResult.tests?.length > 0
+              ? '**Failed tests found on this PR:**\n\n'
+                + listResult.tests.map(name => `- \`/create-issue ${name}\``).join('\n')
+                + '\n\n'
+              : listResult.message + '\n\n';
 
             await postComment(`${body}${helpBlock}`);
             return;

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -229,6 +229,27 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task FormatListResponseReturnsErrorWhenResolverFailedWithResult()
+    {
+        var result = await InvokeHarnessAsync<FormatListResponseResult>(
+            "formatListResponse",
+            new
+            {
+                resolverOutcome = "failure",
+                resultJson = new
+                {
+                    success = false,
+                    errorMessage = "Could not find any TRX files.",
+                    allFailures = new { tests = Array.Empty<object>() }
+                }
+            });
+
+        Assert.True(result.Error);
+        Assert.Contains("Could not find any TRX files", result.Message);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task BuildIssueSearchQueryTargetsFailingTestIssuesByMetadataMarker()
     {
         var query = await InvokeHarnessAsync<string>(

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -82,6 +82,25 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ParseCommandSupportsPositionalTestNameWithFlags()
+    {
+        var result = await InvokeHarnessAsync<ParseCommandResult>(
+            "parseCommand",
+            new
+            {
+                body = "/create-issue Tests.Namespace.Type.Method --force-new",
+                defaultSourceUrl = "https://github.com/microsoft/aspire/pull/999"
+            });
+
+        Assert.True(result.Success);
+        Assert.Equal("Tests.Namespace.Type.Method", result.TestQuery);
+        Assert.Equal("https://github.com/microsoft/aspire/pull/999", result.SourceUrl);
+        Assert.True(result.ForceNew);
+        Assert.False(result.ListOnly);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task ParseCommandRejectsAmbiguousPositionalSyntax()
     {
         var result = await InvokeHarnessAsync<ParseCommandResult>(
@@ -89,6 +108,21 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
             new
             {
                 body = "/create-issue Tests Namespace Type Method"
+            });
+
+        Assert.False(result.Success);
+        Assert.Contains("ambiguous", result.ErrorMessage);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ParseCommandRejectsPositionalBeforeTestFlag()
+    {
+        var result = await InvokeHarnessAsync<ParseCommandResult>(
+            "parseCommand",
+            new
+            {
+                body = "/create-issue MyTest --test OtherTest"
             });
 
         Assert.False(result.Success);
@@ -129,6 +163,68 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
         Assert.Equal(string.Empty, result.TestQuery);
         Assert.Equal("https://github.com/microsoft/aspire/actions/runs/123", result.SourceUrl);
         Assert.Equal("custom.yml", result.Workflow);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatListResponseReturnsErrorWhenResolverFailed()
+    {
+        var result = await InvokeHarnessAsync<FormatListResponseResult>(
+            "formatListResponse",
+            new
+            {
+                resolverOutcome = "failure",
+                resultJson = (object?)null
+            });
+
+        Assert.True(result.Error);
+        Assert.Contains("resolver failed", result.Message);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatListResponseReturnsTestNamesFromResult()
+    {
+        var result = await InvokeHarnessAsync<FormatListResponseResult>(
+            "formatListResponse",
+            new
+            {
+                resolverOutcome = "success",
+                resultJson = new
+                {
+                    allFailures = new
+                    {
+                        tests = new[]
+                        {
+                            new { canonicalTestName = "Namespace.Class.MethodA", displayTestName = "MethodA" },
+                            new { canonicalTestName = "Namespace.Class.MethodB", displayTestName = "MethodB" }
+                        }
+                    }
+                }
+            });
+
+        Assert.False(result.Error);
+        Assert.NotNull(result.Tests);
+        Assert.Equal(2, result.Tests!.Length);
+        Assert.Contains("Namespace.Class.MethodA", result.Tests);
+        Assert.Contains("Namespace.Class.MethodB", result.Tests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatListResponseReturnsNoFailuresWhenResultIsEmpty()
+    {
+        var result = await InvokeHarnessAsync<FormatListResponseResult>(
+            "formatListResponse",
+            new
+            {
+                resolverOutcome = "success",
+                resultJson = new { allFailures = new { tests = Array.Empty<object>() } }
+            });
+
+        Assert.False(result.Error);
+        Assert.Contains("No test failures", result.Message);
+        Assert.Null(result.Tests);
     }
 
     [Fact]
@@ -184,4 +280,6 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
     private sealed record HarnessResponse<T>(T Result);
 
     private sealed record ParseCommandResult(bool Success, string TestQuery, string? SourceUrl, string Workflow, bool ForceNew, bool ListOnly, string? ErrorMessage);
+
+    private sealed record FormatListResponseResult(bool Error, string Message, string[]? Tests);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/create-failing-test-issue.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/create-failing-test-issue.harness.js
@@ -20,6 +20,9 @@ async function dispatch(operation, payload) {
         case 'buildIssueSearchQuery':
             return helper.buildIssueSearchQuery(payload.owner ?? 'microsoft', payload.repo ?? 'aspire', payload.metadataMarker);
 
+        case 'formatListResponse':
+            return helper.formatListResponse(payload.resolverOutcome, payload.resultJson ?? null);
+
         default:
             throw new Error(`Unsupported operation '${operation}'.`);
     }

--- a/tools/CreateFailingTestIssue/CreateFailingTestIssue.csproj
+++ b/tools/CreateFailingTestIssue/CreateFailingTestIssue.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Aspire.TestTools\Aspire.TestTools.csproj" />
+    <Compile Include="..\Aspire.TestTools\*.cs" LinkBase="Aspire.TestTools" />
   </ItemGroup>
 
 </Project>

--- a/tools/CreateFailingTestIssue/Directory.Build.props
+++ b/tools/CreateFailingTestIssue/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Cut inheritance from repo root to avoid Arcade SDK dependency -->
+</Project>

--- a/tools/CreateFailingTestIssue/Directory.Build.targets
+++ b/tools/CreateFailingTestIssue/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Cut inheritance from repo root to avoid Arcade SDK dependency -->
+</Project>

--- a/tools/CreateFailingTestIssue/Directory.Packages.props
+++ b/tools/CreateFailingTestIssue/Directory.Packages.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="System.CommandLine" Version="2.0.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Description

Fixes the `/create-issue` workflow to work correctly and makes it faster.

The command now accepts a positional test name (`/create-issue TestName`) instead of requiring the `--test` flag. Ambiguous inputs like `/create-issue A --test B` are rejected in both orderings.

The list-mode logic (when `/create-issue` is run with no test name) is extracted into a testable `formatListResponse` helper, with proper error handling when the resolver step fails.

The tool is isolated from the repo's Arcade SDK so it builds independently, and `restore.sh` is replaced with `actions/setup-dotnet` — the full repo restore isn't needed since the tool manages its own packages.

### Design decisions

**Partial results on resolver failure** — `formatListResponse` returns test names even when the resolver reported failure, because the step runs with `continue-on-error: true` and partial results may still be useful.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No