### PR TITLE
Store polyglot artifacts under the workspace .aspire folder

### DIFF
--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -21,16 +21,16 @@ public interface INuGetService
     /// <param name="targetFramework">The target framework.</param>
     /// <param name="runtimeIdentifier">The runtime identifier used to prefer runtime-specific assets in the generated layout.</param>
     /// <param name="sources">Additional NuGet sources.</param>
-    /// <param name="workingDirectory">Working directory for nuget.config discovery.</param>
+    /// <param name="workingDirectory">Working directory for nuget.config discovery and for resolving the workspace-local restore cache. Required.</param>
     /// <param name="nugetConfigPath">An explicit NuGet.config file to use during restore.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Path to the restored libs directory.</returns>
     Task<string> RestorePackagesAsync(
         IEnumerable<(string Id, string Version)> packages,
+        string workingDirectory,
         string targetFramework = "net10.0",
         string? runtimeIdentifier = null,
         IEnumerable<string>? sources = null,
-        string? workingDirectory = null,
         string? nugetConfigPath = null,
         CancellationToken ct = default);
 }
@@ -62,13 +62,15 @@ internal sealed class BundleNuGetService : INuGetService
 
     public async Task<string> RestorePackagesAsync(
         IEnumerable<(string Id, string Version)> packages,
+        string workingDirectory,
         string targetFramework = "net10.0",
         string? runtimeIdentifier = null,
         IEnumerable<string>? sources = null,
-        string? workingDirectory = null,
         string? nugetConfigPath = null,
         CancellationToken ct = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+
         var layout = _layoutDiscovery.DiscoverLayout();
         if (layout is null)
         {
@@ -135,12 +137,9 @@ internal sealed class BundleNuGetService : INuGetService
             }
         }
 
-        // Pass working directory for nuget.config discovery
-        if (!string.IsNullOrEmpty(workingDirectory))
-        {
-            restoreArgs.Add("--working-dir");
-            restoreArgs.Add(workingDirectory);
-        }
+        // Pass working directory for nuget.config discovery.
+        restoreArgs.Add("--working-dir");
+        restoreArgs.Add(workingDirectory);
 
         if (!string.IsNullOrEmpty(nugetConfigPath))
         {
@@ -283,15 +282,10 @@ internal sealed class BundleNuGetService : INuGetService
         }
     }
 
-    private static string GetPackagesDirectory(string? workingDirectory)
+    private static string GetPackagesDirectory(string workingDirectory)
     {
-        if (!string.IsNullOrWhiteSpace(workingDirectory))
-        {
-            var workspaceAspireDirectory = ConfigurationHelper.GetWorkspaceAspireDirectory(
-                new DirectoryInfo(Path.GetFullPath(workingDirectory)));
-            return Path.Combine(workspaceAspireDirectory.FullName, "packages");
-        }
-
-        return Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "packages");
+        var workspaceAspireDirectory = ConfigurationHelper.GetWorkspaceAspireDirectory(
+            new DirectoryInfo(Path.GetFullPath(workingDirectory)));
+        return Path.Combine(workspaceAspireDirectory.FullName, "packages");
     }
 }

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Layout;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.NuGet;
@@ -21,6 +22,7 @@ public interface INuGetService
     /// <param name="runtimeIdentifier">The runtime identifier used to prefer runtime-specific assets in the generated layout.</param>
     /// <param name="sources">Additional NuGet sources.</param>
     /// <param name="workingDirectory">Working directory for nuget.config discovery.</param>
+    /// <param name="nugetConfigPath">An explicit NuGet.config file to use during restore.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Path to the restored libs directory.</returns>
     Task<string> RestorePackagesAsync(
@@ -29,6 +31,7 @@ public interface INuGetService
         string? runtimeIdentifier = null,
         IEnumerable<string>? sources = null,
         string? workingDirectory = null,
+        string? nugetConfigPath = null,
         CancellationToken ct = default);
 }
 
@@ -42,7 +45,6 @@ internal sealed class BundleNuGetService : INuGetService
     private readonly IFeatures _features;
     private readonly CliExecutionContext _executionContext;
     private readonly ILogger<BundleNuGetService> _logger;
-    private readonly string _cacheDirectory;
 
     public BundleNuGetService(
         ILayoutDiscovery layoutDiscovery,
@@ -56,7 +58,6 @@ internal sealed class BundleNuGetService : INuGetService
         _features = features;
         _executionContext = executionContext;
         _logger = logger;
-        _cacheDirectory = GetCacheDirectory();
     }
 
     public async Task<string> RestorePackagesAsync(
@@ -65,6 +66,7 @@ internal sealed class BundleNuGetService : INuGetService
         string? runtimeIdentifier = null,
         IEnumerable<string>? sources = null,
         string? workingDirectory = null,
+        string? nugetConfigPath = null,
         CancellationToken ct = default)
     {
         var layout = _layoutDiscovery.DiscoverLayout();
@@ -85,9 +87,10 @@ internal sealed class BundleNuGetService : INuGetService
             throw new ArgumentException("At least one package is required", nameof(packages));
         }
 
-        // Compute a hash for the package set to create a unique restore location
-        var packageHash = ComputePackageHash(packageList, targetFramework, runtimeIdentifier, managedPath);
-        var restoreDir = Path.Combine(_cacheDirectory, "restore", packageHash);
+        // Compute a hash for the package set to create a unique restore location.
+        var packageHash = ComputePackageHash(packageList, targetFramework, runtimeIdentifier, managedPath, sources);
+        var packagesDirectory = GetPackagesDirectory(workingDirectory);
+        var restoreDir = Path.Combine(packagesDirectory, "restore", packageHash);
         var objDir = Path.Combine(restoreDir, "obj");
         var libsDir = Path.Combine(restoreDir, "libs");
         var assetsPath = Path.Combine(objDir, "project.assets.json");
@@ -137,6 +140,12 @@ internal sealed class BundleNuGetService : INuGetService
         {
             restoreArgs.Add("--working-dir");
             restoreArgs.Add(workingDirectory);
+        }
+
+        if (!string.IsNullOrEmpty(nugetConfigPath))
+        {
+            restoreArgs.Add("--nuget-config");
+            restoreArgs.Add(nugetConfigPath);
         }
 
         // Enable verbose output for debugging
@@ -222,12 +231,21 @@ internal sealed class BundleNuGetService : INuGetService
         return libsDir;
     }
 
-    internal static string ComputePackageHash(List<(string Id, string Version)> packages, string tfm, string? runtimeIdentifier, string? managedPath = null)
+    internal static string ComputePackageHash(
+        List<(string Id, string Version)> packages,
+        string tfm,
+        string? runtimeIdentifier,
+        string? managedPath = null,
+        IEnumerable<string>? sources = null)
     {
         var content = string.Join(";", packages.OrderBy(p => p.Id).Select(p => $"{p.Id}:{p.Version}"));
         content += $";tfm:{tfm}";
         content += $";rid:{runtimeIdentifier ?? "<none>"}";
         content += $";managed:{GetManagedToolFingerprint(managedPath)}";
+        if (sources is not null)
+        {
+            content += $";sources:{string.Join("|", sources.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))}";
+        }
 
         // Use SHA256 for stable hash across processes/runtimes
         var hashBytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(content));
@@ -265,9 +283,15 @@ internal sealed class BundleNuGetService : INuGetService
         }
     }
 
-    private static string GetCacheDirectory()
+    private static string GetPackagesDirectory(string? workingDirectory)
     {
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        return Path.Combine(home, ".aspire", "packages");
+        if (!string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            var workspaceAspireDirectory = ConfigurationHelper.GetWorkspaceAspireDirectory(
+                new DirectoryInfo(Path.GetFullPath(workingDirectory)));
+            return Path.Combine(workspaceAspireDirectory.FullName, "packages");
+        }
+
+        return Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "packages");
     }
 }

