### PR TITLE
Deploy DTS resources with application

### DIFF
--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
@@ -1,8 +1,8 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureStorage("storage");//.RunAsEmulator();
+var storage = builder.AddAzureStorage("storage").RunAsEmulator();
 
-var scheduler = builder.AddDurableTaskScheduler("scheduler");//.RunAsEmulator();
+var scheduler = builder.AddDurableTaskScheduler("scheduler").RunAsEmulator();
 
 var taskHub = scheduler.AddTaskHub("taskhub");
 

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
@@ -1,8 +1,8 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureStorage("storage").RunAsEmulator();
+var storage = builder.AddAzureStorage("storage");//.RunAsEmulator();
 
-var scheduler = builder.AddDurableTaskScheduler("scheduler").RunAsEmulator();
+var scheduler = builder.AddDurableTaskScheduler("scheduler");//.RunAsEmulator();
 
 var taskHub = scheduler.AddTaskHub("taskhub");
 

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskDashboardUrlService.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskDashboardUrlService.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Hosting;
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// Watches resource state updates for Durable Task hub resources and adds dashboard URL
+/// annotations when sufficient provisioning data is available.
+/// </summary>
+internal sealed class DurableTaskDashboardUrlService(
+    DistributedApplicationModel appModel,
+    ResourceNotificationService notificationService) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Track which hub resources already have their dashboard URL annotation.
+        var hubsWithUrls = new HashSet<string>();
+
+        await foreach (var resourceEvent in notificationService.WatchAsync(stoppingToken).ConfigureAwait(false))
+        {
+            if (resourceEvent.Resource is not DurableTaskHubResource hub)
+            {
+                continue;
+            }
+
+            if (hubsWithUrls.Contains(hub.Name))
+            {
+                continue;
+            }
+
+            var url = TryBuildDashboardUrl(hub);
+            if (url is null)
+            {
+                continue;
+            }
+
+            // Add the annotation so the URL survives all future state re-publishes.
+            hub.Annotations.Add(new ResourceUrlAnnotation { Url = url, DisplayText = "Task Hub Dashboard" });
+            hubsWithUrls.Add(hub.Name);
+
+            // Publish an update to make the URL visible immediately.
+            await notificationService.PublishUpdateAsync(hub, snapshot => snapshot with
+            {
+                Urls = [.. snapshot.Urls, new("dashboard", url, false) { DisplayProperties = new() { DisplayName = "Task Hub Dashboard" } }]
+            }).ConfigureAwait(false);
+
+            // Stop watching once every hub has a URL.
+            if (hubsWithUrls.Count == appModel.Resources.OfType<DurableTaskHubResource>().Count())
+            {
+                break;
+            }
+        }
+    }
+
+    private static string? TryBuildDashboardUrl(DurableTaskHubResource hub)
+    {
+        var scheduler = hub.Parent;
+
+        if (scheduler.IsEmulator)
+        {
+            return TryBuildEmulatorDashboardUrl(hub);
+        }
+
+        return TryBuildAzureDashboardUrl(hub, scheduler);
+    }
+
+    private static string? TryBuildEmulatorDashboardUrl(DurableTaskHubResource hub)
+    {
+        var scheduler = hub.Parent;
+
+        // The emulator dashboard endpoint is available once the container's "dashboard" endpoint is allocated.
+        if (!scheduler.TryGetEndpoints(out var endpoints))
+        {
+            return null;
+        }
+
+        var dashboardEndpoint = endpoints.FirstOrDefault(e => e.Name == "dashboard");
+        if (dashboardEndpoint?.AllocatedEndpoint is not { } allocated)
+        {
+            return null;
+        }
+
+        var hubName = hub.HubName;
+        return $"{allocated.UriString}/subscriptions/default/schedulers/default/taskhubs/{hubName}";
+    }
+
+    private static string? TryBuildAzureDashboardUrl(DurableTaskHubResource hub, DurableTaskSchedulerResource scheduler)
+    {
+        if (!scheduler.Outputs.TryGetValue("subscriptionId", out var subObj) ||
+            !scheduler.Outputs.TryGetValue("schedulerEndpoint", out var endpointObj) ||
+            !scheduler.Outputs.TryGetValue("name", out var nameObj))
+        {
+            return null;
+        }
+
+        var subscriptionId = subObj?.ToString();
+        var endpoint = endpointObj?.ToString();
+        var schedulerName = nameObj?.ToString();
+
+        if (subscriptionId is null || endpoint is null || schedulerName is null)
+        {
+            return null;
+        }
+
+        scheduler.Outputs.TryGetValue("tenantId", out var tenantObj);
+        var tenantId = tenantObj?.ToString();
+        var taskHubName = hub.HubName;
+
+        var encodedEndpoint = Uri.EscapeDataString(endpoint);
+        var url = $"https://dashboard.durabletask.io/subscriptions/{subscriptionId}/schedulers/{schedulerName}/taskhubs/{taskHubName}?endpoint={encodedEndpoint}";
+        if (tenantId is not null)
+        {
+            url += $"&tenantId={tenantId}";
+        }
+
+        return url;
+    }
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubProvisioningResource.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Core;
+using Azure.Provisioning;
+using Azure.Provisioning.Primitives;
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// A custom provisioning resource for Azure Durable Task Hub.
+/// This is a sub-resource of a Durable Task Scheduler.
+/// This is used until an official Azure.Provisioning.DurableTask package is available.
+/// </summary>
+internal sealed class DurableTaskHubProvisioningResource : ProvisionableResource
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="DurableTaskHubProvisioningResource"/>.
+    /// </summary>
+    /// <param name="bicepIdentifier">The Bicep identifier for this resource.</param>
+    /// <param name="resourceVersion">The API version for the resource.</param>
+    public DurableTaskHubProvisioningResource(string bicepIdentifier, string? resourceVersion = "2025-11-01")
+        : base(bicepIdentifier, new ResourceType("Microsoft.DurableTask/schedulers/taskhubs"), resourceVersion)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the Task Hub.
+    /// </summary>
+    public BicepValue<string> Name
+    {
+        get { Initialize(); return _name!; }
+        set { Initialize(); _name!.Assign(value); }
+    }
+    private BicepValue<string>? _name;
+
+    /// <summary>
+    /// Gets or sets the parent Durable Task Scheduler.
+    /// </summary>
+    public DurableTaskSchedulerProvisioningResource? Parent
+    {
+        get { Initialize(); return _parent!.Value; }
+        set { Initialize(); _parent!.Value = value; }
+    }
+    private ResourceReference<DurableTaskSchedulerProvisioningResource>? _parent;
+
+    /// <inheritdoc/>
+    protected override void DefineProvisionableProperties()
+    {
+        _name = DefineProperty<string>(nameof(Name), ["name"], isOutput: false, isRequired: true);
+        _parent = DefineResource<DurableTaskSchedulerProvisioningResource>(nameof(Parent), ["parent"], isRequired: true);
+    }
+
+    /// <summary>
+    /// Creates a reference to an existing Durable Task Hub resource.
+    /// </summary>
+    /// <param name="bicepIdentifier">The Bicep identifier for this resource.</param>
+    /// <param name="resourceVersion">The API version for the resource.</param>
+    /// <returns>A new instance configured as an existing resource reference.</returns>
+    public static DurableTaskHubProvisioningResource FromExisting(string bicepIdentifier, string? resourceVersion = "2025-11-01")
+    {
+        return new DurableTaskHubProvisioningResource(bicepIdentifier, resourceVersion)
+        {
+            IsExistingResource = true
+        };
+    }
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubResource.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning;
+using Azure.Provisioning.Primitives;
 
 namespace Aspire.Hosting.Azure.DurableTask;
 
@@ -14,8 +16,16 @@ namespace Aspire.Hosting.Azure.DurableTask;
 /// <param name="scheduler">The durable task scheduler resource whose connection string is the base for this hub.</param>
 [AspireExport(ExposeProperties = true)]
 public sealed class DurableTaskHubResource(string name, DurableTaskSchedulerResource scheduler)
