### PR TITLE
Fix signing for aspire-managed bundle payload

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -56,8 +56,11 @@
     <FileSignInfo Include="Tuf.dll" CertificateName="3PartySHA2" />
 
     <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="aspire.exe" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="aspire-managed.exe" CertificateName="MicrosoftDotNet500" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsLinux())" Include="aspire" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsLinux())" Include="aspire-managed" CertificateName="MicrosoftDotNet500" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsMacOS())" Include="aspire" CertificateName="MacDeveloperHardenWithNotarization" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsMacOS())" Include="aspire-managed" CertificateName="MacDeveloperHardenWithNotarization" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="get-aspire-cli.ps1" CertificateName="MicrosoftDotNet500" />
 
     <!-- Sign the manifest catalog on Windows -->
@@ -72,6 +75,11 @@
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\aspire-cli-*.zip" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\aspire-cli-*.tar.gz" />
     <ItemsToSign Include="$(RepoRoot)eng\scripts\get-aspire-cli.ps1" Condition="$([System.OperatingSystem]::IsWindows())" />
+
+    <!-- Sign the aspire-managed binary at its publish output path (before it gets packed into the bundle archive) -->
+    <ItemsToSign Condition="$([System.OperatingSystem]::IsWindows())" Include="$(ArtifactsBinDir)Aspire.Managed\**\publish\aspire-managed.exe" />
+    <ItemsToSign Condition="$([System.OperatingSystem]::IsLinux())" Include="$(ArtifactsBinDir)Aspire.Managed/**/publish/aspire-managed" />
+    <ItemsToSign Condition="$([System.OperatingSystem]::IsMacOS())" Include="$(ArtifactsBinDir)Aspire.Managed/**/publish/aspire-managed" />
     <!-- 
       Note: VS Code extension (.vsix) is NOT included here.
       Signing the VSIX changes its hash, breaking manifest integrity verification.

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -41,19 +41,42 @@ parameters:
 steps:
   # Internal pipeline: Build with pack+sign
   - ${{ if ne(parameters.runAsPublic, 'true') }}:
-    # Build bundle payload (aspire-managed) for each target RID before the main build
+    # Build, publish, and sign aspire-managed for each target RID before the main build.
+    # This ensures aspire-managed is signed before CreateLayout packs it into the bundle archive.
+    # Step 1: dotnet publish produces the self-contained single-file binary.
+    # Step 2: build.cmd -sign runs Arcade's signing, which picks up the binary via ItemsToSign in Signing.props.
+    # Step 3: Bundle.proj creates the bundle layout and archive using the signed binary.
     - ${{ each targetRid in parameters.targetRids }}:
+      - script: ${{ parameters.dotnetScript }}
+                publish
+                $(Build.SourcesDirectory)/src/Aspire.Managed/Aspire.Managed.csproj
+                -c ${{ parameters.buildConfig }}
+                -r ${{ targetRid }}
+                --self-contained
+                /p:GenerateDocumentationFile=false
+                /p:EnforceCodeStyleInBuild=false
+                $(_OfficialBuildIdArgs)
+                /bl:${{ parameters.repoLogPath }}/PublishManaged-${{ targetRid }}.binlog
+        displayName: 🟣Publish aspire-managed (${{ targetRid }})
+
+      - script: ${{ parameters.buildScript }}
+                -restore -sign $(_SignArgs)
+                -configuration ${{ parameters.buildConfig }}
+                $(_OfficialBuildIdArgs)
+                -projects $(Build.SourcesDirectory)/src/Aspire.Managed/Aspire.Managed.csproj
+                /bl:${{ parameters.repoLogPath }}/SignManaged-${{ targetRid }}.binlog
+        displayName: 🟣Sign aspire-managed (${{ targetRid }})
+
       - script: ${{ parameters.dotnetScript }}
                 msbuild
                 $(Build.SourcesDirectory)/eng/Bundle.proj
-                /restore
+                "/t:_RestoreDcpPackage;_RunCreateLayout"
                 /p:Configuration=${{ parameters.buildConfig }}
                 /p:TargetRid=${{ targetRid }}
                 /p:BundleVersion=ci-bundlepayload
-                /p:SkipNativeBuild=true
                 /p:ContinuousIntegrationBuild=true
-                /bl:${{ parameters.repoLogPath }}/BundlePayload-${{ targetRid }}.binlog
-        displayName: 🟣Build bundle payload (${{ targetRid }})
+                /bl:${{ parameters.repoLogPath }}/BundleLayout-${{ targetRid }}.binlog
+        displayName: 🟣Create bundle layout (${{ targetRid }})
 
     - script: ${{ parameters.buildScript }}
               -restore -build

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -63,18 +63,46 @@ jobs:
             displayName: 🟣Restore
 
         steps:
