### PR TITLE
Disable auto restore for the Aspire repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "dotnet.solution.autoOpen": "./Aspire.slnx",
     "dotnet.preview.enableSupportForSlnx": true,
     "dotnet.testWindow.useTestingPlatformProtocol": true,
-    "aspire.enableSettingsFileCreationPromptOnStartup": false
+    "aspire.enableSettingsFileCreationPromptOnStartup": false,
+    "aspire.enableAutoRestore": false
 }


### PR DESCRIPTION
We have the unique situation of having several hundred aspire projects in the same workspace. 