-    : Resource(name), IResourceWithConnectionString, IResourceWithParent<DurableTaskSchedulerResource>, IResourceWithAzureFunctionsConfig
+    : AzureProvisioningResource(name, ConfigureTaskHubInfrastructure), IResourceWithConnectionString, IResourceWithParent<DurableTaskSchedulerResource>, IResourceWithAzureFunctionsConfig
 {
+    // The TaskHub doesn't create its own infrastructure - it's created as part of the Scheduler's infrastructure.
+    // This callback is a no-op but is required by AzureProvisioningResource.
+    private static void ConfigureTaskHubInfrastructure(AzureResourceInfrastructure infrastructure)
+    {
+        // TaskHubs are created within the parent Scheduler's infrastructure.
+        // This method intentionally does nothing.
+    }
+
     /// <summary>
     /// Gets the connection string expression composed of the scheduler connection string and the TaskHub name.
     /// </summary>
@@ -30,6 +40,63 @@ public sealed class DurableTaskHubResource(string name, DurableTaskSchedulerReso
     /// Gets the name of the Task Hub. If not provided, the logical name of this resource is returned.
     /// </summary>
     public ReferenceExpression TaskHubName => GetTaskHubName();
+
+    /// <summary>
+    /// Gets the actual Task Hub name as a string for use in provisioning.
+    /// </summary>
+    internal string HubName => GetHubNameString();
+
+    private string GetHubNameString()
+    {
+        if (this.TryGetLastAnnotation<DurableTaskHubNameAnnotation>(out var taskHubNameAnnotation))
+        {
+            return taskHubNameAnnotation.HubName switch
+            {
+                string hubName => hubName,
+                _ => Name // Default to resource name if parameter is used
+            };
+        }
+
+        return Name;
+    }
+
+    /// <summary>
+    /// Converts this resource to an Azure Provisioning entity.
+    /// </summary>
+    /// <returns>A <see cref="DurableTaskHubProvisioningResource"/> instance.</returns>
+    internal DurableTaskHubProvisioningResource ToProvisioningEntity()
+    {
+        var taskHub = new DurableTaskHubProvisioningResource(Infrastructure.NormalizeBicepIdentifier(Name));
+        taskHub.Name = HubName;
+        return taskHub;
+    }
+
+    /// <inheritdoc/>
+    public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)
+    {
+        var bicepIdentifier = this.GetBicepIdentifier();
+        var resources = infra.GetProvisionableResources();
+
+        // Check if a TaskHub with the same identifier already exists
+        var existingTaskHub = resources.OfType<DurableTaskHubProvisioningResource>()
+            .SingleOrDefault(th => th.BicepIdentifier == bicepIdentifier);
+
+        if (existingTaskHub is not null)
+        {
+            return existingTaskHub;
+        }
+
+        // First, add the parent scheduler as an existing resource
+        var parentScheduler = (DurableTaskSchedulerProvisioningResource)Parent.AddAsExistingResource(infra);
+
+        // Create the TaskHub as existing, referencing the parent scheduler
+        var taskHub = DurableTaskHubProvisioningResource.FromExisting(bicepIdentifier);
+        taskHub.Name = HubName;
+        taskHub.Parent = parentScheduler;
+
+        infra.Add(taskHub);
+        return taskHub;
+    }
 
     /// <inheritdoc />
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -83,8 +83,6 @@ public static class DurableTaskResourceExtensions
 
         var scheduler = new DurableTaskSchedulerResource(name, configureInfrastructure);
 
-        scheduler.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
-
         return builder.AddResource(scheduler);
     }
 
@@ -258,8 +256,6 @@ public static class DurableTaskResourceExtensions
         var hub = new DurableTaskHubResource(name, builder.Resource);
 
         builder.Resource.Hubs.Add(hub);
-
-        hub.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
 
         var hubBuilder = builder.ApplicationBuilder.AddResource(hub);
 

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -7,7 +7,6 @@ using Aspire.Hosting.Azure.DurableTask;
 using Azure.Provisioning;
 using Azure.Provisioning.Expressions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -268,49 +267,76 @@ public static class DurableTaskResourceExtensions
 
         var hubBuilder = builder.ApplicationBuilder.AddResource(hub);
 
+        // Subscribe to the hub's ConnectionStringAvailableEvent to set the Azure dashboard URL.
+        // We add a ResourceUrlAnnotation so it persists across state updates from the
+        // ApplicationOrchestrator and BicepProvisioner, which replace snapshot URLs.
+        builder.ApplicationBuilder.Eventing.Subscribe<ConnectionStringAvailableEvent>(hub, (@event, ct) =>
+        {
+            if (builder.Resource.IsEmulator)
+            {
+                return Task.CompletedTask;
+            }
+
+            var scheduler = hub.Parent;
+
+            if (!scheduler.Outputs.TryGetValue("subscriptionId", out var subObj) ||
+                !scheduler.Outputs.TryGetValue("schedulerEndpoint", out var endpointObj) ||
+                !scheduler.Outputs.TryGetValue("name", out var nameObj))
+            {
+                return Task.CompletedTask;
+            }
+
+            var subscriptionId = subObj?.ToString();
+            var endpoint = endpointObj?.ToString();
+            var schedulerName = nameObj?.ToString();
+            scheduler.Outputs.TryGetValue("tenantId", out var tenantObj);
+            var tenantId = tenantObj?.ToString();
+            var taskHubName = hub.HubName;
+
+            if (subscriptionId is null || endpoint is null || schedulerName is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            // Only add the annotation once (the event may fire multiple times).
+            if (hub.Annotations.OfType<ResourceUrlAnnotation>().Any(a => a.DisplayText == "Task Hub Dashboard"))
+            {
+                return Task.CompletedTask;
+            }
+
+            var encodedEndpoint = Uri.EscapeDataString(endpoint);
+            var url = $"https://dashboard.durabletask.io/subscriptions/{subscriptionId}/schedulers/{schedulerName}/taskhubs/{taskHubName}?endpoint={encodedEndpoint}";
+            if (tenantId is not null)
+            {
+                url += $"&tenantId={tenantId}";
+            }
+
+            hub.Annotations.Add(new ResourceUrlAnnotation { Url = url, DisplayText = "Task Hub Dashboard" });
+
+            return Task.CompletedTask;
+        });
+
         hubBuilder.OnResourceReady(
             async (r, e, ct) =>
             {
+                if (!builder.Resource.IsEmulator)
+                {
+                    // Azure dashboard URLs are published via the scheduler's
+                    // ConnectionStringAvailableEvent subscription.
+                    return;
+                }
+
                 var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
-                var logger = e.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Aspire.Hosting.Azure.DurableTask");
 
-                logger.LogWarning("OnResourceReady fired for hub '{Hub}', IsEmulator={IsEmulator}", r.Name, builder.Resource.IsEmulator);
+                var url = await ReferenceExpression.Create($"{r.Parent.EmulatorDashboardEndpoint}/subscriptions/default/schedulers/default/taskhubs/{r.TaskHubName}").GetValueAsync(ct).ConfigureAwait(false);
 
-                ReferenceExpression dashboardUrl;
-                if (builder.Resource.IsEmulator)
+                await notifications.PublishUpdateAsync(r, snapshot => snapshot with
                 {
-                    dashboardUrl = ReferenceExpression.Create($"{r.Parent.EmulatorDashboardEndpoint}/subscriptions/default/schedulers/default/taskhubs/{r.TaskHubName}");
-                }
-                else
-                {
-                    var s = r.Parent;
-                    dashboardUrl = ReferenceExpression.Create($"https://dashboard.durabletask.io/subscriptions/{s.SubscriptionId}/schedulers/{s.NameOutputReference}/taskhubs/{r.TaskHubName}?endpoint={s.SchedulerEndpoint}&tenantId={s.TenantId}");
-                    logger.LogWarning("Azure dashboard ReferenceExpression format: {Format}", dashboardUrl.Format);
-                }
-
-                try
-                {
-                    var url = await dashboardUrl.GetValueAsync(ct).ConfigureAwait(false);
-                    logger.LogWarning("Dashboard URL resolved to: {Url}", url ?? "(null)");
-
-                    await notifications.PublishUpdateAsync(r, snapshot =>
-                    {
-                        logger.LogWarning("PublishUpdateAsync callback for hub '{Hub}': current Urls count={Count}, current State={State}", r.Name, snapshot.Urls.Length, snapshot.State?.Text);
-
-                        return snapshot with
-                        {
-                            Urls = url is not null
-                                ? [.. snapshot.Urls, new("dashboard", url, false) { DisplayProperties = new() { DisplayName = "Task Hub Dashboard" } }]
-                                : snapshot.Urls
-                        };
-                    }).ConfigureAwait(false);
-
-                    logger.LogWarning("PublishUpdateAsync completed for hub '{Hub}'", r.Name);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to resolve dashboard URL for hub '{Hub}'", r.Name);
-                }
+                    State = KnownResourceStates.Running,
+                    Urls = url is not null
+                        ? [new("dashboard", url, false) { DisplayProperties = new() { DisplayName = "Task Hub Dashboard" } }]
+                        : []
+                }).ConfigureAwait(false);
             });
 
         return hubBuilder;

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -33,7 +33,7 @@ public static class DurableTaskResourceExtensions
     [AspireExport(Description = "Adds a Durable Task scheduler resource to the distributed application.")]
     public static IResourceBuilder<DurableTaskSchedulerResource> AddDurableTaskScheduler(this IDistributedApplicationBuilder builder, [ResourceName] string name)
     {
-       builder.AddAzureProvisioning();
+        builder.AddAzureProvisioning();
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
@@ -346,5 +346,4 @@ public static class DurableTaskResourceExtensions
             IResourceBuilder<ParameterResource> parameter => builder.WithTaskHubName(parameter),
             _ => throw new ArgumentException($"Unexpected task hub name type: {taskHubName.GetType().Name}", nameof(taskHubName))
         };
-
 }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -291,7 +291,10 @@ public static class DurableTaskResourceExtensions
         // TryAddEnumerable ensures it is only registered once even if AddTaskHub is called multiple times.
         builder.ApplicationBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DurableTaskDashboardUrlService>());
 
-        return hubBuilder;
+        return hubBuilder
+            .WithDefaultRoleAssignments(
+                DurableTaskSchedulerBuiltInRole.GetBuiltInRoleName,
+                DurableTaskSchedulerBuiltInRole.DurableTaskDataContributor);
     }
 
     /// <summary>