+          # Build, publish, and sign aspire-managed before creating the bundle layout.
+          # This ensures aspire-managed is signed before CreateLayout packs it into the bundle archive.
+          # Step 1: dotnet publish produces the self-contained single-file binary.
+          # Step 2: build.sh --sign runs Arcade's signing (only when codeSign is enabled).
+          # Step 3: Bundle.proj creates the bundle layout and archive using the signed binary.
+          - script: >-
+              $(Build.SourcesDirectory)/$(dotnetScript)
+              publish
+              $(Build.SourcesDirectory)/src/Aspire.Managed/Aspire.Managed.csproj
+              -c $(_BuildConfig)
+              -r ${{ targetRid }}
+              --self-contained
+              /p:GenerateDocumentationFile=false
+              /p:EnforceCodeStyleInBuild=false
+              ${{ parameters.extraBuildArgs }}
+              /bl:$(Build.Arcade.LogsPath)PublishManaged.binlog
+            displayName: 🟣Publish aspire-managed
+
+          - ${{ if eq(parameters.codeSign, true) }}:
+            - script: >-
+                $(Build.SourcesDirectory)/$(scriptName)
+                --restore --sign
+                ${{ parameters.extraBuildArgs }}
+                -projects $(Build.SourcesDirectory)/src/Aspire.Managed/Aspire.Managed.csproj
+                /bl:$(Build.Arcade.LogsPath)SignManaged.binlog
+              displayName: 🟣Sign aspire-managed
+              env:
+                SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
           - script: >-
               $(Build.SourcesDirectory)/$(dotnetScript)
               msbuild
               $(Build.SourcesDirectory)/eng/Bundle.proj
-              /restore
+              "/t:_RestoreDcpPackage;_RunCreateLayout"
               /p:Configuration=$(_BuildConfig)
               /p:TargetRid=${{ targetRid }}
               /p:BundleVersion=ci-bundlepayload
-              /p:SkipNativeBuild=true
               /p:ContinuousIntegrationBuild=true
-              /bl:$(Build.Arcade.LogsPath)BundlePayload.binlog
-            displayName: 🟣Build bundle payload
+              /bl:$(Build.Arcade.LogsPath)BundleLayout.binlog
+            displayName: 🟣Create bundle layout
 
           - script: >-
               $(Build.SourcesDirectory)/$(scriptName)


### PR DESCRIPTION
Fixes https://github.com/microsoft/aspire/issues/15989

## Description

Fix the CLI bundle signing gap where `aspire-managed` was not being signed before being packed into the bundle archive.

**Root cause:** The managed bundle payload was published via `Bundle.proj` using a standalone `dotnet publish` call, which runs outside of Arcade's signing infrastructure. By the time Arcade's signing phase ran during the main build, `aspire-managed` was already packed inside `bundle.tar.gz` and embedded in the native `aspire` CLI binary — unreachable by the signing tooling.

### Approach

Split the bundle payload pipeline step into three phases so that `aspire-managed` goes through Arcade's standard signing infrastructure **before** `CreateLayout` packs it into the archive:

1. **`dotnet publish`** — produces the self-contained single-file `aspire-managed` binary
2. **`build.cmd/sh -restore -sign`** — Arcade's `SignToolTask` discovers the binary via `ItemsToSign` globs in `Signing.props` and signs it in-place using ESRP/MicroBuild
3. **`Bundle.proj /t:_RestoreDcpPackage;_RunCreateLayout`** — creates the `bundle.tar.gz` archive with the already-signed binary

### Changes

- **`eng/Signing.props`**: Register `aspire-managed.exe` / `aspire-managed` in `FileSignInfo` (certificate mapping) and `ItemsToSign` (glob pointing at publish output path)
- **`eng/pipelines/templates/BuildAndTest.yml`**: Replace single Bundle.proj step with the three-phase publish -> sign -> layout flow per target RID
- **`eng/pipelines/templates/build_sign_native.yml`**: Same restructuring for macOS/Linux native stage. Sign step is conditional on `codeSign: true` (macOS only; Linux ELF binaries are not signed)

### Validation

Tested via internal ADO build [2947441](https://dev.azure.com/dnceng/internal/_build/results?buildId=2947441). The signing step reported:
```
SignToolTask starting.
Signing mode: Real
Round 0: Signing 2 files
Build artifacts signed and validated.
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] Yes
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [x] No