### PR TITLE
Enable NuGet signature verification for aspire-managed on Linux

### DIFF
--- a/src/Aspire.Cli/KnownFeatures.cs
+++ b/src/Aspire.Cli/KnownFeatures.cs
@@ -29,6 +29,7 @@ internal static class KnownFeatures
     public static string ExperimentalPolyglotJava => "experimentalPolyglot:java";
     public static string ExperimentalPolyglotGo => "experimentalPolyglot:go";
     public static string ExperimentalPolyglotPython => "experimentalPolyglot:python";
+    public static string NuGetSignatureVerificationEnabled => "nugetSignatureVerificationEnabled";
 
     private static readonly Dictionary<string, FeatureMetadata> s_featureMetadata = new()
     {
@@ -80,7 +81,12 @@ internal static class KnownFeatures
         [ExperimentalPolyglotPython] = new(
             ExperimentalPolyglotPython,
             "Enable or disable experimental Python language support for polyglot Aspire applications",
-            DefaultValue: false)
+            DefaultValue: false),
+
+        [NuGetSignatureVerificationEnabled] = new(
+            NuGetSignatureVerificationEnabled,
+            "Enable or disable defaulting the DOTNET_NUGET_SIGNATURE_VERIFICATION environment variable for spawned processes",
+            DefaultValue: true)
     };
 
     /// <summary>

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Layout;
 using Microsoft.Extensions.Logging;
 
@@ -38,16 +39,19 @@ internal sealed class BundleNuGetService : INuGetService
 {
     private readonly ILayoutDiscovery _layoutDiscovery;
     private readonly LayoutProcessRunner _layoutProcessRunner;
+    private readonly IFeatures _features;
     private readonly ILogger<BundleNuGetService> _logger;
     private readonly string _cacheDirectory;
 
     public BundleNuGetService(
         ILayoutDiscovery layoutDiscovery,
         LayoutProcessRunner layoutProcessRunner,
+        IFeatures features,
         ILogger<BundleNuGetService> logger)
     {
         _layoutDiscovery = layoutDiscovery;
         _layoutProcessRunner = layoutProcessRunner;
+        _features = features;
         _logger = logger;
         _cacheDirectory = GetCacheDirectory();
     }
@@ -142,12 +146,16 @@ internal sealed class BundleNuGetService : INuGetService
         _logger.LogDebug("aspire-managed path: {ManagedPath}", managedPath);
         _logger.LogDebug("NuGet restore args: {Args}", string.Join(" ", restoreArgs));
 
+        var environmentVariables = new Dictionary<string, string>();
+        NuGetSignatureVerificationEnabler.Apply(environmentVariables, _features);
+
         var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
             managedPath,
             restoreArgs,
+            environmentVariables: environmentVariables,
             ct: ct);
 
