### PR TITLE
Skip version prompt when --version is explicitly specified

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -197,13 +197,15 @@ internal sealed class AddCommand : BaseCommand
             // If we didn't match any, show a complete list. If we matched one, and its
             // an exact match, then we still prompt, but it will only prompt for
             // the version. If there is more than one match then we prompt.
+            // When --version is explicitly specified, skip the version prompt entirely
+            // and let 'dotnet add package --version' validate the version.
+            var skipVersionPrompt = version is not null;
             var selectedNuGetPackage = filteredPackagesWithShortName.Count() switch
             {
-                0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(packagesWithShortName, integrationName, cancellationToken),
-                1 => filteredPackagesWithShortName.First().Package.Version == version
-                    ? filteredPackagesWithShortName.First()
-                    : await GetPackageByInteractiveFlow(filteredPackagesWithShortName, null, cancellationToken),
-                > 1 => await GetPackageByInteractiveFlow(filteredPackagesWithShortName, version, cancellationToken),
+                0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(packagesWithShortName, integrationName, skipVersionPrompt, cancellationToken),
+                1 when skipVersionPrompt => filteredPackagesWithShortName.First(),
+                1 => await GetPackageByInteractiveFlow(filteredPackagesWithShortName, null, cancellationToken),
+                > 1 => await GetPackageByInteractiveFlow(filteredPackagesWithShortName, version, cancellationToken, skipVersionPrompt),
                 _ => throw new InvalidOperationException(AddCommandStrings.UnexpectedNumberOfPackagesFound)
             };
 
@@ -212,7 +214,7 @@ internal sealed class AddCommand : BaseCommand
             {
                 AppHostFile = effectiveAppHostProjectFile,
                 PackageId = selectedNuGetPackage.Package.Id,
-                PackageVersion = selectedNuGetPackage.Package.Version,
+                PackageVersion = version ?? selectedNuGetPackage.Package.Version,
                 Source = source
             };
 
@@ -249,7 +251,7 @@ internal sealed class AddCommand : BaseCommand
                 return ExitCodeConstants.FailedToAddPackage;
             }
 
-            InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageAddedSuccessfully, selectedNuGetPackage.Package.Id, selectedNuGetPackage.Package.Version));
+            InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageAddedSuccessfully, selectedNuGetPackage.Package.Id, context.PackageVersion));
             return ExitCodeConstants.Success;
         }
         catch (ProjectLocatorException ex)
@@ -280,7 +282,7 @@ internal sealed class AddCommand : BaseCommand
         }
     }
 
-    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlow(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? preferredVersion, CancellationToken cancellationToken)
+    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlow(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? preferredVersion, CancellationToken cancellationToken, bool skipVersionPrompt = false)
     {
         var distinctPackages = possiblePackages.DistinctBy(p => p.Package.Id);
 
@@ -310,7 +312,7 @@ internal sealed class AddCommand : BaseCommand
         var orderedPackageVersions = packageVersions
             .OrderByDescending(p => p.Channel.Type is PackageChannelType.Implicit)
             .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer);
-        if (!_hostEnvironment.SupportsInteractiveInput)
+        if (skipVersionPrompt || !_hostEnvironment.SupportsInteractiveInput)
         {
             return orderedPackageVersions.First();
         }
@@ -321,14 +323,14 @@ internal sealed class AddCommand : BaseCommand
         return version;
     }
 
-    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlowWithNoMatchesMessage(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? searchTerm, CancellationToken cancellationToken)
+    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlowWithNoMatchesMessage(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? searchTerm, bool skipVersionPrompt, CancellationToken cancellationToken)
     {
         if (searchTerm is not null)
         {
             InteractionService.DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.NoPackagesMatchedSearchTerm, searchTerm));
         }
 
