### PR TITLE
Enable Windows CLI E2E tests with Hex1b PTY proxy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,6 +200,26 @@ jobs:
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
+  # Windows ARM64 E2E tests run on windows-11-arm to validate the CLI on ARM hardware.
+  # Docker-based tests are auto-skipped (RequiresLinuxDockerFact), so only bare-terminal
+  # tests run: WindowsPtySmokeTests, StarterValidationTests, and other non-Docker tests.
+  cli_e2e_windows_arm64:
+    name: CLI E2E (Windows ARM64)
+    uses: ./.github/workflows/run-tests.yml
+    needs: [setup_for_tests, build_packages, build_cli_archive_windows_arm]
+    if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'microsoft' }}
+    with:
+      testShortName: Cli.EndToEnd-arm64
+      os: windows-11-arm
+      testProjectPath: tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+      testSessionTimeout: "30m"
+      testHangTimeout: "15m"
+      extraTestArgs: "--filter-not-trait \"quarantined=true\" --filter-not-trait \"outerloop=true\""
+      versionOverrideArg: ${{ inputs.versionOverrideArg }}
+      requiresNugets: true
+      requiresTestSdk: true
+      requiresCliArchive: true
+
   cli_starter_validation_windows:
     name: Aspire CLI Starter Validation (${{ matrix.os.name }})
     runs-on: ${{ matrix.os.runner }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,7 +176,7 @@ jobs:
   tests_requires_cli_archive:
     name: ${{ matrix.shortname }}
     uses: ./.github/workflows/run-tests.yml
-    needs: [setup_for_tests, build_packages, build_cli_archive_linux]
+    needs: [setup_for_tests, build_packages, build_cli_archive_linux, build_cli_archive_windows]
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_cli_archive).include[0] != null }}
     strategy:
       fail-fast: false

--- a/eng/scripts/split-test-projects-for-ci.ps1
+++ b/eng/scripts/split-test-projects-for-ci.ps1
@@ -100,7 +100,9 @@ try {
   }
 
   if ($toolExitCode -ne 0) {
-    Write-Error "ExtractTestPartitions failed with exit code $toolExitCode."
+    # Partition extraction can fail when the tool (net8.0) can't load assemblies
+    # targeting a newer TFM (e.g., net10.0). Fall through to class-based splitting.
+    Write-Warning "ExtractTestPartitions failed with exit code $toolExitCode. Will fall back to class-based splitting."
   }
 
   # Read partitions if the file was created

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -22,7 +22,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     /// - aspire mcp --help (legacy, still works)
     /// - aspire mcp start --help (legacy, still works)
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AgentCommands_AllHelpOutputs_AreCorrect()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -84,7 +84,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     /// Tests that deprecated MCP configs are detected and can be migrated
     /// to the new agent mcp format during aspire agent init.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AgentInitCommand_MigratesDeprecatedConfig()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -159,7 +159,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     /// <summary>
     /// Tests that aspire doctor warns about deprecated agent configs.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task DoctorCommand_DetectsDeprecatedAgentConfig()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -199,7 +199,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     /// prompts, and that accepting the defaults (Standard location + all skills) completes
     /// successfully and creates the skill file in the .agents/skills/ directory.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AgentInitCommand_DefaultSelection_InstallsSkillOnly()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
@@ -17,8 +17,9 @@
     <!-- Disable strong name signing because Hex1b package is not signed -->
     <SignAssembly>false</SignAssembly>
 
-    <!-- Only run on Linux since Hex1b requires a Linux terminal environment -->
-    <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
+    <!-- Hex1b 0.126.0+ supports Windows via PTY proxy (hex1bpty.exe).
+         Docker-based tests are skipped on Windows at runtime. -->
+    <RunOnGithubActionsWindows>true</RunOnGithubActionsWindows>
     <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
     <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class BannerTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task Banner_DisplayedOnFirstRun()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -56,7 +56,7 @@ public sealed class BannerTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task Banner_DisplayedWithExplicitFlag()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -88,7 +88,7 @@ public sealed class BannerTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task Banner_NotDisplayedWithNoLogoFlag()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class BundleSmokeTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateAndRunAspireStarterProjectWithBundle()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
@@ -17,7 +17,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class CentralPackageManagementTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AspireUpdateRemovesAppHostPackageVersionFromDirectoryPackagesProps()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -120,7 +120,7 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AspireAddPackageVersionToDirectoryPackagesProps()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CertificatesCommandTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class CertificatesCommandTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CertificatesTrust_WithUntrustedCert_TrustsCertificate()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -58,7 +58,7 @@ public sealed class CertificatesCommandTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CertificatesClean_RemovesCertificates()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -101,7 +101,7 @@ public sealed class CertificatesCommandTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CertificatesTrust_WithNoCert_CreatesAndTrustsCertificate()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigDiscoveryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigDiscoveryTests.cs
@@ -27,7 +27,7 @@ public sealed class ConfigDiscoveryTests(ITestOutputHelper output)
     /// existing <c>aspire.config.json</c> next to the apphost rather than creating a
     /// new one in the current working directory.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task RunFromParentDirectory_UsesExistingConfigNearAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigHealingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigHealingTests.cs
@@ -21,7 +21,7 @@ public sealed class ConfigHealingTests(ITestOutputHelper output)
     /// the CLI auto-detects the correct apphost, runs it successfully, and updates ("heals")
     /// the config file with the correct path.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task InvalidAppHostPathWithComments_IsHealedOnRun()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigMigrationTests.cs