-        // Log stderr output (verbose info from NuGetHelper)
+        // Log stderr at debug level for diagnostics
         if (!string.IsNullOrWhiteSpace(error))
         {
             _logger.LogDebug("NuGetHelper restore stderr: {Error}", error);
@@ -190,9 +198,10 @@ internal sealed class BundleNuGetService : INuGetService
         (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
             managedPath,
             layoutArgs,
+            environmentVariables: environmentVariables,
             ct: ct);
 
-        // Log stderr output (verbose info from NuGetHelper)
+        // Log stderr at debug level for diagnostics
         if (!string.IsNullOrWhiteSpace(error))
         {
             _logger.LogDebug("NuGetHelper layout stderr: {Error}", error);

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -40,6 +40,7 @@ internal sealed class BundleNuGetService : INuGetService
     private readonly ILayoutDiscovery _layoutDiscovery;
     private readonly LayoutProcessRunner _layoutProcessRunner;
     private readonly IFeatures _features;
+    private readonly CliExecutionContext _executionContext;
     private readonly ILogger<BundleNuGetService> _logger;
     private readonly string _cacheDirectory;
 
@@ -47,11 +48,13 @@ internal sealed class BundleNuGetService : INuGetService
         ILayoutDiscovery layoutDiscovery,
         LayoutProcessRunner layoutProcessRunner,
         IFeatures features,
+        CliExecutionContext executionContext,
         ILogger<BundleNuGetService> logger)
     {
         _layoutDiscovery = layoutDiscovery;
         _layoutProcessRunner = layoutProcessRunner;
         _features = features;
+        _executionContext = executionContext;
         _logger = logger;
         _cacheDirectory = GetCacheDirectory();
     }
@@ -147,7 +150,7 @@ internal sealed class BundleNuGetService : INuGetService
         _logger.LogDebug("NuGet restore args: {Args}", string.Join(" ", restoreArgs));
 
         var environmentVariables = new Dictionary<string, string>();
-        NuGetSignatureVerificationEnabler.Apply(environmentVariables, _features);
+        NuGetSignatureVerificationEnabler.Apply(environmentVariables, _features, _executionContext);
 
         var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
             managedPath,

--- a/src/Aspire.Cli/NuGet/NuGetSignatureVerificationEnabler.cs
+++ b/src/Aspire.Cli/NuGet/NuGetSignatureVerificationEnabler.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Configuration;
+
+namespace Aspire.Cli.NuGet;
+
+/// <summary>
+/// Enables NuGet signature verification when spawning aspire-managed processes.
+/// Mirrors the .NET SDK's NuGetSignatureVerificationEnabler behavior.
+/// </summary>
+internal static class NuGetSignatureVerificationEnabler
+{
+    internal const string DotNetNuGetSignatureVerification = "DOTNET_NUGET_SIGNATURE_VERIFICATION";
+
+    /// <summary>
+    /// Applies NuGet signature verification environment variables to the given dictionary.
+    /// On Linux, sets DOTNET_NUGET_SIGNATURE_VERIFICATION to "true" unless the user
+    /// has explicitly set it to "false". The behavior can be disabled via the
+    /// <see cref="KnownFeatures.NuGetSignatureVerificationEnabled"/> feature flag.
+    /// </summary>
+    public static void Apply(Dictionary<string, string> environmentVariables, IFeatures features)
+    {
+        if (!OperatingSystem.IsLinux() ||
+            !features.IsFeatureEnabled(
+                KnownFeatures.NuGetSignatureVerificationEnabled,
+                KnownFeatures.GetFeatureMetadata(KnownFeatures.NuGetSignatureVerificationEnabled)!.DefaultValue))
+        {
+            return;
+        }
+
+        var value = Environment.GetEnvironmentVariable(DotNetNuGetSignatureVerification);
+
+        // If the user explicitly set it to "false", respect that
+        var effectiveValue = string.Equals(bool.FalseString, value, StringComparison.OrdinalIgnoreCase)
+            ? bool.FalseString
+            : bool.TrueString;
+
+        environmentVariables[DotNetNuGetSignatureVerification] = effectiveValue;
+    }
+}

--- a/src/Aspire.Cli/NuGet/NuGetSignatureVerificationEnabler.cs
+++ b/src/Aspire.Cli/NuGet/NuGetSignatureVerificationEnabler.cs
@@ -19,7 +19,7 @@ internal static class NuGetSignatureVerificationEnabler
     /// has explicitly set it to "false". The behavior can be disabled via the
     /// <see cref="KnownFeatures.NuGetSignatureVerificationEnabled"/> feature flag.
     /// </summary>
-    public static void Apply(Dictionary<string, string> environmentVariables, IFeatures features)
+    public static void Apply(Dictionary<string, string> environmentVariables, IFeatures features, CliExecutionContext executionContext)
     {
         if (!OperatingSystem.IsLinux() ||
             !features.IsFeatureEnabled(
@@ -29,10 +29,10 @@ internal static class NuGetSignatureVerificationEnabler
             return;
         }
 
-        var value = Environment.GetEnvironmentVariable(DotNetNuGetSignatureVerification);
+        var value = executionContext.GetEnvironmentVariable(DotNetNuGetSignatureVerification);
 
         // If the user explicitly set it to "false", respect that
-        var effectiveValue = string.Equals(bool.FalseString, value, StringComparison.OrdinalIgnoreCase)
+        var effectiveValue = bool.TryParse(value, out var boolValue) && !boolValue
             ? bool.FalseString
             : bool.TrueString;
 

--- a/src/Aspire.Managed/Aspire.Managed.csproj
+++ b/src/Aspire.Managed/Aspire.Managed.csproj
@@ -19,7 +19,16 @@
 
     <!-- Self-contained single-file publish settings (applied only during publish via Bundle.proj) -->
     <PublishSingleFile>true</PublishSingleFile>
+
+    <!-- Locate the SDK's trustedroots directory for NuGet signature verification certificates -->
+    <_SdkTrustedRootsDir>$([System.IO.Path]::Combine($([System.IO.Path]::GetDirectoryName($(BundledRuntimeIdentifierGraphFile))), 'trustedroots'))</_SdkTrustedRootsDir>
   </PropertyGroup>
+
+  <!-- Embed NuGet trusted root certificates from the .NET SDK for signature verification on Linux -->
+  <ItemGroup>
+    <EmbeddedResource Include="$(_SdkTrustedRootsDir)\*.pem" />
+    <EmbeddedResource Update="$(_SdkTrustedRootsDir)\*.pem" LogicalName="%(Filename)%(Extension)" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Dashboard\Aspire.Dashboard.csproj" />

--- a/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
@@ -194,6 +194,10 @@ public static class RestoreCommand
                 MachineWideSettings = machineWideSettings,
             };
 
+            // Initialize NuGet's trust store with embedded trusted root certificates
+            // so that package signature verification works on Linux.
+            TrustedRootsHelper.InitializeTrustStore(logger);
+
             var results = await RestoreRunner.RunAsync(restoreArgs).ConfigureAwait(false);
             var summary = results.Count > 0 ? results[0] : null;
 

--- a/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
@@ -196,7 +196,7 @@ public static class RestoreCommand
 
             // Initialize NuGet's trust store with embedded trusted root certificates
             // so that package signature verification works on Linux.
-            TrustedRootsHelper.InitializeTrustStore(logger);
+            TrustedRootsHelper.InitializeTrustStore();
 
             var results = await RestoreRunner.RunAsync(restoreArgs).ConfigureAwait(false);
             var summary = results.Count > 0 ? results[0] : null;

--- a/src/Aspire.Managed/NuGet/TrustedRootsHelper.cs
+++ b/src/Aspire.Managed/NuGet/TrustedRootsHelper.cs
@@ -1,0 +1,227 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable CA1852 // DispatchProxy classes can't be sealed
+
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Packaging.Signing;
+using INuGetLogger = NuGet.Common.ILogger;
+
+namespace Aspire.Managed.NuGet;
+
+/// <summary>
+/// Initializes NuGet's X509 trust store from embedded trusted root PEM certificates
+/// for package signature verification on Linux, without writing to disk.
+/// </summary>
+internal static class TrustedRootsHelper
+{
+    /// <summary>
+    /// Initializes the NuGet trust store with embedded trusted root certificates.
+    /// On Linux, when DOTNET_NUGET_SIGNATURE_VERIFICATION is set to "true", NuGet requires
+    /// certificate bundles for signature verification. The .NET SDK ships these as PEM files
+    /// in its trustedroots directory, but aspire-managed is a single-file app without access
+    /// to the SDK's directory structure. This method loads embedded PEM resources in memory
+    /// and uses DispatchProxy to create IX509ChainFactory implementations that NuGet's trust
+    /// store can use.
+    /// </summary>
+    /// <remarks>
+    /// TODO: Remove this once NuGet supports a public API for configuring the trust store,
+    /// or when it supports single-file apps. See https://github.com/dotnet/aspire/issues/15282.
+    /// </remarks>
+    public static void InitializeTrustStore(INuGetLogger logger)
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            // On Windows, NuGet uses the system certificate store directly.
+            // On macOS, matching .NET SDK behavior which only enables this on Linux.
+            return;
+        }
+
+        var envValue = Environment.GetEnvironmentVariable("DOTNET_NUGET_SIGNATURE_VERIFICATION");
+        if (!string.Equals(bool.TrueString, envValue, StringComparison.OrdinalIgnoreCase))
+        {
+            // If DOTNET_NUGET_SIGNATURE_VERIFICATION is not set to "true", NuGet won't
+            // perform signature verification on Linux, so there's no need to initialize
+            // the trust store.
+            return;
+        }
+
+        try
+        {
+            InitializeTrustStoreFromEmbeddedResources(logger);
+        }
+        catch (Exception ex)
+        {
+            // Log but don't fail the restore. If trust store initialization fails,
+            // NuGet may still work if signature verification is not required or if
+            // the system has its own certificate bundles.
+            logger.LogWarning($"Failed to initialize NuGet trust store from embedded certificates: {ex.Message}");
+        }
+    }
+
+    private static void InitializeTrustStoreFromEmbeddedResources(INuGetLogger logger)
+    {
+        var nugetPackagingAssembly = typeof(X509TrustStore).Assembly;
+
+        // Resolve internal NuGet types needed for DispatchProxy creation
+        var chainFactoryInterfaceType = nugetPackagingAssembly.GetType("NuGet.Packaging.Signing.IX509ChainFactory");
+        var chainInterfaceType = nugetPackagingAssembly.GetType("NuGet.Packaging.Signing.IX509Chain");
+
+        if (chainFactoryInterfaceType is null || chainInterfaceType is null)
+        {
+            logger.LogWarning("Could not find IX509ChainFactory or IX509Chain types in NuGet.Packaging.");
+            return;
+        }
+
+        // Set up code signing trust store
+        SetTrustStoreFactory(
+            "SetCodeSigningX509ChainFactory",
+            "codesignctl.pem",
+            chainFactoryInterfaceType,
+            chainInterfaceType,
+            logger);
+
+        // Set up timestamping trust store
+        SetTrustStoreFactory(
+            "SetTimestampingX509ChainFactory",
+            "timestampctl.pem",
+            chainFactoryInterfaceType,
+            chainInterfaceType,
+            logger);
+    }
+
+    private static void SetTrustStoreFactory(
+        string setterMethodName,
+        string resourceName,
+        Type chainFactoryInterfaceType,
+        Type chainInterfaceType,
+        INuGetLogger logger)
+    {
+        var certificates = LoadCertificatesFromResource(resourceName);
+        if (certificates is null || certificates.Count == 0)
+        {
+            logger.LogWarning($"No certificates loaded from embedded resource: {resourceName}");
+            return;
+        }
+
+        // Create IX509ChainFactory proxy via DispatchProxy
+        var factory = ChainFactoryDispatchProxy.CreateFactory(
+            chainFactoryInterfaceType, chainInterfaceType, certificates);
+
+        // Call the setter on X509TrustStore to register the factory
+        var setter = typeof(X509TrustStore).GetMethod(
+            setterMethodName,
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        if (setter is null)
+        {
+            logger.LogWarning($"Could not find {setterMethodName} on X509TrustStore.");
+            return;
+        }
+
+        setter.Invoke(null, [factory]);
+        logger.LogInformation($"Initialized NuGet trust store from embedded resource: {resourceName} ({certificates.Count} certificates)");
+    }
+
+    private static X509Certificate2Collection? LoadCertificatesFromResource(string resourceName)
+    {
+        using var stream = typeof(TrustedRootsHelper).Assembly.GetManifestResourceStream(resourceName);
+        if (stream is null)
+        {
+            return null;
+        }
+
+        using var reader = new StreamReader(stream);
+        var pemContents = reader.ReadToEnd();
+
+        var certificates = new X509Certificate2Collection();
+        certificates.ImportFromPem(pemContents);
+        return certificates;
+    }
+}
+
+/// <summary>
+/// DispatchProxy that implements NuGet's internal IX509ChainFactory interface.
+/// Creates X509Chain instances configured with custom root trust using embedded certificates.
+/// </summary>
+internal class ChainFactoryDispatchProxy : DispatchProxy
+{
+    private X509Certificate2Collection _certificates = [];
+    private Type _chainInterfaceType = null!;
+
+    internal static object CreateFactory(
+        Type chainFactoryInterfaceType,
+        Type chainInterfaceType,
+        X509Certificate2Collection certificates)
+    {
+        var proxy = (ChainFactoryDispatchProxy)Create(chainFactoryInterfaceType, typeof(ChainFactoryDispatchProxy));
+
+        proxy._certificates = certificates;
+        proxy._chainInterfaceType = chainInterfaceType;
+        return proxy;
+    }
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        // IX509ChainFactory has a single method: IX509Chain Create()
+        if (targetMethod?.Name == "Create")
+        {
+            return CreateChain();
+        }
+
+        throw new NotSupportedException($"Method {targetMethod?.Name} is not supported.");
+    }
+
+    private object CreateChain()
+    {
+        // Create an IX509Chain proxy that wraps an X509Chain with custom root trust
+        return ChainDispatchProxy.CreateChain(_chainInterfaceType, _certificates);
+    }
+}
+
+/// <summary>
+/// DispatchProxy that implements NuGet's internal IX509Chain interface.
+/// Wraps an X509Chain configured with CustomRootTrust mode.
+/// </summary>
+internal class ChainDispatchProxy : DispatchProxy
+{
+    private readonly X509Chain _chain = new();
+
+    internal static object CreateChain(
+        Type chainInterfaceType,
+        X509Certificate2Collection certificates)
+    {
+        var proxy = (ChainDispatchProxy)Create(chainInterfaceType, typeof(ChainDispatchProxy));
+
+        proxy._chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        proxy._chain.ChainPolicy.CustomTrustStore.AddRange(certificates);
+        return proxy;
+    }
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        return targetMethod?.Name switch
+        {
+            "Build" => Build((X509Certificate2)args![0]!),
+            "Dispose" => Dispose(),
+            "get_ChainElements" => _chain.ChainElements,
+            "get_ChainPolicy" => _chain.ChainPolicy,
+            "get_ChainStatus" => _chain.ChainStatus,
+            "get_PrivateReference" => _chain,
+            "get_AdditionalContext" => (global::NuGet.Common.ILogMessage?)null,
+            _ => throw new NotSupportedException($"Method {targetMethod?.Name} is not supported.")
+        };
+    }
+
+    private bool Build(X509Certificate2 certificate)
+    {
+        return _chain.Build(certificate);
+    }
+
+    private object? Dispose()
+    {
+        _chain.Dispose();
+        return null;
+    }
+}