@@ -346,4 +349,129 @@ public static class DurableTaskResourceExtensions
             IResourceBuilder<ParameterResource> parameter => builder.WithTaskHubName(parameter),
             _ => throw new ArgumentException($"Unexpected task hub name type: {taskHubName.GetType().Name}", nameof(taskHubName))
         };
+
+    /// <summary>
+    /// Assigns the specified roles to the given resource, granting it the necessary permissions
+    /// on the target Durable Task Scheduler resource. This replaces the default role assignments for the resource.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource to assign the roles to.</typeparam>
+    /// <param name="builder">The resource to which the specified roles will be assigned.</param>
+    /// <param name="target">The target Durable Task Scheduler resource.</param>
+    /// <param name="roles">The built-in Durable Task Scheduler roles to be assigned.</param>
+    /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
+    /// This overload is not available in polyglot app hosts. Use
+    /// <see cref="WithRoleAssignments{T}(IResourceBuilder{T}, IResourceBuilder{DurableTaskSchedulerResource}, DurableTaskSchedulerRole[])"/>
+    /// instead.
+    /// <example>
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler");
+    ///
+    /// var worker = builder.AddProject&lt;Projects.Worker&gt;("worker")
+    ///   .WithRoleAssignments(scheduler, DurableTaskSchedulerBuiltInRole.DurableTaskWorker)
+    ///   .WithReference(scheduler);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExportIgnore(Reason = "DurableTaskSchedulerBuiltInRole is a custom type not compatible with ATS. Use the DurableTaskSchedulerRole-based overload instead.")]
+    public static IResourceBuilder<T> WithRoleAssignments<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<DurableTaskSchedulerResource> target,
+        params DurableTaskSchedulerBuiltInRole[] roles)
+        where T : IResource
+    {
+        return builder.WithRoleAssignments(target, DurableTaskSchedulerBuiltInRole.GetBuiltInRoleName, roles);
+    }
+
+    [AspireExport("withDurableTaskSchedulerRoleAssignments", Description = "Assigns Durable Task Scheduler roles to a resource")]
+    internal static IResourceBuilder<T> WithRoleAssignments<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<DurableTaskSchedulerResource> target,
+        params DurableTaskSchedulerRole[] roles)
+        where T : IResource
+    {
+        if (roles is null || roles.Length == 0)
+        {
+            return builder.WithRoleAssignments(target, Array.Empty<DurableTaskSchedulerBuiltInRole>());
+        }
+
+        var builtInRoles = new DurableTaskSchedulerBuiltInRole[roles.Length];
+        for (var i = 0; i < roles.Length; i++)
+        {
+            builtInRoles[i] = roles[i] switch
+            {
+                DurableTaskSchedulerRole.DurableTaskDataContributor => DurableTaskSchedulerBuiltInRole.DurableTaskDataContributor,
+                DurableTaskSchedulerRole.DurableTaskDataReader => DurableTaskSchedulerBuiltInRole.DurableTaskDataReader,
+                DurableTaskSchedulerRole.DurableTaskWorker => DurableTaskSchedulerBuiltInRole.DurableTaskWorker,
+                _ => throw new ArgumentException($"'{roles[i]}' is not a valid {nameof(DurableTaskSchedulerRole)} value.", nameof(roles))
+            };
+        }
+
+        return builder.WithRoleAssignments(target, builtInRoles);
+    }
+
+    /// <summary>
+    /// Assigns the specified roles to the given resource, granting it the necessary permissions
+    /// on the target Durable Task Hub resource. This replaces the default role assignments for the resource.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource to assign the roles to.</typeparam>
+    /// <param name="builder">The resource to which the specified roles will be assigned.</param>
+    /// <param name="target">The target Durable Task Hub resource.</param>
+    /// <param name="roles">The built-in Durable Task Scheduler roles to be assigned.</param>
+    /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
+    /// This overload is not available in polyglot app hosts. Use
+    /// <see cref="WithRoleAssignments{T}(IResourceBuilder{T}, IResourceBuilder{DurableTaskHubResource}, DurableTaskSchedulerRole[])"/>
+    /// instead.
+    /// <example>
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler");
+    /// var hub = scheduler.AddTaskHub("hub");
+    ///
+    /// var worker = builder.AddProject&lt;Projects.Worker&gt;("worker")
+    ///   .WithRoleAssignments(hub, DurableTaskSchedulerBuiltInRole.DurableTaskWorker)
+    ///   .WithReference(hub);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExportIgnore(Reason = "DurableTaskSchedulerBuiltInRole is a custom type not compatible with ATS. Use the DurableTaskSchedulerRole-based overload instead.")]
+    public static IResourceBuilder<T> WithRoleAssignments<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<DurableTaskHubResource> target,
+        params DurableTaskSchedulerBuiltInRole[] roles)
+        where T : IResource
+    {
+        return builder.WithRoleAssignments(target, DurableTaskSchedulerBuiltInRole.GetBuiltInRoleName, roles);
+    }
+
+    [AspireExport("withDurableTaskHubRoleAssignments", Description = "Assigns Durable Task Scheduler roles to a resource scoped to a task hub")]
+    internal static IResourceBuilder<T> WithRoleAssignments<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<DurableTaskHubResource> target,
+        params DurableTaskSchedulerRole[] roles)
+        where T : IResource
+    {
+        if (roles is null || roles.Length == 0)
+        {
+            return builder.WithRoleAssignments(target, Array.Empty<DurableTaskSchedulerBuiltInRole>());
+        }
+
+        var builtInRoles = new DurableTaskSchedulerBuiltInRole[roles.Length];
+        for (var i = 0; i < roles.Length; i++)
+        {
+            builtInRoles[i] = roles[i] switch
+            {
+                DurableTaskSchedulerRole.DurableTaskDataContributor => DurableTaskSchedulerBuiltInRole.DurableTaskDataContributor,
+                DurableTaskSchedulerRole.DurableTaskDataReader => DurableTaskSchedulerBuiltInRole.DurableTaskDataReader,
+                DurableTaskSchedulerRole.DurableTaskWorker => DurableTaskSchedulerBuiltInRole.DurableTaskWorker,
+                _ => throw new ArgumentException($"'{roles[i]}' is not a valid {nameof(DurableTaskSchedulerRole)} value.", nameof(roles))
+            };
+        }
+
+        return builder.WithRoleAssignments(target, builtInRoles);
+    }
 }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.DurableTask;
+using Azure.Provisioning;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
@@ -28,7 +30,58 @@ public static class DurableTaskResourceExtensions
     [AspireExport(Description = "Adds a Durable Task scheduler resource to the distributed application.")]
     public static IResourceBuilder<DurableTaskSchedulerResource> AddDurableTaskScheduler(this IDistributedApplicationBuilder builder, [ResourceName] string name)
     {
-        var scheduler = new DurableTaskSchedulerResource(name);
+       builder.AddAzureProvisioning();
+
+        var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
+        {
+            var aspireResource = (DurableTaskSchedulerResource)infrastructure.AspireResource;
+
+            // Create the Durable Task Scheduler resource using the custom provisioning resource
+            var scheduler = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(
+                infrastructure,
+                (identifier, name) =>
+                {
+                    var resource = DurableTaskSchedulerProvisioningResource.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
+                },
+                (infra) =>
+                {
+                    var skuParameter = new ProvisioningParameter("sku", typeof(string))
+                    {
+                        Value = "Consumption"
+                    };
+                    infra.Add(skuParameter);
+
+                    var resource = new DurableTaskSchedulerProvisioningResource(infra.AspireResource.GetBicepIdentifier())
+                    {
+                        Name = infra.AspireResource.Name,
+                        Location = new ProvisioningParameter(AzureBicepResource.KnownParameters.Location, typeof(string)),
+                        SkuName = skuParameter,
+                        IpAllowlist = ["0.0.0.0/0"]
+                    };
+                    return resource;
+                });
+
+            // Output the scheduler endpoint for connection string construction
+            infrastructure.Add(new ProvisioningOutput("schedulerEndpoint", typeof(string))
+            {
+                Value = scheduler.Endpoint
+            });
+
+            // Output the name for role assignments
+            infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = scheduler.Name });
+
+            // Create TaskHub sub-resources
+            foreach (var hub in aspireResource.Hubs)
+            {
+                var taskHub = hub.ToProvisioningEntity();
+                taskHub.Parent = scheduler;
+                infrastructure.Add(taskHub);
+            }
+        };
+
+        var scheduler = new DurableTaskSchedulerResource(name, configureInfrastructure);
 
         scheduler.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
 
