### PR TITLE
Add multiple DNS zones for Foundry private endpoint

### DIFF
--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationResource.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationResource.cs
@@ -79,5 +79,5 @@ public class AzureAppConfigurationResource(string name, Action<AzureResourceInfr
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["configurationStores"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.azconfig.io";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.azconfig.io"];
 }

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIResource.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIResource.cs
@@ -113,7 +113,7 @@ public class AzureOpenAIResource(string name, Action<AzureResourceInfrastructure
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["account"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.openai.azure.com";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.openai.azure.com"];
 
     IEnumerable<KeyValuePair<string, ReferenceExpression>> IResourceWithConnectionString.GetConnectionProperties()
     {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -266,5 +266,5 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["Sql"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.documents.azure.com";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.documents.azure.com"];
 }

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsResource.cs
@@ -216,5 +216,5 @@ public class AzureEventHubsResource(string name, Action<AzureResourceInfrastruct
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["namespace"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.servicebus.windows.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.servicebus.windows.net"];
 }

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -149,5 +149,5 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["vault"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.vaultcore.azure.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.vaultcore.azure.net"];
 }

--- a/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs
@@ -65,10 +65,13 @@ public static class AzurePrivateEndpointExtensions
             return builder.CreateResourceBuilder(resource);
         }
 
-        // Get or create the shared Private DNS Zone for this zone name
-        var zoneName = target.Resource.GetPrivateDnsZoneName();
-        var dnsZone = GetOrCreatePrivateDnsZone(builder, zoneName, vnet);
-        resource.DnsZone = dnsZone;
+        // Get or create the shared Private DNS Zones for this resource type
+        var zoneNames = target.Resource.GetPrivateDnsZoneNames();
+        foreach (var zoneName in zoneNames)
+        {
+            var dnsZone = GetOrCreatePrivateDnsZone(builder, zoneName, vnet);
+            resource.DnsZones.Add(dnsZone);
+        }
 
         // Add annotation to the target's root parent (e.g., storage account) to signal
         // that it should deny public network access and to associate the private endpoint
@@ -95,12 +98,16 @@ public static class AzurePrivateEndpointExtensions
         {
             var azureResource = (AzurePrivateEndpointResource)infra.AspireResource;
 
-            // Get the shared DNS Zone as an existing resource
-            var dnsZone = azureResource.DnsZone!;
-            var dnsZoneIdentifier = dnsZone.GetBicepIdentifier();
-            var privateDnsZone = PrivateDnsZone.FromExisting(dnsZoneIdentifier);
-            privateDnsZone.Name = dnsZone.NameOutputReference.AsProvisioningParameter(infra);
-            infra.Add(privateDnsZone);
+            // Get the shared DNS Zones as existing resources
+            var privateDnsZones = new List<(string Identifier, PrivateDnsZone Zone)>();
+            foreach (var dnsZone in azureResource.DnsZones)
+            {
+                var dnsZoneIdentifier = dnsZone.GetBicepIdentifier();
+                var privateDnsZone = PrivateDnsZone.FromExisting(dnsZoneIdentifier);
+                privateDnsZone.Name = dnsZone.NameOutputReference.AsProvisioningParameter(infra);
+                infra.Add(privateDnsZone);
+                privateDnsZones.Add((dnsZoneIdentifier, privateDnsZone));
+            }
 
             // Create the Private Endpoint
             var endpoint = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infra,
@@ -138,15 +145,17 @@ public static class AzurePrivateEndpointExtensions
             {
                 Name = "default",
                 Parent = endpoint,
-                PrivateDnsZoneConfigs =
-                {
-                    new PrivateDnsZoneConfig
-                    {
-                        Name = dnsZoneIdentifier,
-                        PrivateDnsZoneId = privateDnsZone.Id
-                    }
-                }
             };
+
+            foreach (var (identifier, zone) in privateDnsZones)
+            {
+                dnsZoneGroup.PrivateDnsZoneConfigs.Add(new PrivateDnsZoneConfig
+                {
+                    Name = identifier,
+                    PrivateDnsZoneId = zone.Id
+                });
+            }
+
             infra.Add(dnsZoneGroup);
 
             // Output the Private Endpoint ID for references

--- a/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointResource.cs
@@ -41,9 +41,9 @@ public class AzurePrivateEndpointResource(
     public IAzurePrivateEndpointTarget Target { get; } = target;
 
     /// <summary>
-    /// Gets or sets the Private DNS Zone for this endpoint.
+    /// Gets the Private DNS Zones for this endpoint.
     /// </summary>
-    internal AzurePrivateDnsZoneResource? DnsZone { get; set; }
+    internal List<AzurePrivateDnsZoneResource> DnsZones { get; } = [];
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -316,5 +316,5 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["postgresqlServer"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.postgres.database.azure.com";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.postgres.database.azure.com"];
 }

--- a/src/Aspire.Hosting.Azure.Redis/AzureManagedRedisResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureManagedRedisResource.cs
@@ -253,5 +253,5 @@ public class AzureManagedRedisResource(string name, Action<AzureResourceInfrastr
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["redisEnterprise"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.redis.azure.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.redis.azure.net"];
 }

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchResource.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchResource.cs
@@ -93,5 +93,5 @@ public class AzureSearchResource(string name, Action<AzureResourceInfrastructure
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["searchService"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.search.windows.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.search.windows.net"];
 }

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
@@ -196,5 +196,5 @@ public class AzureServiceBusResource(string name, Action<AzureResourceInfrastruc
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["namespace"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.servicebus.windows.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.servicebus.windows.net"];
 }

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRResource.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRResource.cs
@@ -96,5 +96,5 @@ public class AzureSignalRResource(string name, Action<AzureResourceInfrastructur
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["signalr"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.service.signalr.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.service.signalr.net"];
 }

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlServerResource.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlServerResource.cs
@@ -432,7 +432,7 @@ public class AzureSqlServerResource : AzureProvisioningResource, IResourceWithCo
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["sqlServer"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.database.windows.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.database.windows.net"];
 
     void IAzurePrivateEndpointTargetNotification.OnPrivateEndpointCreated(IResourceBuilder<AzurePrivateEndpointResource> privateEndpoint)
     {
@@ -515,7 +515,7 @@ public class AzureSqlServerResource : AzureProvisioningResource, IResourceWithCo
 
         public IResource Parent => storage;
 
-        public string GetPrivateDnsZoneName() => "privatelink.file.core.windows.net";
+        public IEnumerable<string> GetPrivateDnsZoneNames() => ["privatelink.file.core.windows.net"];
 
         public IEnumerable<string> GetPrivateLinkGroupIds()
         {

--- a/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageResource.cs
@@ -88,7 +88,7 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["blob"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.blob.core.windows.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.blob.core.windows.net"];
 
     IEnumerable<KeyValuePair<string, ReferenceExpression>> IResourceWithConnectionString.GetConnectionProperties()
     {

--- a/src/Aspire.Hosting.Azure.Storage/AzureDataLakeStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureDataLakeStorageResource.cs
@@ -84,5 +84,5 @@ public class AzureDataLakeStorageResource(string name, AzureStorageResource stor
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["dfs"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.dfs.core.windows.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.dfs.core.windows.net"];
 }

--- a/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageResource.cs
@@ -81,7 +81,7 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["queue"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.queue.core.windows.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.queue.core.windows.net"];
 
     IEnumerable<KeyValuePair<string, ReferenceExpression>> IResourceWithConnectionString.GetConnectionProperties()
     {

--- a/src/Aspire.Hosting.Azure.Storage/AzureTableStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureTableStorageResource.cs
@@ -80,5 +80,5 @@ public class AzureTableStorageResource(string name, AzureStorageResource storage
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["table"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.table.core.windows.net";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.table.core.windows.net"];
 }

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubResource.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubResource.cs
@@ -83,5 +83,5 @@ public class AzureWebPubSubResource(string name, Action<AzureResourceInfrastruct
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["webpubsub"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.webpubsub.azure.com";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.webpubsub.azure.com"];
 }

--- a/src/Aspire.Hosting.Azure/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting.Azure/CompatibilitySuppressions.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.Azure.IAzurePrivateEndpointTarget.GetPrivateDnsZoneName</Target>
+    <Left>lib/net8.0/Aspire.Hosting.Azure.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.Azure.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Azure.IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames</Target>
+    <Left>lib/net8.0/Aspire.Hosting.Azure.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.Azure.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Aspire.Hosting.Azure/IAzurePrivateEndpointTarget.cs
+++ b/src/Aspire.Hosting.Azure/IAzurePrivateEndpointTarget.cs
@@ -24,8 +24,8 @@ public interface IAzurePrivateEndpointTarget : IResource
     IEnumerable<string> GetPrivateLinkGroupIds();
 
     /// <summary>
-    /// Gets the private DNS zone name for this resource type (e.g., "privatelink.blob.core.windows.net" for blob storage).
+    /// Gets the private DNS zone names for this resource type (e.g., "privatelink.blob.core.windows.net" for blob storage).
     /// </summary>
-    /// <returns>The private DNS zone name for the private endpoint.</returns>
-    string GetPrivateDnsZoneName();
+    /// <returns>A collection of private DNS zone names for the private endpoint.</returns>
+    IEnumerable<string> GetPrivateDnsZoneNames();
 }

--- a/src/Aspire.Hosting.Foundry/FoundryResource.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryResource.cs
@@ -135,7 +135,12 @@ public class FoundryResource(string name, Action<AzureResourceInfrastructure> co
 
     IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["account"];
 
-    string IAzurePrivateEndpointTarget.GetPrivateDnsZoneName() => "privatelink.cognitiveservices.azure.com";
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() =>
+    [
+        "privatelink.services.ai.azure.com",
+        "privatelink.openai.azure.com",
+        "privatelink.cognitiveservices.azure.com"
+    ];
 }
 
 /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePrivateEndpointExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePrivateEndpointExtensionsTests.cs
@@ -126,7 +126,7 @@ public class AzurePrivateEndpointExtensionsTests
 
         var target = (IAzurePrivateEndpointTarget)blobs.Resource;
         Assert.Equal(["blob"], target.GetPrivateLinkGroupIds());
-        Assert.Equal("privatelink.blob.core.windows.net", target.GetPrivateDnsZoneName());
+        Assert.Equal(["privatelink.blob.core.windows.net"], target.GetPrivateDnsZoneNames());
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class AzurePrivateEndpointExtensionsTests
 
         var target = (IAzurePrivateEndpointTarget)queues.Resource;
         Assert.Equal(["queue"], target.GetPrivateLinkGroupIds());
-        Assert.Equal("privatelink.queue.core.windows.net", target.GetPrivateDnsZoneName());
+        Assert.Equal(["privatelink.queue.core.windows.net"], target.GetPrivateDnsZoneNames());
     }
 
     [Fact]
@@ -208,4 +208,35 @@ public class AzurePrivateEndpointExtensionsTests
         // Each DNS Zone should have one VNet Link
         Assert.All(dnsZones, z => Assert.Single(z.VNetLinks));
     }
+
+    [Fact]
+    public async Task AddPrivateEndpoint_CreatesMultipleDnsZones_ForMultiZoneTarget()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("myvnet");
+        var subnet = vnet.AddSubnet("pesubnet", "10.0.1.0/24");
+        var foundry = builder.AddFoundry("foundry");
+
+        var pe = subnet.AddPrivateEndpoint(foundry);
+
+        // Foundry returns 3 DNS zone names
+        var dnsZones = builder.Resources.OfType<AzurePrivateDnsZoneResource>().ToList();
+        Assert.Equal(3, dnsZones.Count);
+        Assert.Contains(dnsZones, z => z.ZoneName == "privatelink.services.ai.azure.com");
+        Assert.Contains(dnsZones, z => z.ZoneName == "privatelink.openai.azure.com");
+        Assert.Contains(dnsZones, z => z.ZoneName == "privatelink.cognitiveservices.azure.com");
+
+        // Each DNS Zone should have one VNet Link
+        Assert.All(dnsZones, z => Assert.Single(z.VNetLinks));
+
+        // The PE resource should reference all 3 DNS zones
+        Assert.Equal(3, pe.Resource.DnsZones.Count);
+
+        // Verify the bicep for the PE resource
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(pe.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
+
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePrivateEndpointExtensionsTests.AddPrivateEndpoint_CreatesMultipleDnsZones_ForMultiZoneTarget.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePrivateEndpointExtensionsTests.AddPrivateEndpoint_CreatesMultipleDnsZones_ForMultiZoneTarget.verified.bicep
@@ -1,0 +1,79 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param privatelink_services_ai_azure_com_outputs_name string
+
+param privatelink_openai_azure_com_outputs_name string
+
+param privatelink_cognitiveservices_azure_com_outputs_name string
+
+param myvnet_outputs_pesubnet_id string
+
+param foundry_outputs_id string
+
+resource privatelink_services_ai_azure_com 'Microsoft.Network/privateDnsZones@2024-06-01' existing = {
+  name: privatelink_services_ai_azure_com_outputs_name
+}
+
+resource privatelink_openai_azure_com 'Microsoft.Network/privateDnsZones@2024-06-01' existing = {
+  name: privatelink_openai_azure_com_outputs_name
+}
+
+resource privatelink_cognitiveservices_azure_com 'Microsoft.Network/privateDnsZones@2024-06-01' existing = {
+  name: privatelink_cognitiveservices_azure_com_outputs_name
+}
+
+resource pesubnet_foundry_pe 'Microsoft.Network/privateEndpoints@2025-05-01' = {
+  name: take('pesubnet_foundry_pe-${uniqueString(resourceGroup().id)}', 64)
+  location: location
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        properties: {
+          privateLinkServiceId: foundry_outputs_id
+          groupIds: [
+            'account'
+          ]
+        }
+        name: 'pesubnet-foundry-pe-connection'
+      }
+    ]
+    subnet: {
+      id: myvnet_outputs_pesubnet_id
+    }
+  }
+  tags: {
+    'aspire-resource-name': 'pesubnet-foundry-pe'
+  }
+}
+
+resource pesubnet_foundry_pe_dnsgroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2025-05-01' = {
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'privatelink_services_ai_azure_com'
+        properties: {
+          privateDnsZoneId: privatelink_services_ai_azure_com.id
+        }
+      }
+      {
+        name: 'privatelink_openai_azure_com'
+        properties: {
+          privateDnsZoneId: privatelink_openai_azure_com.id
+        }
+      }
+      {
+        name: 'privatelink_cognitiveservices_azure_com'
+        properties: {
+          privateDnsZoneId: privatelink_cognitiveservices_azure_com.id
+        }
+      }
+    ]
+  }
+  parent: pesubnet_foundry_pe
+}
+
+output id string = pesubnet_foundry_pe.id
+
+output name string = pesubnet_foundry_pe.name


### PR DESCRIPTION
## Description

Foundry has multiple DNS names it can use, we should support the common ones when creating a private endpoint to a Foundry resource.

This involves a minor binary breaking change on IAzurePrivateEndpointTarget, which is public but experimental.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
