### PR TITLE
Fix signing for aspire-managed bundle payload

### DIFF
--- a/eng/Bundle.proj
+++ b/eng/Bundle.proj
@@ -46,8 +46,15 @@
     <BundleVersion Condition="'$(BundleVersion)' == '' and '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</BundleVersion>
     <BundleVersion Condition="'$(BundleVersion)' == ''">$(VersionPrefix)-dev</BundleVersion>
 
-    <!-- Forward VersionSuffix to Exec-invoked dotnet commands (MSBuild properties don't flow to child processes) -->
+    <!-- Forward CI/signing/version properties to Exec-invoked dotnet commands (MSBuild properties don't flow to child processes) -->
+    <_ContinuousIntegrationBuildArg Condition="'$(ContinuousIntegrationBuild)' != ''">/p:ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)</_ContinuousIntegrationBuildArg>
     <_VersionSuffixArg Condition="'$(VersionSuffix)' != ''">/p:VersionSuffix=$(VersionSuffix)</_VersionSuffixArg>
+    <_OfficialBuildIdArg Condition="'$(OfficialBuildId)' != ''">/p:OfficialBuildId=$(OfficialBuildId)</_OfficialBuildIdArg>
+    <_SignArg Condition="'$(Sign)' != ''">/p:Sign=$(Sign)</_SignArg>
+    <_DotNetSignTypeArg Condition="'$(DotNetSignType)' != ''">/p:DotNetSignType=$(DotNetSignType)</_DotNetSignTypeArg>
+    <_DotNetPublishUsingPipelinesArg Condition="'$(DotNetPublishUsingPipelines)' != ''">/p:DotNetPublishUsingPipelines=$(DotNetPublishUsingPipelines)</_DotNetPublishUsingPipelinesArg>
+    <_TeamNameArg Condition="'$(TeamName)' != ''">/p:TeamName=$(TeamName)</_TeamNameArg>
+    <_PostBuildSignArg Condition="'$(PostBuildSign)' != ''">/p:PostBuildSign=$(PostBuildSign)</_PostBuildSignArg>
 
     <!-- Binlog arguments for dotnet commands -->
     <_BinlogArg Condition="'$(ContinuousIntegrationBuild)' == 'true'">-bl:$(ArtifactsLogDir)</_BinlogArg>
@@ -91,7 +98,7 @@
       <_BundleArchivePath>$(ArtifactsDir)bundle\aspire-$(BundleVersion)-$(TargetRid).tar.gz</_BundleArchivePath>
     </PropertyGroup>
     <Message Importance="high" Text="Publishing native AOT CLI with embedded bundle: $(_BundleArchivePath)" />
-    <Exec Command="dotnet publish &quot;$(CliProjectPath)&quot; -c $(Configuration) -r $(TargetRid) /p:BundlePayloadPath=&quot;$(_BundleArchivePath)&quot; $(_VersionSuffixArg) $(_CliBinlog)" />
+    <Exec Command="dotnet publish &quot;$(CliProjectPath)&quot; -c $(Configuration) -r $(TargetRid) /p:BundlePayloadPath=&quot;$(_BundleArchivePath)&quot; $(_ContinuousIntegrationBuildArg) $(_VersionSuffixArg) $(_OfficialBuildIdArg) $(_SignArg) $(_DotNetSignTypeArg) $(_DotNetPublishUsingPipelinesArg) $(_TeamNameArg) $(_PostBuildSignArg) $(_CliBinlog)" />
   </Target>
 
   <Target Name="_PublishManagedProjects" Condition="'$(SkipManagedBuild)' != 'true'">
@@ -100,7 +107,7 @@
     </PropertyGroup>
     <Message Importance="high" Text="Publishing aspire-managed (self-contained)..." />
     <!-- Publish as self-contained single-file for the target RID -->
-    <Exec Command="dotnet publish &quot;$(ManagedProjectPath)&quot; -c $(Configuration) -r $(TargetRid) --self-contained /p:GenerateDocumentationFile=false /p:EnforceCodeStyleInBuild=false $(_VersionSuffixArg) $(_ManagedBinlog)" />
+    <Exec Command="dotnet publish &quot;$(ManagedProjectPath)&quot; -c $(Configuration) -r $(TargetRid) --self-contained /p:GenerateDocumentationFile=false /p:EnforceCodeStyleInBuild=false $(_ContinuousIntegrationBuildArg) $(_VersionSuffixArg) $(_OfficialBuildIdArg) $(_SignArg) $(_DotNetSignTypeArg) $(_DotNetPublishUsingPipelinesArg) $(_TeamNameArg) $(_PostBuildSignArg) $(_ManagedBinlog)" />
   </Target>
 
   <Target Name="_RestoreDcpPackage">

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -56,8 +56,11 @@
     <FileSignInfo Include="Tuf.dll" CertificateName="3PartySHA2" />
 
     <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="aspire.exe" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="aspire-managed.exe" CertificateName="MicrosoftDotNet500" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsLinux())" Include="aspire" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsLinux())" Include="aspire-managed" CertificateName="MicrosoftDotNet500" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsMacOS())" Include="aspire" CertificateName="MacDeveloperHardenWithNotarization" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsMacOS())" Include="aspire-managed" CertificateName="MacDeveloperHardenWithNotarization" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="get-aspire-cli.ps1" CertificateName="MicrosoftDotNet500" />
 
     <!-- Sign the manifest catalog on Windows -->

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -155,9 +155,15 @@ if ($bundle) {
     "/p:TargetRid=$rid"
   )
   