@@ -203,6 +256,8 @@ public static class DurableTaskResourceExtensions
     public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, [ResourceName] string name)
     {
         var hub = new DurableTaskHubResource(name, builder.Resource);
+
+        builder.Resource.Hubs.Add(hub);
 
         hub.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
 

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -7,6 +7,8 @@ using Aspire.Hosting.Azure.DurableTask;
 using Azure.Provisioning;
 using Azure.Provisioning.Expressions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
 
@@ -267,77 +269,10 @@ public static class DurableTaskResourceExtensions
 
         var hubBuilder = builder.ApplicationBuilder.AddResource(hub);
 
-        // Subscribe to the hub's ConnectionStringAvailableEvent to set the Azure dashboard URL.
-        // We add a ResourceUrlAnnotation so it persists across state updates from the
-        // ApplicationOrchestrator and BicepProvisioner, which replace snapshot URLs.
-        builder.ApplicationBuilder.Eventing.Subscribe<ConnectionStringAvailableEvent>(hub, (@event, ct) =>
-        {
-            if (builder.Resource.IsEmulator)
-            {
-                return Task.CompletedTask;
-            }
-
-            var scheduler = hub.Parent;
-
-            if (!scheduler.Outputs.TryGetValue("subscriptionId", out var subObj) ||
-                !scheduler.Outputs.TryGetValue("schedulerEndpoint", out var endpointObj) ||
-                !scheduler.Outputs.TryGetValue("name", out var nameObj))
-            {
-                return Task.CompletedTask;
-            }
-
-            var subscriptionId = subObj?.ToString();
-            var endpoint = endpointObj?.ToString();
-            var schedulerName = nameObj?.ToString();
-            scheduler.Outputs.TryGetValue("tenantId", out var tenantObj);
-            var tenantId = tenantObj?.ToString();
-            var taskHubName = hub.HubName;
-
-            if (subscriptionId is null || endpoint is null || schedulerName is null)
-            {
-                return Task.CompletedTask;
-            }
-
-            // Only add the annotation once (the event may fire multiple times).
-            if (hub.Annotations.OfType<ResourceUrlAnnotation>().Any(a => a.DisplayText == "Task Hub Dashboard"))
-            {
-                return Task.CompletedTask;
-            }
-
-            var encodedEndpoint = Uri.EscapeDataString(endpoint);
-            var url = $"https://dashboard.durabletask.io/subscriptions/{subscriptionId}/schedulers/{schedulerName}/taskhubs/{taskHubName}?endpoint={encodedEndpoint}";
-            if (tenantId is not null)
-            {
-                url += $"&tenantId={tenantId}";
-            }
-
-            hub.Annotations.Add(new ResourceUrlAnnotation { Url = url, DisplayText = "Task Hub Dashboard" });
-
-            return Task.CompletedTask;
-        });
-
-        hubBuilder.OnResourceReady(
-            async (r, e, ct) =>
-            {
-                if (!builder.Resource.IsEmulator)
-                {
-                    // Azure dashboard URLs are published via the scheduler's
-                    // ConnectionStringAvailableEvent subscription.
-                    return;
-                }
-
-                var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
-
-                var url = await ReferenceExpression.Create($"{r.Parent.EmulatorDashboardEndpoint}/subscriptions/default/schedulers/default/taskhubs/{r.TaskHubName}").GetValueAsync(ct).ConfigureAwait(false);
-
-                await notifications.PublishUpdateAsync(r, snapshot => snapshot with
-                {
-                    State = KnownResourceStates.Running,
-                    Urls = url is not null
-                        ? [new("dashboard", url, false) { DisplayProperties = new() { DisplayName = "Task Hub Dashboard" } }]
-                        : []
-                }).ConfigureAwait(false);
-            });
+        // Register the background service that watches resource state updates and adds
+        // dashboard URL annotations to hub resources when provisioning data becomes available.
+        // TryAddEnumerable ensures it is only registered once even if AddTaskHub is called multiple times.
+        builder.ApplicationBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DurableTaskDashboardUrlService>());
 
         return hubBuilder;
     }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -83,7 +83,10 @@ public static class DurableTaskResourceExtensions
 
         var scheduler = new DurableTaskSchedulerResource(name, configureInfrastructure);
 
-        return builder.AddResource(scheduler);
+        return builder.AddResource(scheduler)
+            .WithDefaultRoleAssignments(
+                DurableTaskSchedulerBuiltInRole.GetBuiltInRoleName,
+                DurableTaskSchedulerBuiltInRole.DurableTaskDataContributor);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -5,7 +5,9 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.DurableTask;
 using Azure.Provisioning;
+using Azure.Provisioning.Expressions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -71,6 +73,10 @@ public static class DurableTaskResourceExtensions
 
             // Output the name for role assignments
             infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = scheduler.Name });
+
+            // Output subscription and tenant IDs for dashboard URL construction
+            infrastructure.Add(new ProvisioningOutput("subscriptionId", typeof(string)) { Value = BicepFunction.GetSubscription().SubscriptionId });
+            infrastructure.Add(new ProvisioningOutput("tenantId", typeof(string)) { Value = BicepFunction.GetSubscription().TenantId });
 
             // Create TaskHub sub-resources
             foreach (var hub in aspireResource.Hubs)
@@ -266,18 +272,45 @@ public static class DurableTaskResourceExtensions
             async (r, e, ct) =>
             {
                 var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
+                var logger = e.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Aspire.Hosting.Azure.DurableTask");
 
-                var url = builder.Resource.IsEmulator
-                    ? await ReferenceExpression.Create($"{r.Parent.EmulatorDashboardEndpoint}/subscriptions/default/schedulers/default/taskhubs/{r.TaskHubName}").GetValueAsync(ct).ConfigureAwait(false)
-                    : null;
+                logger.LogWarning("OnResourceReady fired for hub '{Hub}', IsEmulator={IsEmulator}", r.Name, builder.Resource.IsEmulator);
 
-                await notifications.PublishUpdateAsync(r, snapshot => snapshot with
+                ReferenceExpression dashboardUrl;
+                if (builder.Resource.IsEmulator)
                 {
-                    State = KnownResourceStates.Running,
-                    Urls = url is not null
-                        ? [new("dashboard", url, false) { DisplayProperties = new() { DisplayName = "Task Hub Dashboard" } }]
-                        : []
-                }).ConfigureAwait(false);
+                    dashboardUrl = ReferenceExpression.Create($"{r.Parent.EmulatorDashboardEndpoint}/subscriptions/default/schedulers/default/taskhubs/{r.TaskHubName}");
+                }
+                else
+                {
+                    var s = r.Parent;
+                    dashboardUrl = ReferenceExpression.Create($"https://dashboard.durabletask.io/subscriptions/{s.SubscriptionId}/schedulers/{s.NameOutputReference}/taskhubs/{r.TaskHubName}?endpoint={s.SchedulerEndpoint}&tenantId={s.TenantId}");
+                    logger.LogWarning("Azure dashboard ReferenceExpression format: {Format}", dashboardUrl.Format);
+                }
+
+                try
+                {
+                    var url = await dashboardUrl.GetValueAsync(ct).ConfigureAwait(false);
+                    logger.LogWarning("Dashboard URL resolved to: {Url}", url ?? "(null)");
+
+                    await notifications.PublishUpdateAsync(r, snapshot =>
+                    {
+                        logger.LogWarning("PublishUpdateAsync callback for hub '{Hub}': current Urls count={Count}, current State={State}", r.Name, snapshot.Urls.Length, snapshot.State?.Text);
+
+                        return snapshot with
+                        {
+                            Urls = url is not null
+                                ? [.. snapshot.Urls, new("dashboard", url, false) { DisplayProperties = new() { DisplayName = "Task Hub Dashboard" } }]
+                                : snapshot.Urls
+                        };
+                    }).ConfigureAwait(false);
+
+                    logger.LogWarning("PublishUpdateAsync completed for hub '{Hub}'", r.Name);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to resolve dashboard URL for hub '{Hub}'", r.Name);
+                }
             });
 
         return hubBuilder;
@@ -335,4 +368,5 @@ public static class DurableTaskResourceExtensions
             IResourceBuilder<ParameterResource> parameter => builder.WithTaskHubName(parameter),
             _ => throw new ArgumentException($"Unexpected task hub name type: {taskHubName.GetType().Name}", nameof(taskHubName))
         };
+
 }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -194,6 +194,16 @@ public static class DurableTaskResourceExtensions
         // Mark this resource as an emulator for consistent resource identification and tooling support
         builder.WithAnnotation(new EmulatorResourceAnnotation());
 
+        // Propagate emulator annotation to any hubs already registered with this scheduler,
+        // so the Azure provisioner skips them.
+        foreach (var hub in builder.Resource.Hubs)
+        {
+            if (!hub.IsEmulator())
+            {
+                hub.Annotations.Add(new EmulatorResourceAnnotation());
+            }
+        }
+
         builder.WithHttpEndpoint(name: "grpc", targetPort: 8080)
                .WithEndpoint("grpc", endpoint => endpoint.Transport = "http2")
                .WithHttpEndpoint(name: "http", targetPort: 8081)
