### PR TITLE
Fix issue 15806 ("aspire stop" is not cleaning up application containers)

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -129,6 +129,7 @@
     <Compile Include="$(SharedDir)ConsoleLogs\SharedAIHelpers.cs" Link="ConsoleLogs\SharedAIHelpers.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\TimestampParser.cs" Link="ConsoleLogs\TimestampParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\UrlParser.cs" Link="ConsoleLogs\UrlParser.cs" />
+    <Compile Include="$(SharedDir)ProcessSignaler.cs" Link="Utils\ProcessSignaler.cs" />
     <Compile Include="$(SharedDir)NpmVersionHelper.cs" Link="Utils\NpmVersionHelper.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
@@ -193,16 +192,12 @@ internal sealed class StopCommand : BaseCommand
 
         _interactionService.DisplayMessage(KnownEmojis.StopSign, "Sending stop signal...");
 
-        // Get the CLI process ID - this is the process we need to kill
-        // Killing the CLI process will tear down everything including the AppHost
-        var cliProcessId = appHostInfo?.CliProcessId;
-
-        if (cliProcessId is int cliPid)
+        if (appHostInfo?.CliProcessId is int cliPid)
         {
             _logger.LogDebug("Sending stop signal to CLI process (PID {Pid})", cliPid);
             try
             {
-                SendStopSignal(cliPid);
+                SendStopSignal(cliPid, appHostInfo?.CliStartedAt);
             }
             catch (Exception ex)
             {
@@ -213,55 +208,55 @@ internal sealed class StopCommand : BaseCommand
         }
         else
         {
-            // Fallback: Try the RPC method if we don't have CLI process ID
+            // Fallback: Try the RPC method if we don't have CLI process ID.
             _logger.LogDebug("No CLI process ID available, trying RPC stop");
             var rpcSucceeded = false;
             try
             {
                 rpcSucceeded = await connection.StopAppHostAsync(cancellationToken).ConfigureAwait(false);
+                if (!rpcSucceeded)
+                {
+                    _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
+                    return ExitCodeConstants.FailedToDotnetRunAppHost;
+                }
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to send stop signal via RPC");
             }
-
-            // If RPC didn't work, try sending SIGINT to AppHost process directly
-            if (!rpcSucceeded && appHostInfo?.ProcessId is int appHostPid)
-            {
-                _logger.LogDebug("RPC stop not available, sending SIGINT to AppHost PID {Pid}", appHostPid);
-                try
-                {
-                    SendStopSignal(appHostPid);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to send stop signal to process {Pid}", appHostPid);
-                    _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
-                    return ExitCodeConstants.FailedToDotnetRunAppHost;
-                }
-            }
-            else if (!rpcSucceeded)
-            {
-                _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
-                return ExitCodeConstants.FailedToDotnetRunAppHost;
-            }
         }
 
+        var manager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
         var stopped = await _interactionService.ShowStatusAsync(
             StopCommandStrings.StoppingAppHost,
             async () =>
             {
                 try
                 {
-                    // Wait for processes to terminate
-                    var manager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
-
-                    if (appHostInfo is not null)
+                    if (appHostInfo is null)
                     {
-                        return await manager.MonitorProcessesForTerminationAsync(appHostInfo, cancellationToken).ConfigureAwait(false);
+                        return true;
                     }
 
-                    return true;
+                    if (await manager.MonitorProcessesForTerminationAsync(appHostInfo, cancellationToken).ConfigureAwait(false))
+                    {
+                        return true;
+                    }
+
+                    var procsToKill = new HashSet<(int, DateTimeOffset?)> { (appHostInfo.ProcessId, appHostInfo.StartedAt) };
+
+                    if (appHostInfo.CliProcessId is int cliPid)
+                    {
+                        procsToKill.Add((cliPid, appHostInfo.CliStartedAt));
+                    }
+
+                    foreach (var (pid, startTime) in procsToKill)
+                    {
+                        _logger.LogWarning("AppHost did not stop gracefully within timeout. Forcing process {Pid} to terminate.", pid);
+                        ForceKillProcess(pid, startTime);
+                    }
+
+                    return await manager.MonitorProcessesForTerminationAsync(appHostInfo, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -286,28 +281,21 @@ internal sealed class StopCommand : BaseCommand
     }
 
     /// <summary>
-    /// Sends a stop signal to a process to terminate it and its process tree.
-    /// Uses Process.Kill(entireProcessTree: true) to ensure all child processes are terminated.
+    /// Sends a best-effort graceful shutdown signal to the target process.
+    /// Uses Ctrl-C on Windows and SIGTERM on non-Windows.
     /// </summary>
-    private static void SendStopSignal(int pid)
+    private void SendStopSignal(int pid, DateTimeOffset? startTime)
     {
-        try
-        {
-            using var process = Process.GetProcessById(pid);
-            process.Kill(entireProcessTree: true);
-        }
-        catch (ArgumentException)
-        {
-            // Process doesn't exist - already terminated
-        }
-        catch (InvalidOperationException)
-        {
-            // Process has already exited
-        }
-        catch (Exception)
-        {
-            // Some other error (e.g., permission denied) - ignore
-        }
+        ProcessSignaler.RequestGracefulShutdown(pid, startTime, _logger);
+    }
+
+    /// <summary>
+    /// Forcefully kills the target process after the graceful shutdown timeout elapses.
+    /// This does not terminate the entire process tree.
+    /// </summary>
+    private void ForceKillProcess(int pid, DateTimeOffset? startTime)
+    {
+        ProcessSignaler.ForceKill(pid, startTime, _logger);
     }
 
 }

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -214,15 +214,31 @@ internal sealed class StopCommand : BaseCommand
             try
             {
                 rpcSucceeded = await connection.StopAppHostAsync(cancellationToken).ConfigureAwait(false);
-                if (!rpcSucceeded)
-                {
-                    _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
-                    return ExitCodeConstants.FailedToDotnetRunAppHost;
-                }
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to send stop signal via RPC");
+            }
+
+            // If RPC didn't work, try sending SIGINT to AppHost process directly
+            if (!rpcSucceeded && appHostInfo?.ProcessId is int appHostPid)
+            {
+                _logger.LogDebug("RPC stop not available, sending SIGTERM to AppHost PID {Pid}", appHostPid);
+                try
+                {
+                    SendStopSignal(appHostPid, appHostInfo?.StartedAt);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to send stop signal to process {Pid}", appHostPid);
+                    _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
+                    return ExitCodeConstants.FailedToDotnetRunAppHost;
+                }
+            }
+            else if (!rpcSucceeded)
+            {
+                _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
+                return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
         }
 
@@ -282,7 +298,7 @@ internal sealed class StopCommand : BaseCommand
 
     /// <summary>
     /// Sends a best-effort graceful shutdown signal to the target process.
-    /// Uses Ctrl-C on Windows and SIGTERM on non-Windows.
+    /// Uses Ctrl-Break on Windows and SIGTERM on non-Windows.
     /// </summary>
     private void SendStopSignal(int pid, DateTimeOffset? startTime)
     {

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -77,16 +77,17 @@ internal static partial class DetachedProcessLauncher
 
                     var si = new STARTUPINFOEX();
                     si.cb = Marshal.SizeOf<STARTUPINFOEX>();
-                    si.dwFlags = StartfUseStdHandles;
+                    si.dwFlags = StartfUseStdHandles | StartfUseShowWindow;
                     si.hStdInput = nint.Zero;
                     si.hStdOutput = nulRawHandle;
                     si.hStdError = nulRawHandle;
                     si.lpAttributeList = attrList;
+                    si.wShowWindow = ShowWindowHide;
 
                     // Build the command line string: "fileName" arg1 arg2 ...
                     var commandLine = BuildCommandLine(fileName, arguments);
 
-                    var flags = CreateUnicodeEnvironment | ExtendedStartupInfoPresent | CreateNoWindow;
+                    var flags = CreateUnicodeEnvironment | ExtendedStartupInfoPresent | CreateNewProcessGroup;
 
                     // Build a filtered environment block if variables need to be removed.
                     // CreateProcessW with lpEnvironment=nint.Zero inherits the parent's
@@ -293,9 +294,11 @@ internal static partial class DetachedProcessLauncher
     private const uint OpenExisting = 3;
     private const uint HandleFlagInherit = 0x00000001;
     private const uint StartfUseStdHandles = 0x00000100;
+    private const uint StartfUseShowWindow = 0x00000001;
     private const uint CreateUnicodeEnvironment = 0x00000400;
     private const uint ExtendedStartupInfoPresent = 0x00080000;
-    private const uint CreateNoWindow = 0x08000000;
+    private const uint CreateNewProcessGroup = 0x00000200;
+    private const ushort ShowWindowHide = 0x0000;
     private static readonly nint s_procThreadAttributeHandleList = (nint)0x00020002;
 
     // --- Structs ---

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using Aspire.Cli.Agents;
@@ -680,6 +681,13 @@ public class Program
             cts.Cancel();
             eventArgs.Cancel = true;
         };
+        using var sigTermRegistration = OperatingSystem.IsWindows()
+            ? null
+            : PosixSignalRegistration.Create(PosixSignal.SIGTERM, context =>
+            {
+                cts.Cancel();
+                context.Cancel = true;
+            });
 
         Console.OutputEncoding = Encoding.UTF8;
 
@@ -695,6 +703,7 @@ public class Program
         // Logging the log file path is useful so that when console logging is enabled (for example with --log-level debug),
         // the path is written to the console logger (stderr) for easier discovery.
         logger.LogInformation("Log file: {LogFilePath}", loggingOptions.LogFilePath);
+        logger.LogInformation("CLI process ID: {ProcessId}", Environment.ProcessId);
 
         IHost? app = null;
         try

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -56,6 +56,7 @@
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="UserSecrets\UserSecretsPathHelper.cs" />
     <Compile Include="$(SharedDir)X509Certificate2Extensions.cs" Link="Utils\X509Certificate2Extensions.cs" />
     <Compile Include="$(SharedDir)PasswordGenerator.cs" Link="Utils\PasswordGenerator.cs" />
+    <Compile Include="$(SharedDir)ProcessSignaler.cs" Link="Utils\ProcessSignaler.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -366,13 +366,20 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         {
             cliProcessId = parsedCliPid;
         }
+        DateTimeOffset? cliStartedAt = null;
+        var cliStartedAtString = configuration[KnownConfigNames.CliProcessStarted];
+        if (!string.IsNullOrEmpty(cliStartedAtString) && long.TryParse(cliStartedAtString, out var parsedCliStartedAt))
+        {
+            cliStartedAt = DateTimeOffset.FromUnixTimeSeconds(parsedCliStartedAt);
+        }
 
         return Task.FromResult(new AppHostInformation
         {
             AppHostPath = appHostPath,
             ProcessId = Environment.ProcessId,
             CliProcessId = cliProcessId,
-            StartedAt = new DateTimeOffset(Process.GetCurrentProcess().StartTime)
+            StartedAt = new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+            CliStartedAt = cliStartedAt
         });
     }
 

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -1020,6 +1020,12 @@ internal sealed class AppHostInformation
     /// Gets or sets when the AppHost process started.
     /// </summary>
     public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>
+    /// Gets or sets when the CLI process that launched the AppHost started.
+    /// This value is only set when the AppHost is launched via the Aspire CLI.
+    /// </summary>
+    public DateTimeOffset? CliStartedAt { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
+++ b/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -12,37 +11,14 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 {
     internal Func<int, bool> IsProcessRunning { get; set; } = (int pid) =>
     {
-        try
-        {
-            return !Process.GetProcessById(pid).HasExited;
-        }
-        catch (ArgumentException)
-        {
-            // If Process.GetProcessById throws it means the process in not running.
-            return false;
-        }
+        using var process = ProcessSignaler.TryGetRunningProcess(pid, null, logger);
+        return process is not null;
     };
 
     internal Func<int, long, bool> IsProcessRunningWithStartTime { get; set; } = (int pid, long expectedStartTimeUnix) =>
     {
-        try
-        {
-            var process = Process.GetProcessById(pid);
-            if (process.HasExited)
-            {
-                return false;
-            }
-
-            // Check if the process start time matches the expected start time exactly.
-            var actualStartTimeUnix = ((DateTimeOffset)process.StartTime).ToUnixTimeSeconds();
-            return actualStartTimeUnix == expectedStartTimeUnix;
-        }
-        catch
-        {
-            // If we can't get the process and/or can't get the start time, 
-            // then we interpret both exceptions as the process not being there.
-            return false;
-        }
+        using var process = ProcessSignaler.TryGetRunningProcess(pid, DateTimeOffset.FromUnixTimeSeconds(expectedStartTimeUnix), logger);
+        return process is not null;
     };
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Provides best-effort process signaling for graceful shutdown and forceful termination.
+/// </summary>
+internal static partial class ProcessSignaler
+{
+    public static void RequestGracefulShutdown(int pid, DateTimeOffset? expectedStartTime, ILogger logger)
+    {
+        using var process = TryGetRunningProcess(pid, expectedStartTime, logger);
+        if (process is null)
+        {
+            return; // Process is not running or does not match the expected start time
+        }
+
+        logger.LogDebug("Requesting graceful shutdown of process {Pid}...", pid);
+
+        if (OperatingSystem.IsWindows())
+        {
+            RequestGracefulShutdownWindows(pid, logger);
+        }
+        else
+        {
+            RequestGracefulShutdownUnix(pid, logger);
+        }
+    }
+
+    public static void ForceKill(int pid, DateTimeOffset? expectedStartTime, ILogger logger)
+    {
+        using var process = TryGetRunningProcess(pid, expectedStartTime, logger);
+        if (process is { })
+        {
+            logger.LogDebug("Killing process {Pid}...", pid);
+            process.Kill(entireProcessTree: false);
+        }
+    }
+
+    public static Process? TryGetRunningProcess(int pid, DateTimeOffset? expectedStartTime, ILogger logger)
+    {
+        try
+        {
+            var process = Process.GetProcessById(pid);
+            if (expectedStartTime is not null && !AreClose(expectedStartTime, process.StartTime))
+            {
+                logger.LogDebug("Process {Pid} start time {ProcessStartTime} does not match expected start time {ExpectedStartTime}", pid, process.StartTime, expectedStartTime);
+                process.Dispose();
+                return null; // Do not return processes that do not match the expected start time
+            }
+
+            if (process.HasExited)
+            {
+                process.Dispose();
+                return null;
+            }
+
+            return process;
+        }
+        catch (ArgumentException)
+        {
+            // Process doesn't exist - already terminated.
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            // Process has already exited.
+            return null;
+        }
+    }
+
+    private static bool AreClose(DateTimeOffset? expectedStartTime, DateTime processStartTime, TimeSpan? tolerance = default)
+    {
+        if (expectedStartTime is null)
+        {
+            return true;
+        }
+
+        tolerance ??= TimeSpan.FromMilliseconds(1);
+        return ((DateTimeOffset)expectedStartTime - new DateTimeOffset(processStartTime)).Duration() <= tolerance;
+    }
+
+    private const int SigTerm = 15;
+
+    private static void RequestGracefulShutdownUnix(int pid, ILogger logger)
+    {
+        var result = kill(pid, SigTerm);
+        if (result != 0)
+        {
+            int errno = Marshal.GetLastSystemError();
+            // Best effort.
+            logger.LogWarning("Could not gracefully stop Aspire application host process {Pid}; the error code from signal send operation was {ErrorCode}", pid, errno);
+        }
+    }
+
+    private const uint CtrlBreakEvent = 1;
+
+    private static void RequestGracefulShutdownWindows(int pid, ILogger logger)
+    {
+        var success = GenerateConsoleCtrlEvent(CtrlBreakEvent, (uint)pid);
+        if (!success)
+        {
+            // Best effort.
+            logger.LogWarning("Could not gracefully stop Aspire application host process {Pid}", pid);
+        }
+    }
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, uint dwProcessGroupId);
+
+    // "libc" here is a moniker for standard C library, which .NET maps to system C library on Unix-like systems.
+    // See https://developers.redhat.com/blog/2019/03/25/using-net-pinvoke-for-linux-system-functions
+    [LibraryImport("libc", SetLastError = true, EntryPoint = "kill")]
+    private static partial int kill(int pid, int sig);
+}

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -79,7 +79,7 @@ internal static partial class ProcessSignaler
             return true;
         }
 
-        tolerance ??= TimeSpan.FromMilliseconds(1);
+        tolerance ??= TimeSpan.FromSeconds(1);
         return ((DateTimeOffset)expectedStartTime - new DateTimeOffset(processStartTime)).Duration() <= tolerance;
     }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -56,6 +56,12 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