--- a/src/Aspire.Managed/NuGet/TrustedRootsHelper.cs
+++ b/src/Aspire.Managed/NuGet/TrustedRootsHelper.cs
@@ -6,7 +6,6 @@
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Packaging.Signing;
-using INuGetLogger = NuGet.Common.ILogger;
 
 namespace Aspire.Managed.NuGet;
 
@@ -16,6 +15,8 @@ namespace Aspire.Managed.NuGet;
 /// </summary>
 internal static class TrustedRootsHelper
 {
+    private static bool s_initialized;
+
     /// <summary>
     /// Initializes the NuGet trust store with embedded trusted root certificates.
     /// On Linux, when DOTNET_NUGET_SIGNATURE_VERIFICATION is set to "true", NuGet requires
@@ -29,8 +30,13 @@ internal static class TrustedRootsHelper
     /// TODO: Remove this once NuGet supports a public API for configuring the trust store,
     /// or when it supports single-file apps. See https://github.com/dotnet/aspire/issues/15282.
     /// </remarks>
-    public static void InitializeTrustStore(INuGetLogger logger)
+    public static void InitializeTrustStore()
     {
+        if (s_initialized)
+        {
+            return;
+        }
+
         if (!OperatingSystem.IsLinux())
         {
             // On Windows, NuGet uses the system certificate store directly.
@@ -39,7 +45,7 @@ internal static class TrustedRootsHelper
         }
 
         var envValue = Environment.GetEnvironmentVariable("DOTNET_NUGET_SIGNATURE_VERIFICATION");
-        if (!string.Equals(bool.TrueString, envValue, StringComparison.OrdinalIgnoreCase))
+        if (!(bool.TryParse(envValue, out var enabled) && enabled))
         {
             // If DOTNET_NUGET_SIGNATURE_VERIFICATION is not set to "true", NuGet won't
             // perform signature verification on Linux, so there's no need to initialize
@@ -49,18 +55,19 @@ internal static class TrustedRootsHelper
 
         try
         {
-            InitializeTrustStoreFromEmbeddedResources(logger);
+            InitializeTrustStoreFromEmbeddedResources();
+            s_initialized = true;
         }
         catch (Exception ex)
         {
             // Log but don't fail the restore. If trust store initialization fails,
             // NuGet may still work if signature verification is not required or if
             // the system has its own certificate bundles.
-            logger.LogWarning($"Failed to initialize NuGet trust store from embedded certificates: {ex.Message}");
+            Console.Error.WriteLine($"WARNING: Failed to initialize NuGet trust store from embedded certificates: {ex}");
         }
     }
 
-    private static void InitializeTrustStoreFromEmbeddedResources(INuGetLogger logger)
+    private static void InitializeTrustStoreFromEmbeddedResources()
     {
         var nugetPackagingAssembly = typeof(X509TrustStore).Assembly;
 
@@ -70,7 +77,7 @@ internal static class TrustedRootsHelper
 
         if (chainFactoryInterfaceType is null || chainInterfaceType is null)
         {
-            logger.LogWarning("Could not find IX509ChainFactory or IX509Chain types in NuGet.Packaging.");
+            Console.Error.WriteLine("WARNING: Could not find IX509ChainFactory or IX509Chain types in NuGet.Packaging.");
             return;
         }
 
@@ -79,29 +86,26 @@ internal static class TrustedRootsHelper
             "SetCodeSigningX509ChainFactory",
             "codesignctl.pem",
             chainFactoryInterfaceType,
-            chainInterfaceType,
-            logger);
+            chainInterfaceType);
 
         // Set up timestamping trust store
         SetTrustStoreFactory(
             "SetTimestampingX509ChainFactory",
             "timestampctl.pem",
             chainFactoryInterfaceType,
-            chainInterfaceType,
-            logger);
+            chainInterfaceType);
     }
 
     private static void SetTrustStoreFactory(
         string setterMethodName,
         string resourceName,
         Type chainFactoryInterfaceType,
-        Type chainInterfaceType,
-        INuGetLogger logger)
+        Type chainInterfaceType)
     {
         var certificates = LoadCertificatesFromResource(resourceName);
         if (certificates is null || certificates.Count == 0)
         {
-            logger.LogWarning($"No certificates loaded from embedded resource: {resourceName}");
+            Console.Error.WriteLine($"WARNING: No certificates loaded from embedded resource: {resourceName}");
             return;
         }
 
@@ -116,12 +120,11 @@ internal static class TrustedRootsHelper
 
         if (setter is null)
         {
-            logger.LogWarning($"Could not find {setterMethodName} on X509TrustStore.");
+            Console.Error.WriteLine($"WARNING: Could not find {setterMethodName} on X509TrustStore.");
             return;
         }
 
         setter.Invoke(null, [factory]);
-        logger.LogInformation($"Initialized NuGet trust store from embedded resource: {resourceName} ({certificates.Count} certificates)");
     }
 
     private static X509Certificate2Collection? LoadCertificatesFromResource(string resourceName)