--- a/src/Aspire.Cli/Packaging/NuGetConfigMerger.cs
+++ b/src/Aspire.Cli/Packaging/NuGetConfigMerger.cs
@@ -960,7 +960,7 @@ internal class NuGetConfigMerger
         AddGlobalPackagesFolderConfiguration(configContext.Configuration);
     }
 
-    private static void AddGlobalPackagesFolderConfiguration(XElement configuration)
+    internal static void AddGlobalPackagesFolderConfiguration(XElement configuration)
     {
         // Check if config section already exists
         var config = configuration.Element("config");

--- a/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
+++ b/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
@@ -21,14 +21,29 @@ internal sealed class TemporaryNuGetConfig : IDisposable
     public static async Task<TemporaryNuGetConfig> CreateAsync(PackageMapping[] mappings, bool configureGlobalPackagesFolder = false)
     {
         var tempDirectory = Directory.CreateTempSubdirectory("aspire-nuget-config").FullName;
-        var tempFilePath = Path.Combine(tempDirectory, "nuget.config");
-        var configFile = new FileInfo(tempFilePath);
-        await GenerateNuGetConfigAsync(mappings, configFile);
-        if (configureGlobalPackagesFolder)
+        try
         {
-            await AddGlobalPackagesFolderToConfigAsync(configFile);
+            var tempFilePath = Path.Combine(tempDirectory, "nuget.config");
+            var configFile = new FileInfo(tempFilePath);
+            await GenerateNuGetConfigAsync(mappings, configFile);
+            if (configureGlobalPackagesFolder)
+            {
+                await AddGlobalPackagesFolderToConfigAsync(configFile);
+            }
+            return new TemporaryNuGetConfig(configFile);
         }
-        return new TemporaryNuGetConfig(configFile);
+        catch
+        {
+            try
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+            catch
+            {
+                // Ignore cleanup failures; surface the original exception instead.
+            }
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
+++ b/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Xml;
+using System.Xml.Linq;
 
 namespace Aspire.Cli.Packaging;
 
@@ -17,12 +18,16 @@ internal sealed class TemporaryNuGetConfig : IDisposable
 
     public FileInfo ConfigFile => _configFile;
 
-    public static async Task<TemporaryNuGetConfig> CreateAsync(PackageMapping[] mappings)
+    public static async Task<TemporaryNuGetConfig> CreateAsync(PackageMapping[] mappings, bool configureGlobalPackagesFolder = false)
     {
         var tempDirectory = Directory.CreateTempSubdirectory("aspire-nuget-config").FullName;
         var tempFilePath = Path.Combine(tempDirectory, "nuget.config");
         var configFile = new FileInfo(tempFilePath);
         await GenerateNuGetConfigAsync(mappings, configFile);
+        if (configureGlobalPackagesFolder)
+        {
+            await AddGlobalPackagesFolderToConfigAsync(configFile);
+        }
         return new TemporaryNuGetConfig(configFile);
     }
 
@@ -103,6 +108,28 @@ internal sealed class TemporaryNuGetConfig : IDisposable
 
         await xmlWriter.WriteEndElementAsync(); // configuration
         await xmlWriter.WriteEndDocumentAsync();
+    }
+
+    private static async Task AddGlobalPackagesFolderToConfigAsync(FileInfo configFile)
+    {
+        XDocument document;
+        await using (var stream = configFile.OpenRead())
+        {
+            document = XDocument.Load(stream);
+        }
+
+        var configuration = document.Root ?? new XElement("configuration");
+        if (document.Root is null)
+        {
+            document.Add(configuration);
+        }
+
+        NuGetConfigMerger.AddGlobalPackagesFolderConfiguration(configuration);
+
+        var content = document.Declaration is null
+            ? document.ToString()
+            : $"{document.Declaration}{Environment.NewLine}{document}";
+        await File.WriteAllTextAsync(configFile.FullName, content);
     }
 
     public void Dispose()

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -166,27 +166,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     /// Falls back to <paramref name="appHostDirectory"/> when no config file is found.
     /// </summary>
     private static DirectoryInfo GetConfigDirectory(DirectoryInfo appHostDirectory)
-    {
-        // Search from the apphost's directory upward to find the nearest config file.
-        var nearAppHost = ConfigurationHelper.FindNearestConfigFilePath(appHostDirectory);
-        if (nearAppHost is not null)
-        {
-            var configFile = new FileInfo(nearAppHost);
-            if (configFile.Directory is { Exists: true })
-            {
-                // For legacy .aspire/settings.json, the config directory is the parent of .aspire/
-                if (string.Equals(configFile.Directory.Name, ".aspire", StringComparison.OrdinalIgnoreCase)
-                    && configFile.Directory.Parent is not null)
-                {
-                    return configFile.Directory.Parent;
-                }
-
-                return configFile.Directory;
-            }
-        }
-
-        return appHostDirectory;
-    }
+        => ConfigurationHelper.GetConfigRootDirectory(appHostDirectory);
 
     private AspireConfigFile LoadConfiguration(DirectoryInfo directory)
     {

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -75,7 +75,8 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         // Create a working directory for this app host session
         var pathHash = SHA256.HashData(Encoding.UTF8.GetBytes(_appDirectoryPath));
         var pathDir = Convert.ToHexString(pathHash)[..12].ToLowerInvariant();
-        _workingDirectory = Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "bundle-hosts", pathDir);
+        var workspaceAspireDirectory = ConfigurationHelper.GetWorkspaceAspireDirectory(new DirectoryInfo(_appDirectoryPath));
+        _workingDirectory = Path.Combine(workspaceAspireDirectory.FullName, "bundle-hosts", pathDir);
         Directory.CreateDirectory(_workingDirectory);
     }
 

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -171,6 +171,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         _logger.LogDebug("Restoring {Count} integration packages via bundled NuGet", packageRefs.Count);
 
         var packages = packageRefs.Select(r => (r.Name, r.Version!)).ToList();
+        using var temporaryNuGetConfig = await TryCreateTemporaryNuGetConfigAsync(channelName, cancellationToken);
         var sources = await GetNuGetSourcesAsync(channelName, cancellationToken);
 
         return await _nugetService.RestorePackagesAsync(
@@ -179,6 +180,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
             runtimeIdentifier: RuntimeInformation.RuntimeIdentifier,
             sources: sources,
             workingDirectory: _appDirectoryPath,
+            nugetConfigPath: temporaryNuGetConfig?.ConfigFile.FullName,
             ct: cancellationToken);
     }
 
@@ -399,6 +401,35 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         }
 
         return sources.Count > 0 ? sources : null;
+    }
+
+    private async Task<TemporaryNuGetConfig?> TryCreateTemporaryNuGetConfigAsync(string? channelName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(channelName))
+        {
+            return null;
+        }
+
+        try
+        {
+            var channels = await _packagingService.GetChannelsAsync(cancellationToken);
+            var channel = channels.FirstOrDefault(c =>
+                c.Type == PackageChannelType.Explicit &&
+                c.Mappings is { Length: > 0 } &&
+                string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
+
+            if (channel?.Mappings is null)
+            {
+                return null;
+            }
+
+            return await TemporaryNuGetConfig.CreateAsync(channel.Mappings, channel.ConfigureGlobalPackagesFolder);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create a temporary NuGet config for channel '{Channel}'", channelName);
+            return null;
+        }
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -176,10 +176,10 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
 
         return await _nugetService.RestorePackagesAsync(
             packages,
-            DotNetBasedAppHostServerProject.TargetFramework,
+            workingDirectory: _appDirectoryPath,
+            targetFramework: DotNetBasedAppHostServerProject.TargetFramework,
             runtimeIdentifier: RuntimeInformation.RuntimeIdentifier,
             sources: sources,
-            workingDirectory: _appDirectoryPath,
             nugetConfigPath: temporaryNuGetConfig?.ConfigFile.FullName,
             ct: cancellationToken);
     }