-        return await GetPackageByInteractiveFlow(possiblePackages, null, cancellationToken);
+        return await GetPackageByInteractiveFlow(possiblePackages, null, cancellationToken, skipVersionPrompt);
     }
 
     internal static (string FriendlyName, NuGetPackage Package, PackageChannel Channel) GenerateFriendlyName((NuGetPackage Package, PackageChannel Channel) packageWithChannel)

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -158,6 +158,50 @@ public sealed class StartStopTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task AddPackageWithNonExistentVersionFailsGracefully()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: false, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        // Prepare Docker environment (prompt counting, umask, env vars)
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+
+        // Install the Aspire CLI
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        // Create a new project using aspire new
+        await auto.AspireNewAsync("AspireAddVersionFailApp", counter);
+
+        // Navigate to the AppHost directory
+        await auto.TypeAsync("cd AspireAddVersionFailApp/AspireAddVersionFailApp.AppHost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Try to add a package with a version that doesn't exist.
+        // This should fail gracefully with the PackageInstallationFailed error message
+        // rather than prompting for a version or crashing.
+        await auto.TypeAsync("aspire add redis --version 99.99.99");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("The package installation failed", timeout: TimeSpan.FromMinutes(2));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Exit the shell
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
+    [Fact]
     public async Task AddPackageInteractiveWhileAppHostRunningDetached()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -255,6 +255,210 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AddCommandDoesNotPromptForVersionIfVersionSpecifiedButNotInSearchResults()
+    {
+        var promptedForVersion = false;
+        string? addedPackageVersion = null;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+
+            options.AddCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestAddCommandPrompter(interactionService);
+
+                prompter.PromptForIntegrationVersionCallback = (packages) =>
+                {
+                    promptedForVersion = true;
+                    throw new InvalidOperationException("Should not have been prompted for integration version.");
+                };
+
+                return prompter;
+            };
+
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var redisPackage = new NuGetPackage()
+                    {
+                        Id = "Aspire.Hosting.Redis",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (
+                        0, // Exit code.
+                        new NuGetPackage[] { redisPackage }
+                        );
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
+                {
+                    addedPackageVersion = packageVersion;
+                    return 0; // Success.
+                };
+
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add redis --version 9.3.0");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, exitCode);
+        Assert.False(promptedForVersion);
+        Assert.Equal("9.3.0", addedPackageVersion);
+    }
+
+    [Fact]
+    public async Task AddCommandDoesNotPromptForVersionWithMultipleMatchesIfVersionSpecified()
+    {
+        var promptedForVersion = false;
+        string? addedPackageVersion = null;
+        string? addedPackageName = null;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+
+            options.AddCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestAddCommandPrompter(interactionService);
+
+                prompter.PromptForIntegrationCallback = (packages) =>
+                {
+                    return packages.Single(p => p.Package.Id == "Aspire.Hosting.Redis");
+                };
+
+                prompter.PromptForIntegrationVersionCallback = (packages) =>
+                {
+                    promptedForVersion = true;
+                    throw new InvalidOperationException("Should not have been prompted for integration version.");
+                };
+
+                return prompter;
+            };
+
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var redisPackage = new NuGetPackage()
+                    {
+                        Id = "Aspire.Hosting.Redis",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    var azureRedisPackage = new NuGetPackage()
+                    {
+                        Id = "Aspire.Hosting.Azure.Redis",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (
+                        0, // Exit code.
+                        new NuGetPackage[] { redisPackage, azureRedisPackage }
+                        );
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
+                {
+                    addedPackageName = packageName;
+                    addedPackageVersion = packageVersion;
+                    return 0; // Success.
+                };
+
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add red --version 9.3.0");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, exitCode);
+        Assert.False(promptedForVersion);
+        Assert.Equal("Aspire.Hosting.Redis", addedPackageName);
+        Assert.Equal("9.3.0", addedPackageVersion);
+    }
+
+    [Fact]
+    public async Task AddCommandFailsGracefullyWhenSpecifiedVersionDoesNotExist()
+    {
+        TestInteractionService? testInteractionService = null;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = (sp) =>
+            {
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
+            };
+
+            options.AddCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                return new TestAddCommandPrompter(interactionService);
+            };
+
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var redisPackage = new NuGetPackage()
+                    {
+                        Id = "Aspire.Hosting.Redis",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (
+                        0, // Exit code.
+                        new NuGetPackage[] { redisPackage }
+                        );
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
+                {
+                    // Simulate dotnet add package failing because the version doesn't exist.
+                    return 1;
+                };
+
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add redis --version 99.99.99");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
+        Assert.NotNull(testInteractionService);
+        Assert.Contains(testInteractionService.DisplayedErrors, e => e.Contains(AddCommandStrings.PackageInstallationFailed.Split('{')[0].TrimEnd()));
+    }
+
+    [Fact]
     public async Task AddCommandPromptsForDisambiguation()
     {
         IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)>? promptedPackages = null;


### PR DESCRIPTION
## Description

When `aspire add <integration> --version <ver>` is used with a version that isn't found in the NuGet search results, the CLI falls into the interactive flow and prompts the user to select a version — even though the version was explicitly specified on the command line. This breaks non-interactive/CI scenarios (e.g., the CPM test).

This PR fixes the issue by skipping the version prompt entirely when `--version` is explicitly provided. The specified version is passed directly to `dotnet add package --version`, letting NuGet validate the version in the proper context. If the version doesn't exist, the `dotnet add` command will fail naturally with an appropriate error.

### Changes

- **`AddCommand.cs`**: When `--version` is specified:
  - `count == 1`: Skip the interactive flow entirely, take the matched package directly.
  - `count > 1`: Only prompt for package name disambiguation, skip version prompt.
  - `count == 0`: Show all packages for name selection, skip version prompt.
  - Override `PackageVersion` with the CLI-specified version.
- **`AddCommandTests.cs`**: Added two new tests:
  - Version not in search results with single match → no prompt, CLI version used.
  - Version not in search results with multiple name matches → name prompt only, no version prompt.

Fixes #15396

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