@@ -104,7 +104,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     /// ~/.aspire/aspire.config.json when a CLI command is run, and that the legacy file
     /// is preserved for backward compatibility with older CLI versions.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task GlobalSettings_MigratedFromLegacyFormat()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -169,7 +169,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     /// Verifies that global migration does NOT overwrite an existing aspire.config.json.
     /// If the user already has the new format, legacy globalsettings.json should be ignored.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task GlobalMigration_SkipsWhenNewConfigExists()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -219,7 +219,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     /// Verifies that the CLI gracefully handles malformed JSON in legacy globalsettings.json
     /// without crashing, and that subsequent config operations still work.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task GlobalMigration_HandlesMalformedLegacyJson()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -278,7 +278,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     /// Verifies that legacy globalsettings.json containing JSON comments and trailing commas
     /// (common when hand-edited) is correctly parsed and migrated to aspire.config.json.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task GlobalMigration_HandlesCommentsAndTrailingCommas()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -348,7 +348,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     /// (the new format) and that aspire config get correctly reads from this structure.
     /// Also confirms globalsettings.json is NOT created when using the new CLI.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task ConfigSetGet_CreatesNestedJsonFormat()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -432,7 +432,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     /// value types: channel (string), features (dictionary of bools), and packages
     /// (dictionary of strings).
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task GlobalMigration_PreservesAllValueTypes()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -516,7 +516,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     /// predates the aspire.config.json consolidation, sets global config values using the
     /// old format, then upgrades to the new CLI and verifies all settings are migrated.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/15937")]
     [OuterloopTest("Requires downloading two separate CLI versions from GitHub")]
     public async Task FullUpgrade_LegacyCliToNewCli_MigratesGlobalSettings()

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     [CaptureWorkspaceOnFailure]
     public async Task DashboardRunWithOtelTracesReturnsNoTraces()
     {

--- a/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class DescribeCommandTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task DescribeCommandShowsRunningResources()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -85,7 +85,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task DescribeCommandResolvesReplicaNames()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
@@ -18,7 +18,7 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
 {
     private const string ProjectName = "AspireDockerDeployTest";
 
-    [Fact]
+    [RequiresLinuxFact]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/15930")]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/15882")]
     public async Task CreateAndDeployToDockerCompose()
@@ -141,7 +141,7 @@ builder.Build().Run();
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxFact]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/15930")]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/15871")]
     public async Task CreateAndDeployToDockerComposeInteractive()

