### PR TITLE
Make feature issue template use Feature issue type, rather than use a tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/20_feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/20_feature-request.yml
@@ -1,6 +1,6 @@
 name: 💡 Feature request
 description: Suggest an idea for this project
-labels: [ 'enhancement' ]
+type: Feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Description

Make feature issues use a `Feature` issue type, rather than use an `enhancement` tag

Per @davidfowl - https://discord.com/channels/1361488941836140614/1361488942813286403/1491898661934862356
