### PR TITLE
Remove custom Npgsql histogram view on .NET 10+

### DIFF
--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
@@ -26,6 +26,12 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
 
+  <!-- When targeting net8.0 or net9.0, we use older Npgsql versions (8.x/9.x) whose metrics
+       don't align with the OpenTelemetry spec. LEGACY_NPGSQL enables custom histogram views. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
+    <DefineConstants>$(DefineConstants);LEGACY_NPGSQL</DefineConstants>
+  </PropertyGroup>
+
   <!-- Npgsql EF needs to match the same major version as the underlying Npgsql assemblies. -->
   <!-- This is to override CentralPackageTransitivePinningEnabled -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Components/Aspire.Npgsql/NpgsqlCommon.cs
+++ b/src/Components/Aspire.Npgsql/NpgsqlCommon.cs
@@ -11,9 +11,10 @@ internal static class NpgsqlCommon
         meterProviderBuilder
             .AddMeter("Npgsql");
 
-#if !NET10_0_OR_GREATER
-        // starting with Npgsql 10.0, the metrics align with OpenTelemetry's spec
-        // see https://github.com/npgsql/npgsql/commit/a27566ff3e75ab1f75feb6d24cb69cdbd3340ab4
+#if LEGACY_NPGSQL
+        // Npgsql versions prior to 10.0 don't align their metrics with the OpenTelemetry spec,
+        // so custom histogram bucket boundaries are needed for the duration metrics.
+        // See https://github.com/npgsql/npgsql/commit/a27566ff3e75ab1f75feb6d24cb69cdbd3340ab4
         double[] secondsBuckets = [0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10];
 
         meterProviderBuilder

--- a/src/Components/Aspire.Npgsql/NpgsqlCommon.cs
+++ b/src/Components/Aspire.Npgsql/NpgsqlCommon.cs
@@ -7,11 +7,16 @@ internal static class NpgsqlCommon
 {
     public static void AddNpgsqlMetrics(MeterProviderBuilder meterProviderBuilder)
     {
-        double[] secondsBuckets = [0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10];
-
         // https://github.com/npgsql/npgsql/blob/4c9921de2dfb48fb5a488787fc7422add3553f50/src/Npgsql/MetricsReporter.cs#L48
         meterProviderBuilder
-            .AddMeter("Npgsql")
+            .AddMeter("Npgsql");
+
+#if !NET10_0_OR_GREATER
+        // starting with Npgsql 10.0, the metrics align with OpenTelemetry's spec
+        // see https://github.com/npgsql/npgsql/commit/a27566ff3e75ab1f75feb6d24cb69cdbd3340ab4
+        double[] secondsBuckets = [0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10];
+
+        meterProviderBuilder
             // Npgsql's histograms are in seconds, not milliseconds.
             .AddView("db.client.commands.duration",
                 new ExplicitBucketHistogramConfiguration
@@ -23,5 +28,6 @@ internal static class NpgsqlCommon
                 {
                     Boundaries = secondsBuckets
                 });
+#endif
     }
 }


### PR DESCRIPTION
## Description

Starting with Npgsql 10.0, the library's metrics now align with the OpenTelemetry specification natively (see [npgsql/npgsql@a27566f](https://github.com/npgsql/npgsql/commit/a27566ff3e75ab1f75feb6d24cb69cdbd3340ab4)). This means the custom `ExplicitBucketHistogramConfiguration` views we were adding for `db.client.commands.duration` and `db.client.connections.create_time` are no longer needed on .NET 10+.

This change guards the custom histogram views with `#if !NET10_0_OR_GREATER` so they only apply on older TFMs, while keeping the `AddMeter("Npgsql")` call unconditional.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