--- a/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class DoctorCommandTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task DoctorCommand_WithoutSslCertDir_ShowsPartiallyTrusted()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -53,7 +53,7 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task DoctorCommand_WithSslCertDir_ShowsTrusted()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateAndRunEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -270,7 +270,17 @@ internal static class CliE2EAutomatorHelpers
         int prNumber,
         SequenceCounter counter)
     {
-        var command = $"ref=$(gh api repos/microsoft/aspire/pulls/{prNumber} --jq '.head.sha') && curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/$ref/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber}";
+        string command;
+        if (OperatingSystem.IsWindows())
+        {
+            command = $"$ref = (gh api repos/microsoft/aspire/pulls/{prNumber} --jq '.head.sha'); " +
+                      $"iex \"& {{ $(irm https://raw.githubusercontent.com/microsoft/aspire/$ref/eng/scripts/get-aspire-cli-pr.ps1) }} {prNumber}\"";
+        }
+        else
+        {
+            command = $"ref=$(gh api repos/microsoft/aspire/pulls/{prNumber} --jq '.head.sha') && curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/$ref/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber}";
+        }
+
         await auto.TypeAsync(command);
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
@@ -284,7 +294,20 @@ internal static class CliE2EAutomatorHelpers
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter)
     {
-        await auto.TypeAsync("export PATH=~/.aspire/bin:~/.aspire:$PATH ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
+        if (OperatingSystem.IsWindows())
+        {
+            await auto.TypeAsync(
+                "$env:PATH = \"$HOME\\.aspire\\bin;$HOME\\.aspire;$env:PATH\"; " +
+                "$env:ASPIRE_PLAYGROUND = 'true'; " +
+                "$env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'; " +
+                "$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true'; " +
+                "$env:DOTNET_GENERATE_ASPNET_CERTIFICATE = 'false'");
+        }
+        else
+        {
+            await auto.TypeAsync("export PATH=~/.aspire/bin:~/.aspire:$PATH ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
+        }
+
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
     }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -315,8 +315,8 @@ internal static class CliE2EAutomatorHelpers
     /// <summary>
     /// Pre-trusts the ASP.NET Core HTTPS development certificate so that <c>aspire new</c>
     /// and <c>aspire start</c> don't hang on the Windows certificate trust dialog.
-    /// On CI runners (admin context), this succeeds silently. On Linux, this is a no-op
-    /// because cert trust is handled differently (SSL_CERT_DIR).
+    /// Exports the dev cert and imports it directly into the trusted root store (no UI prompt).
+    /// On Linux, this is a no-op (cert trust is handled via SSL_CERT_DIR).
     /// </summary>
     internal static async Task EnsureDevCertsTrustedAsync(
         this Hex1bTerminalAutomator auto,
@@ -324,15 +324,24 @@ internal static class CliE2EAutomatorHelpers
     {
         if (OperatingSystem.IsWindows())
         {
-            await auto.TypeAsync("dotnet dev-certs https --trust");
+            // Create the dev cert (without --trust to avoid UI dialog), export it, then
+            // import into Trusted Root store using PowerShell (no UI prompt needed).
+            var certCommands =
+                "dotnet dev-certs https --export-path $env:TEMP\\aspire-dev-cert.pfx --password '' --format pfx 2>$null; " +
+                "if (Test-Path $env:TEMP\\aspire-dev-cert.pfx) { " +
+                "Import-PfxCertificate -FilePath $env:TEMP\\aspire-dev-cert.pfx -CertStoreLocation Cert:\\CurrentUser\\Root -Password (ConvertTo-SecureString '' -AsPlainText -Force) | Out-Null; " +
+                "Remove-Item $env:TEMP\\aspire-dev-cert.pfx -Force " +
+                "}";
+            await auto.TypeAsync(certCommands);
         }
         else
         {
-            await auto.TypeAsync("dotnet dev-certs https --trust 2>/dev/null || true");
+            // Linux: cert trust is handled by the CLI via SSL_CERT_DIR, just ensure cert exists
+            await auto.TypeAsync("dotnet dev-certs https 2>/dev/null || true");
         }
 
         await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+        await auto.WaitForAnyPromptAsync(counter, TimeSpan.FromSeconds(30));
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -99,10 +99,27 @@ internal static class CliE2EAutomatorHelpers
 
     /// <summary>
     /// Prepares a non-Docker terminal environment with prompt counting and workspace navigation.
-    /// Used by tests that run with <see cref="CliE2ETestHelpers.CreateTestTerminal"/> (bare bash, no Docker).
+    /// On Linux/macOS, launches bash with a custom PROMPT_COMMAND.
+    /// On Windows, launches pwsh.exe with a custom prompt function.
+    /// Both produce the same <c>[N OK] $ </c> prompt pattern for consistent prompt detection.
     /// </summary>
     internal static async Task PrepareEnvironmentAsync(
         this Hex1bTerminalAutomator auto,
+        TemporaryWorkspace workspace,
+        SequenceCounter counter)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            await PrepareWindowsEnvironmentAsync(auto, workspace, counter);
+        }
+        else
+        {
+            await PrepareBashEnvironmentAsync(auto, workspace, counter);
+        }
+    }
+
+    private static async Task PrepareBashEnvironmentAsync(
+        Hex1bTerminalAutomator auto,
         TemporaryWorkspace workspace,
         SequenceCounter counter)
     {
@@ -125,6 +142,46 @@ internal static class CliE2EAutomatorHelpers
         await auto.WaitForSuccessPromptAsync(counter);
     }
 
+    private static async Task PrepareWindowsEnvironmentAsync(
+        Hex1bTerminalAutomator auto,
+        TemporaryWorkspace workspace,
+        SequenceCounter counter)
+    {
+        // Wait for the initial PowerShell prompt
+        await auto.WaitUntilAsync(
+            snapshot => snapshot.GetScreenText().Contains("PS "),
+            timeout: TimeSpan.FromSeconds(15),
+            description: "initial pwsh prompt (PS )");
+        await auto.WaitAsync(500);
+
+        // Set up the prompt function to produce the same [N OK] $ pattern as bash.
+        // PowerShell updates $LASTEXITCODE only for native executables, so we treat
+        // null (no native exe has run yet) as success.
+        const string promptSetup =
+            "$global:CMDCOUNT = 0; " +
+            "function prompt { " +
+            "$s = if ($global:LASTEXITCODE -eq 0 -or $null -eq $global:LASTEXITCODE) { 'OK' } else { \"ERR:$($global:LASTEXITCODE)\" }; " +
+            "$global:CMDCOUNT++; " +
+            "\"[$global:CMDCOUNT $s] `$ \" }";
+        await auto.TypeAsync(promptSetup);
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Navigate to workspace
+        await auto.TypeAsync($"Set-Location '{workspace.WorkspaceRoot.FullName}'");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Set environment variables
+        await auto.TypeAsync(
+            "$env:ASPIRE_PLAYGROUND = 'true'; " +
+            "$env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'; " +
+            "$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true'; " +
+            "$env:DOTNET_GENERATE_ASPNET_CERTIFICATE = 'false'");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+
     /// <summary>
     /// Installs the Aspire CLI from PR build artifacts in a non-Docker environment.
     /// </summary>
@@ -133,7 +190,16 @@ internal static class CliE2EAutomatorHelpers
         int prNumber,
         SequenceCounter counter)
     {
-        var command = $"curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber}";
+        string command;
+        if (OperatingSystem.IsWindows())
+        {
+            command = $"iex \"& {{ $(irm https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.ps1) }} {prNumber}\"";
+        }
+        else
+        {
+            command = $"curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber}";
+        }
+
         await auto.TypeAsync(command);
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
@@ -146,7 +212,20 @@ internal static class CliE2EAutomatorHelpers
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter)
     {
-        await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
+        if (OperatingSystem.IsWindows())
+        {
+            await auto.TypeAsync(
+                "$env:PATH = \"$HOME\\.aspire\\bin;$env:PATH\"; " +
+                "$env:ASPIRE_PLAYGROUND = 'true'; " +
+                "$env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'; " +
+                "$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true'; " +
+                "$env:DOTNET_GENERATE_ASPNET_CERTIFICATE = 'false'");
+        }
+        else
+        {
+            await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
+        }
+
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
     }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -313,6 +313,29 @@ internal static class CliE2EAutomatorHelpers
     }
 
     /// <summary>
+    /// Pre-trusts the ASP.NET Core HTTPS development certificate so that <c>aspire new</c>
+    /// and <c>aspire start</c> don't hang on the Windows certificate trust dialog.
+    /// On CI runners (admin context), this succeeds silently. On Linux, this is a no-op
+    /// because cert trust is handled differently (SSL_CERT_DIR).
+    /// </summary>
+    internal static async Task EnsureDevCertsTrustedAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            await auto.TypeAsync("dotnet dev-certs https --trust");
+        }
+        else
+        {
+            await auto.TypeAsync("dotnet dev-certs https --trust 2>/dev/null || true");
+        }
+
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
     /// Clears the terminal screen by running the <c>clear</c> command and waiting for the prompt.
     /// </summary>
     internal static async Task ClearScreenAsync(

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Aspire.Cli.Tests.Utils;
 using Hex1b;
@@ -156,7 +157,8 @@ internal static class CliE2ETestHelpers
 
     /// <summary>
     /// Finds the locally-built native AOT CLI publish directory.
-    /// Searches for the aspire binary under artifacts/bin/Aspire.Cli/*/net*/linux-x64/publish/.
+    /// Searches for the aspire binary under artifacts/bin/Aspire.Cli/*/net*/&lt;rid&gt;/publish/.
+    /// On Windows, searches for win-x64 (or win-arm64); on Linux, searches for linux-x64.
     /// </summary>
     /// <returns>The publish directory path, or null if not found.</returns>
     internal static string? FindLocalCliBinary(string repoRoot)
@@ -167,9 +169,25 @@ internal static class CliE2ETestHelpers
             return null;
         }
 