+        await auto.ClearScreenAsync(counter);
+
+        // Ensure application container is cleaned up (zero containers running)
+        // We expect one container left because the test is running in a container itself
+        await auto.ExecuteCommandUntilOutputAsync(counter, "docker ps --all --format json | wc -l", "1", timeout: TimeSpan.FromMinutes(2));
+
         // Exit the shell
         await auto.TypeAsync("exit");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -20,6 +20,8 @@ public sealed class StartStopTests(ITestOutputHelper output)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var projectSuffix = Guid.NewGuid().ToString("N")[..6];
+        var projectName = $"StarterApp_{projectSuffix}";
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -37,10 +39,10 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await auto.InstallAspireCliInDockerAsync(installMode, counter);
 
         // Create a new project using aspire new
-        await auto.AspireNewAsync("AspireStarterApp", counter);
+        await auto.AspireNewAsync(projectName, counter);
 
         // Navigate to the AppHost directory
-        await auto.TypeAsync("cd AspireStarterApp/AspireStarterApp.AppHost");
+        await auto.TypeAsync($"cd {projectName}/{projectName}.AppHost");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -58,9 +60,8 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         await auto.ClearScreenAsync(counter);
 
-        // Ensure application container is cleaned up (zero containers running)
-        // We expect one container left because the test is running in a container itself
-        await auto.ExecuteCommandUntilOutputAsync(counter, "docker ps --all --format json | wc -l", "1", timeout: TimeSpan.FromMinutes(2));
+        // Ensure the test-specific Docker network is cleaned up (which signifies end of container cleanup) 
+        await auto.ExecuteCommandUntilOutputAsync(counter, $"docker network ls --format json | grep -i -- '{projectName}' | wc -l", "0", timeout: TimeSpan.FromMinutes(2));
 
         // Exit the shell
         await auto.TypeAsync("exit");

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Hex1b.Automation;
+using Hex1b.Input;
 
 namespace Aspire.Tests.Shared;
 