@@ -170,7 +173,7 @@ internal class ChainFactoryDispatchProxy : DispatchProxy
             return CreateChain();
         }
 
-        throw new NotSupportedException($"Method {targetMethod?.Name} is not supported.");
+        throw new NotSupportedException($"Method '{targetMethod?.Name}' is not supported on IX509ChainFactory proxy. This may indicate a NuGet.Packaging version mismatch — the library may have added new interface members.");
     }
 
     private object CreateChain()
@@ -210,7 +213,7 @@ internal class ChainDispatchProxy : DispatchProxy
             "get_ChainStatus" => _chain.ChainStatus,
             "get_PrivateReference" => _chain,
             "get_AdditionalContext" => (global::NuGet.Common.ILogMessage?)null,
-            _ => throw new NotSupportedException($"Method {targetMethod?.Name} is not supported.")
+            _ => throw new NotSupportedException($"Method '{targetMethod?.Name}' is not supported on IX509Chain proxy. This may indicate a NuGet.Packaging version mismatch — the library may have added new interface members.")
         };
     }
 

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetSignatureVerificationEnablerTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetSignatureVerificationEnablerTests.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.NuGet;
+using Aspire.Cli.Tests.TestServices;
+
+namespace Aspire.Cli.Tests.NuGet;
+
+public class NuGetSignatureVerificationEnablerTests
+{
+    private static CliExecutionContext CreateContext(Dictionary<string, string?>? envVars = null)
+    {
+        var dir = new DirectoryInfo(Path.GetTempPath());
+        return new CliExecutionContext(
+            dir, dir, dir, dir, dir, "test.log",
+            environmentVariables: envVars);
+    }
+
+    [Fact]
+    public void Apply_FeatureFlagDisabled_DoesNotSetEnvVar()
+    {
+        var envVars = new Dictionary<string, string>();
+        var features = new TestFeatures().SetFeature(KnownFeatures.NuGetSignatureVerificationEnabled, false);
+        var context = CreateContext();
+
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+
+        Assert.Empty(envVars);
+    }
+
+    [Fact]
+    public void Apply_FeatureEnabled_NoUserOverride_SetsTrueOnLinux()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        var envVars = new Dictionary<string, string>();
+        var features = new TestFeatures(); // default is true for this feature
+        var context = CreateContext(new Dictionary<string, string?>()); // empty env — no user override
+
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+
+        Assert.True(envVars.ContainsKey(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification));
+        Assert.Equal("True", envVars[NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification]);
+    }
+
+    [Fact]
+    public void Apply_FeatureEnabled_UserOverrideFalse_PropagatesFalseOnLinux()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        var envVars = new Dictionary<string, string>();
+        var features = new TestFeatures();
+        var context = CreateContext(new Dictionary<string, string?>
+        {
+            [NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification] = "false"
+        });
+
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+
+        Assert.True(envVars.ContainsKey(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification));
+        Assert.Equal("False", envVars[NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification]);
+    }
+
+    [Fact]
+    public void Apply_FeatureEnabled_UserOverrideTrue_SetsTrueOnLinux()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        var envVars = new Dictionary<string, string>();
+        var features = new TestFeatures();
+        var context = CreateContext(new Dictionary<string, string?>
+        {
+            [NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification] = "true"
+        });
+
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+
+        Assert.True(envVars.ContainsKey(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification));
+        Assert.Equal("True", envVars[NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification]);
+    }
+
+    [Fact]
+    public void Apply_NonLinux_DoesNotSetEnvVar()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        var envVars = new Dictionary<string, string>();
+        var features = new TestFeatures(); // default is true
+        var context = CreateContext();
+
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+
+        Assert.Empty(envVars);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -155,7 +155,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
-        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
+        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
         var server = new PrebuiltAppHostServer(
             workspace.WorkspaceRoot.FullName,
             "test.sock",
@@ -209,7 +209,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             OnGetConfiguration = key => key == "channel" ? "pr-old" : null
         };
 