@@ -410,26 +410,22 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
             return null;
         }
 
-        try
-        {
-            var channels = await _packagingService.GetChannelsAsync(cancellationToken);
-            var channel = channels.FirstOrDefault(c =>
-                c.Type == PackageChannelType.Explicit &&
-                c.Mappings is { Length: > 0 } &&
-                string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
+        var channels = await _packagingService.GetChannelsAsync(cancellationToken);
+        var channel = channels.FirstOrDefault(c =>
+            c.Type == PackageChannelType.Explicit &&
+            c.Mappings is { Length: > 0 } &&
+            string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
 
-            if (channel?.Mappings is null)
-            {
-                return null;
-            }
-
-            return await TemporaryNuGetConfig.CreateAsync(channel.Mappings, channel.ConfigureGlobalPackagesFolder);
-        }
-        catch (Exception ex)
+        if (channel?.Mappings is null)
         {
-            _logger.LogWarning(ex, "Failed to create a temporary NuGet config for channel '{Channel}'", channelName);
             return null;
         }
+
+        // Materializing the temp config is required for explicit channels so that
+        // restore honors the channel's package source mappings. Let IO/XML failures
+        // surface instead of silently falling back to the caller's unmapped sources,
+        // which could otherwise restore from an unintended feed.
+        return await TemporaryNuGetConfig.CreateAsync(channel.Mappings, channel.ConfigureGlobalPackagesFolder);
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -316,7 +316,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
         foreach (var fileName in scaffoldFileNames)
         {
-            if (IsGitIgnoreFile(fileName))
+            if (IsGitIgnoreFile(fileName) || IsPackageJsonFile(fileName))
             {
                 continue;
             }
@@ -363,6 +363,9 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
     private static bool IsGitIgnoreFile(string fileName)
         => Path.GetFileName(fileName).Equals(".gitignore", StringComparison.Ordinal);
+
+    private static bool IsPackageJsonFile(string fileName)
+        => Path.GetFileName(fileName).Equals(PackageJsonFileName, StringComparison.OrdinalIgnoreCase);
 
     private static IEnumerable<string> ReadGitIgnoreEntries(string content)
     {

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -98,7 +98,18 @@ internal sealed class ScaffoldingService : IScaffoldingService
             context.ProjectName,
             cancellationToken);
 
-        // Step 4: Write scaffold files to disk, merging package.json with existing content
+        var conflictingFiles = GetConflictingScaffoldFiles(directory.FullName, scaffoldFiles.Keys);
+        if (conflictingFiles.Count > 0)
+        {
+            _logger.LogWarning(
+                "Scaffolding in '{Directory}' would overwrite existing files: {Files}",
+                directory.FullName,
+                string.Join(", ", conflictingFiles));
+            _interactionService.DisplayError(TemplatingStrings.ProjectAlreadyExists);
+            return false;
+        }
+
+        // Step 4: Write scaffold files to disk, merging package.json and .gitignore when they already exist.
         foreach (var (fileName, content) in scaffoldFiles)
         {
             var filePath = Path.Combine(directory.FullName, fileName);
@@ -117,6 +128,11 @@ internal sealed class ScaffoldingService : IScaffoldingService
                     content,
                     _logger,
                     toolchainCommand: GetPackageManagerCommand(directory, language));
+            }
+            else if (IsGitIgnoreFile(fileName) && File.Exists(filePath))
+            {
+                var existingContent = await File.ReadAllTextAsync(filePath, cancellationToken);
+                contentToWrite = MergeGitIgnoreContent(existingContent, content);
             }
 
             await File.WriteAllTextAsync(filePath, contentToWrite, cancellationToken);
@@ -289,5 +305,91 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
         var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory);
         return TypeScriptAppHostToolchainResolver.GetCommandName(toolchain);
+    }
+
+    internal static IReadOnlyList<string> GetConflictingScaffoldFiles(string rootDirectory, IEnumerable<string> scaffoldFileNames)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rootDirectory);
+        ArgumentNullException.ThrowIfNull(scaffoldFileNames);
+
+        var conflicts = new List<string>();
+
+        foreach (var fileName in scaffoldFileNames)
+        {
+            if (IsGitIgnoreFile(fileName))
+            {
+                continue;
+            }
+
+            var filePath = Path.Combine(rootDirectory, fileName);
+            if (File.Exists(filePath) || Directory.Exists(filePath))
+            {
+                conflicts.Add(fileName);
+            }
+        }
+
+        return conflicts;
+    }
+
+    internal static string MergeGitIgnoreContent(string existingContent, string scaffoldContent)
+    {
+        ArgumentNullException.ThrowIfNull(existingContent);
+        ArgumentNullException.ThrowIfNull(scaffoldContent);
+
+        if (string.IsNullOrEmpty(existingContent))
+        {
+            return scaffoldContent;
+        }
+
+        var existingEntries = ReadGitIgnoreEntries(existingContent).ToHashSet(StringComparer.Ordinal);
+        var missingEntries = ReadGitIgnoreEntries(scaffoldContent)
+            .Where(entry => !HasEquivalentGitIgnoreEntry(existingEntries, entry))
+            .ToArray();
+
+        if (missingEntries.Length == 0)
+        {
+            return existingContent;
+        }
+
+        var newline = existingContent.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+        var mergedContent = existingContent;
+        if (!mergedContent.EndsWith("\n", StringComparison.Ordinal))
+        {
+            mergedContent += newline;
+        }
+
+        return mergedContent + string.Join(newline, missingEntries) + newline;
+    }
+
+    private static bool IsGitIgnoreFile(string fileName)
+        => Path.GetFileName(fileName).Equals(".gitignore", StringComparison.Ordinal);
+
+    private static IEnumerable<string> ReadGitIgnoreEntries(string content)
+    {
+        using var reader = new StringReader(content);
+        string? line;
+
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                yield return line.TrimEnd();
+            }
+        }
+    }
+
+    private static bool HasEquivalentGitIgnoreEntry(HashSet<string> existingEntries, string entry)
+    {
+        if (existingEntries.Contains(entry))
+        {
+            return true;
+        }
+
+        return entry switch
+        {
+            "/.aspire/" => existingEntries.Contains(".aspire/"),
+            ".aspire/" => existingEntries.Contains("/.aspire/"),
+            _ => false
+        };
     }
 }

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -342,8 +342,13 @@ internal sealed class ScaffoldingService : IScaffoldingService
         }
 
         var existingEntries = ReadGitIgnoreEntries(existingContent).ToHashSet(StringComparer.Ordinal);
+        var existingNormalized = existingEntries
+            .Select(NormalizeGitIgnoreEntry)
+            .ToHashSet(StringComparer.Ordinal);
+
         var missingEntries = ReadGitIgnoreEntries(scaffoldContent)
-            .Where(entry => !HasEquivalentGitIgnoreEntry(existingEntries, entry))
+            .Where(entry => !existingEntries.Contains(entry)
+                && !existingNormalized.Contains(NormalizeGitIgnoreEntry(entry)))
             .ToArray();
 
         if (missingEntries.Length == 0)
@@ -381,18 +386,8 @@ internal sealed class ScaffoldingService : IScaffoldingService
         }
     }
 
