### PR TITLE
Use Spectre.Console built-in choices for confirm prompt styling

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -441,14 +441,13 @@ internal class ConsoleInteractionService : IInteractionService
         MessageLogger.LogInformation("Confirm: {PromptText} (default: {DefaultValue})", promptText, defaultValue);
 
         // Use [Y/n] or [y/N] convention where the capitalized letter indicates the default value.
-        // Double brackets [[ ]] are used to escape literal brackets in Spectre.Console markup.
-        var yesChoice = defaultValue ? "Y" : "y";
-        var noChoice = defaultValue ? "n" : "N";
-        var fullPromptText = $"{promptText} [[{yesChoice}/{noChoice}]]";
+        var yesChoice = defaultValue ? 'Y' : 'y';
+        var noChoice = defaultValue ? 'n' : 'N';
 
-        var prompt = new ConfirmationPrompt(fullPromptText)
+        var prompt = new ConfirmationPrompt(promptText)
         {
-            ShowChoices = false,
+            Yes = yesChoice,
+            No = noChoice,
             ShowDefaultValue = false,
             DefaultValue = defaultValue,
         };


### PR DESCRIPTION
## Description

Use Spectre.Console's built-in `Yes` and `No` properties on `ConfirmationPrompt` to control the confirm prompt choice styling (e.g., `[Y/n]` or `[y/N]`), instead of manually formatting the choices into the prompt text with escaped brackets and hiding the built-in choices display.

This simplifies the code and lets Spectre.Console handle rendering the choices consistently.

13.2:
<img width="1004" height="52" alt="image" src="https://github.com/user-attachments/assets/04d3b65d-3002-4234-ba57-fff02d74629a" />

main:
<img width="901" height="43" alt="image" src="https://github.com/user-attachments/assets/538cd2d6-e90b-4232-99f8-bf97256db8e6" />

PR:
<img width="951" height="65" alt="image" src="https://github.com/user-attachments/assets/fc3973e9-db37-4ab6-97a4-819343530a6e" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