-        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
+        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
         var server = new PrebuiltAppHostServer(
             workspace.WorkspaceRoot.FullName,
             "test.sock",

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
@@ -155,7 +156,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
-        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
+        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), TestExecutionContextFactory.CreateTestContext(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
         var server = new PrebuiltAppHostServer(
             workspace.WorkspaceRoot.FullName,
             "test.sock",
@@ -209,7 +210,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             OnGetConfiguration = key => key == "channel" ? "pr-old" : null
         };
 
-        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
+        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), TestExecutionContextFactory.CreateTestContext(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
         var server = new PrebuiltAppHostServer(
             workspace.WorkspaceRoot.FullName,
             "test.sock",

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaManagedRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaManagedRedisDeploymentTests.cs
@@ -84,6 +84,9 @@ public sealed class AcaManagedRedisDeploymentTests(ITestOutputHelper output)
             var waitingForRedisPrompt = new CellPatternSearcher()
                 .Find("Use Redis Cache");
 
+            var waitingForAgentInitPrompt = new CellPatternSearcher()
+                .Find("configure AI agent environments");
+
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -135,7 +138,22 @@ public sealed class AcaManagedRedisDeploymentTests(ITestOutputHelper output)
                 .Enter() // Select "No" for localhost URLs (default)
                 .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
                 .Enter() // Select "Yes" for Redis Cache (first/default option)
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+                .WaitUntil(s =>
+                {
+                    if (waitingForAgentInitPrompt.Search(s).Count > 0)
+                    {
+                        return true;
+                    }
+                    var successSearcher = new CellPatternSearcher()
+                        .FindPattern(counter.Value.ToString())
+                        .RightText(" OK] $ ");
+                    return successSearcher.Search(s).Count > 0;
+                },
+                    TimeSpan.FromMinutes(5))
+                .Wait(TimeSpan.FromMilliseconds(500))
+                .Type("n") // Decline agent init prompt (or harmless if already at bash prompt)
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(1));
 
             // Step 4: Navigate to project directory
             output.WriteLine("Step 4: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
@@ -103,13 +103,14 @@ public sealed class AcrPurgeTaskDeploymentTests(ITestOutputHelper output)
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
 
-            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync();
+                await auto.WaitForAspireAddCompletionAsync(counter);
             }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            }
 
             // Step 6: Modify apphost.cs to add ACA environment with purge task
             // Python template uses single-file AppHost (apphost.cs in project root)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