-  # Pass through SkipNativeBuild if set
-  if ($properties -contains "/p:SkipNativeBuild=true") {
-    $bundleArgs += "/p:SkipNativeBuild=true"
+  foreach ($property in $properties) {
+    if ($property -eq "-sign") {
+      $bundleArgs += "/p:Sign=true"
+      continue
+    }
+
+    if ($property.StartsWith("/p:", [System.StringComparison]::OrdinalIgnoreCase)) {
+      $bundleArgs += $property
+    }
   }
   
   # CI flag is passed to Bundle.proj which handles version computation via Versions.props

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -58,6 +58,7 @@ usage()
 
 arguments=''
 extraargs=''
+bundle_passthrough_args=()
 build_bundle=false
 runtime_version=""
 config="Debug"
@@ -169,6 +170,11 @@ while [[ $# > 0 ]]; do
       ;;
 
      *)
+      if [[ "$opt" == "-sign" ]]; then
+        bundle_passthrough_args+=("/p:Sign=true")
+      elif [[ "$1" == "/p:"* || "$1" == "-p:"* ]]; then
+        bundle_passthrough_args+=("$1")
+      fi
       extraargs="$extraargs $1"
       shift 1
       ;;
@@ -246,13 +252,9 @@ if [ "$build_bundle" = true ]; then
         "/p:TargetRid=$rid"
     )
     
-    # Pass through SkipNativeBuild if set
-    for arg in "$@"; do
-        if [[ "$arg" == *"SkipNativeBuild=true"* ]]; then
-            bundle_args+=("/p:SkipNativeBuild=true")
-            break
-        fi
-    done
+    if [ ${#bundle_passthrough_args[@]} -gt 0 ]; then
+        bundle_args+=("${bundle_passthrough_args[@]}")
+    fi
     
     # CI flag is passed to Bundle.proj which handles version computation via Versions.props
     if [ "${CI:-}" = "true" ]; then

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -52,8 +52,27 @@ steps:
                 /p:BundleVersion=ci-bundlepayload
                 /p:SkipNativeBuild=true
                 /p:ContinuousIntegrationBuild=true
+                $(_SignArgs)
+                $(_OfficialBuildIdArgs)
                 /bl:${{ parameters.repoLogPath }}/BundlePayload-${{ targetRid }}.binlog
         displayName: 🟣Build bundle payload (${{ targetRid }})
+
+      - pwsh: |
+          $managedPath = Join-Path '${{ parameters.repoArtifactsPath }}/bin/Aspire.Managed/${{ parameters.buildConfig }}/net10.0/${{ targetRid }}/publish' 'aspire-managed.exe'
+          if (-not (Test-Path $managedPath)) {
+            Write-Host "##[error]aspire-managed.exe not found at $managedPath"
+            exit 1
+          }
+
+          $signature = Get-AuthenticodeSignature $managedPath
+          if ($signature.Status -eq [System.Management.Automation.SignatureStatus]::NotSigned) {
+            Write-Host "##[error]aspire-managed.exe is not signed: $managedPath"
+            exit 1
+          }
+
+          Write-Host "✅ aspire-managed.exe signature status: $($signature.Status)"
+        displayName: 🟣Verify managed bundle signature (${{ targetRid }})
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'), startsWith('${{ targetRid }}', 'win-'))
 
     - script: ${{ parameters.buildScript }}
               -restore -build

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -65,14 +65,19 @@ steps:
           }
 
           $signature = Get-AuthenticodeSignature $managedPath
-          if ($signature.Status -eq [System.Management.Automation.SignatureStatus]::NotSigned) {
-            Write-Host "##[error]aspire-managed.exe is not signed: $managedPath"
+          $allowedStatuses = @(
+            [System.Management.Automation.SignatureStatus]::Valid,
+            [System.Management.Automation.SignatureStatus]::NotTrusted
+          )
+
+          if ($signature.Status -notin $allowedStatuses) {
+            Write-Host "##[error]aspire-managed.exe has an unexpected signature status '$($signature.Status)': $managedPath"
             exit 1
           }
 
           Write-Host "✅ aspire-managed.exe signature status: $($signature.Status)"
         displayName: 🟣Verify managed bundle signature (${{ targetRid }})
-        condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'), startsWith('${{ targetRid }}', 'win-'))
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['_Sign'], 'true'), in(variables['_SignType'], 'real', 'test'), startsWith('${{ targetRid }}', 'win-'))
 
     - script: ${{ parameters.buildScript }}
               -restore -build

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -73,6 +73,7 @@ jobs:
               /p:BundleVersion=ci-bundlepayload
               /p:SkipNativeBuild=true
               /p:ContinuousIntegrationBuild=true
+              ${{ parameters.extraBuildArgs }}
               /bl:$(Build.Arcade.LogsPath)BundlePayload.binlog
             displayName: 🟣Build bundle payload
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/aspire/issues/15989

## Description

Fix the CLI bundle signing gap where `aspire-managed.exe` could miss the same signing path as `aspire.exe`.

**Root cause:** the managed bundle payload is published earlier via `eng/Bundle.proj`, while the later native CLI build receives the usual signing properties. On top of that, `eng/Signing.props` only registered `aspire.exe`/`aspire`, so the bundle could preserve an unsigned `aspire-managed.exe`.

### Changes

- register `aspire-managed.exe` / `aspire-managed` in `eng/Signing.props`
- forward signing-related MSBuild properties through `eng/Bundle.proj` so the managed payload publish participates in the same signing flow
- pass the same sign/property plumbing through the local `build.ps1` / `build.sh --bundle` path
- add a Windows pipeline validation step in `BuildAndTest.yml` that fails if the produced bundle payload contains an unsigned `aspire-managed.exe`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No