+        // Determine the platform-specific binary name and RID
+        string binaryName;
+        string[] rids;
+        if (OperatingSystem.IsWindows())
+        {
+            binaryName = "aspire.exe";
+            rids = RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? ["win-arm64", "win-x64"]
+                : ["win-x64"];
+        }
+        else
+        {
+            binaryName = "aspire";
+            rids = ["linux-x64"];
+        }
+
         // Search for the native AOT binary under any config/TFM combination.
-        var matches = Directory.GetFiles(cliBaseDir, "aspire", SearchOption.AllDirectories)
-            .Where(f => f.Contains("linux-x64") && f.Contains("publish"))
+        var matches = Directory.GetFiles(cliBaseDir, binaryName, SearchOption.AllDirectories)
+            .Where(f => rids.Any(rid => f.Contains(rid)) && f.Contains("publish"))
             .ToArray();
 
         return matches.Length > 0 ? Path.GetDirectoryName(matches[0]) : null;

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/RequiresLinuxDockerFactAttribute.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/RequiresLinuxDockerFactAttribute.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests.Helpers;
+
+/// <summary>
+/// Marks a test that requires Linux Docker containers. On Windows, these tests
+/// are automatically skipped because the E2E Docker containers are Linux-based.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+internal sealed class RequiresLinuxDockerFactAttribute : FactAttribute
+{
+    public RequiresLinuxDockerFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Skip = "This test requires Linux Docker containers and cannot run on Windows.";
+        }
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/RequiresLinuxFactAttribute.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/RequiresLinuxFactAttribute.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests.Helpers;
+
+/// <summary>
+/// Marks a test that requires a Linux environment (uses bash commands, Linux tools, etc.).
+/// On Windows, these tests are automatically skipped.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+internal sealed class RequiresLinuxFactAttribute : FactAttribute
+{
+    public RequiresLinuxFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Skip = "This test requires a Linux environment (uses bash commands and Linux tools).";
+        }
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaCodegenValidationTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class JavaCodegenValidationTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task RestoreGeneratesSdkFiles()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class JavaEmptyAppHostTemplateTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateAndRunJavaEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class JavaPolyglotTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateJavaAppHostWithViteApp()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs
@@ -19,7 +19,7 @@ public sealed class JavaScriptPublishTests(ITestOutputHelper output)
         CliE2ETestHelpers.GetRepoRoot(),
         "tests", "Aspire.Cli.EndToEnd.Tests", "Fixtures", "JsPublish");
 
-    [Fact]
+    [RequiresLinuxFact]
     [CaptureWorkspaceOnFailure]
     public async Task AllPublishMethodsBuildDockerImages()
     {

--- a/tests/Aspire.Cli.EndToEnd.Tests/JsReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JsReactTemplateTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class JsReactTemplateTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateAndRunJsReactProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
@@ -26,7 +26,7 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
     private static string GenerateUniqueClusterName() =>
         $"{ClusterNamePrefix}-{Guid.NewGuid():N}"[..32]; // KinD cluster names max 32 chars
 
-    [Fact]
+    [RequiresLinuxFact]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/15930")]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/15870")]
     public async Task CreateAndPublishToKubernetes()

--- a/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
@@ -35,7 +35,7 @@ public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
     /// "apphost.ts" exercises the same code path as "../src/apphost.ts" → "src/apphost.ts".
     /// </para>
     /// </remarks>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task LegacySettingsMigration_AdjustsRelativeAppHostPath()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class LogsCommandTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task LogsCommandShowsResourceLogs()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class MultipleAppHostTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task DetachFormatJsonProducesValidJson()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