@@ -112,30 +112,31 @@ public sealed class AcrPurgeTaskDeploymentTests(ITestOutputHelper output)
                 await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
             }
 
-            // Step 6: Modify apphost.cs to add ACA environment with purge task
-            // Python template uses single-file AppHost (apphost.cs in project root)
+            // Step 6: Modify apphost.ts to add ACA environment with purge task
+            // Python template uses TypeScript AppHost (apphost.ts in project root)
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
-            var appHostFilePath = Path.Combine(projectDir, "apphost.cs");
+            var appHostFilePath = Path.Combine(projectDir, "apphost.ts");
 
-            output.WriteLine($"Looking for apphost.cs at: {appHostFilePath}");
+            output.WriteLine($"Looking for apphost.ts at: {appHostFilePath}");
 
             var content = File.ReadAllText(appHostFilePath);
 
-            var buildRunPattern = "builder.Build().Run();";
-            var replacement = """
+            // Add Azure Container App Environment with purge task before build().run()
+            content = content.Replace(
+                "await builder.build().run();",
+                """
 // Add Azure Container App Environment and configure ACR purge task
-var infra = builder.AddAzureContainerAppEnvironment("infra");
+const infra = builder.addAzureContainerAppEnvironment("infra");
 // Schedule once a month so it never fires during the test; the task is triggered manually via az acr task run
-infra.GetAzureContainerRegistry()
-    .WithPurgeTask("0 0 1 * *", keep: 1);
+infra.getAzureContainerRegistry()
+    .withPurgeTask("0 0 1 * *", { keep: 1 });
 
-builder.Build().Run();
-""";
+await builder.build().run();
+""");
 
-            content = content.Replace(buildRunPattern, replacement);
             File.WriteAllText(appHostFilePath, content);
 
-            output.WriteLine($"Modified apphost.cs at: {appHostFilePath}");
+            output.WriteLine($"Modified apphost.ts at: {appHostFilePath}");
 
             // Step 7: Set environment variables for deployment
             await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
@@ -105,15 +105,16 @@ public sealed class AppServicePythonDeploymentTests(ITestOutputHelper output)
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppService");
             await auto.EnterAsync();
 
-            // In CI, aspire add shows a version selection prompt when packages aren't from local hive.
-            // When using bundle install (PR > 0), the CLI auto-selects from the local hive.
-            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
+            // aspire add may or may not show a version selection prompt depending on
+            // whether packages are available from the local hive (bundle install).
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync(); // select first version (PR build)
+                await auto.WaitForAspireAddCompletionAsync(counter);
             }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            }
 
             // Step 6: Modify apphost.cs to add Azure App Service Environment
             // Note: Python template uses single-file AppHost (apphost.cs in project root)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
@@ -105,8 +105,9 @@ public sealed class AppServicePythonDeploymentTests(ITestOutputHelper output)
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppService");
             await auto.EnterAsync();
 
-            // In CI, aspire add shows a version selection prompt
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            // In CI, aspire add shows a version selection prompt when packages aren't from local hive.
+            // When using bundle install (PR > 0), the CLI auto-selects from the local hive.
+            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
             {
                 await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
                 await auto.EnterAsync(); // select first version (PR build)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
@@ -116,29 +116,28 @@ public sealed class AppServicePythonDeploymentTests(ITestOutputHelper output)
                 await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
             }
 