-    private static bool HasEquivalentGitIgnoreEntry(HashSet<string> existingEntries, string entry)
-    {
-        if (existingEntries.Contains(entry))
-        {
-            return true;
-        }
-
-        return entry switch
-        {
-            "/.aspire/" => existingEntries.Contains(".aspire/"),
-            ".aspire/" => existingEntries.Contains("/.aspire/"),
-            _ => false
-        };
-    }
+    // Normalizes a .gitignore entry so rooted (`/foo/`) and unrooted (`foo/`) forms
+    // are treated as equivalent when deciding whether to append a scaffold entry.
+    private static string NormalizeGitIgnoreEntry(string entry)
+        => entry.StartsWith('/') ? entry[1..] : entry;
 }

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -4,6 +4,7 @@
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 

--- a/src/Aspire.Cli/Templating/Templates/java-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/java-starter/.gitignore
@@ -1,3 +1,3 @@
 .java-build/
 .modules/
-/.aspire/
+.aspire/

--- a/src/Aspire.Cli/Templating/Templates/java-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/java-starter/.gitignore
@@ -1,0 +1,3 @@
+.java-build/
+.modules/
+.aspire/

--- a/src/Aspire.Cli/Templating/Templates/java-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/java-starter/.gitignore
@@ -1,3 +1,3 @@
 .java-build/
 .modules/
-.aspire/
+/.aspire/

--- a/src/Aspire.Cli/Templating/Templates/py-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/py-starter/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 .modules/
 dist/
 .venv/
-.aspire/
+/.aspire/

--- a/src/Aspire.Cli/Templating/Templates/py-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/py-starter/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.modules/
+dist/
+.venv/
+.aspire/

--- a/src/Aspire.Cli/Templating/Templates/py-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/py-starter/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 .modules/
 dist/
 .venv/
-/.aspire/
+.aspire/

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.modules/
+dist/
+.aspire/

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 .modules/
 dist/
-/.aspire/
+.aspire/

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 .modules/
 dist/
-.aspire/
+/.aspire/

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -85,6 +85,37 @@ internal static class ConfigurationHelper
         return settingsDirectory.Parent;
     }
 
+    internal static DirectoryInfo GetConfigRootDirectory(DirectoryInfo startDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(startDirectory);
+
+        var configPath = FindNearestConfigFilePath(startDirectory);
+        if (configPath is null)
+        {
+            return startDirectory;
+        }
+
+        var configFile = new FileInfo(configPath);
+
+        // Legacy layout: <root>/.aspire/settings.json -> <root>
+        var legacyRoot = GetLegacySettingsRootDirectory(configFile);
+        if (legacyRoot is not null)
+        {
+            return legacyRoot;
+        }
+
+        // Modern layout: <root>/aspire.config.json -> <root>
+        return configFile.Directory is { Exists: true } configDirectory
+            ? configDirectory
+            : startDirectory;
+    }
+
+    internal static DirectoryInfo GetWorkspaceAspireDirectory(DirectoryInfo startDirectory)
+    {
+        var configRoot = GetConfigRootDirectory(startDirectory);
+        return new DirectoryInfo(Path.Combine(configRoot.FullName, AspireJsonConfiguration.SettingsFolder));
+    }
+
     /// <summary>
     /// Searches upward from <paramref name="startDirectory"/> for the nearest
     /// <c>aspire.config.json</c> or legacy <c>.aspire/settings.json</c>.

--- a/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
@@ -35,7 +35,7 @@ internal sealed class JavaLanguageSupport : ILanguageSupport
         files[".gitignore"] = """
             .java-build/
             .modules/
-            /.aspire/
+            .aspire/
             """;
 
         files["AppHost.java"] = """

--- a/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
@@ -35,7 +35,7 @@ internal sealed class JavaLanguageSupport : ILanguageSupport
         files[".gitignore"] = """
             .java-build/
             .modules/
-            .aspire/
+            /.aspire/
             """;
 
         files["AppHost.java"] = """

--- a/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
@@ -32,6 +32,12 @@ internal sealed class JavaLanguageSupport : ILanguageSupport
     {
         var files = new Dictionary<string, string>();
 
+        files[".gitignore"] = """
+            .java-build/
+            .modules/
+            .aspire/
+            """;
+
         files["AppHost.java"] = """
             // Aspire Java AppHost
             // For more information, see: https://aspire.dev

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -86,7 +86,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             node_modules/
             .modules/
             dist/
-            /.aspire/
+            .aspire/
             """;
         files[PackageJsonFileName] = CreatePackageJson(request);
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -86,7 +86,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             node_modules/
             .modules/
             dist/
-            .aspire/
+            /.aspire/
             """;
         files[PackageJsonFileName] = CreatePackageJson(request);
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -82,6 +82,12 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             await builder.build().run();
             """;
 
+        files[".gitignore"] = """
+            node_modules/
+            .modules/
+            dist/
+            .aspire/
+            """;
         files[PackageJsonFileName] = CreatePackageJson(request);
 
         // Create eslint.config.mjs for catching unawaited promises in apphost.ts

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/GitIgnoreAssertions.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/GitIgnoreAssertions.cs
@@ -12,7 +12,7 @@ internal static class GitIgnoreAssertions
         var gitIgnorePath = Path.Combine(projectRoot, ".gitignore");
         Assert.True(File.Exists(gitIgnorePath), $"Expected generated .gitignore at {gitIgnorePath}");
 
-        var gitIgnoreContent = File.ReadAllText(gitIgnorePath);
-        Assert.Contains(entry, gitIgnoreContent, StringComparison.Ordinal);
+        var gitIgnoreLines = File.ReadAllLines(gitIgnorePath);
+        Assert.Contains(entry, gitIgnoreLines);
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/GitIgnoreAssertions.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/GitIgnoreAssertions.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests.Helpers;
+
+internal static class GitIgnoreAssertions
+{
+    public static void AssertContainsEntry(string projectRoot, string entry)
+    {
+        var gitIgnorePath = Path.Combine(projectRoot, ".gitignore");
+        Assert.True(File.Exists(gitIgnorePath), $"Expected generated .gitignore at {gitIgnorePath}");
+
+        var gitIgnoreContent = File.ReadAllText(gitIgnorePath);
+        Assert.Contains(entry, gitIgnoreContent, StringComparison.Ordinal);
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
@@ -38,7 +38,7 @@ public sealed class JavaEmptyAppHostTemplateTests(ITestOutputHelper output)
 
         GitIgnoreAssertions.AssertContainsEntry(
             Path.Combine(workspace.WorkspaceRoot.FullName, "JavaEmptyApp"),
-            "/.aspire/");
+            ".aspire/");
 
         await auto.TypeAsync("cd JavaEmptyApp");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
@@ -36,6 +36,10 @@ public sealed class JavaEmptyAppHostTemplateTests(ITestOutputHelper output)
 
         await auto.AspireNewAsync("JavaEmptyApp", counter, template: AspireTemplate.JavaEmptyAppHost);
 
+        GitIgnoreAssertions.AssertContainsEntry(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "JavaEmptyApp"),
+            ".aspire/");
+
         await auto.TypeAsync("cd JavaEmptyApp");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
@@ -38,7 +38,7 @@ public sealed class JavaEmptyAppHostTemplateTests(ITestOutputHelper output)
 
         GitIgnoreAssertions.AssertContainsEntry(
             Path.Combine(workspace.WorkspaceRoot.FullName, "JavaEmptyApp"),
-            ".aspire/");
+            "/.aspire/");
 
         await auto.TypeAsync("cd JavaEmptyApp");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
@@ -35,6 +35,10 @@ public sealed class PythonReactTemplateTests(ITestOutputHelper output)
         // Step 1: Create project using aspire new, selecting the FastAPI/React template
         await auto.AspireNewAsync("AspirePyReactApp", counter, template: AspireTemplate.PythonReact, useRedisCache: false);
 
+        GitIgnoreAssertions.AssertContainsEntry(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "AspirePyReactApp"),
+            ".aspire/");
+
         // Step 2: Navigate into the project directory so config resolution finds the
         // project-level aspire.config.json (which has the packages section).
         // See https://github.com/microsoft/aspire/issues/15623

