### PR TITLE
Rename NameOutput to NameOutputReference in Aspire.Hosting.Azure.Network

### DIFF
--- a/src/Aspire.Hosting.Azure.Network/Aspire.Hosting.Azure.Network.csproj
+++ b/src/Aspire.Hosting.Azure.Network/Aspire.Hosting.Azure.Network.csproj
@@ -6,7 +6,6 @@
     <PackageTags>aspire integration hosting azure network vnet virtual-network subnet nat-gateway public-ip cloud</PackageTags>
     <Description>Azure Virtual Network resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <NoWarn>$(NoWarn);AZPROVISION001;ASPIREAZURE003</NoWarn>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Azure.Network/Aspire.Hosting.Azure.Network.csproj
+++ b/src/Aspire.Hosting.Azure.Network/Aspire.Hosting.Azure.Network.csproj
@@ -6,6 +6,7 @@
     <PackageTags>aspire integration hosting azure network vnet virtual-network subnet nat-gateway public-ip cloud</PackageTags>
     <Description>Azure Virtual Network resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <NoWarn>$(NoWarn);AZPROVISION001;ASPIREAZURE003</NoWarn>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Azure.Network/AzureNatGatewayResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureNatGatewayResource.cs
@@ -27,7 +27,7 @@ public class AzureNatGatewayResource(string name, Action<AzureResourceInfrastruc
     /// <summary>
     /// Gets the "name" output reference for the resource.
     /// </summary>
-    public BicepOutputReference NameOutput => new("name", this);
+    public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <summary>
     /// Gets the list of explicit Public IP Address resources associated with this NAT Gateway.
@@ -51,7 +51,7 @@ public class AzureNatGatewayResource(string name, Action<AzureResourceInfrastruc
 
         if (!TryApplyExistingResourceAnnotation(this, infra, natGw))
         {
-            natGw.Name = NameOutput.AsProvisioningParameter(infra);
+            natGw.Name = NameOutputReference.AsProvisioningParameter(infra);
         }
 
         infra.Add(natGw);

--- a/src/Aspire.Hosting.Azure.Network/AzureNetworkSecurityGroupResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureNetworkSecurityGroupResource.cs
@@ -27,7 +27,7 @@ public class AzureNetworkSecurityGroupResource(string name, Action<AzureResource
     /// <summary>
     /// Gets the "name" output reference for the resource.
     /// </summary>
-    public BicepOutputReference NameOutput => new("name", this);
+    public BicepOutputReference NameOutputReference => new("name", this);
 
     internal bool IsImplicitlyCreated { get; set; }
 
@@ -50,7 +50,7 @@ public class AzureNetworkSecurityGroupResource(string name, Action<AzureResource
 
         if (!TryApplyExistingResourceAnnotation(this, infra, nsg))
         {
-            nsg.Name = NameOutput.AsProvisioningParameter(infra);
+            nsg.Name = NameOutputReference.AsProvisioningParameter(infra);
         }
 
         infra.Add(nsg);

--- a/src/Aspire.Hosting.Azure.Network/AzurePrivateDnsZoneResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzurePrivateDnsZoneResource.cs
@@ -37,7 +37,7 @@ internal sealed class AzurePrivateDnsZoneResource : AzureProvisioningResource
     /// <summary>
     /// Gets the "name" output reference from the Private DNS Zone resource.
     /// </summary>
-    public BicepOutputReference NameOutput => new("name", this);
+    public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <summary>
     /// Tracks VNet Links for this DNS Zone, keyed by VNet resource.
@@ -66,7 +66,7 @@ internal sealed class AzurePrivateDnsZoneResource : AzureProvisioningResource
             infra,
             dnsZone))
         {
-            dnsZone.Name = NameOutput.AsProvisioningParameter(infra);
+            dnsZone.Name = NameOutputReference.AsProvisioningParameter(infra);
         }
 
         infra.Add(dnsZone);

--- a/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs
@@ -99,7 +99,7 @@ public static class AzurePrivateEndpointExtensions
             var dnsZone = azureResource.DnsZone!;
             var dnsZoneIdentifier = dnsZone.GetBicepIdentifier();
             var privateDnsZone = PrivateDnsZone.FromExisting(dnsZoneIdentifier);
-            privateDnsZone.Name = dnsZone.NameOutput.AsProvisioningParameter(infra);
+            privateDnsZone.Name = dnsZone.NameOutputReference.AsProvisioningParameter(infra);
             infra.Add(privateDnsZone);
 
             // Create the Private Endpoint

--- a/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointResource.cs
@@ -28,7 +28,7 @@ public class AzurePrivateEndpointResource(
     /// <summary>
     /// Gets the "name" output reference for the resource.
     /// </summary>
-    public BicepOutputReference NameOutput => new("name", this);
+    public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <summary>
     /// Gets the subnet where the private endpoint will be created.
@@ -67,7 +67,7 @@ public class AzurePrivateEndpointResource(
             infra,
             endpoint))
         {
-            endpoint.Name = NameOutput.AsProvisioningParameter(infra);
+            endpoint.Name = NameOutputReference.AsProvisioningParameter(infra);
         }
 
         infra.Add(endpoint);

--- a/src/Aspire.Hosting.Azure.Network/AzurePublicIPAddressResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzurePublicIPAddressResource.cs
@@ -26,7 +26,7 @@ public class AzurePublicIPAddressResource(string name, Action<AzureResourceInfra
     /// <summary>
     /// Gets the "name" output reference for the resource.
     /// </summary>
-    public BicepOutputReference NameOutput => new("name", this);
+    public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <summary>
     /// Gets the "ipAddress" output reference containing the allocated IP address for the resource.
@@ -50,7 +50,7 @@ public class AzurePublicIPAddressResource(string name, Action<AzureResourceInfra
 
         if (!TryApplyExistingResourceAnnotation(this, infra, pip))
         {
-            pip.Name = NameOutput.AsProvisioningParameter(infra);
+            pip.Name = NameOutputReference.AsProvisioningParameter(infra);
         }
 
         infra.Add(pip);

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkResource.cs
@@ -43,7 +43,7 @@ public class AzureVirtualNetworkResource(string name, Action<AzureResourceInfras
     /// <summary>
     /// Gets the "name" output reference for the resource.
     /// </summary>
-    public BicepOutputReference NameOutput => new("name", this);
+    public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureVirtualNetworkResource"/> class with a string address prefix.
@@ -92,7 +92,7 @@ public class AzureVirtualNetworkResource(string name, Action<AzureResourceInfras
             infra,
             vnet))
         {
-            vnet.Name = NameOutput.AsProvisioningParameter(infra);
+            vnet.Name = NameOutputReference.AsProvisioningParameter(infra);
         }
 
         infra.Add(vnet);


### PR DESCRIPTION
## Description

Rename `NameOutput` properties to `NameOutputReference` across all Azure Network resource types in `Aspire.Hosting.Azure.Network` to be consistent with the naming convention used by all other Azure hosting integrations (e.g. CosmosDB, Redis, Storage, KeyVault, ServiceBus, etc.).

This is acceptable breaking change because this library has an Experimental attribute on it:

https://github.com/microsoft/aspire/blob/a50892b3e6b824ed4be4d6bc940b6a3dfdc92553/src/Aspire.Hosting.Azure.Network/AssemblyInfo.cs#L6

Updated files:
- `AzureNatGatewayResource.cs`
- `AzureNetworkSecurityGroupResource.cs`
- `AzurePrivateDnsZoneResource.cs`
- `AzurePrivateEndpointResource.cs`
- `AzurePrivateEndpointExtensions.cs`
- `AzurePublicIPAddressResource.cs`
- `AzureVirtualNetworkResource.cs`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