-            // Step 6: Modify apphost.cs to add Azure App Service Environment
-            // Note: Python template uses single-file AppHost (apphost.cs in project root)
+            // Step 6: Modify apphost.ts to add Azure App Service Environment
+            // Note: Python template uses TypeScript AppHost (apphost.ts in project root)
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
-            // Single-file AppHost is in the project root, not a subdirectory
-            var appHostFilePath = Path.Combine(projectDir, "apphost.cs");
+            var appHostFilePath = Path.Combine(projectDir, "apphost.ts");
 
-            output.WriteLine($"Looking for apphost.cs at: {appHostFilePath}");
+            output.WriteLine($"Looking for apphost.ts at: {appHostFilePath}");
 
             var content = File.ReadAllText(appHostFilePath);
 
-            // Insert the Azure App Service Environment before builder.Build().Run();
-            var buildRunPattern = "builder.Build().Run();";
-            var replacement = """
+            // Add Azure App Service Environment before build().run()
+            content = content.Replace(
+                "await builder.build().run();",
+                """
 // Add Azure App Service Environment for deployment
-builder.AddAzureAppServiceEnvironment("infra");
+await builder.addAzureAppServiceEnvironment("infra");
 
-builder.Build().Run();
-""";
+await builder.build().run();
+""");
 
-            content = content.Replace(buildRunPattern, replacement);
             File.WriteAllText(appHostFilePath, content);
 
-            output.WriteLine($"Modified apphost.cs at: {appHostFilePath}");
+            output.WriteLine($"Modified apphost.ts at: {appHostFilePath}");
 
             // Step 7: Set environment for deployment
             // - Unset ASPIRE_PLAYGROUND to avoid conflicts

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2EAutomatorHelpers.cs
@@ -113,6 +113,46 @@ internal static class DeploymentE2EAutomatorHelpers
     }
 
     /// <summary>
+    /// Waits for <c>aspire add</c> to complete, handling the optional version selection prompt.
+    /// In CI with bundle install, the CLI may or may not show a version selection prompt.
+    /// This method waits for either the prompt or the success prompt, and dismisses the prompt if shown.
+    /// </summary>
+    internal static async Task WaitForAspireAddCompletionAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(180);
+
+        var versionPrompt = new CellPatternSearcher()
+            .Find("based on NuGet.config");
+        var successPrompt = new CellPatternSearcher()
+            .FindPattern(counter.Value.ToString())
+            .RightText(" OK] $ ");
+
+        var sawVersionPrompt = false;
+        await auto.WaitUntilAsync(s =>
+        {
+            if (versionPrompt.Search(s).Count > 0)
+            {
+                sawVersionPrompt = true;
+                return true;
+            }
+            return successPrompt.Search(s).Count > 0;
+        }, timeout: effectiveTimeout, description: $"version prompt or success prompt [{counter.Value} OK] $");
+
+        if (sawVersionPrompt)
+        {
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, effectiveTimeout);
+        }
+        else
+        {
+            counter.Increment();
+        }
+    }
+
+    /// <summary>
     /// Destroys the current deployment using <c>aspire destroy --yes</c> and waits for pipeline success.
     /// </summary>
     internal static async Task AspireDestroyAsync(

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2EAutomatorHelpers.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
@@ -105,8 +105,9 @@ public sealed class PythonFastApiDeploymentTests(ITestOutputHelper output)
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
 
-            // In CI, aspire add shows a version selection prompt
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            // In CI, aspire add shows a version selection prompt when packages aren't from local hive.
+            // When using bundle install (PR > 0), the CLI auto-selects from the local hive.
+            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
             {
                 await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
                 await auto.EnterAsync(); // select first version (PR build)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
@@ -105,15 +105,17 @@ public sealed class PythonFastApiDeploymentTests(ITestOutputHelper output)
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
 
-            // In CI, aspire add shows a version selection prompt when packages aren't from local hive.
-            // When using bundle install (PR > 0), the CLI auto-selects from the local hive.
-            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
+            // aspire add may or may not show a version selection prompt depending on
+            // whether packages are available from the local hive (bundle install).
+            // Wait for either the version prompt or the success prompt.
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync(); // select first version (PR build)
+                await auto.WaitForAspireAddCompletionAsync(counter);
             }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            }
 
             // Step 6: Modify apphost.cs to add Azure Container App Environment
             // Note: Python template uses single-file AppHost (apphost.cs in project root)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
@@ -117,30 +117,29 @@ public sealed class PythonFastApiDeploymentTests(ITestOutputHelper output)
                 await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
             }
 
-            // Step 6: Modify apphost.cs to add Azure Container App Environment
-            // Note: Python template uses single-file AppHost (apphost.cs in project root)
+            // Step 6: Modify apphost.ts to add Azure Container App Environment
+            // Note: Python template uses TypeScript AppHost (apphost.ts in project root)
             {
                 var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
-                // Single-file AppHost is in the project root, not a subdirectory
-                var appHostFilePath = Path.Combine(projectDir, "apphost.cs");
+                var appHostFilePath = Path.Combine(projectDir, "apphost.ts");
 
-                output.WriteLine($"Looking for apphost.cs at: {appHostFilePath}");
+                output.WriteLine($"Looking for apphost.ts at: {appHostFilePath}");
 
                 var content = File.ReadAllText(appHostFilePath);
 
-                // Insert the Azure Container App Environment before builder.Build().Run();
-                var buildRunPattern = "builder.Build().Run();";
-                var replacement = """
+                // Add Azure Container App Environment before build().run()
+                content = content.Replace(
+                    "await builder.build().run();",
+                    """
 // Add Azure Container App Environment for deployment
-builder.AddAzureContainerAppEnvironment("infra");
+await builder.addAzureContainerAppEnvironment("infra");
 
-builder.Build().Run();
-""";
+await builder.build().run();
+""");
 