--- a/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
@@ -37,7 +37,7 @@ public sealed class PythonReactTemplateTests(ITestOutputHelper output)
 
         GitIgnoreAssertions.AssertContainsEntry(
             Path.Combine(workspace.WorkspaceRoot.FullName, "AspirePyReactApp"),
-            "/.aspire/");
+            ".aspire/");
 
         // Step 2: Navigate into the project directory so config resolution finds the
         // project-level aspire.config.json (which has the packages section).

--- a/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
@@ -37,7 +37,7 @@ public sealed class PythonReactTemplateTests(ITestOutputHelper output)
 
         GitIgnoreAssertions.AssertContainsEntry(
             Path.Combine(workspace.WorkspaceRoot.FullName, "AspirePyReactApp"),
-            ".aspire/");
+            "/.aspire/");
 
         // Step 2: Navigate into the project directory so config resolution finds the
         // project-level aspire.config.json (which has the packages section).

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -35,6 +35,10 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
 
         await auto.AspireNewAsync("TsEmptyApp", counter, template: AspireTemplate.TypeScriptEmptyAppHost);
 
+        GitIgnoreAssertions.AssertContainsEntry(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "TsEmptyApp"),
+            ".aspire/");
+
         // Start the empty TypeScript AppHost to verify the scaffolded project works
         await auto.TypeAsync("cd TsEmptyApp");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -37,7 +37,7 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
 
         GitIgnoreAssertions.AssertContainsEntry(
             Path.Combine(workspace.WorkspaceRoot.FullName, "TsEmptyApp"),
-            ".aspire/");
+            "/.aspire/");
 
         // Start the empty TypeScript AppHost to verify the scaffolded project works
         await auto.TypeAsync("cd TsEmptyApp");

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -37,7 +37,7 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
 
         GitIgnoreAssertions.AssertContainsEntry(
             Path.Combine(workspace.WorkspaceRoot.FullName, "TsEmptyApp"),
-            "/.aspire/");
+            ".aspire/");
 
         // Start the empty TypeScript AppHost to verify the scaffolded project works
         await auto.TypeAsync("cd TsEmptyApp");

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -38,7 +38,7 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
 
         // Step 1.5: Verify starter creation also restored the generated TypeScript SDK.
         var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "TsStarterApp");
-        GitIgnoreAssertions.AssertContainsEntry(projectRoot, ".aspire/");
+        GitIgnoreAssertions.AssertContainsEntry(projectRoot, "/.aspire/");
         var modulesDir = Path.Combine(projectRoot, ".modules");
 
         if (!Directory.Exists(modulesDir))

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -38,6 +38,7 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
 
         // Step 1.5: Verify starter creation also restored the generated TypeScript SDK.
         var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "TsStarterApp");
+        GitIgnoreAssertions.AssertContainsEntry(projectRoot, ".aspire/");
         var modulesDir = Path.Combine(projectRoot, ".modules");
 
         if (!Directory.Exists(modulesDir))

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -38,7 +38,7 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
 
         // Step 1.5: Verify starter creation also restored the generated TypeScript SDK.
         var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "TsStarterApp");
-        GitIgnoreAssertions.AssertContainsEntry(projectRoot, "/.aspire/");
+        GitIgnoreAssertions.AssertContainsEntry(projectRoot, ".aspire/");
         var modulesDir = Path.Combine(projectRoot, ".modules");
 
         if (!Directory.Exists(modulesDir))

--- a/tests/Aspire.Cli.Tests/Configuration/ConfigurationHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/ConfigurationHelperTests.cs
@@ -141,4 +141,34 @@ public class ConfigurationHelperTests(ITestOutputHelper outputHelper)
         Assert.True(config.Features["polyglotSupportEnabled"]);
         Assert.False(config.Features["showAllTemplates"]);
     }
+
+    [Fact]
+    public void GetConfigRootDirectory_UsesNearestAspireConfigDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configRoot = workspace.CreateDirectory("project");
+        Directory.CreateDirectory(Path.Combine(configRoot.FullName, "nested", "apphost"));
+        File.WriteAllText(Path.Combine(configRoot.FullName, AspireConfigFile.FileName), "{}");
+
+        var resolvedRoot = ConfigurationHelper.GetConfigRootDirectory(
+            new DirectoryInfo(Path.Combine(configRoot.FullName, "nested", "apphost")));
+
+        Assert.Equal(configRoot.FullName, resolvedRoot.FullName);
+    }
+
+    [Fact]
+    public void GetWorkspaceAspireDirectory_UsesLegacySettingsParentDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostDirectory = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "nested", "apphost"));
+        appHostDirectory.Create();
+
+        var aspireDirectory = ConfigurationHelper.GetWorkspaceAspireDirectory(appHostDirectory);
+
+        Assert.Equal(
+            Path.Combine(workspace.WorkspaceRoot.FullName, AspireJsonConfiguration.SettingsFolder),
+            aspireDirectory.FullName);
+    }
 }

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
@@ -50,6 +50,73 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
         Assert.Equal(Path.Combine(restoreDirectory, "obj", "project.assets.json"), GetArgumentValue(invocations[1], "--assets"));
     }
 
