### PR TITLE
Add compatibility suppressions for NameOutput rename in Azure.Network

### DIFF
--- a/src/Aspire.Hosting.Azure.Network/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting.Azure.Network/CompatibilitySuppressions.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.Azure.AzureNatGatewayResource.get_NameOutput</Target>
+    <Left>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.Azure.AzureNetworkSecurityGroupResource.get_NameOutput</Target>
+    <Left>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.Azure.AzurePrivateEndpointResource.get_NameOutput</Target>
+    <Left>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.Azure.AzurePublicIPAddressResource.get_NameOutput</Target>
+    <Left>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.Azure.AzureVirtualNetworkResource.get_NameOutput</Target>
+    <Left>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.Azure.Network.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>


### PR DESCRIPTION
## Description

Add `CompatibilitySuppressions.xml` for `Aspire.Hosting.Azure.Network` to suppress CP0002 package validation diagnostics caused by the `NameOutput` → `NameOutputReference` rename in #16004, after the baseline version was bumped in #16008.

The following resources have suppressions for the removed `NameOutput` getter:
- `AzureNatGatewayResource`
- `AzureNetworkSecurityGroupResource`
- `AzurePrivateEndpointResource`
- `AzurePublicIPAddressResource`
- `AzureVirtualNetworkResource`

This is acceptable because this library is still Experimental.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
