### PR TITLE
Fix pr-docs-check: remove invalid discussions permission

### DIFF
--- a/.github/workflows/pr-docs-check.lock.yml
+++ b/.github/workflows/pr-docs-check.lock.yml
@@ -921,7 +921,6 @@ jobs:
     if: always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
-      discussions: write
       issues: write
     concurrency:
       group: "gh-aw-conclusion-pr-docs-check"
@@ -950,7 +949,6 @@ jobs:
             aspire.dev
             aspire
           github-api-url: ${{ github.api_url }}
-          permission-discussions: write
           permission-issues: write
       - name: Download agent output artifact
         id: download-agent-output
@@ -1242,7 +1240,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
@@ -1305,7 +1302,6 @@ jobs:
             aspire
           github-api-url: ${{ github.api_url }}
           permission-contents: write
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Checkout repository

--- a/.github/workflows/pr-docs-check.md
+++ b/.github/workflows/pr-docs-check.md
@@ -76,6 +76,10 @@ safe-outputs:
     fallback-as-issue: true
   add-comment:
     target-repo: "microsoft/aspire"
+    # Note: The compiler adds 'discussions: write' permission which is not a valid
+    # GitHub Apps API scope and breaks token minting. After any recompile, manually
+    # remove 'discussions: write' and 'permission-discussions: write' from the lock
+    # file. Tracked: https://github.com/github/gh-aw/issues/25467
     hide-older-comments: true
 
 timeout-minutes: 20


### PR DESCRIPTION
## Description

Fixes the `pr-docs-check` gh aw workflow that fails on every run due to an invalid `discussions` permission the compiler always emits.

**Root cause**: The `gh aw` compiler (v0.67.2) unconditionally adds `discussions: write` to the conclusion and safe_outputs jobs whenever `add-comment` is configured. The `discussions` scope is **not a valid GitHub Apps API permission**, so `create-github-app-token` fails with HTTP 422: *"The permissions requested are not granted to this installation."*

Setting `discussion: false` on `add-comment` is rejected by the compiler (`value must be true`), confirming this is a compiler bug. Filed upstream: https://github.com/github/gh-aw/issues/25467

**Fix**: Surgically removes **only the 4 invalid lines** from the existing compiled lock file — no recompile, so all fixes from PRs #15923, #15929, #15943, #15960 are preserved:
- 2× `discussions: write` (job-level permissions on conclusion + safe_outputs)
- 2× `permission-discussions: write` (token inputs on conclusion + safe_outputs)

**Also adds**:
- `.github/aw/patch-lock.sh` — helper script to re-apply this patch after future `gh aw compile` runs
- Comment in the `.md` source documenting the workaround

**Failed run this fixes** (most recent):
- https://github.com/microsoft/aspire/actions/runs/24149802519/job/70474846900

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