+    [Fact]
+    public async Task RestorePackagesAsync_UsesDistinctCachePathsForDifferentSources()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostDirectory = workspace.CreateDirectory("apphost");
+        var layoutRoot = workspace.CreateDirectory("layout");
+        var managedDirectory = layoutRoot.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName);
+        var managedPath = Path.Combine(
+            managedDirectory.FullName,
+            BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        File.WriteAllText(managedPath, string.Empty);
+
+        var executionFactory = new TestProcessExecutionFactory();
+        var service = new BundleNuGetService(
+            new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
+            new LayoutProcessRunner(executionFactory),
+            NullLogger<BundleNuGetService>.Instance);
+
+        var libsPathA = await service.RestorePackagesAsync(
+            [("Aspire.Hosting.JavaScript", "9.4.0")],
+            sources: ["https://example.com/feed-a/index.json"],
+            workingDirectory: appHostDirectory.FullName);
+
+        var libsPathB = await service.RestorePackagesAsync(
+            [("Aspire.Hosting.JavaScript", "9.4.0")],
+            sources: ["https://example.com/feed-b/index.json"],
+            workingDirectory: appHostDirectory.FullName);
+
+        Assert.NotEqual(libsPathA, libsPathB);
+    }
+
+    [Fact]
+    public async Task RestorePackagesAsync_PassesNuGetConfigToRestore()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostDirectory = workspace.CreateDirectory("apphost");
+        var layoutRoot = workspace.CreateDirectory("layout");
+        var managedDirectory = layoutRoot.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName);
+        var managedPath = Path.Combine(
+            managedDirectory.FullName,
+            BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        File.WriteAllText(managedPath, string.Empty);
+
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        File.WriteAllText(nugetConfigPath, "<configuration />");
+
+        List<string[]> invocations = [];
+        var executionFactory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (args, _, _, _) => invocations.Add(args.ToArray())
+        };
+
+        var service = new BundleNuGetService(
+            new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
+            new LayoutProcessRunner(executionFactory),
+            NullLogger<BundleNuGetService>.Instance);
+
+        await service.RestorePackagesAsync(
+            [("Aspire.Hosting.JavaScript", "9.4.0")],
+            workingDirectory: appHostDirectory.FullName,
+            nugetConfigPath: nugetConfigPath);
+
+        Assert.Equal(nugetConfigPath, GetArgumentValue(invocations[0], "--nuget-config"));
+    }
+
     private static string GetArgumentValue(string[] arguments, string optionName)
     {
         var optionIndex = Array.IndexOf(arguments, optionName);

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Layout;
+using Aspire.Cli.NuGet;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.NuGet;
+
+public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task RestorePackagesAsync_UsesWorkspaceAspireDirectoryForRestoreArtifacts()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostDirectory = workspace.CreateDirectory("apphost");
+        var layoutRoot = workspace.CreateDirectory("layout");
+        var managedDirectory = layoutRoot.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName);
+        var managedPath = Path.Combine(
+            managedDirectory.FullName,
+            BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        File.WriteAllText(managedPath, string.Empty);
+
+        List<string[]> invocations = [];
+        var executionFactory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (args, _, _, _) => invocations.Add(args.ToArray())
+        };
+
+        var service = new BundleNuGetService(
+            new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
+            new LayoutProcessRunner(executionFactory),
+            NullLogger<BundleNuGetService>.Instance);
+
+        var libsPath = await service.RestorePackagesAsync(
+            [("Aspire.Hosting.JavaScript", "9.4.0")],
+            workingDirectory: appHostDirectory.FullName);
+
+        var restoreRoot = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "packages", "restore");
+        var restoreDirectory = Directory.GetParent(libsPath)!.FullName;
+
+        Assert.StartsWith(restoreRoot, libsPath, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(2, invocations.Count);
+        Assert.Equal(Path.Combine(restoreDirectory, "obj"), GetArgumentValue(invocations[0], "--output"));
+        Assert.Equal(libsPath, GetArgumentValue(invocations[1], "--output"));
+        Assert.Equal(Path.Combine(restoreDirectory, "obj", "project.assets.json"), GetArgumentValue(invocations[1], "--assets"));
+    }
+
+    private static string GetArgumentValue(string[] arguments, string optionName)
+    {
+        var optionIndex = Array.IndexOf(arguments, optionName);
+        Assert.True(optionIndex >= 0 && optionIndex < arguments.Length - 1, $"Option '{optionName}' was not found.");
+        return arguments[optionIndex + 1];
+    }
+
+    private sealed class FixedLayoutDiscovery(LayoutConfiguration layout) : ILayoutDiscovery
+    {
+        public LayoutConfiguration? DiscoverLayout(string? projectDirectory = null) => layout;
+
+        public string? GetComponentPath(LayoutComponent component, string? projectDirectory = null) => layout.GetComponentPath(component);
+
+        public bool IsBundleModeAvailable(string? projectDirectory = null) => true;
+    }
+}

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
@@ -117,6 +117,49 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
         Assert.Equal(nugetConfigPath, GetArgumentValue(invocations[0], "--nuget-config"));
     }
 