-                content = content.Replace(buildRunPattern, replacement);
                 File.WriteAllText(appHostFilePath, content);
 
-                output.WriteLine($"Modified apphost.cs at: {appHostFilePath}");
+                output.WriteLine($"Modified apphost.ts at: {appHostFilePath}");
             }
 
             // Step 7: Set environment for deployment

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptExpressDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptExpressDeploymentTests.cs
@@ -102,11 +102,13 @@ public sealed class TypeScriptExpressDeploymentTests(ITestOutputHelper output)
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
 
-            // In CI, aspire add shows a version selection prompt
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            // When using bundle install (InstallAspireBundleFromPullRequestAsync), the CLI
+            // auto-selects the package version from the local hive without prompting.
+            // Only wait for the version selection prompt when the bundle is NOT installed.
+            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
             {
                 await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync(); // select first version (PR build)
+                await auto.EnterAsync();
             }
 
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptExpressDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptExpressDeploymentTests.cs
@@ -102,16 +102,16 @@ public sealed class TypeScriptExpressDeploymentTests(ITestOutputHelper output)
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
 
-            // When using bundle install (InstallAspireBundleFromPullRequestAsync), the CLI
-            // auto-selects the package version from the local hive without prompting.
-            // Only wait for the version selection prompt when the bundle is NOT installed.
-            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
+            // aspire add may or may not show a version selection prompt depending on
+            // whether packages are available from the local hive (bundle install).
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync();
+                await auto.WaitForAspireAddCompletionAsync(counter);
             }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            }
 
             // Step 6: Modify apphost.ts to add Azure Container App Environment for deployment
             {

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptVnetSqlServerInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptVnetSqlServerInfraDeploymentTests.cs
@@ -147,7 +147,7 @@ public sealed class TypeScriptVnetSqlServerInfraDeploymentTests(ITestOutputHelpe
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
 
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
             {
                 await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
                 await auto.EnterAsync();
@@ -160,7 +160,7 @@ public sealed class TypeScriptVnetSqlServerInfraDeploymentTests(ITestOutputHelpe
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Network");
             await auto.EnterAsync();
 
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
             {
                 await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
                 await auto.EnterAsync();
@@ -173,7 +173,7 @@ public sealed class TypeScriptVnetSqlServerInfraDeploymentTests(ITestOutputHelpe
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Sql");
             await auto.EnterAsync();
 
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
             {
                 await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
                 await auto.EnterAsync();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptVnetSqlServerInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptVnetSqlServerInfraDeploymentTests.cs
@@ -147,39 +147,42 @@ public sealed class TypeScriptVnetSqlServerInfraDeploymentTests(ITestOutputHelpe
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
 
-            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync();
+                await auto.WaitForAspireAddCompletionAsync(counter);
             }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            }
 
             // Step 4b: Add Aspire.Hosting.Azure.Network
             output.WriteLine("Step 4b: Adding Azure Network hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Network");
             await auto.EnterAsync();
 
-            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync();
+                await auto.WaitForAspireAddCompletionAsync(counter);
             }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            }
 
             // Step 4c: Add Aspire.Hosting.Azure.Sql
             output.WriteLine("Step 4c: Adding Azure SQL hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Sql");
             await auto.EnterAsync();
 
-            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync();
+                await auto.WaitForAspireAddCompletionAsync(counter);
             }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            }
 
             // Step 5: Modify apphost.ts to add VNet + PE + SQL infrastructure
             {


### PR DESCRIPTION
## Description

Enable NuGet package signature verification for `aspire-managed` on Linux, matching the .NET SDK's behavior.

Currently, `aspire restore` does not verify NuGet package signatures because:
1. The `DOTNET_NUGET_SIGNATURE_VERIFICATION` environment variable is not set when spawning `aspire-managed` processes
2. The trusted root certificates from the .NET SDK are not available to the NuGet code running inside `aspire-managed`

This PR fixes both issues:

- **`NuGetSignatureVerificationEnabler`** (in Aspire.Cli): Sets `DOTNET_NUGET_SIGNATURE_VERIFICATION=true` on Linux when spawning aspire-managed processes, mirroring the [.NET SDK's `NuGetSignatureVerificationEnabler`](https://github.com/dotnet/sdk/blob/a6af77909c46799080943ee15c028462867c60f5/src/Cli/dotnet/NuGetSignatureVerificationEnabler.cs). Respects user override to `false`.

- **Embedded PEM certificates** (in Aspire.Managed.csproj): Embeds the SDK's `codesignctl.pem` and `timestampctl.pem` trusted root certificates as assembly resources.

- **`TrustedRootsHelper`** (in Aspire.Managed): Extracts embedded PEM resources and uses reflection to initialize NuGet's `X509TrustStore` with the proper certificate chain factories. Reflection is needed because `aspire-managed` is a single-file app where NuGet's fallback certificate bundle discovery (assembly-relative path) doesn't work since `Assembly.Location` returns empty string. (We need https://github.com/NuGet/NuGet.Client/pull/7197 in order to not use reflection. Will update when that is released.)

Porting #15294 to main after it wasn't taken in release/13.2.

Fixes #15282

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [x] No