@@ -25,7 +25,7 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
     /// 4. Playwright CLI is installed and available on PATH
     /// 5. The <c>.claude/skills/playwright-cli/SKILL.md</c> skill file is generated
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AgentInit_InstallsPlaywrightCli_AndGeneratesSkillFiles()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -109,7 +109,7 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
     /// the missing <c>WorkingDirectory</c> on <c>ProcessStartInfo</c> caused skill files
     /// to be dropped in the CLI process's current working directory.
     /// </summary>
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AgentInit_WhenCwdDiffersFromWorkspaceRoot_PlacesSkillFilesInWorkspaceRoot()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
@@ -19,7 +19,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class ProjectReferenceTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/15831")]
     public async Task TypeScriptAppHostWithProjectReferenceIntegration()
     {

--- a/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class PsCommandTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task PsCommandListsRunningAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -85,7 +85,7 @@ public sealed class PsCommandTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task PsFormatJsonOutputsOnlyJsonToStdout()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class PythonReactTemplateTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     [CaptureWorkspaceOnFailure]
     public async Task CreateAndRunPythonReactProject()
     {

--- a/tests/Aspire.Cli.EndToEnd.Tests/SecretDotNetAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SecretDotNetAppHostTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class SecretDotNetAppHostTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task SecretCrudOnDotNetAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/SecretTypeScriptAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SecretTypeScriptAppHostTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class SecretTypeScriptAppHostTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task SecretCrudOnTypeScriptAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class SmokeTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateAndRunAspireStarterProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class StagingChannelTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task StagingChannel_ConfigureAndVerifySettings_ThenSwitchChannels()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class StartStopTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateStartAndStopAspireProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -63,7 +63,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task StopWithNoRunningAppHostExitsSuccessfully()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -97,7 +97,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AddPackageWhileAppHostRunningDetached()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -157,7 +157,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task AddPackageInteractiveWhileAppHostRunningDetached()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
@@ -9,19 +9,13 @@ using Xunit;
 namespace Aspire.Cli.EndToEnd.Tests;
 
 /// <summary>
-/// End-to-end tests that validate Aspire CLI starter templates can be created and started.
-/// These tests run natively on the host (no Docker) using the Hex1b PTY proxy on Windows
-/// and bare bash on Linux. They replace the PowerShell-based cli-starter-validation.ps1 script.
+/// End-to-end tests that validate Aspire CLI starter templates can be created and started
+/// on Windows. Uses the interactive <c>aspire new</c> flow (same as the Docker-based tests)
+/// so no <c>--channel</c> flag or pre-installed CLI is needed.
 /// </summary>
-/// <remarks>
-/// These tests require:
-/// - The Aspire CLI to be installed (from PR build in CI, or GA release locally)
-/// - NuGet packages to be available for the starter templates (via --channel in CI)
-/// - Node.js for TypeScript templates
-/// </remarks>
 public sealed class StarterValidationTests(ITestOutputHelper output)
 {
-    [Fact(Skip = "Requires dedicated CI job with pre-installed CLI and NuGet packages — not yet wired into the test matrix")]
+    [Fact]
     public async Task CSharpStarter_NewStartStop()
     {
         var workspace = TemporaryWorkspace.Create(output);
@@ -34,25 +28,21 @@ public sealed class StarterValidationTests(ITestOutputHelper output)
 
         await auto.PrepareEnvironmentAsync(workspace, counter);
 
-        // Install CLI (GA release for local, PR build for CI)
         if (CliE2ETestHelpers.IsRunningInCI)
         {
             var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
-            await auto.InstallAspireCliFromPullRequestAsync(prNumber, counter);
+            var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+            await auto.InstallAspireBundleFromPullRequestAsync(prNumber, counter);
+            await auto.SourceAspireBundleEnvironmentAsync(counter);
+            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
-
-        await auto.SourceAspireCliEnvironmentAsync(counter);
 
         output.WriteLine("Creating C# starter app...");
 
-        // aspire new with non-interactive mode
-        // In CI, use --channel to pick up NuGet packages from the PR dogfood feed
-        var channelArg = CliE2ETestHelpers.IsRunningInCI
-            ? $"--channel pr-{CliE2ETestHelpers.GetRequiredPrNumber()}"
-            : "";
-        await auto.TypeAsync($"aspire new aspire-starter --name StarterCsSmoke {channelArg} --non-interactive --nologo");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
+        // Use the interactive aspire new flow (same approach as Docker-based E2E tests)
+        await auto.AspireNewAsync("StarterCsSmoke", counter, useRedisCache: false);
+
+        output.WriteLine("Created. Navigating into project...");
 
         // Navigate into the project
         var cdCommand = OperatingSystem.IsWindows()
@@ -64,112 +54,29 @@ public sealed class StarterValidationTests(ITestOutputHelper output)
 
         output.WriteLine("Starting app...");
 
-        // Start the app
         await auto.TypeAsync("aspire start");
         await auto.EnterAsync();
 
-        // Wait for successful startup indication
         await auto.WaitUntilAsync(
             snapshot => snapshot.GetScreenText().Contains("Apphost started successfully"),
             timeout: TimeSpan.FromMinutes(3),
             description: "aspire start to complete (Apphost started successfully)");
         await auto.WaitForSuccessPromptAsync(counter);
 
-        output.WriteLine("App started. Waiting for resources...");
+        output.WriteLine("App started. Waiting for apiservice...");
 
-        // Wait for the apiservice resource to be up
         await auto.TypeAsync("aspire wait apiservice --status up --timeout 120");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
 
         output.WriteLine("Resources are up. Stopping...");
 
-        // Stop the app
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
         output.WriteLine("C# starter validation complete.");
 
-        // Exit cleanly
-        await auto.TypeAsync("exit");
-        await auto.EnterAsync();
-        await pendingRun;
-    }
-
-    [Fact(Skip = "Requires dedicated CI job with pre-installed CLI and NuGet packages — not yet wired into the test matrix")]
-    public async Task TypeScriptStarter_NewStartStop()
-    {
-        var workspace = TemporaryWorkspace.Create(output);
-
-        using var terminal = CliE2ETestHelpers.CreateTestTerminal();
-        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
-
-        var counter = new SequenceCounter();
-        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(300));
-
-        await auto.PrepareEnvironmentAsync(workspace, counter);
-
-        // Install CLI (GA release for local, PR build for CI)
-        if (CliE2ETestHelpers.IsRunningInCI)
-        {
-            var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
-            await auto.InstallAspireCliFromPullRequestAsync(prNumber, counter);
-        }
-
-        await auto.SourceAspireCliEnvironmentAsync(counter);
-
-        output.WriteLine("Creating TypeScript starter app...");
-
-        // aspire new with non-interactive mode
-        var channelArg = CliE2ETestHelpers.IsRunningInCI
-            ? $"--channel pr-{CliE2ETestHelpers.GetRequiredPrNumber()}"
-            : "";
-        await auto.TypeAsync($"aspire new aspire-ts-starter --name StarterTsSmoke {channelArg} --non-interactive --nologo");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
-
-        // Navigate into the project
-        var cdCommand = OperatingSystem.IsWindows()
-            ? "Set-Location StarterTsSmoke"
-            : "cd StarterTsSmoke";
-        await auto.TypeAsync(cdCommand);
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        output.WriteLine("Starting app...");
-
-        // Start the app
-        await auto.TypeAsync("aspire start");
-        await auto.EnterAsync();
-
-        await auto.WaitUntilAsync(
-            snapshot => snapshot.GetScreenText().Contains("Apphost started successfully"),
-            timeout: TimeSpan.FromMinutes(3),
-            description: "aspire start to complete (Apphost started successfully)");
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        output.WriteLine("App started. Waiting for resources...");
-
-        // Wait for resources to be up
-        await auto.TypeAsync("aspire wait app --status up --timeout 120");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
-
-        await auto.TypeAsync("aspire wait frontend --status up --timeout 120");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
-
-        output.WriteLine("Resources are up. Stopping...");
-
-        // Stop the app
-        await auto.TypeAsync("aspire stop");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
-
-        output.WriteLine("TypeScript starter validation complete.");
-
-        // Exit cleanly
         await auto.TypeAsync("exit");
         await auto.EnterAsync();
         await pendingRun;

--- a/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class StarterValidationTests(ITestOutputHelper output)
 {
-    [Fact(Skip = "aspire new hangs on Windows certificate trust step — needs DOTNET_GENERATE_ASPNET_CERTIFICATE=false to be respected by the CLI")]
+    [Fact]
     public async Task CSharpStarter_NewStartStop()
     {
         var workspace = TemporaryWorkspace.Create(output);
@@ -36,6 +36,10 @@ public sealed class StarterValidationTests(ITestOutputHelper output)
             await auto.SourceAspireBundleEnvironmentAsync(counter);
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
+
+        // Pre-trust the dev certificate so aspire new doesn't hang on the Windows cert trust dialog.
+        // On CI runners this succeeds silently (admin context). Locally, it may show a UAC prompt.
+        await auto.EnsureDevCertsTrustedAsync(counter);
 
         output.WriteLine("Creating C# starter app...");
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
@@ -40,7 +40,11 @@ public sealed class StarterValidationTests(ITestOutputHelper output)
         output.WriteLine("Creating C# starter app...");
 
         // aspire new with non-interactive mode
-        await auto.TypeAsync("aspire new aspire-starter --name StarterCsSmoke --non-interactive --nologo");
+        // In CI, use --channel to pick up NuGet packages from the PR dogfood feed
+        var channelArg = CliE2ETestHelpers.IsRunningInCI
+            ? $"--channel pr-{CliE2ETestHelpers.GetRequiredPrNumber()}"
+            : "";
+        await auto.TypeAsync($"aspire new aspire-starter --name StarterCsSmoke {channelArg} --non-interactive --nologo");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
 
@@ -112,7 +116,10 @@ public sealed class StarterValidationTests(ITestOutputHelper output)
         output.WriteLine("Creating TypeScript starter app...");
 
         // aspire new with non-interactive mode
-        await auto.TypeAsync("aspire new aspire-ts-starter --name StarterTsSmoke --non-interactive --nologo");
+        var channelArg = CliE2ETestHelpers.IsRunningInCI
+            ? $"--channel pr-{CliE2ETestHelpers.GetRequiredPrNumber()}"
+            : "";
+        await auto.TypeAsync($"aspire new aspire-ts-starter --name StarterTsSmoke {channelArg} --non-interactive --nologo");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class StarterValidationTests(ITestOutputHelper output)
 {
-    [Fact]
+    [Fact(Skip = "aspire new hangs on Windows certificate trust step — needs DOTNET_GENERATE_ASPNET_CERTIFICATE=false to be respected by the CLI")]
     public async Task CSharpStarter_NewStartStop()
     {
         var workspace = TemporaryWorkspace.Create(output);

--- a/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
@@ -13,9 +13,15 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// These tests run natively on the host (no Docker) using the Hex1b PTY proxy on Windows
 /// and bare bash on Linux. They replace the PowerShell-based cli-starter-validation.ps1 script.
 /// </summary>
+/// <remarks>
+/// These tests require:
+/// - The Aspire CLI to be installed (from PR build in CI, or GA release locally)
+/// - NuGet packages to be available for the starter templates (via --channel in CI)
+/// - Node.js for TypeScript templates
+/// </remarks>
 public sealed class StarterValidationTests(ITestOutputHelper output)
 {
-    [Fact]
+    [Fact(Skip = "Requires dedicated CI job with pre-installed CLI and NuGet packages — not yet wired into the test matrix")]
     public async Task CSharpStarter_NewStartStop()
     {
         var workspace = TemporaryWorkspace.Create(output);
@@ -91,7 +97,7 @@ public sealed class StarterValidationTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [Fact(Skip = "Requires dedicated CI job with pre-installed CLI and NuGet packages — not yet wired into the test matrix")]
     public async Task TypeScriptStarter_NewStartStop()
     {
         var workspace = TemporaryWorkspace.Create(output);

--- a/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests that validate Aspire CLI starter templates can be created and started.
+/// These tests run natively on the host (no Docker) using the Hex1b PTY proxy on Windows
+/// and bare bash on Linux. They replace the PowerShell-based cli-starter-validation.ps1 script.
+/// </summary>
+public sealed class StarterValidationTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task CSharpStarter_NewStartStop()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateTestTerminal();
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(300));
+
+        await auto.PrepareEnvironmentAsync(workspace, counter);
+
+        // Install CLI (GA release for local, PR build for CI)
+        if (CliE2ETestHelpers.IsRunningInCI)
+        {
+            var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+            await auto.InstallAspireCliFromPullRequestAsync(prNumber, counter);
+        }
+
+        await auto.SourceAspireCliEnvironmentAsync(counter);
+
+        output.WriteLine("Creating C# starter app...");
+
+        // aspire new with non-interactive mode
+        await auto.TypeAsync("aspire new aspire-starter --name StarterCsSmoke --non-interactive --nologo");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
+
+        // Navigate into the project
+        var cdCommand = OperatingSystem.IsWindows()
+            ? "Set-Location StarterCsSmoke"
+            : "cd StarterCsSmoke";
+        await auto.TypeAsync(cdCommand);
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        output.WriteLine("Starting app...");
+
+        // Start the app
+        await auto.TypeAsync("aspire start");
+        await auto.EnterAsync();
+
+        // Wait for successful startup indication
+        await auto.WaitUntilAsync(
+            snapshot => snapshot.GetScreenText().Contains("Apphost started successfully"),
+            timeout: TimeSpan.FromMinutes(3),
+            description: "aspire start to complete (Apphost started successfully)");
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        output.WriteLine("App started. Waiting for resources...");
+
+        // Wait for the apiservice resource to be up
+        await auto.TypeAsync("aspire wait apiservice --status up --timeout 120");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
+
+        output.WriteLine("Resources are up. Stopping...");
+
+        // Stop the app
+        await auto.TypeAsync("aspire stop");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        output.WriteLine("C# starter validation complete.");
+
+        // Exit cleanly
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+
+    [Fact]
+    public async Task TypeScriptStarter_NewStartStop()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateTestTerminal();
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(300));
+
+        await auto.PrepareEnvironmentAsync(workspace, counter);
+
+        // Install CLI (GA release for local, PR build for CI)
+        if (CliE2ETestHelpers.IsRunningInCI)
+        {
+            var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+            await auto.InstallAspireCliFromPullRequestAsync(prNumber, counter);
+        }
+
+        await auto.SourceAspireCliEnvironmentAsync(counter);
+
+        output.WriteLine("Creating TypeScript starter app...");
+
+        // aspire new with non-interactive mode
+        await auto.TypeAsync("aspire new aspire-ts-starter --name StarterTsSmoke --non-interactive --nologo");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
+
+        // Navigate into the project
+        var cdCommand = OperatingSystem.IsWindows()
+            ? "Set-Location StarterTsSmoke"
+            : "cd StarterTsSmoke";
+        await auto.TypeAsync(cdCommand);
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        output.WriteLine("Starting app...");
+
+        // Start the app
+        await auto.TypeAsync("aspire start");
+        await auto.EnterAsync();
+
+        await auto.WaitUntilAsync(
+            snapshot => snapshot.GetScreenText().Contains("Apphost started successfully"),
+            timeout: TimeSpan.FromMinutes(3),
+            description: "aspire start to complete (Apphost started successfully)");
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        output.WriteLine("App started. Waiting for resources...");
+
+        // Wait for resources to be up
+        await auto.TypeAsync("aspire wait app --status up --timeout 120");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
+
+        await auto.TypeAsync("aspire wait frontend --status up --timeout 120");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(3));
+
+        output.WriteLine("Resources are up. Stopping...");
+
+        // Stop the app
+        await auto.TypeAsync("aspire stop");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        output.WriteLine("TypeScript starter validation complete.");
+
+        // Exit cleanly
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StarterValidationTests.cs
@@ -24,7 +24,8 @@ public sealed class StarterValidationTests(ITestOutputHelper output)
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
         var counter = new SequenceCounter();
-        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(300));
+        // Use a long default timeout — Windows CI runners can be slow for dotnet new + restore
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromMinutes(10));
 
         await auto.PrepareEnvironmentAsync(workspace, counter);
 
@@ -43,7 +44,8 @@ public sealed class StarterValidationTests(ITestOutputHelper output)
 
         output.WriteLine("Creating C# starter app...");
 
-        // Use the interactive aspire new flow (same approach as Docker-based E2E tests)
+        // Use the interactive aspire new flow. Use a long timeout for DeclineAgentInitPrompt
+        // because dotnet new + NuGet restore can take 10+ minutes on slow Windows CI runners.
         await auto.AspireNewAsync("StarterCsSmoke", counter, useRedisCache: false);
 
         output.WriteLine("Created. Navigating into project...");

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class StopNonInteractiveTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task StopNonInteractiveSingleAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -73,7 +73,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task StopAllAppHostsFromAppHostDirectory()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -140,7 +140,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task StopAllAppHostsFromUnrelatedDirectory()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -212,7 +212,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         await pendingRun;
     }
 
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task StopNonInteractiveMultipleAppHostsShowsError()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task RestoreGeneratesSdkFiles()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateAndRunTypeScriptEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateTypeScriptAppHostWithViteApp()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class TypeScriptPublishTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task PublishWithDockerComposeServiceCallbackSucceeds()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptReusablePackageTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptReusablePackageTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class TypeScriptReusablePackageTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task RestoreSupportsConfigOnlyHelperPackageAndCrossPackageTypes()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     public async Task CreateAndRunTypeScriptStarterProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class WaitCommandTests(ITestOutputHelper output)
 {
-    [Fact]
+    [RequiresLinuxDockerFact]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/14993")]
     public async Task CreateStartWaitAndStopAspireProject()
     {

--- a/tests/Aspire.Cli.EndToEnd.Tests/WindowsPtySmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/WindowsPtySmokeTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// Minimal smoke test to validate that Hex1b's PTY proxy works on Windows.
+/// This test launches pwsh.exe via Hex1b, types a command, and verifies the output.
+/// No Aspire CLI, no prompt counting — just raw Hex1b on Windows.
+/// </summary>
+public sealed class WindowsPtySmokeTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task PwshTerminal_CanEchoAndExit()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            output.WriteLine("Skipping: this test only runs on Windows.");
+            return;
+        }
+
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath("PwshTerminal_CanEchoAndExit");
+
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("pwsh.exe", ["-NoProfile", "-NoLogo"])
+            .Build();
+
+        output.WriteLine($"Recording: {recordingPath}");
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(30));
+
+        // Wait for the initial PowerShell prompt
+        await auto.WaitUntilAsync(
+            snapshot => snapshot.GetScreenText().Contains("PS "),
+            timeout: TimeSpan.FromSeconds(15),
+            description: "initial pwsh prompt (PS )");
+
+        output.WriteLine("Got initial pwsh prompt.");
+
+        // Type a simple echo command
+        await auto.TypeAsync("Write-Output 'hex1b-windows-works'");
+        await auto.EnterAsync();
+
+        // Wait for the output to appear
+        await auto.WaitUntilAsync(
+            snapshot => snapshot.GetScreenText().Contains("hex1b-windows-works"),
+            timeout: TimeSpan.FromSeconds(10),
+            description: "echo output (hex1b-windows-works)");
+
+        output.WriteLine("Saw echo output.");
+
+        // Exit cleanly
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+
+        output.WriteLine("pwsh terminal exited cleanly.");
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/WindowsPtySmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/WindowsPtySmokeTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
 using Hex1b;
 using Hex1b.Automation;
 using Xunit;
@@ -9,9 +10,9 @@ using Xunit;
 namespace Aspire.Cli.EndToEnd.Tests;
 
 /// <summary>
-/// Minimal smoke test to validate that Hex1b's PTY proxy works on Windows.
-/// This test launches pwsh.exe via Hex1b, types a command, and verifies the output.
-/// No Aspire CLI, no prompt counting — just raw Hex1b on Windows.
+/// Smoke tests to validate that Hex1b's PTY proxy works on Windows.
+/// These tests launch pwsh.exe via Hex1b, interact with the terminal,
+/// and verify the prompt counting infrastructure works cross-platform.
 /// </summary>
 public sealed class WindowsPtySmokeTests(ITestOutputHelper output)
 {
@@ -66,5 +67,50 @@ public sealed class WindowsPtySmokeTests(ITestOutputHelper output)
         await pendingRun;
 
         output.WriteLine("pwsh terminal exited cleanly.");
+    }
+
+    [Fact]
+    public async Task PromptCounting_WorksOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            output.WriteLine("Skipping: this test only runs on Windows.");
+            return;
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateTestTerminal();
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(30));
+
+        // Use the infrastructure to set up prompt counting
+        await auto.PrepareEnvironmentAsync(workspace, counter);
+
+        output.WriteLine($"Prompt counting setup complete. Counter at {counter.Value}.");
+
+        // Run a simple command and verify prompt detection works
+        await auto.TypeAsync("Write-Output 'prompt-counting-works'");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        output.WriteLine($"First command succeeded. Counter at {counter.Value}.");
+
+        // Run another command to verify counter increments properly
+        await auto.TypeAsync("Write-Output 'second-command'");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        output.WriteLine($"Second command succeeded. Counter at {counter.Value}.");
+
+        // Exit cleanly
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+
+        output.WriteLine("Prompt counting test completed successfully.");
     }
 }

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -112,7 +112,7 @@ internal static class Hex1bAutomatorTestHelpers
         SequenceCounter counter,
         TimeSpan? timeout = null)
     {
-        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(600);
 
         var agentInitPrompt = new CellPatternSearcher()
             .Find("configure AI agent environments");

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -94,8 +94,16 @@ internal static class Hex1bTestHelpers
         var builder = Hex1bTerminal.CreateBuilder()
             .WithHeadless()
             .WithDimensions(width, height)
-            .WithAsciinemaRecording(recordingPath)
-            .WithPtyProcess("/bin/bash", ["--norc"]);
+            .WithAsciinemaRecording(recordingPath);
+
+        if (OperatingSystem.IsWindows())
+        {
+            builder.WithPtyProcess("pwsh.exe", ["-NoProfile", "-NoLogo"]);
+        }
+        else
+        {
+            builder.WithPtyProcess("/bin/bash", ["--norc"]);
+        }
 
         return builder.Build();
     }


### PR DESCRIPTION
## Description

Enable Aspire CLI E2E tests to run on Windows using Hex1b's new PTY proxy support (hex1bpty.exe, added in v0.126.0).

### What changed

**Infrastructure (shared helpers):**
- `Hex1bTestHelpers.CreateTestTerminal()` — uses `pwsh.exe -NoProfile -NoLogo` on Windows, `/bin/bash --norc` on Linux/macOS
- `CliE2EAutomatorHelpers.PrepareEnvironmentAsync()` — Windows branch sets up a PowerShell `prompt` function that produces the **identical `[N OK] $ ` pattern** as bash, so all existing shared helpers (`WaitForSuccessPromptAsync`, `WaitForErrorPromptAsync`, etc.) work unchanged on both platforms
- `InstallAspireCliFromPullRequestAsync()` — uses PowerShell install script on Windows
- `SourceAspireCliEnvironmentAsync()` — uses `$env:` syntax on Windows
- `FindLocalCliBinary()` — searches for `win-x64`/`aspire.exe` on Windows

**CI integration:**
- `RunOnGithubActionsWindows=true` in the E2E test csproj (was `false`)
- Created `RequiresLinuxDockerFactAttribute` — auto-skips Docker-based tests on Windows
- Applied `[RequiresLinuxDockerFact]` to all 60 Docker-dependent test methods (36 files)
- `tests.yml` — `tests_requires_cli_archive` now also depends on `build_cli_archive_windows`

**New tests:**
- `WindowsPtySmokeTests.PwshTerminal_CanEchoAndExit` — validates raw Hex1b PTY works with pwsh.exe
- `WindowsPtySmokeTests.PromptCounting_WorksOnWindows` — validates full prompt counting infrastructure

### Key design decision
PowerShell's `prompt` function produces the same `[N OK] $ ` text pattern as bash's `PROMPT_COMMAND`/`PS1`. This means zero modifications were needed to any of the shared prompt detection helpers.

### What's deferred
- Retiring `cli-starter-validation.ps1` — keep until Windows E2E coverage is proven stable in CI
- `AspireStartAsync()` Windows equivalent — uses bash-specific commands (`tee`, `sed`, `curl`)
- macOS support — straightforward to add later

Fixes #16031

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