+    [Fact]
+    public async Task RestorePackagesAsync_SharesRestoreCacheAcrossAppHostsInSameWorkspace()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var firstAppHost = workspace.CreateDirectory(Path.Combine("apps", "api"));
+        var secondAppHost = workspace.CreateDirectory(Path.Combine("apps", "web"));
+        var layoutRoot = workspace.CreateDirectory("layout");
+        var managedDirectory = layoutRoot.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName);
+        var managedPath = Path.Combine(
+            managedDirectory.FullName,
+            BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        File.WriteAllText(managedPath, string.Empty);
+
+        var executionFactory = new TestProcessExecutionFactory();
+        var service = new BundleNuGetService(
+            new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
+            new LayoutProcessRunner(executionFactory),
+            NullLogger<BundleNuGetService>.Instance);
+
+        var restoreRoot = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "packages", "restore");
+
+        // Same packages + sources across two apphosts in one workspace should share the cache.
+        var sharedLibsFirst = await service.RestorePackagesAsync(
+            [("Aspire.Hosting.JavaScript", "9.4.0")],
+            workingDirectory: firstAppHost.FullName);
+        var sharedLibsSecond = await service.RestorePackagesAsync(
+            [("Aspire.Hosting.JavaScript", "9.4.0")],
+            workingDirectory: secondAppHost.FullName);
+
+        Assert.StartsWith(restoreRoot, sharedLibsFirst, StringComparison.OrdinalIgnoreCase);
+        Assert.StartsWith(restoreRoot, sharedLibsSecond, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(sharedLibsFirst, sharedLibsSecond);
+
+        // Different package sets must NOT collide even when workspace is shared.
+        var divergedLibs = await service.RestorePackagesAsync(
+            [("Aspire.Hosting.Python", "9.4.0")],
+            workingDirectory: secondAppHost.FullName);
+
+        Assert.StartsWith(restoreRoot, divergedLibs, StringComparison.OrdinalIgnoreCase);
+        Assert.NotEqual(sharedLibsSecond, divergedLibs);
+    }
+
     private static string GetArgumentValue(string[] arguments, string optionName)
     {
         var optionIndex = Array.IndexOf(arguments, optionName);

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
+using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared;
@@ -34,6 +35,8 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
         var service = new BundleNuGetService(
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
+            new TestFeatures(),
+            TestExecutionContextFactory.CreateTestContext(),
             NullLogger<BundleNuGetService>.Instance);
 
         var libsPath = await service.RestorePackagesAsync(
@@ -67,6 +70,8 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
         var service = new BundleNuGetService(
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
+            new TestFeatures(),
+            TestExecutionContextFactory.CreateTestContext(),
             NullLogger<BundleNuGetService>.Instance);
 
         var libsPathA = await service.RestorePackagesAsync(
@@ -107,6 +112,8 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
         var service = new BundleNuGetService(
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
+            new TestFeatures(),
+            TestExecutionContextFactory.CreateTestContext(),
             NullLogger<BundleNuGetService>.Instance);
 
         await service.RestorePackagesAsync(
@@ -135,6 +142,8 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
         var service = new BundleNuGetService(
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
+            new TestFeatures(),
+            TestExecutionContextFactory.CreateTestContext(),
             NullLogger<BundleNuGetService>.Instance);
 
         var restoreRoot = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "packages", "restore");

--- a/tests/Aspire.Cli.Tests/Packaging/TemporaryNuGetConfigTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/TemporaryNuGetConfigTests.cs
@@ -108,4 +108,20 @@ public class TemporaryNuGetConfigTests
         var packageSourceMappingNode = xmlDoc.SelectSingleNode("//packageSourceMapping");
         Assert.Null(packageSourceMappingNode);
     }
+
+    [Fact]
+    public async Task CreateAsync_WithConfiguredGlobalPackagesFolder_AddsConfigEntry()
+    {
+        using var tempConfig = await TemporaryNuGetConfig.CreateAsync(
+            [new PackageMapping("Aspire.*", "https://example.com/feed")],
+            configureGlobalPackagesFolder: true);
+
+        var configContent = await File.ReadAllTextAsync(tempConfig.ConfigFile.FullName);
+        var xmlDoc = new XmlDocument();
+        xmlDoc.LoadXml(configContent);
+
+        var globalPackagesFolder = xmlDoc.SelectSingleNode("//config/add[@key='globalPackagesFolder']");
+        Assert.NotNull(globalPackagesFolder);
+        Assert.Equal(".nugetpackages", globalPackagesFolder!.Attributes!["value"]!.Value);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -9,7 +9,6 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
-using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Tests.Projects;
 
@@ -152,13 +151,14 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void Constructor_UsesUserAspireDirectoryForWorkingDirectory()
+    public void Constructor_UsesWorkspaceAspireDirectoryForWorkingDirectory()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDirectory = workspace.CreateDirectory("apphost");
 
         var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), TestExecutionContextFactory.CreateTestContext(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
         var server = new PrebuiltAppHostServer(
-            workspace.WorkspaceRoot.FullName,
+            appHostDirectory.FullName,
             "test.sock",
             new LayoutConfiguration(),
             nugetService,
@@ -173,7 +173,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
                 .GetField("_workingDirectory", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
                 .GetValue(server));
 
-        var rootDirectory = Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "bundle-hosts");
+        var rootDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "bundle-hosts");
         var isUnderRoot = workingDirectory.StartsWith(rootDirectory, StringComparison.OrdinalIgnoreCase);
         var parentDirectory = Path.GetDirectoryName(workingDirectory);
         var isDirectChildOfRoot = parentDirectory is not null &&

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -203,6 +203,8 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         var nugetService = new BundleNuGetService(
             new NullLayoutDiscovery(),
             new LayoutProcessRunner(new TestProcessExecutionFactory()),
+            new TestFeatures(),
+            TestExecutionContextFactory.CreateTestContext(),
             Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
 
         PrebuiltAppHostServer CreateServer(string appHostDirectory) => new(
@@ -212,7 +214,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             nugetService,
             new TestDotNetCliRunner(),
             new TestDotNetSdkInstaller(),
-            new Aspire.Cli.Tests.Mcp.MockPackagingService(),
+            Aspire.Cli.Tests.Mcp.MockPackagingServiceFactory.Create(),
             new TestConfigurationService(),
             Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
 

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -194,6 +194,57 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void Constructor_UsesDistinctWorkingDirectoriesForMultipleAppHostsInSameWorkspace()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var firstAppHost = workspace.CreateDirectory(Path.Combine("apps", "api"));
+        var secondAppHost = workspace.CreateDirectory(Path.Combine("apps", "web"));
+
+        var nugetService = new BundleNuGetService(
+            new NullLayoutDiscovery(),
+            new LayoutProcessRunner(new TestProcessExecutionFactory()),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
+
+        PrebuiltAppHostServer CreateServer(string appHostDirectory) => new(
+            appHostDirectory,
+            "test.sock",
+            new LayoutConfiguration(),
+            nugetService,
+            new TestDotNetCliRunner(),
+            new TestDotNetSdkInstaller(),
+            new Aspire.Cli.Tests.Mcp.MockPackagingService(),
+            new TestConfigurationService(),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+        var firstServer = CreateServer(firstAppHost.FullName);
+        var secondServer = CreateServer(secondAppHost.FullName);
+
+        var workingDirectoryField = typeof(PrebuiltAppHostServer)
+            .GetField("_workingDirectory", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var firstWorkingDirectory = Assert.IsType<string>(workingDirectoryField.GetValue(firstServer));
+        var secondWorkingDirectory = Assert.IsType<string>(workingDirectoryField.GetValue(secondServer));
+
+        var bundleHostsRoot = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "bundle-hosts");
+
+        try
+        {
+            Assert.StartsWith(bundleHostsRoot, firstWorkingDirectory, StringComparison.OrdinalIgnoreCase);
+            Assert.StartsWith(bundleHostsRoot, secondWorkingDirectory, StringComparison.OrdinalIgnoreCase);
+            Assert.NotEqual(firstWorkingDirectory, secondWorkingDirectory);
+        }
+        finally
+        {
+            foreach (var dir in new[] { firstWorkingDirectory, secondWorkingDirectory })
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+        }
+    }
+
+    [Fact]
     public async Task ResolveChannelNameAsync_UsesProjectLocalAspireConfig_NotGlobalChannel()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Scaffolding;
+
+namespace Aspire.Cli.Tests.Scaffolding;
+
+public class ScaffoldingServiceTests
+{
+    [Fact]
+    public void GetConflictingScaffoldFiles_IgnoresGitIgnoreButReturnsOtherExistingFiles()
+    {
+        var rootDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            File.WriteAllText(Path.Combine(rootDirectory.FullName, ".gitignore"), "node_modules/\n");
+            File.WriteAllText(Path.Combine(rootDirectory.FullName, "package.json"), "{}");
+
+            var conflicts = ScaffoldingService.GetConflictingScaffoldFiles(
+                rootDirectory.FullName,
+                [".gitignore", "package.json", "apphost.ts"]);
+
+            Assert.Equal(["package.json"], conflicts);
+        }
+        finally
+        {
+            rootDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MergeGitIgnoreContent_AppendsMissingEntriesWithoutOverwritingExistingContent()
+    {
+        var existingContent = "node_modules/\ncustom/\n";
+        var scaffoldContent = "node_modules/\n.modules/\ndist/\n/.aspire/\n";
+
+        var mergedContent = ScaffoldingService.MergeGitIgnoreContent(existingContent, scaffoldContent);
+        var lines = mergedContent.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        Assert.Equal(
+            ["node_modules/", "custom/", ".modules/", "dist/", "/.aspire/"],
+            lines);
+    }
+
+    [Fact]
+    public void MergeGitIgnoreContent_DoesNotAddRootAspireEntryWhenLegacyEntryAlreadyExists()
+    {
+        var existingContent = ".aspire/\n";
+        var scaffoldContent = "/.aspire/\n";
+
+        var mergedContent = ScaffoldingService.MergeGitIgnoreContent(existingContent, scaffoldContent);
+
+        Assert.Equal(existingContent, mergedContent);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
@@ -33,21 +33,21 @@ public class ScaffoldingServiceTests
     public void MergeGitIgnoreContent_AppendsMissingEntriesWithoutOverwritingExistingContent()
     {
         var existingContent = "node_modules/\ncustom/\n";
-        var scaffoldContent = "node_modules/\n.modules/\ndist/\n/.aspire/\n";
+        var scaffoldContent = "node_modules/\n.modules/\ndist/\n.aspire/\n";
 
         var mergedContent = ScaffoldingService.MergeGitIgnoreContent(existingContent, scaffoldContent);
         var lines = mergedContent.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         Assert.Equal(
-            ["node_modules/", "custom/", ".modules/", "dist/", "/.aspire/"],
+            ["node_modules/", "custom/", ".modules/", "dist/", ".aspire/"],
             lines);
     }
 
     [Fact]
-    public void MergeGitIgnoreContent_DoesNotAddRootAspireEntryWhenLegacyEntryAlreadyExists()
+    public void MergeGitIgnoreContent_DoesNotAddDuplicateAspireEntryWhenEquivalentEntryAlreadyExists()
     {
-        var existingContent = ".aspire/\n";
-        var scaffoldContent = "/.aspire/\n";
+        var existingContent = "/.aspire/\n";
+        var scaffoldContent = ".aspire/\n";
 
         var mergedContent = ScaffoldingService.MergeGitIgnoreContent(existingContent, scaffoldContent);
 

--- a/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
@@ -8,7 +8,7 @@ namespace Aspire.Cli.Tests.Scaffolding;
 public class ScaffoldingServiceTests
 {
     [Fact]
-    public void GetConflictingScaffoldFiles_IgnoresGitIgnoreButReturnsOtherExistingFiles()
+    public void GetConflictingScaffoldFiles_IgnoresMergeableFilesButReturnsOtherExistingFiles()
     {
         var rootDirectory = Directory.CreateTempSubdirectory();
 
@@ -16,12 +16,13 @@ public class ScaffoldingServiceTests
         {
             File.WriteAllText(Path.Combine(rootDirectory.FullName, ".gitignore"), "node_modules/\n");
             File.WriteAllText(Path.Combine(rootDirectory.FullName, "package.json"), "{}");
+            File.WriteAllText(Path.Combine(rootDirectory.FullName, "apphost.ts"), string.Empty);
 
             var conflicts = ScaffoldingService.GetConflictingScaffoldFiles(
                 rootDirectory.FullName,
                 [".gitignore", "package.json", "apphost.ts"]);
 
-            Assert.Equal(["package.json"], conflicts);
+            Assert.Equal(["apphost.ts"], conflicts);
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/Templating/TemplateGitIgnoreTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateGitIgnoreTests.cs
@@ -15,8 +15,8 @@ public class TemplateGitIgnoreTests
 
         Assert.True(File.Exists(filePath), $"Expected template .gitignore at {filePath}");
 
-        var content = File.ReadAllText(filePath);
-        Assert.Contains(".aspire/", content, StringComparison.Ordinal);
+        var lines = File.ReadAllLines(filePath);
+        Assert.Contains("/.aspire/", lines);
     }
 
     private static string GetRepoRoot()

--- a/tests/Aspire.Cli.Tests/Templating/TemplateGitIgnoreTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateGitIgnoreTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Tests.Templating;
+
+public class TemplateGitIgnoreTests
+{
+    [Theory]
+    [InlineData("src\\Aspire.Cli\\Templating\\Templates\\ts-starter\\.gitignore")]
+    [InlineData("src\\Aspire.Cli\\Templating\\Templates\\py-starter\\.gitignore")]
+    [InlineData("src\\Aspire.Cli\\Templating\\Templates\\java-starter\\.gitignore")]
+    public void StarterTemplates_IgnoreWorkspaceAspireDirectory(string relativePath)
+    {
+        var filePath = Path.Combine(GetRepoRoot(), relativePath);
+
+        Assert.True(File.Exists(filePath), $"Expected template .gitignore at {filePath}");
+
+        var content = File.ReadAllText(filePath);
+        Assert.Contains(".aspire/", content, StringComparison.Ordinal);
+    }
+
+    private static string GetRepoRoot()
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+}

--- a/tests/Aspire.Cli.Tests/Templating/TemplateGitIgnoreTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateGitIgnoreTests.cs
@@ -6,12 +6,12 @@ namespace Aspire.Cli.Tests.Templating;
 public class TemplateGitIgnoreTests
 {
     [Theory]
-    [InlineData("src\\Aspire.Cli\\Templating\\Templates\\ts-starter\\.gitignore")]
-    [InlineData("src\\Aspire.Cli\\Templating\\Templates\\py-starter\\.gitignore")]
-    [InlineData("src\\Aspire.Cli\\Templating\\Templates\\java-starter\\.gitignore")]
-    public void StarterTemplates_IgnoreWorkspaceAspireDirectory(string relativePath)
+    [InlineData("ts-starter")]
+    [InlineData("py-starter")]
+    [InlineData("java-starter")]
+    public void StarterTemplates_IgnoreWorkspaceAspireDirectory(string templateName)
     {
-        var filePath = Path.Combine(GetRepoRoot(), relativePath);
+        var filePath = Path.Combine(GetRepoRoot(), "src", "Aspire.Cli", "Templating", "Templates", templateName, ".gitignore");
 
         Assert.True(File.Exists(filePath), $"Expected template .gitignore at {filePath}");
 

--- a/tests/Aspire.Cli.Tests/Templating/TemplateGitIgnoreTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateGitIgnoreTests.cs
@@ -16,7 +16,7 @@ public class TemplateGitIgnoreTests
         Assert.True(File.Exists(filePath), $"Expected template .gitignore at {filePath}");
 
         var lines = File.ReadAllLines(filePath);
-        Assert.Contains("/.aspire/", lines);
+        Assert.Contains(".aspire/", lines);
     }
 
     private static string GetRepoRoot()


### PR DESCRIPTION
## Summary

Stores all polyglot/bundled CLI artifacts under a workspace-local `<workspace>/.aspire/` directory instead of the user-profile `~/.aspire/` directory, and makes polyglot scaffolding safe against pre-existing files.

### Workspace root resolution

- Adds `ConfigurationHelper.GetConfigRootDirectory(...)` and `ConfigurationHelper.GetWorkspaceAspireDirectory(...)` that walk upward from a starting directory to the nearest `aspire.config.json` (or legacy `.aspire/settings.json`) and return the containing workspace root plus its `.aspire` directory. When no config file is found the starting directory is treated as the workspace.
- `GuestAppHostProject` now delegates to the shared helper instead of duplicating the walk logic.

### Workspace-local CLI artifacts

- `PrebuiltAppHostServer` stages prebuilt AppHost working directories under `<workspace>/.aspire/bundle-hosts/<sha12(appHostDirectory)>`. The per-apphost SHA keeps multiple AppHosts in the same workspace isolated (e.g. `apps/api` and `apps/web`).
- `BundleNuGetService` stores restore output under `<workspace>/.aspire/packages/restore/<packageHash>`. The hash keys on package set, TFM, RID, managed-tool fingerprint, and sources, so identical package sets across AppHosts in the same workspace share the cache, while different sets or feeds are isolated.
- `INuGetService.RestorePackagesAsync` now requires a `workingDirectory`; the previous `~/.aspire/packages` fallback has been removed so restore artifacts are always workspace-local.

### Staging restore isolation (addresses #15399)

- `PrebuiltAppHostServer` materializes a temporary `nuget.config` for explicit packaging channels and flows it through the new `nugetConfigPath` parameter on `RestorePackagesAsync`, so bundled restore honors channel mappings and doesn't silently fall back to unmapped sources. Failures to materialize the config surface instead of being swallowed.
- `TemporaryNuGetConfig.CreateAsync` gains a `configureGlobalPackagesFolder` option and cleans up its temp directory if config generation fails.
- `BundleNuGetService.ComputePackageHash` includes sources so same-version packages from different feeds no longer collide in the restore cache.

### Polyglot scaffolding safety

- `ScaffoldingService` now detects pre-existing non-mergeable scaffold files (e.g. `apphost.ts`) before writing and aborts with `ProjectAlreadyExists` instead of overwriting them.
- Existing root `.gitignore` and `package.json` files are merged (not overwritten). The `.gitignore` merge normalizes leading-slash entries so rooted/unrooted forms of the same pattern (e.g. `/node_modules/` vs `node_modules/`) dedupe correctly.

### Generated `.gitignore` entries

- TypeScript, Python, and Java language generators now emit a project-root `.gitignore` that includes `.aspire/` (alongside `.modules/`, `node_modules/`, `dist/`, `.venv/`, `.java-build/` as appropriate for each language).
- Matching starter templates (`ts-starter`, `py-starter`, `java-starter`) ship the same `.gitignore` so freshly scaffolded projects keep the workspace-local artifact folder untracked by default.
- The root `.gitignore` entry is `.aspire/` (unrooted), by design: generated projects live at the workspace root, and ignoring the unrooted form matches other standard entries like `node_modules/`.

## Testing

- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj` — focused on the touched areas:
  - `Aspire.Cli.Tests.NuGet.BundleNuGetServiceTests` — workspace-local restore root, source-aware hashing, explicit `--nuget-config` flow, shared cache across AppHosts in one workspace, isolation between different package sets.
  - `Aspire.Cli.Tests.Packaging.TemporaryNuGetConfigTests` — `configureGlobalPackagesFolder` writes the expected `<config>` entry.
  - `Aspire.Cli.Tests.Projects.PrebuiltAppHostServerTests` — workspace-local `bundle-hosts` root, distinct working directories for multiple AppHosts in one workspace, project-local channel resolution.
  - `Aspire.Cli.Tests.Scaffolding.ScaffoldingServiceTests` — conflict detection ignores mergeable files, `.gitignore` merge appends missing entries, rooted/unrooted equivalence.
  - `Aspire.Cli.Tests.Templating.TemplateGitIgnoreTests` — starter templates include `.aspire/`.
  - `Aspire.Cli.Tests.Configuration.ConfigurationHelperTests` — config-root walk and workspace `.aspire` resolution.
- `dotnet build tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj` — E2E tests added/updated to assert a project-root `.gitignore` containing `.aspire/` for the TypeScript starter, TypeScript empty, Python React, and Java empty templates.

Fixes #15967.
Addresses #15399.