@@ -264,6 +274,13 @@ public static class DurableTaskResourceExtensions
     public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, [ResourceName] string name)
     {
         var hub = new DurableTaskHubResource(name, builder.Resource);
+
+        // If the scheduler is already in emulator mode, propagate the annotation so the
+        // Azure provisioner skips this hub resource.
+        if (builder.Resource.IsEmulator())
+        {
+            hub.Annotations.Add(new EmulatorResourceAnnotation());
+        }
 
         builder.Resource.Hubs.Add(hub);
 

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerBuiltInRole.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerBuiltInRole.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// Represents built-in Azure Durable Task Scheduler roles that can be assigned to identities.
+/// </summary>
+public readonly struct DurableTaskSchedulerBuiltInRole : IEquatable<DurableTaskSchedulerBuiltInRole>
+{
+    private readonly string _value;
+
+    private DurableTaskSchedulerBuiltInRole(string value)
+    {
+        _value = value;
+    }
+
+    /// <summary>
+    /// Durable Task Data Contributor role - provides full access to durable task data operations.
+    /// Role ID: 0ad04412-c4d5-4796-b79c-f76d14c8d402
+    /// </summary>
+    public static DurableTaskSchedulerBuiltInRole DurableTaskDataContributor { get; } = new("0ad04412-c4d5-4796-b79c-f76d14c8d402");
+
+    /// <summary>
+    /// Durable Task Data Reader role - provides read-only access to durable task data.
+    /// Role ID: d6a5505f-6ebb-45a4-896e-ac8274cfc0ac
+    /// </summary>
+    public static DurableTaskSchedulerBuiltInRole DurableTaskDataReader { get; } = new("d6a5505f-6ebb-45a4-896e-ac8274cfc0ac");
+
+    /// <summary>
+    /// Durable Task Worker role - provides access to execute durable task orchestrations and activities.
+    /// Role ID: 80d0d6b0-f522-40a4-8886-a5a11720c375
+    /// </summary>
+    public static DurableTaskSchedulerBuiltInRole DurableTaskWorker { get; } = new("80d0d6b0-f522-40a4-8886-a5a11720c375");
+
+    /// <summary>
+    /// Gets the role ID as a string.
+    /// </summary>
+    /// <returns>The role ID.</returns>
+    public override string ToString() => _value;
+
+    /// <summary>
+    /// Gets the human-readable name for the built-in role.
+    /// </summary>
+    /// <param name="role">The role to get the name for.</param>
+    /// <returns>The human-readable role name.</returns>
+    public static string GetBuiltInRoleName(DurableTaskSchedulerBuiltInRole role)
+    {
+        return role._value switch
+        {
+            "0ad04412-c4d5-4796-b79c-f76d14c8d402" => "Durable_Task_Data_Contributor",
+            "d6a5505f-6ebb-45a4-896e-ac8274cfc0ac" => "Durable_Task_Data_Reader",
+            "80d0d6b0-f522-40a4-8886-a5a11720c375" => "Durable_Task_Worker",
+            _ => role._value
+        };
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(DurableTaskSchedulerBuiltInRole other) => _value == other._value;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is DurableTaskSchedulerBuiltInRole other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+
+    /// <summary>
+    /// Determines if two <see cref="DurableTaskSchedulerBuiltInRole"/> values are equal.
+    /// </summary>
+    public static bool operator ==(DurableTaskSchedulerBuiltInRole left, DurableTaskSchedulerBuiltInRole right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines if two <see cref="DurableTaskSchedulerBuiltInRole"/> values are not equal.
+    /// </summary>
+    public static bool operator !=(DurableTaskSchedulerBuiltInRole left, DurableTaskSchedulerBuiltInRole right) => !left.Equals(right);
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerProvisioningResource.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Core;
+using Azure.Provisioning;
+using Azure.Provisioning.Primitives;
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// A custom provisioning resource for Azure Durable Task Scheduler.
+/// This is used until an official Azure.Provisioning.DurableTask package is available.
+/// </summary>
+internal sealed class DurableTaskSchedulerProvisioningResource : ProvisionableResource
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="DurableTaskSchedulerProvisioningResource"/>.
+    /// </summary>
+    /// <param name="bicepIdentifier">The Bicep identifier for this resource.</param>
+    /// <param name="resourceVersion">The API version for the resource.</param>
+    public DurableTaskSchedulerProvisioningResource(string bicepIdentifier, string? resourceVersion = "2025-11-01")
+        : base(bicepIdentifier, new ResourceType("Microsoft.DurableTask/schedulers"), resourceVersion)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the Durable Task Scheduler.
+    /// </summary>
+    public BicepValue<string> Name
+    {
+        get { Initialize(); return _name!; }
+        set { Initialize(); _name!.Assign(value); }
+    }
+    private BicepValue<string>? _name;
+
+    /// <summary>
+    /// Gets or sets the location of the Durable Task Scheduler.
+    /// </summary>
+    public BicepValue<string> Location
+    {
+        get { Initialize(); return _location!; }
+        set { Initialize(); _location!.Assign(value); }
+    }
+    private BicepValue<string>? _location;
+
+    /// <summary>
+    /// Gets or sets the SKU of the Durable Task Scheduler.
+    /// </summary>
+    public BicepValue<string> SkuName
+    {
+        get { Initialize(); return _skuName!; }
+        set { Initialize(); _skuName!.Assign(value); }
+    }
+    private BicepValue<string>? _skuName;
+
+    /// <summary>
+    /// Gets or sets the SKU capacity of the Durable Task Scheduler.
+    /// </summary>
+    public BicepValue<int> SkuCapacity
+    {
+        get { Initialize(); return _skuCapacity!; }
+        set { Initialize(); _skuCapacity!.Assign(value); }
+    }
+    private BicepValue<int>? _skuCapacity;
+
+    /// <summary>
+    /// Gets or sets the IP allowlist of the Durable Task Scheduler.
+    /// </summary>
+    public BicepList<string> IpAllowlist
+    {
+        get { Initialize(); return _ipAllowlist!; }
+        set { Initialize(); _ipAllowlist!.Assign(value); }
+    }
+    private BicepList<string>? _ipAllowlist;
+
+    /// <summary>
+    /// Gets the endpoint of the Durable Task Scheduler (output).
+    /// </summary>
+    public BicepValue<string> Endpoint
+    {
+        get { Initialize(); return _endpoint!; }
+    }
+    private BicepValue<string>? _endpoint;
+
+    /// <inheritdoc/>
+    protected override void DefineProvisionableProperties()
+    {
+        _name = DefineProperty<string>(nameof(Name), ["name"], isOutput: false, isRequired: true);
+        _location = DefineProperty<string>(nameof(Location), ["location"], isOutput: false, isRequired: true);
+        _skuName = DefineProperty<string>(nameof(SkuName), ["properties", "sku", "name"], isOutput: false, isRequired: false);
+        _skuCapacity = DefineProperty<int>(nameof(SkuCapacity), ["properties", "sku", "capacity"], isOutput: false, isRequired: false);
+        _ipAllowlist = DefineListProperty<string>(nameof(IpAllowlist), ["properties", "ipAllowlist"], isOutput: false, isRequired: false);
+        _endpoint = DefineProperty<string>(nameof(Endpoint), ["properties", "endpoint"], isOutput: true, isRequired: false);
+    }
+
+    /// <summary>
+    /// Creates a reference to an existing Durable Task Scheduler resource.
+    /// </summary>
+    /// <param name="bicepIdentifier">The Bicep identifier for this resource.</param>
+    /// <param name="resourceVersion">The API version for the resource.</param>
+    /// <returns>A new instance configured as an existing resource reference.</returns>
+    public static DurableTaskSchedulerProvisioningResource FromExisting(string bicepIdentifier, string? resourceVersion = "2025-11-01")
+    {
+        return new DurableTaskSchedulerProvisioningResource(bicepIdentifier, resourceVersion)
+        {
+            IsExistingResource = true
+        };
+    }
+}
+

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
@@ -28,6 +28,16 @@ public sealed class DurableTaskSchedulerResource(string name, Action<AzureResour
     public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <summary>
+    /// Gets the "subscriptionId" output reference for the resource.
+    /// </summary>
+    internal BicepOutputReference SubscriptionId => new("subscriptionId", this);
+
+    /// <summary>
+    /// Gets the "tenantId" output reference for the resource.
+    /// </summary>
+    internal BicepOutputReference TenantId => new("tenantId", this);
+
+    /// <summary>
     /// Gets the expression that resolves to the connection string for the Durable Task scheduler.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression => CreateConnectionString();

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning.Primitives;
 
 namespace Aspire.Hosting.Azure.DurableTask;
 
@@ -10,8 +11,17 @@ namespace Aspire.Hosting.Azure.DurableTask;
 /// and a connection string for Durable Task orchestration scheduling.
 /// </summary>
 /// <param name="name">The unique resource name.</param>
-public sealed class DurableTaskSchedulerResource(string name) : Resource(name), IResourceWithEndpoints, IResourceWithConnectionString
+/// <param name="configureInfrastructure"></param>
+public sealed class DurableTaskSchedulerResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
+    : AzureProvisioningResource(name, configureInfrastructure), IResourceWithEndpoints, IResourceWithConnectionString
 {
+    internal List<DurableTaskHubResource> Hubs { get; } = [];
+
+    /// <summary>
+    /// Gets the "name" output reference for the resource.
+    /// </summary>
+    public BicepOutputReference NameOutputReference => new("name", this);
+
     /// <summary>
     /// Gets the expression that resolves to the connection string for the Durable Task scheduler.
     /// </summary>
@@ -24,6 +34,33 @@ public sealed class DurableTaskSchedulerResource(string name) : Resource(name), 
     /// emulator (container) instead of a cloud-hosted service.
     /// </summary>
     public bool IsEmulator => this.IsContainer();
+
+    /// <inheritdoc/>
+    public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)
+    {
+        var bicepIdentifier = this.GetBicepIdentifier();
+        var resources = infra.GetProvisionableResources();
+
+        // Check if a scheduler with the same identifier already exists
+        var existingScheduler = resources.OfType<DurableTaskSchedulerProvisioningResource>()
+            .SingleOrDefault(s => s.BicepIdentifier == bicepIdentifier);
+
+        if (existingScheduler is not null)
+        {
+            return existingScheduler;
+        }
+
+        // Create and add new resource if it doesn't exist
+        var scheduler = DurableTaskSchedulerProvisioningResource.FromExisting(bicepIdentifier);
+
+        if (!TryApplyExistingResourceAnnotation(this, infra, scheduler))
+        {
+            scheduler.Name = NameOutputReference.AsProvisioningParameter(infra);
+        }
+
+        infra.Add(scheduler);
+        return scheduler;
+    }
 
     private ReferenceExpression CreateConnectionString()
     {

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Azure.DurableTask;
 /// and a connection string for Durable Task orchestration scheduling.
 /// </summary>
 /// <param name="name">The unique resource name.</param>
-/// <param name="configureInfrastructure"></param>
+/// <param name="configureInfrastructure">Callback to configure the Azure infrastructure for this resource.</param>
 public sealed class DurableTaskSchedulerResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
     : AzureProvisioningResource(name, configureInfrastructure), IResourceWithEndpoints, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
@@ -13,9 +13,14 @@ namespace Aspire.Hosting.Azure.DurableTask;
 /// <param name="name">The unique resource name.</param>
 /// <param name="configureInfrastructure"></param>
 public sealed class DurableTaskSchedulerResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
-    : AzureProvisioningResource(name, configureInfrastructure), IResourceWithEndpoints, IResourceWithConnectionString
+    : AzureProvisioningResource(name, configureInfrastructure), IResourceWithEndpoints, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     internal List<DurableTaskHubResource> Hubs { get; } = [];
+
+    /// <summary>
+    /// Gets the "schedulerEndpoint" output reference from the bicep template for the Durable Task scheduler resource.
+    /// </summary>
+    public BicepOutputReference SchedulerEndpoint => new("schedulerEndpoint", this);
 
     /// <summary>
     /// Gets the "name" output reference for the resource.
@@ -81,7 +86,8 @@ public sealed class DurableTaskSchedulerResource(string name, Action<AzureResour
             };
         }
 
-        throw new InvalidOperationException($"Unable to resolve the Durable Task Scheduler connection string. Configure the scheduler using {nameof(DurableTaskResourceExtensions.RunAsEmulator)}() or {nameof(DurableTaskResourceExtensions.RunAsExisting)}(connectionString) before accessing {nameof(ConnectionStringExpression)}.");
+        // For Azure deployment, use the scheduler endpoint from Bicep output
+        return ReferenceExpression.Create($"Endpoint={SchedulerEndpoint};Authentication=DefaultAzure");
     }
 
     private ReferenceExpression CreateDashboardEndpoint()
@@ -94,5 +100,19 @@ public sealed class DurableTaskSchedulerResource(string name, Action<AzureResour
         }
 
         throw new InvalidOperationException("Dashboard endpoint is only available when running as an emulator.");
+    }
+
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
+    {
+        if (IsEmulator)
+        {
+            // For emulator, use the full connection string
+            target[connectionName] = ConnectionStringExpression;
+        }
+        else
+        {
+            // For Azure deployment, use the scheduler endpoint
+            target[$"{connectionName}__endpoint"] = SchedulerEndpoint;
+        }
     }
 }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerRole.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerRole.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Represents ATS-compatible Durable Task Scheduler roles.
+/// </summary>
+internal enum DurableTaskSchedulerRole
+{
+    DurableTaskDataContributor,
+    DurableTaskDataReader,
+    DurableTaskWorker,
+}

--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -99,6 +99,69 @@ var scheduler = builder.AddDurableTaskScheduler("scheduler")
 var taskHubName = builder.AddParameter("taskhub-name", "mytaskhub");
 var taskHub = scheduler.AddTaskHub("taskhub").WithTaskHubName(taskHubName);
 ```
+
+### Deploy a new Scheduler to Azure
+
+When you publish your Aspire application, the Durable Task Scheduler and its Task Hubs are automatically provisioned as Azure resources via generated Bicep templates. The generated infrastructure includes:
+
+- A `Microsoft.DurableTask/schedulers` resource with the `Consumption` SKU.
+- A `Microsoft.DurableTask/schedulers/taskhubs` sub-resource for each Task Hub added in the app model.
+- Role assignments granting the `Durable Task Data Contributor` role to applications that reference the Scheduler.
+
+No additional configuration is needed. The connection string is automatically resolved from provisioning outputs using `DefaultAzure` authentication.
+
+#### Use an existing Scheduler at publish time
+
+To reference an existing Scheduler during deployment (instead of provisioning a new one), use `PublishAsExisting`:
+
+```csharp
+var existingName = builder.AddParameter("existingSchedulerName");
+var scheduler = builder.AddDurableTaskScheduler("scheduler")
+    .PublishAsExisting(existingName, resourceGroupParameter: default);
+
+var taskHub = scheduler.AddTaskHub("taskhub");
+```
+
+#### Customize Scheduler infrastructure
+
+You can modify the generated Bicep infrastructure using `ConfigureInfrastructure`. For example, to add additional provisioning outputs:
+
+```csharp
+var scheduler = builder.AddDurableTaskScheduler("scheduler")
+    .ConfigureInfrastructure(infra =>
+    {
+        // Add a custom output to the generated Bicep
+        infra.Add(new ProvisioningOutput("customOutput", typeof(string))
+        {
+            Value = "my-custom-value"
+        });
+    });
+```
+
+#### Role assignments
+
+By default, applications that reference a Scheduler or Task Hub resource are assigned the **Durable Task Data Contributor** role, which provides full access to durable task data operations. The role is scoped to whichever DTS resource is referenced (the scheduler or a specific task hub).
+
+To customize the role assigned to a referencing application, use `WithRoleAssignments`:
+
+```csharp
+var scheduler = builder.AddDurableTaskScheduler("scheduler");
+var hub = scheduler.AddTaskHub("hub");
+
+// Assign a narrower role scoped to the task hub
+builder.AddAzureFunctionsProject<Projects.Company_FunctionApp>("worker")
+    .WithRoleAssignments(hub, DurableTaskSchedulerBuiltInRole.DurableTaskWorker)
+    .WithReference(hub);
+```
+
+The following built-in roles are available via `DurableTaskSchedulerBuiltInRole`:
+
+| Role | Description |
+|------|-------------|
+| Durable Task Data Contributor | Full access to durable task data operations (default) |
+| Durable Task Data Reader | Read-only access to durable task data |
+| Durable Task Worker | Access to execute durable task orchestrations and activities |
+
 ## Additional documentation
 
 - https://learn.microsoft.com/azure/azure-functions

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -78,10 +78,10 @@ public class DurableTaskResourceExtensionsTests
             .RunAsExisting(dtsConnectionString);
 
         var taskHub = dts.AddTaskHub("mytaskhub");
-        
+
         if (taskHubName is not null)
         {
-            taskHub = taskHub.WithTaskHubName(taskHubName);   
+            taskHub = taskHub.WithTaskHubName(taskHubName);
         }
 
         var connectionString = await taskHub.Resource.ConnectionStringExpression.GetValueAsync(default);

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -266,6 +266,84 @@ public class DurableTaskResourceExtensionsTests
     }
 
     [Fact]
+    public void AddDurableTaskScheduler_HasDefaultRoleAssignment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+
+        Assert.True(dts.Resource.TryGetAnnotationsOfType<DefaultRoleAssignmentsAnnotation>(out var annotations));
+        var annotation = Assert.Single(annotations);
+        var role = Assert.Single(annotation.Roles);
+        Assert.Equal(DurableTaskSchedulerBuiltInRole.DurableTaskDataContributor.ToString(), role.Id);
+    }
+
+    [Fact]
+    public void AddTaskHub_HasDefaultRoleAssignment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        var hub = dts.AddTaskHub("myhub");
+
+        Assert.True(hub.Resource.TryGetAnnotationsOfType<DefaultRoleAssignmentsAnnotation>(out var annotations));
+        var annotation = Assert.Single(annotations);
+        var role = Assert.Single(annotation.Roles);
+        Assert.Equal(DurableTaskSchedulerBuiltInRole.DurableTaskDataContributor.ToString(), role.Id);
+    }
+
+    [Fact]
+    public void WithRoleAssignments_Scheduler_AppliesRoleAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        var project = builder.AddResource(new TestResource("myapp"))
+            .WithRoleAssignments(dts, DurableTaskSchedulerBuiltInRole.DurableTaskWorker);
+
+        Assert.True(project.Resource.TryGetAnnotationsOfType<RoleAssignmentAnnotation>(out var annotations));
+        var annotation = Assert.Single(annotations);
+        Assert.Equal(dts.Resource, annotation.Target);
+        var role = Assert.Single(annotation.Roles);
+        Assert.Equal(DurableTaskSchedulerBuiltInRole.DurableTaskWorker.ToString(), role.Id);
+    }
+
+    [Fact]
+    public void WithRoleAssignments_TaskHub_AppliesRoleAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        var hub = dts.AddTaskHub("myhub");
+        var project = builder.AddResource(new TestResource("myapp"))
+            .WithRoleAssignments(hub, DurableTaskSchedulerBuiltInRole.DurableTaskDataReader);
+
+        Assert.True(project.Resource.TryGetAnnotationsOfType<RoleAssignmentAnnotation>(out var annotations));
+        var annotation = Assert.Single(annotations);
+        Assert.Equal(hub.Resource, annotation.Target);
+        var role = Assert.Single(annotation.Roles);
+        Assert.Equal(DurableTaskSchedulerBuiltInRole.DurableTaskDataReader.ToString(), role.Id);
+    }
+
+    [Fact]
+    public void WithRoleAssignments_Scheduler_MultipleRoles()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        var project = builder.AddResource(new TestResource("myapp"))
+            .WithRoleAssignments(dts,
+                DurableTaskSchedulerBuiltInRole.DurableTaskDataReader,
+                DurableTaskSchedulerBuiltInRole.DurableTaskWorker);
+
+        Assert.True(project.Resource.TryGetAnnotationsOfType<RoleAssignmentAnnotation>(out var annotations));
+        var annotation = Assert.Single(annotations);
+        Assert.Equal(2, annotation.Roles.Count);
+        Assert.Contains(annotation.Roles, r => r.Id == DurableTaskSchedulerBuiltInRole.DurableTaskDataReader.ToString());
+        Assert.Contains(annotation.Roles, r => r.Id == DurableTaskSchedulerBuiltInRole.DurableTaskWorker.ToString());
+    }
+
+    [Fact]
     public async Task AddDurableTaskScheduler_GeneratesBicep()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
@@ -476,4 +554,6 @@ public class DurableTaskResourceExtensionsTests
         var urlAnnotation = hub.Resource.Annotations.OfType<ResourceUrlAnnotation>().SingleOrDefault();
         Assert.Null(urlAnnotation);
     }
+
+    private sealed class TestResource(string name) : Resource(name);
 }

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.DurableTask;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 
@@ -345,5 +346,134 @@ public class DurableTaskResourceExtensionsTests
         var manifest = await AzureManifestUtils.GetManifestWithBicep(dts.Resource);
 
         await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task DashboardUrlService_AzureMode_AddsDashboardUrlAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        var hub = dts.AddTaskHub("myhub");
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var appModel = new DistributedApplicationModel([dts.Resource, hub.Resource]);
+        var service = new DurableTaskDashboardUrlService(appModel, notificationService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // Set Azure outputs on the scheduler
+        dts.Resource.Outputs["subscriptionId"] = "sub-123";
+        dts.Resource.Outputs["schedulerEndpoint"] = "https://myscheduler.durabletask.io";
+        dts.Resource.Outputs["name"] = "myscheduler";
+        dts.Resource.Outputs["tenantId"] = "tenant-456";
+
+        // Publish update before starting so WatchAsync replays the snapshot
+        await notificationService.PublishUpdateAsync(hub.Resource, snapshot => snapshot with { State = KnownResourceStates.Running });
+
+        await service.StartAsync(cts.Token);
+        await service.ExecuteTask!.WaitAsync(cts.Token);
+
+        var urlAnnotation = hub.Resource.Annotations.OfType<ResourceUrlAnnotation>().SingleOrDefault();
+        Assert.NotNull(urlAnnotation);
+        Assert.Contains("https://dashboard.durabletask.io/subscriptions/sub-123/schedulers/myscheduler/taskhubs/myhub", urlAnnotation.Url);
+        Assert.Contains("endpoint=" + Uri.EscapeDataString("https://myscheduler.durabletask.io"), urlAnnotation.Url);
+        Assert.Contains("tenantId=tenant-456", urlAnnotation.Url);
+    }
+
+    [Fact]
+    public async Task DashboardUrlService_AzureMode_WithoutTenantId_OmitsTenantIdFromUrl()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        var hub = dts.AddTaskHub("myhub");
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var appModel = new DistributedApplicationModel([dts.Resource, hub.Resource]);
+        var service = new DurableTaskDashboardUrlService(appModel, notificationService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // Set Azure outputs on the scheduler without tenantId
+        dts.Resource.Outputs["subscriptionId"] = "sub-123";
+        dts.Resource.Outputs["schedulerEndpoint"] = "https://myscheduler.durabletask.io";
+        dts.Resource.Outputs["name"] = "myscheduler";
+
+        await notificationService.PublishUpdateAsync(hub.Resource, snapshot => snapshot with { State = KnownResourceStates.Running });
+
+        await service.StartAsync(cts.Token);
+        await service.ExecuteTask!.WaitAsync(cts.Token);
+
+        var urlAnnotation = hub.Resource.Annotations.OfType<ResourceUrlAnnotation>().SingleOrDefault();
+        Assert.NotNull(urlAnnotation);
+        Assert.Contains("https://dashboard.durabletask.io/subscriptions/sub-123/schedulers/myscheduler/taskhubs/myhub", urlAnnotation.Url);
+        Assert.DoesNotContain("tenantId", urlAnnotation.Url);
+    }
+
+    [Fact]
+    public async Task DashboardUrlService_EmulatorMode_AddsDashboardUrlAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts")
+            .RunAsEmulator(e =>
+            {
+                e.WithEndpoint("grpc", e => e.AllocatedEndpoint = new(e, "localhost", 8080));
+                e.WithEndpoint("http", e => e.AllocatedEndpoint = new(e, "localhost", 8081));
+                e.WithEndpoint("dashboard", e => e.AllocatedEndpoint = new(e, "localhost", 8082));
+            });
+        var hub = dts.AddTaskHub("myhub");
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var appModel = new DistributedApplicationModel([dts.Resource, hub.Resource]);
+        var service = new DurableTaskDashboardUrlService(appModel, notificationService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await notificationService.PublishUpdateAsync(hub.Resource, snapshot => snapshot with { State = KnownResourceStates.Running });
+
+        await service.StartAsync(cts.Token);
+        await service.ExecuteTask!.WaitAsync(cts.Token);
+
+        var urlAnnotation = hub.Resource.Annotations.OfType<ResourceUrlAnnotation>().SingleOrDefault();
+        Assert.NotNull(urlAnnotation);
+        Assert.Equal("http://localhost:8082/subscriptions/default/schedulers/default/taskhubs/myhub", urlAnnotation.Url);
+    }
+
+    [Fact]
+    public async Task DashboardUrlService_AzureMode_MissingOutputs_DoesNotAddUrl()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        var hub = dts.AddTaskHub("myhub");
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var appModel = new DistributedApplicationModel([dts.Resource, hub.Resource]);
+        var service = new DurableTaskDashboardUrlService(appModel, notificationService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Only set partial outputs - missing schedulerEndpoint and name
+        dts.Resource.Outputs["subscriptionId"] = "sub-123";
+
+        await notificationService.PublishUpdateAsync(hub.Resource, snapshot => snapshot with { State = KnownResourceStates.Running });
+
+        await service.StartAsync(cts.Token);
+
+        // The service should keep watching since it can't build a URL. Cancel to unblock.
+        cts.Cancel();
+
+        try
+        {
+            await service.ExecuteTask!;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        var urlAnnotation = hub.Resource.Annotations.OfType<ResourceUrlAnnotation>().SingleOrDefault();
+        Assert.Null(urlAnnotation);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -90,7 +90,7 @@ public class DurableTaskResourceExtensionsTests
     }
 
     [Fact]
-    public void AddDurableTaskScheduler_IsExcludedFromPublishingManifest()
+    public void AddDurableTaskScheduler_HasManifestPublishingCallback()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
@@ -98,11 +98,11 @@ public class DurableTaskResourceExtensionsTests
 
         Assert.True(dts.Resource.TryGetAnnotationsOfType<ManifestPublishingCallbackAnnotation>(out var manifestAnnotations));
         var annotation = Assert.Single(manifestAnnotations);
-        Assert.Equal(ManifestPublishingCallbackAnnotation.Ignore, annotation);
+        Assert.NotNull(annotation.Callback);
     }
 
     [Fact]
-    public void AddDurableTaskHub_IsExcludedFromPublishingManifest()
+    public void AddDurableTaskHub_HasManifestPublishingCallback()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
@@ -111,7 +111,7 @@ public class DurableTaskResourceExtensionsTests
 
         Assert.True(taskHub.Resource.TryGetAnnotationsOfType<ManifestPublishingCallbackAnnotation>(out var manifestAnnotations));
         var annotation = Assert.Single(manifestAnnotations);
-        Assert.Equal(ManifestPublishingCallbackAnnotation.Ignore, annotation);
+        Assert.NotNull(annotation.Callback);
     }
 
     [Fact]
@@ -125,8 +125,11 @@ public class DurableTaskResourceExtensionsTests
         Assert.False(dts.ApplicationBuilder.ExecutionContext.IsRunMode);
         Assert.True(dts.ApplicationBuilder.ExecutionContext.IsPublishMode);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => _ = dts.Resource.ConnectionStringExpression);
-        Assert.Contains("Unable to resolve the Durable Task Scheduler connection string", ex.Message);
+        // In publish mode, RunAsExisting does not apply the connection string annotation;
+        // instead, the connection string falls through to the provisioned-mode Bicep output reference.
+        var connectionString = dts.Resource.ConnectionStringExpression;
+        Assert.Contains("Endpoint=", connectionString.Format);
+        Assert.Contains("Authentication=DefaultAzure", connectionString.Format);
     }
 
     [Fact]
@@ -140,7 +143,11 @@ public class DurableTaskResourceExtensionsTests
         Assert.False(dts.Resource.IsEmulator);
         Assert.DoesNotContain(dts.Resource.Annotations, a => a is EmulatorResourceAnnotation);
 
-        Assert.Throws<InvalidOperationException>(() => _ = dts.Resource.ConnectionStringExpression);
+        // In publish mode, the emulator is a no-op, but the connection string resolves
+        // to the provisioned-mode Bicep output reference instead of throwing.
+        var connectionString = dts.Resource.ConnectionStringExpression;
+        Assert.Contains("Endpoint=", connectionString.Format);
+        Assert.Contains("Authentication=DefaultAzure", connectionString.Format);
     }
 
     [Fact]
@@ -244,13 +251,68 @@ public class DurableTaskResourceExtensionsTests
     }
 
     [Fact]
-    public void DurableTaskSchedulerResource_WithoutEmulatorOrExistingConnectionString_Throws()
+    public void DurableTaskSchedulerResource_WithoutEmulatorOrExistingConnectionString_ResolvesToBicepOutput()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var dts = builder.AddDurableTaskScheduler("dts");
 
-        var ex = Assert.Throws<InvalidOperationException>(() => _ = dts.Resource.ConnectionStringExpression);
-        Assert.Contains("Unable to resolve the Durable Task Scheduler connection string", ex.Message);
+        // Without emulator or RunAsExisting, connection string resolves to the
+        // provisioned-mode Bicep output reference.
+        var connectionString = dts.Resource.ConnectionStringExpression;
+        Assert.Contains("Endpoint=", connectionString.Format);
+        Assert.Contains("Authentication=DefaultAzure", connectionString.Format);
+    }
+
+    [Fact]
+    public async Task AddDurableTaskScheduler_GeneratesBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(dts.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task AddDurableTaskScheduler_WithTaskHub_GeneratesBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        _ = dts.AddTaskHub("myhub");
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(dts.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task AddDurableTaskScheduler_WithNamedTaskHub_GeneratesBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        _ = dts.AddTaskHub("myhub").WithTaskHubName("MyCustomTaskHub");
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(dts.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task AddDurableTaskScheduler_WithMultipleTaskHubs_GeneratesBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+        _ = dts.AddTaskHub("hub1");
+        _ = dts.AddTaskHub("hub2").WithTaskHubName("CustomHub2");
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(dts.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -315,4 +315,35 @@ public class DurableTaskResourceExtensionsTests
 
         await Verify(manifest.BicepText, extension: "bicep");
     }
+
+    [Fact]
+    public async Task AddDurableTaskScheduler_PublishAsExisting_GeneratesBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingName = builder.AddParameter("existingSchedulerName");
+        var dts = builder.AddDurableTaskScheduler("dts")
+            .PublishAsExisting(existingName, resourceGroupParameter: default);
+        _ = dts.AddTaskHub("myhub");
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(dts.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task AddDurableTaskScheduler_PublishAsExisting_WithResourceGroup_GeneratesBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingName = builder.AddParameter("existingSchedulerName");
+        var existingRg = builder.AddParameter("existingResourceGroup");
+        var dts = builder.AddDurableTaskScheduler("dts")
+            .PublishAsExisting(existingName, existingRg);
+        _ = dts.AddTaskHub("myhub");
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(dts.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_GeneratesBicep.verified.bicep
@@ -19,3 +19,7 @@ resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
 output schedulerEndpoint string = dts.properties.endpoint
 
 output name string = 'dts'
+
+output subscriptionId string = subscription().subscriptionId
+
+output tenantId string = subscription().tenantId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_GeneratesBicep.verified.bicep
@@ -1,0 +1,21 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param sku string = 'Consumption'
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
+  name: 'dts'
+  location: location
+  properties: {
+    sku: {
+      name: sku
+    }
+    ipAllowlist: [
+      '0.0.0.0/0'
+    ]
+  }
+}
+
+output schedulerEndpoint string = dts.properties.endpoint
+
+output name string = 'dts'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_PublishAsExisting_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_PublishAsExisting_GeneratesBicep.verified.bicep
@@ -1,0 +1,17 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param existingSchedulerName string
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' existing = {
+  name: existingSchedulerName
+}
+
+resource myhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
+  name: 'myhub'
+  parent: dts
+}
+
+output schedulerEndpoint string = dts.properties.endpoint
+
+output name string = existingSchedulerName

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_PublishAsExisting_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_PublishAsExisting_GeneratesBicep.verified.bicep
@@ -15,3 +15,7 @@ resource myhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
 output schedulerEndpoint string = dts.properties.endpoint
 
 output name string = existingSchedulerName
+
+output subscriptionId string = subscription().subscriptionId
+
+output tenantId string = subscription().tenantId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_PublishAsExisting_WithResourceGroup_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_PublishAsExisting_WithResourceGroup_GeneratesBicep.verified.bicep
@@ -1,0 +1,17 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param existingSchedulerName string
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' existing = {
+  name: existingSchedulerName
+}
+
+resource myhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
+  name: 'myhub'
+  parent: dts
+}
+
+output schedulerEndpoint string = dts.properties.endpoint
+
+output name string = existingSchedulerName

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_PublishAsExisting_WithResourceGroup_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_PublishAsExisting_WithResourceGroup_GeneratesBicep.verified.bicep
@@ -15,3 +15,7 @@ resource myhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
 output schedulerEndpoint string = dts.properties.endpoint
 
 output name string = existingSchedulerName
+
+output subscriptionId string = subscription().subscriptionId
+
+output tenantId string = subscription().tenantId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithMultipleTaskHubs_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithMultipleTaskHubs_GeneratesBicep.verified.bicep
@@ -29,3 +29,7 @@ resource hub2 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
 output schedulerEndpoint string = dts.properties.endpoint
 
 output name string = 'dts'
+
+output subscriptionId string = subscription().subscriptionId
+
+output tenantId string = subscription().tenantId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithMultipleTaskHubs_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithMultipleTaskHubs_GeneratesBicep.verified.bicep
@@ -1,0 +1,31 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param sku string = 'Consumption'
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
+  name: 'dts'
+  location: location
+  properties: {
+    sku: {
+      name: sku
+    }
+    ipAllowlist: [
+      '0.0.0.0/0'
+    ]
+  }
+}
+
+resource hub1 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
+  name: 'hub1'
+  parent: dts
+}
+
+resource hub2 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
+  name: 'CustomHub2'
+  parent: dts
+}
+
+output schedulerEndpoint string = dts.properties.endpoint
+
+output name string = 'dts'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithNamedTaskHub_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithNamedTaskHub_GeneratesBicep.verified.bicep
@@ -24,3 +24,7 @@ resource myhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
 output schedulerEndpoint string = dts.properties.endpoint
 
 output name string = 'dts'
+
+output subscriptionId string = subscription().subscriptionId
+
+output tenantId string = subscription().tenantId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithNamedTaskHub_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithNamedTaskHub_GeneratesBicep.verified.bicep
@@ -1,0 +1,26 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param sku string = 'Consumption'
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
+  name: 'dts'
+  location: location
+  properties: {
+    sku: {
+      name: sku
+    }
+    ipAllowlist: [
+      '0.0.0.0/0'
+    ]
+  }
+}
+
+resource myhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
+  name: 'MyCustomTaskHub'
+  parent: dts
+}
+
+output schedulerEndpoint string = dts.properties.endpoint
+
+output name string = 'dts'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithTaskHub_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithTaskHub_GeneratesBicep.verified.bicep
@@ -1,0 +1,26 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param sku string = 'Consumption'
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-11-01' = {
+  name: 'dts'
+  location: location
+  properties: {
+    sku: {
+      name: sku
+    }
+    ipAllowlist: [
+      '0.0.0.0/0'
+    ]
+  }
+}
+
+resource myhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
+  name: 'myhub'
+  parent: dts
+}
+
+output schedulerEndpoint string = dts.properties.endpoint
+
+output name string = 'dts'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithTaskHub_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/DurableTaskResourceExtensionsTests.AddDurableTaskScheduler_WithTaskHub_GeneratesBicep.verified.bicep
@@ -24,3 +24,7 @@ resource myhub 'Microsoft.DurableTask/schedulers/taskhubs@2025-11-01' = {
 output schedulerEndpoint string = dts.properties.endpoint
 
 output name string = 'dts'
+
+output subscriptionId string = subscription().subscriptionId
+
+output tenantId string = subscription().tenantId


### PR DESCRIPTION
## Description

Enables Durable Task Scheduler resources to be deployed to Azure when publishing an Aspire application. Previously, the DTS integration only supported local emulator and existing-connection-string modes — users could not provision new scheduler infrastructure through Aspire. With this change, `AddDurableTaskScheduler` and `AddTaskHub` generate the necessary Bicep templates, role assignments, and connection configuration for Azure deployment, matching the patterns established by other Aspire Azure hosting integrations.

### What's included

- **Azure provisioning**: Schedulers and task hubs are provisioned as `Microsoft.DurableTask/schedulers` and `Microsoft.DurableTask/schedulers/taskhubs` resources via generated Bicep, with support for `PublishAsExisting` and `ConfigureInfrastructure` customization.
- **Role assignments**: Referencing applications are automatically assigned the `Durable Task Data Contributor` role, with `WithRoleAssignments` APIs for customization (scoped to either the scheduler or a specific task hub).
- **Dashboard URLs**: A background service automatically adds dashboard URL annotations to task hub resources, linking to the DTS dashboard in both emulator and Azure modes.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
