### PR TITLE
Stabilize ConfigurationSchema line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -48,6 +48,7 @@
 *.fsx text=auto
 *.hs text=auto
 *.json text=auto
+src/Components/**/ConfigurationSchema.json text eol=lf
 
 *.csproj text=auto
 *.vbproj text=auto

--- a/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaGenerator.cs
+++ b/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaGenerator.cs
@@ -32,10 +32,13 @@ public partial class ConfigSchemaGenerator
             var emitter = new ConfigSchemaEmitter(spec, compilation);
             var schema = emitter.GenerateSchema();
 
-            if (!schema.EndsWith(Environment.NewLine))
+            // Keep generated schemas stable across platforms and aligned with the checked-in JSON files.
+            schema = schema.ReplaceLineEndings("\n");
+
+            if (schema.Length == 0 || schema[^1] != '\n')
             {
-                // Ensure the file always ends in a newline to stop certain text editors from injecting it
-                schema += Environment.NewLine;
+                // Ensure the file always ends in a newline to stop certain text editors from injecting it.
+                schema += '\n';
             }
 
             File.WriteAllText(outputFile, schema);

--- a/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -1598,8 +1598,11 @@ public partial class GeneratorTests
             referenceAssemblies,
             outputPath);
 
+        var actual = File.ReadAllText(outputPath);
+        Assert.DoesNotContain("\r", actual);
+
         // Compare the two, normalizing line endings.
-        var actual = File.ReadAllText(outputPath).ReplaceLineEndings();
+        actual = actual.ReplaceLineEndings();
         var baseline = File.ReadAllText(Path.Combine("Baselines", "IntegrationTest.baseline.json")).ReplaceLineEndings();
         Assert.Equal(baseline, actual);
     }


### PR DESCRIPTION
## Summary
- emit canonical LF line endings from `ConfigurationSchemaGenerator`
- add a regression test that locks generated schema output to CR-free LF
- force checked-in component `ConfigurationSchema.json` artifacts to check out as LF on Windows

## Problem
`ConfigurationSchema.json` is a checked-in generated artifact, and component builds compare the generated file to the checked-in file as raw text in `src/Components/Directory.Build.targets`.

This surfaced as Windows CI failures in component project builds such as:
- `src/Components/Aspire.MongoDB.EntityFrameworkCore/Aspire.MongoDB.EntityFrameworkCore.csproj`
- `src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj`

These failures were **not** caused by semantically stale schema payloads. The JSON content already stored in git was correct. The mismatch came from line-ending handling in two different places:

1. `ConfigurationSchemaGenerator` appended `Environment.NewLine` and wrote platform-dependent output, so the generated bytes varied by OS.
2. `*.json text=auto` still allowed Windows checkouts to materialize existing `ConfigurationSchema.json` files as CRLF in the worktree, even when the committed blob was LF.

Because the build compares raw file text, either difference was enough to produce a false `ConfigurationSchema.json is out of date` failure.

## Why each file changed

### `src/Tools/ConfigurationSchemaGenerator/ConfigSchemaGenerator.cs`
- normalizes generated schema text to LF and preserves a single trailing LF
- fixes the generator side of the mismatch so emitted schema artifacts are deterministic across Windows, Linux, and macOS

### `tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs`
- adds an explicit assertion that generated schema files contain no `\r`
- protects against regressions where schema content still matches semantically but platform-specific line endings creep back into the generated output

### `.gitattributes`
- forces `src/Components/**/ConfigurationSchema.json` to use `eol=lf`
- fixes the checkout side of the mismatch so Windows worktrees do not rewrite these canonical generated artifacts to CRLF before comparison

## Why no `ConfigurationSchema.json` files changed
After normalizing both generation and checkout policy, the tracked schema artifacts were already at the correct canonical content. The CI failures were caused by Windows-specific line-ending transformation in the working tree, not by stale schema definitions that needed regeneration and check-in.

## Validation
- `./build.cmd -build /p:SkipNativeBuild=true /p:TreatWarningsAsErrors=false`
- `./.dotnet/dotnet.exe test ./tests/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- simulated a Windows `core.autocrlf=true` checkout and built the previously failing component projects:
  - `src/Components/Aspire.MongoDB.EntityFrameworkCore/Aspire.MongoDB.EntityFrameworkCore.csproj`
  - `src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj`