### PR TITLE
Remove telemetry API data limits and refactor URL builders

### DIFF
--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -283,7 +283,7 @@ internal sealed class ExportCommand : BaseCommand
         IReadOnlyList<IOtlpResource> allOtlpResources,
         CancellationToken cancellationToken)
     {
-        var url = DashboardUrls.TelemetryLogsApiUrl(baseUrl, resolvedResources);
+        var url = DashboardUrls.TelemetryLogsApiUrl(baseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
         var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
@@ -314,7 +314,7 @@ internal sealed class ExportCommand : BaseCommand
         IReadOnlyList<IOtlpResource> allOtlpResources,
         CancellationToken cancellationToken)
     {
-        var url = DashboardUrls.TelemetryTracesApiUrl(baseUrl, resolvedResources);
+        var url = DashboardUrls.TelemetryTracesApiUrl(baseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
         var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -29,6 +29,12 @@ internal static class TelemetryCommandHelpers
     /// </summary>
     internal const string ApiKeyHeaderName = "X-API-Key";
 
+    /// <summary>
+    /// Limit passed to dashboard telemetry APIs. All data is fetched in one API call
+    /// so there shouldn't be a limit on data returned.
+    /// </summary>
+    internal const int MaxTelemetryLimit = int.MaxValue;
+
     #region Shared Command Options
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
@@ -136,22 +135,10 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             return ExitCodeConstants.InvalidCommand;
         }
 
-        // Build query string with multiple resource parameters
-        var additionalParams = new List<(string key, string? value)>
-        {
-            ("traceId", traceId),
-            ("severity", severity)
-        };
-        if (limit.HasValue && !follow)
-        {
-            additionalParams.Add(("limit", limit.Value.ToString(CultureInfo.InvariantCulture)));
-        }
-        if (follow)
-        {
-            additionalParams.Add(("follow", "true"));
-        }
+        // Build URL with query parameters
+        int? effectiveLimit = (limit.HasValue && !follow) ? limit.Value : null;
 
-        var url = DashboardUrls.TelemetryLogsApiUrl(baseUrl, resolvedResources, [.. additionalParams]);
+        var url = DashboardUrls.TelemetryLogsApiUrl(baseUrl, resolvedResources, traceId: traceId, severity: severity, limit: effectiveLimit, follow: follow ? true : null);
 
         try
         {

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
@@ -132,25 +131,10 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             return ExitCodeConstants.InvalidCommand;
         }
 
-        // Build query string with multiple resource parameters
-        var additionalParams = new List<(string key, string? value)>
-        {
-            ("traceId", traceId)
-        };
-        if (hasError.HasValue)
-        {
-            additionalParams.Add(("hasError", hasError.Value.ToString().ToLowerInvariant()));
-        }
-        if (limit.HasValue && !follow)
-        {
-            additionalParams.Add(("limit", limit.Value.ToString(CultureInfo.InvariantCulture)));
-        }
-        if (follow)
-        {
-            additionalParams.Add(("follow", "true"));
-        }
+        // Build URL with query parameters
+        int? effectiveLimit = (limit.HasValue && !follow) ? limit.Value : null;
 
-        var url = DashboardUrls.TelemetrySpansApiUrl(baseUrl, resolvedResources, [.. additionalParams]);
+        var url = DashboardUrls.TelemetrySpansApiUrl(baseUrl, resolvedResources, traceId: traceId, hasError: hasError, limit: effectiveLimit, follow: follow ? true : null);
 
         _logger.LogDebug("Fetching spans from {Url}", url);
 

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -189,18 +189,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         // Pre-resolve colors so assignment is deterministic regardless of data order
         TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
 
-        // Build query string with multiple resource parameters
-        var additionalParams = new List<(string key, string? value)>();
-        if (hasError.HasValue)
-        {
-            additionalParams.Add(("hasError", hasError.Value.ToString().ToLowerInvariant()));
-        }
-        if (limit.HasValue)
-        {
-            additionalParams.Add(("limit", limit.Value.ToString(CultureInfo.InvariantCulture)));
-        }
-
-        var url = DashboardUrls.TelemetryTracesApiUrl(baseUrl, resolvedResources, [.. additionalParams]);
+        var url = DashboardUrls.TelemetryTracesApiUrl(baseUrl, resolvedResources, hasError: hasError, limit: limit);
 
         _logger.LogDebug("Fetching traces from {Url}", url);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
@@ -69,6 +69,7 @@ internal sealed class ListStructuredLogsTool(IDashboardInfoProvider dashboardInf
                 };
             }
 
+            // Fetch all logs from the API. Limiting of returned telemetry to the MCP caller happens later.
             var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
 
             logger.LogDebug("Fetching structured logs from {Url}", url);

--- a/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
@@ -69,7 +69,7 @@ internal sealed class ListStructuredLogsTool(IDashboardInfoProvider dashboardInf
                 };
             }
 
-            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, resolvedResources);
+            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
 
             logger.LogDebug("Fetching structured logs from {Url}", url);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
@@ -69,6 +69,7 @@ internal sealed class ListTraceStructuredLogsTool(IDashboardInfoProvider dashboa
             var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, apiBaseUrl, cancellationToken).ConfigureAwait(false);
 
             // Build the logs API URL with traceId filter
+            // Fetch all logs for the trace from the API. Limiting of returned telemetry to the MCP caller happens later.
             var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, traceId: traceId, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
 
             logger.LogDebug("Fetching structured logs from {Url}", url);

--- a/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
@@ -69,7 +69,7 @@ internal sealed class ListTraceStructuredLogsTool(IDashboardInfoProvider dashboa
             var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, apiBaseUrl, cancellationToken).ConfigureAwait(false);
 
             // Build the logs API URL with traceId filter
-            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, resources: null, ("traceId", traceId));
+            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, traceId: traceId, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
 
             logger.LogDebug("Fetching structured logs from {Url}", url);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
@@ -69,6 +69,7 @@ internal sealed class ListTracesTool(IDashboardInfoProvider dashboardInfoProvide
                 };
             }
 
+            // Fetch all traces from the API. Limiting of returned telemetry to the MCP caller happens later.
             var url = DashboardUrls.TelemetryTracesApiUrl(apiBaseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
 
             logger.LogDebug("Fetching traces from {Url}", url);

--- a/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
@@ -69,7 +69,7 @@ internal sealed class ListTracesTool(IDashboardInfoProvider dashboardInfoProvide
                 };
             }
 
-            var url = DashboardUrls.TelemetryTracesApiUrl(apiBaseUrl, resolvedResources);
+            var url = DashboardUrls.TelemetryTracesApiUrl(apiBaseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
 
             logger.LogDebug("Fetching traces from {Url}", url);
 

--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -21,7 +21,6 @@ internal sealed class TelemetryApiService(
 {
     private const int DefaultLimit = 200;
     private const int DefaultTraceLimit = 100;
-    private const int MaxQueryCount = 10000;
 
     private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers = outgoingPeerResolvers.ToArray();
 
@@ -50,7 +49,7 @@ internal sealed class TelemetryApiService(
             {
                 ResourceKey = resourceKey,
                 StartIndex = 0,
-                Count = MaxQueryCount,
+                Count = int.MaxValue,
                 Filters = [],
                 FilterText = string.Empty
             });
@@ -121,7 +120,7 @@ internal sealed class TelemetryApiService(
             {
                 ResourceKey = resourceKey,
                 StartIndex = 0,
-                Count = MaxQueryCount,
+                Count = int.MaxValue,
                 Filters = [],
                 FilterText = string.Empty
             });
@@ -237,7 +236,7 @@ internal sealed class TelemetryApiService(
             {
                 ResourceKey = resourceKey,
                 StartIndex = 0,
-                Count = MaxQueryCount,
+                Count = int.MaxValue,
                 Filters = filters
             });
             allLogs.AddRange(result.Items);

--- a/src/Shared/DashboardUrls.cs
+++ b/src/Shared/DashboardUrls.cs
@@ -193,42 +193,92 @@ internal static class DashboardUrls
     private const string TelemetryApiBasePath = "api/telemetry";
 
     /// <summary>
-    /// Builds the URL for the telemetry logs API with resource filtering.
+    /// Builds the URL for the telemetry logs API.
     /// </summary>
     /// <param name="baseUrl">The dashboard base URL.</param>
     /// <param name="resources">Optional list of resource names to filter by.</param>
-    /// <param name="additionalParams">Additional query parameters.</param>
+    /// <param name="traceId">Optional trace ID to filter logs by.</param>
+    /// <param name="severity">Optional minimum severity level filter.</param>
+    /// <param name="limit">Optional maximum number of results to return.</param>
+    /// <param name="follow">Optional flag to enable streaming mode.</param>
     /// <returns>The full API URL.</returns>
-    public static string TelemetryLogsApiUrl(string baseUrl, List<string>? resources = null, params (string key, string? value)[] additionalParams)
+    public static string TelemetryLogsApiUrl(string baseUrl, List<string>? resources = null, string? traceId = null, string? severity = null, int? limit = null, bool? follow = null)
     {
-        var queryString = BuildResourceQueryString(resources, additionalParams);
-        return CombineUrl(baseUrl, $"{TelemetryApiBasePath}/logs{queryString}");
+        var url = $"/{TelemetryApiBasePath}/logs";
+        url = AddResourceParams(url, resources);
+        if (traceId is not null)
+        {
+            url = AddQueryString(url, "traceId", traceId);
+        }
+        if (severity is not null)
+        {
+            url = AddQueryString(url, "severity", severity);
+        }
+        if (limit is not null)
+        {
+            url = AddQueryString(url, "limit", limit.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        if (follow == true)
+        {
+            url = AddQueryString(url, "follow", "true");
+        }
+        return CombineUrl(baseUrl, url);
     }
 
     /// <summary>
-    /// Builds the URL for the telemetry spans API with resource filtering.
+    /// Builds the URL for the telemetry spans API.
     /// </summary>
     /// <param name="baseUrl">The dashboard base URL.</param>
     /// <param name="resources">Optional list of resource names to filter by.</param>
-    /// <param name="additionalParams">Additional query parameters.</param>
+    /// <param name="traceId">Optional trace ID to filter spans by.</param>
+    /// <param name="hasError">Optional filter for error status.</param>
+    /// <param name="limit">Optional maximum number of results to return.</param>
+    /// <param name="follow">Optional flag to enable streaming mode.</param>
     /// <returns>The full API URL.</returns>
-    public static string TelemetrySpansApiUrl(string baseUrl, List<string>? resources = null, params (string key, string? value)[] additionalParams)
+    public static string TelemetrySpansApiUrl(string baseUrl, List<string>? resources = null, string? traceId = null, bool? hasError = null, int? limit = null, bool? follow = null)
     {
-        var queryString = BuildResourceQueryString(resources, additionalParams);
-        return CombineUrl(baseUrl, $"{TelemetryApiBasePath}/spans{queryString}");
+        var url = $"/{TelemetryApiBasePath}/spans";
+        url = AddResourceParams(url, resources);
+        if (traceId is not null)
+        {
+            url = AddQueryString(url, "traceId", traceId);
+        }
+        if (hasError is not null)
+        {
+            url = AddQueryString(url, "hasError", hasError.Value.ToString().ToLowerInvariant());
+        }
+        if (limit is not null)
+        {
+            url = AddQueryString(url, "limit", limit.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        if (follow == true)
+        {
+            url = AddQueryString(url, "follow", "true");
+        }
+        return CombineUrl(baseUrl, url);
     }
 
     /// <summary>
-    /// Builds the URL for the telemetry traces API with resource filtering.
+    /// Builds the URL for the telemetry traces API.
     /// </summary>
     /// <param name="baseUrl">The dashboard base URL.</param>
     /// <param name="resources">Optional list of resource names to filter by.</param>
-    /// <param name="additionalParams">Additional query parameters.</param>
+    /// <param name="hasError">Optional filter for error status.</param>
+    /// <param name="limit">Optional maximum number of results to return.</param>
     /// <returns>The full API URL.</returns>
-    public static string TelemetryTracesApiUrl(string baseUrl, List<string>? resources = null, params (string key, string? value)[] additionalParams)
+    public static string TelemetryTracesApiUrl(string baseUrl, List<string>? resources = null, bool? hasError = null, int? limit = null)
     {
-        var queryString = BuildResourceQueryString(resources, additionalParams);
-        return CombineUrl(baseUrl, $"{TelemetryApiBasePath}/traces{queryString}");
+        var url = $"/{TelemetryApiBasePath}/traces";
+        url = AddResourceParams(url, resources);
+        if (hasError is not null)
+        {
+            url = AddQueryString(url, "hasError", hasError.Value.ToString().ToLowerInvariant());
+        }
+        if (limit is not null)
+        {
+            url = AddQueryString(url, "limit", limit.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        return CombineUrl(baseUrl, url);
     }
 
     /// <summary>
@@ -255,33 +305,18 @@ internal static class DashboardUrls
     }
 
     /// <summary>
-    /// Builds a query string with multiple resource parameters and optional additional parameters.
+    /// Appends multiple resource query parameters to a URL.
     /// </summary>
-    internal static string BuildResourceQueryString(
-        List<string>? resources,
-        params (string key, string? value)[] additionalParams)
+    private static string AddResourceParams(string url, List<string>? resources)
     {
-        var parts = new List<string>();
-
-        // Add each resource as a separate query parameter
         if (resources is not null)
         {
             foreach (var resource in resources)
             {
-                parts.Add($"resource={Uri.EscapeDataString(resource)}");
+                url = AddQueryString(url, "resource", resource);
             }
         }
-
-        // Add additional parameters
-        foreach (var (key, value) in additionalParams)
-        {
-            if (!string.IsNullOrEmpty(value))
-            {
-                parts.Add($"{key}={Uri.EscapeDataString(value)}");
-            }
-        }
-
-        return parts.Count > 0 ? "?" + string.Join("&", parts) : "";
+        return url;
     }
 
     #endregion

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -34,51 +34,45 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void BuildResourceQueryString_WithNoResources_ReturnsEmptyString()
+    public void TelemetryLogsApiUrl_WithNoParams_ReturnsBaseUrl()
     {
-        var result = DashboardUrls.BuildResourceQueryString(null);
-        Assert.Equal("", result);
+        var result = DashboardUrls.TelemetryLogsApiUrl("https://localhost:5000");
+        Assert.Equal("https://localhost:5000/api/telemetry/logs", result);
     }
 
     [Fact]
-    public void BuildResourceQueryString_WithSingleResource_ReturnsCorrectQueryString()
+    public void TelemetryLogsApiUrl_WithSingleResource_ReturnsCorrectUrl()
     {
-        var result = DashboardUrls.BuildResourceQueryString(["frontend"]);
-        Assert.Equal("?resource=frontend", result);
+        var result = DashboardUrls.TelemetryLogsApiUrl("https://localhost:5000", ["frontend"]);
+        Assert.Equal("https://localhost:5000/api/telemetry/logs?resource=frontend", result);
     }
 
     [Fact]
-    public void BuildResourceQueryString_WithMultipleResources_ReturnsAllResourceParams()
+    public void TelemetryLogsApiUrl_WithMultipleResources_ReturnsAllResourceParams()
     {
-        var result = DashboardUrls.BuildResourceQueryString(["frontend-abc123", "frontend-xyz789"]);
-        Assert.Equal("?resource=frontend-abc123&resource=frontend-xyz789", result);
+        var result = DashboardUrls.TelemetryLogsApiUrl("https://localhost:5000", ["frontend-abc123", "frontend-xyz789"]);
+        Assert.Equal("https://localhost:5000/api/telemetry/logs?resource=frontend-abc123&resource=frontend-xyz789", result);
     }
 
     [Fact]
-    public void BuildResourceQueryString_WithResourcesAndAdditionalParams_CombinesCorrectly()
+    public void TelemetryLogsApiUrl_WithAllParams_CombinesCorrectly()
     {
-        var result = DashboardUrls.BuildResourceQueryString(
-            ["frontend"],
-            ("traceId", "abc123"),
-            ("limit", "10"));
-        Assert.Equal("?resource=frontend&traceId=abc123&limit=10", result);
+        var result = DashboardUrls.TelemetryLogsApiUrl("https://localhost:5000", ["frontend"], traceId: "abc123", severity: "Error", limit: 10, follow: true);
+        Assert.Equal("https://localhost:5000/api/telemetry/logs?resource=frontend&traceId=abc123&severity=Error&limit=10&follow=true", result);
     }
 
     [Fact]
-    public void BuildResourceQueryString_WithNullAdditionalParams_SkipsNullValues()
+    public void TelemetryLogsApiUrl_WithNullParams_SkipsNullValues()
     {
-        var result = DashboardUrls.BuildResourceQueryString(
-            ["frontend"],
-            ("traceId", null),
-            ("limit", "10"));
-        Assert.Equal("?resource=frontend&limit=10", result);
+        var result = DashboardUrls.TelemetryLogsApiUrl("https://localhost:5000", ["frontend"], traceId: null, limit: 10);
+        Assert.Equal("https://localhost:5000/api/telemetry/logs?resource=frontend&limit=10", result);
     }
 
     [Fact]
-    public void BuildResourceQueryString_WithSpecialCharacters_EncodesCorrectly()
+    public void TelemetryLogsApiUrl_WithSpecialCharacters_EncodesCorrectly()
     {
-        var result = DashboardUrls.BuildResourceQueryString(["service with spaces"]);
-        Assert.Equal("?resource=service%20with%20spaces", result);
+        var result = DashboardUrls.TelemetryLogsApiUrl("https://localhost:5000", ["service with spaces"]);
+        Assert.Equal("https://localhost:5000/api/telemetry/logs?resource=service%20with%20spaces", result);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Integration/TelemetryApiTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/TelemetryApiTests.cs
@@ -198,7 +198,7 @@ public class TelemetryApiTests
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.FrontendSingleEndPointAccessor().EndPoint}");
 
         // Act - test query parameters without resource filter (no resources exist in test)
-        var response = await httpClient.GetAsync("/api/telemetry/spans?hasError=true&limit=50").DefaultTimeout();
+        var response = await httpClient.GetAsync($"/api/telemetry/spans?hasError=true&limit={int.MaxValue}").DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -238,7 +238,7 @@ public class TelemetryApiTests
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.FrontendSingleEndPointAccessor().EndPoint}");
 
         // Act - test query parameters without resource filter (no resources exist in test)
-        var response = await httpClient.GetAsync("/api/telemetry/logs?severity=Error&limit=50").DefaultTimeout();
+        var response = await httpClient.GetAsync($"/api/telemetry/logs?severity=Error&limit={int.MaxValue}").DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -454,6 +454,127 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
+    public void GetSpans_WithLimit_ReturnsMostRecentSpans()
+    {
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "trace1", spanId: "old-span", startTime: s_testTime, endTime: s_testTime.AddMinutes(1)),
+                            CreateSpan(traceId: "trace2", spanId: "mid-span", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3)),
+                            CreateSpan(traceId: "trace3", spanId: "new-span", startTime: s_testTime.AddMinutes(4), endTime: s_testTime.AddMinutes(5))
+                        }
+                    }
+                }
+            }
+        });
+
+        var service = CreateService(repository);
+
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: 2);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.TotalCount);
+        Assert.Equal(2, result.ReturnedCount);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(result.Data);
+        Assert.DoesNotContain("old-span", json);
+        Assert.Contains("mid-span", json);
+        Assert.Contains("new-span", json);
+    }
+
+    [Fact]
+    public void GetTraces_WithLimit_ReturnsMostRecentTraces()
+    {
+        var repository = CreateRepository();
+
+        for (var i = 1; i <= 3; i++)
+        {
+            repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+            {
+                new ResourceSpans
+                {
+                    Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Scope = CreateScope(),
+                            Spans =
+                            {
+                                CreateSpan(traceId: $"trace{i}", spanId: $"span{i}", startTime: s_testTime.AddMinutes(i * 10), endTime: s_testTime.AddMinutes(i * 10 + 1))
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        var service = CreateService(repository);
+
+        var result = service.GetTraces(resourceNames: null, hasError: null, limit: 2);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.TotalCount);
+        Assert.Equal(2, result.ReturnedCount);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(result.Data);
+        Assert.DoesNotContain("span1", json);
+        Assert.Contains("span2", json);
+        Assert.Contains("span3", json);
+    }
+
+    [Fact]
+    public void GetLogs_WithLimit_ReturnsMostRecentLogs()
+    {
+        var repository = CreateRepository();
+
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(time: s_testTime, message: "old-log", severity: SeverityNumber.Info),
+                            CreateLogRecord(time: s_testTime.AddMinutes(1), message: "mid-log", severity: SeverityNumber.Info),
+                            CreateLogRecord(time: s_testTime.AddMinutes(2), message: "new-log", severity: SeverityNumber.Info)
+                        }
+                    }
+                }
+            }
+        });
+
+        var service = CreateService(repository);
+
+        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: 2);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.TotalCount);
+        Assert.Equal(2, result.ReturnedCount);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(result.Data);
+        Assert.DoesNotContain("old-log", json);
+        Assert.Contains("mid-log", json);
+        Assert.Contains("new-log", json);
+    }
+
+    [Fact]
     public void GetLogs_LargeLimit_ReturnsAllLogs()
     {
         const int totalLogs = 20_000;

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -453,6 +453,43 @@ public class TelemetryApiServiceTests
         }
     }
 
+    [Fact]
+    public void GetLogs_LargeLimit_ReturnsAllLogs()
+    {
+        const int totalLogs = 20_000;
+        var repository = CreateRepository(maxLogCount: totalLogs);
+
+        var logRecords = new RepeatedField<LogRecord>();
+        for (var i = 0; i < totalLogs; i++)
+        {
+            logRecords.Add(CreateLogRecord(time: s_testTime.AddMilliseconds(i), message: $"log{i}", severity: SeverityNumber.Info));
+        }
+
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { logRecords }
+                    }
+                }
+            }
+        });
+
+        var service = CreateService(repository);
+
+        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: 100_000);
+
+        Assert.NotNull(result);
+        Assert.Equal(totalLogs, result.TotalCount);
+        Assert.Equal(totalLogs, result.ReturnedCount);
+    }
+
     /// <summary>
     /// Creates a TelemetryApiService instance for testing with optional custom dependencies.
     /// </summary>

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -237,6 +237,7 @@ internal static class TelemetryTestHelpers
         int? maxAttributeLength = null,
         int? maxSpanEventCount = null,
         int? maxTraceCount = null,
+        int? maxLogCount = null,
         TimeSpan? subscriptionMinExecuteInterval = null,
         ILoggerFactory? loggerFactory = null,
         PauseManager? pauseManager = null,