@@ -57,6 +59,174 @@ internal static class Hex1bAutomatorTestHelpers
         }, timeout: effectiveTimeout, description: $"any prompt [{counter.Value} OK/ERR] $");
 
         counter.Increment();
+    }
+
+    /// <summary>
+    /// Repeatedly types a shell command until the first line of command output matches the expected text
+    /// or the timeout expires. Each attempt waits for either the first output line or the next prompt,
+    /// then waits for the prompt if output appeared first.
+    /// </summary>
+    internal static async Task ExecuteCommandUntilOutputAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string commandText,
+        string desiredOutput,
+        TimeSpan? timeout = null,
+        TimeSpan? retryInterval = null)
+    {
+        ArgumentNullException.ThrowIfNull(auto);
+        ArgumentNullException.ThrowIfNull(counter);
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandText);
+        ArgumentException.ThrowIfNullOrWhiteSpace(desiredOutput);
+
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
+        var effectiveRetryInterval = retryInterval ?? TimeSpan.FromSeconds(5);
+        var stopwatch = Stopwatch.StartNew();
+        var attempt = 0;
+
+        while (stopwatch.Elapsed < effectiveTimeout)
+        {
+            attempt++;
+            var expectedPromptSequence = counter.Value;
+            var sawPrompt = false;
+            var firstOutputMatched = false;
+
+            await auto.TypeAsync(commandText);
+            await auto.EnterAsync();
+
+            var remaining = effectiveTimeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                break;
+            }
+
+            var waitThisAttempt = remaining < effectiveRetryInterval ? remaining : effectiveRetryInterval;
+
+            try
+            {
+                await auto.WaitUntilAsync(snapshot =>
+                {
+                    var firstOutputLine = TryGetFirstOutputLine(snapshot, commandText);
+                    if (firstOutputLine is not null)
+                    {
+                        if (IsPromptLine(firstOutputLine, expectedPromptSequence))
+                        {
+                            sawPrompt = true;
+                            return true;
+                        }
+
+                        firstOutputMatched = firstOutputLine.Contains(desiredOutput, StringComparison.Ordinal);
+                        return true;
+                    }
+
+                    if (IsPromptVisible(snapshot, expectedPromptSequence))
+                    {
+                        sawPrompt = true;
+                        return true;
+                    }
+
+                    return false;
+                }, timeout: waitThisAttempt, description: $"waiting for first output or prompt after '{commandText}' (attempt {attempt})");
+            }
+            catch (TimeoutException) when (stopwatch.Elapsed < effectiveTimeout)
+            {
+                continue;
+            }
+
+            if (!sawPrompt)
+            {
+                remaining = effectiveTimeout - stopwatch.Elapsed;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    break;
+                }
+
+                try
+                {
+                    await auto.WaitForAnyPromptAsync(counter, remaining);
+                    sawPrompt = true;
+                }
+                catch (TimeoutException) when (stopwatch.Elapsed < effectiveTimeout)
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                counter.Increment();
+            }
+
+            if (firstOutputMatched)
+            {
+                return;
+            }
+        }
+
+        throw new TimeoutException(
+            $"Timed out after {effectiveTimeout} waiting for the first output line from '{commandText}' to contain '{desiredOutput}'.");
+    }
+
+    private static bool IsPromptVisible(IHex1bTerminalRegion snapshot, int expectedPromptSequence)
+    {
+        var successSearcher = new CellPatternSearcher()
+            .FindPattern(expectedPromptSequence.ToString())
+            .RightText(" OK] $ ");
+        var errorSearcher = new CellPatternSearcher()
+            .FindPattern(expectedPromptSequence.ToString())
+            .RightText(" ERR:");
+
+        return successSearcher.Search(snapshot).Count > 0 || errorSearcher.Search(snapshot).Count > 0;
+    }
+
+    private static bool IsPromptLine(string line, int expectedPromptSequence)
+    {
+        return line.Contains($"[{expectedPromptSequence} OK] $", StringComparison.Ordinal) ||
+            line.Contains($"[{expectedPromptSequence} ERR:", StringComparison.Ordinal);
+    }
+
+    private static string? TryGetFirstOutputLine(IHex1bTerminalRegion snapshot, string commandText)
+    {
+        var commandLineIndex = FindCommandLineIndex(snapshot, commandText);
+        if (commandLineIndex < 0)
+        {
+            return null;
+        }
+
+        for (var lineIndex = commandLineIndex + 1; lineIndex < snapshot.Height; lineIndex++)
+        {
+            var line = snapshot.GetLineTrimmed(lineIndex);
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                return line;
+            }
+        }
+
+        return null;
+    }
+
+    private static int FindCommandLineIndex(IHex1bTerminalRegion snapshot, string commandText)
+    {
+        for (var lineIndex = snapshot.Height - 1; lineIndex >= 0; lineIndex--)
+        {
+            var line = snapshot.GetLineTrimmed(lineIndex);
+            if (line.EndsWith(commandText, StringComparison.Ordinal) ||
+                line.Contains($"$ {commandText}", StringComparison.Ordinal) ||
+                line.Contains($"# {commandText}", StringComparison.Ordinal))
+            {
+                return lineIndex;
+            }
+        }
+
+        for (var lineIndex = snapshot.Height - 1; lineIndex >= 0; lineIndex--)
+        {
+            var line = snapshot.GetLineTrimmed(lineIndex);
+            if (line.Contains(commandText, StringComparison.Ordinal))
+            {
+                return lineIndex;
+            }
+        }
+
+        return -1;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/microsoft/aspire/issues/15806

The main issue was we were that the `stop` command implementation was killing entire detached CLI process tree, including all DCP processes, which prevented DCP from doing proper cleanup. On Unix-like systems we are able to avoid that by detaching ourselves from the application host process tree, but on Windows manipulating the process tree like that is not possible. Fixed by implementing graceful shutdown request (SIGTERM on Unix-like systems, Ctrl+Break console event on Windows) and limiting the process killing to application host and detached CLI only.

While doing this work I also unified some parts of process-related logic between the CLI and "CLI orphan detector", and enhanced the use of process start time to make sure we are not killing processes that happen to reuse CLI process ID.