@@ -262,6 +263,10 @@ internal static class TelemetryTestHelpers
         if (maxTraceCount != null)
         {
             options.MaxTraceCount = maxTraceCount.Value;
+        }
+        if (maxLogCount != null)
+        {
+            options.MaxLogCount = maxLogCount.Value;
         }
 
         var repository = new TelemetryRepository(


### PR DESCRIPTION
## Description

Remove artificial telemetry data limits in the dashboard API and CLI, and refactor URL builder methods for type safety and consistency.

**Changes:**

- **Remove `MaxQueryCount` from `TelemetryApiService`**: Storage queries now use `int.MaxValue` so all data is returned and limits are controlled by the caller's `limit` parameter.
- **Add `TelemetryCommandHelpers.MaxTelemetryLimit`** (`int.MaxValue`): CLI export and MCP tools pass this to fetch all available telemetry data in a single API call.
- **Refactor `DashboardUrls` telemetry URL builders**: Changed from `params (string, string?)[]` tuples to explicit named parameters matching `MapTelemetryApi` endpoints, improving type safety and discoverability.
- **Replace `BuildQueryString` with `AddQueryString` pattern**: Aligns telemetry URL construction with the existing pattern used by `StructuredLogsUrl` and other URL builders in the same class.
- **Add tests**: Limit-returns-most-recent tests for spans, traces, and logs; large-limit test for 20k logs; updated URL builder tests.

**Motivation:** The export command and MCP tools were silently truncating telemetry data due to default limits (100 traces, 200 logs) when no `limit` parameter was passed. This made exports incomplete without any warning.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
