### PR TITLE
Upgrade HTTP endpoints to HTTPS in Azure App Service

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContext.cs
@@ -22,6 +22,42 @@ internal sealed class AzureAppServiceEnvironmentContext(
     public IServiceProvider ServiceProvider => serviceProvider;
 
     private readonly Dictionary<IResource, AzureAppServiceWebsiteContext> _appServices = new(new ResourceNameComparer());
+    private readonly List<(string ResourceName, string[] EndpointNames)> _upgradedEndpoints = [];
+    private bool _hasLoggedHttpsUpgrade;
+
+    /// <summary>
+    /// Records HTTP endpoints that were upgraded to HTTPS for a resource.
+    /// </summary>
+    public void RecordHttpsUpgrade(string resourceName, string[] endpointNames)
+    {
+        if (endpointNames.Length > 0)
+        {
+            _upgradedEndpoints.Add((resourceName, endpointNames));
+        }
+    }
+
+    /// <summary>
+    /// Logs a single message about all HTTP endpoints that were upgraded to HTTPS.
+    /// </summary>
+    public void LogHttpsUpgradeIfNeeded()
+    {
+        if (_hasLoggedHttpsUpgrade || _upgradedEndpoints.Count == 0)
+        {
+            return;
+        }
+
+        _hasLoggedHttpsUpgrade = true;
+
+        var details = string.Join(", ", _upgradedEndpoints.Select(x =>
+            x.EndpointNames.Length == 1
+                ? $"{x.ResourceName}:{x.EndpointNames[0]}"
+                : $"{x.ResourceName}:{{{string.Join(", ", x.EndpointNames)}}}"));
+
+        Logger.LogInformation(
+            "HTTP endpoints will use HTTPS (port 443) in Azure App Service: {Details}. " +
+            "To opt out, use .WithHttpsUpgrade(false) on the app service environment.",
+            details);
+    }
 
     public AzureAppServiceWebsiteContext GetAppServiceContext(IResource resource)
     {

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -227,6 +227,20 @@ public static partial class AzureAppServiceEnvironmentExtensions
     }
 
     /// <summary>
+    /// Configures whether HTTP endpoints should be automatically upgraded to HTTPS for the Azure App Service environment.
+    /// By default, HTTP endpoints are upgraded to HTTPS (port 443). Use this method to opt out.
+    /// </summary>
+    /// <param name="builder">The <see cref="IResourceBuilder{AzureAppServiceEnvironmentResource}"/> to configure.</param>
+    /// <param name="upgrade">Whether to upgrade HTTP endpoints to HTTPS. Default is true.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining additional configuration.</returns>
+    [AspireExport(Description = "Configures whether HTTP endpoints are automatically upgraded to HTTPS in Azure App Service")]
+    public static IResourceBuilder<AzureAppServiceEnvironmentResource> WithHttpsUpgrade(this IResourceBuilder<AzureAppServiceEnvironmentResource> builder, bool upgrade = true)
+    {
+        builder.Resource.PreserveHttpEndpoints = !upgrade;
+        return builder;
+    }
+
+    /// <summary>
     /// Configures whether the Aspire dashboard should be included in the Azure App Service environment.
     /// </summary>
     /// <param name="builder">The <see cref="IResourceBuilder{AzureAppServiceEnvironmentResource}"/> to configure.</param>

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -228,11 +228,23 @@ public static partial class AzureAppServiceEnvironmentExtensions
 
     /// <summary>
     /// Configures whether HTTP endpoints should be automatically upgraded to HTTPS for the Azure App Service environment.
-    /// By default, HTTP endpoints are upgraded to HTTPS (port 443). Use this method to opt out.
+    /// By default, HTTP endpoints are upgraded to HTTPS for security and WebSocket compatibility.
     /// </summary>
     /// <param name="builder">The <see cref="IResourceBuilder{AzureAppServiceEnvironmentResource}"/> to configure.</param>
     /// <param name="upgrade">Whether to upgrade HTTP endpoints to HTTPS. Default is true.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining additional configuration.</returns>
+    /// <remarks>
+    /// When disabled (<c>false</c>), HTTP endpoints will use HTTP scheme and port 80 in Azure App Service.
+    /// Note that Azure App Service forces HTTP to HTTPS redirects at the platform level,
+    /// so disabling upgrade primarily affects connection strings generated for dependent resources.
+    /// </remarks>
+    /// <example>
+    /// Preserve HTTP endpoints instead of automatically upgrading them to HTTPS:
+    /// <code>
+    /// var appService = builder.AddAzureAppServiceEnvironment("appservice")
+    ///     .WithHttpsUpgrade(false);
+    /// </code>
+    /// </example>
     [AspireExport(Description = "Configures whether HTTP endpoints are automatically upgraded to HTTPS in Azure App Service")]
     public static IResourceBuilder<AzureAppServiceEnvironmentResource> WithHttpsUpgrade(this IResourceBuilder<AzureAppServiceEnvironmentResource> builder, bool upgrade = true)
     {

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -275,6 +275,11 @@ public class AzureAppServiceEnvironmentResource :
     internal BicepOutputReference WebSiteSuffix => new("webSiteSuffix", this);
 
     /// <summary>
+    /// When true, HTTP endpoints are not upgraded to HTTPS. Default is false (HTTP→HTTPS upgrade is enabled).
+    /// </summary>
+    internal bool PreserveHttpEndpoints { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the Aspire dashboard should be included in the container app environment.
     /// Default is true.
     /// </summary>

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceInfrastructure.cs
@@ -71,6 +71,9 @@ internal sealed class AzureAppServiceInfrastructure(
                     ComputeEnvironment = appServiceEnvironment
                 });
             }
+
+            // Log once about all HTTP endpoints upgraded to HTTPS
+            appServiceEnvironmentContext.LogHttpsUpgradeIfNeeded();
         }
     }
 

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -119,6 +119,8 @@ internal sealed class AzureAppServiceWebsiteContext(
             throw new NotSupportedException("App Service does not support resources with multiple external endpoints.");
         }
 
+        var preserveHttp = environmentContext.Environment.PreserveHttpEndpoints;
+
         foreach (var resolved in resolvedEndpoints)
         {
             var endpoint = resolved.Endpoint;
@@ -128,15 +130,31 @@ internal sealed class AzureAppServiceWebsiteContext(
                 throw new NotSupportedException($"The endpoint '{endpoint.Name}' on resource '{resource.Name}' is not external. App Service only supports external endpoints.");
             }
 
+            // By default, HTTP endpoints are upgraded to HTTPS in App Service
+            // If PreserveHttpEndpoints is true, keep the original scheme
+            var scheme = preserveHttp ? endpoint.UriScheme : "https";
+            var port = scheme is "http" ? 80 : 443;
+
             // For App Service, we ignore port mappings since ports are handled by the platform
             // TargetPort is null only for default ProjectResource endpoints (container port decides)
             _endpointMapping[endpoint.Name] = new(
-                Scheme: endpoint.UriScheme,
+                Scheme: scheme,
                 Host: HostName,
-                Port: endpoint.UriScheme == "https" ? 443 : 80,
+                Port: port,
                 TargetPort: resolved.TargetPort,
                 IsHttpIngress: true,
                 External: true); // All App Service endpoints are external
+        }
+
+        // Record HTTP endpoints being upgraded (logged once at environment level)
+        if (!preserveHttp)
+        {
+            var upgradedEndpoints = resolvedEndpoints
+                .Where(r => r.Endpoint.UriScheme is "http")
+                .Select(r => r.Endpoint.Name)
+                .ToArray();
+
+            environmentContext.RecordHttpsUpgrade(resource.Name, upgradedEndpoints);
         }
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -603,6 +603,37 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task CanPreserveHttpSchemeUsingWithHttpsUpgrade()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureAppServiceEnvironment("env")
+               .WithHttpsUpgrade(false);
+
+        var project1 = builder.AddProject<Project>("project1", launchProfileName: null)
+            .WithHttpsEndpoint(targetPort: 8000)
+            .WithHttpEndpoint(targetPort: 8000)
+            .WithExternalHttpEndpoints();
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        project1.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+                .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
     public async Task AddAppServiceWithTargetPortMultipleEndpoints()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -615,13 +615,20 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
             .WithHttpEndpoint(targetPort: 8000)
             .WithExternalHttpEndpoints();
 
+        // Add a second project that references project1 so we can verify
+        // the resolved endpoint URLs use http:// (not upgraded to https://)
+        var project2 = builder.AddProject<Project>("project2", launchProfileName: null)
+            .WithHttpEndpoint(targetPort: 9000)
+            .WithExternalHttpEndpoints()
+            .WithReference(project1);
+
         using var app = builder.Build();
 
         await ExecuteBeforeStartHooksAsync(app, default);
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        project1.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+        project2.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
 
         var resource = target?.DeploymentTarget as AzureProvisioningResource;
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -54,11 +54,11 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'PROJECT1_HTTP'
-          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'services__project1__http__0'
-          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -64,11 +64,11 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'PROJECT1_HTTP'
-          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'services__project1__http__0'
-          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
@@ -9,7 +9,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param env_outputs_azure_container_registry_managed_identity_client_id string
 
-param project2_containerimage string
+param project1_containerimage string
 
 param env_outputs_azure_app_service_dashboard_uri string
 
@@ -21,16 +21,16 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
   name: 'main'
   properties: {
     authType: 'UserAssigned'
-    image: project2_containerimage
+    image: project1_containerimage
     isMain: true
-    targetPort: '9000'
+    targetPort: '8000'
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
+  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -42,7 +42,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
       appSettings: [
         {
           name: 'WEBSITES_PORT'
-          value: '9000'
+          value: '8000'
         }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
@@ -54,23 +54,11 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'HTTP_PORTS'
-          value: '9000'
+          value: '8000'
         }
         {
-          name: 'PROJECT1_HTTPS'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
-        }
-        {
-          name: 'services__project1__https__0'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
-        }
-        {
-          name: 'PROJECT1_HTTP'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
-        }
-        {
-          name: 'services__project1__http__0'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          name: 'HTTPS_PORTS'
+          value: '8000'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -78,7 +66,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'OTEL_SERVICE_NAME'
-          value: 'project2'
+          value: 'project1'
         }
         {
           name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
@@ -111,7 +99,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
   }
 }
 
-resource project2_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource project1_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
   properties: {
     principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
@@ -125,10 +113,6 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   name: 'slotConfigNames'
   properties: {
     appSettingNames: [
-      'PROJECT1_HTTPS'
-      'services__project1__https__0'
-      'PROJECT1_HTTP'
-      'services__project1__http__0'
       'OTEL_SERVICE_NAME'
     ]
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
@@ -9,7 +9,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param env_outputs_azure_container_registry_managed_identity_client_id string
 
-param project1_containerimage string
+param project2_containerimage string
 
 param env_outputs_azure_app_service_dashboard_uri string
 
@@ -21,16 +21,16 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
   name: 'main'
   properties: {
     authType: 'UserAssigned'
-    image: project1_containerimage
+    image: project2_containerimage
     isMain: true
-    targetPort: '8000'
+    targetPort: '9000'
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -42,7 +42,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
       appSettings: [
         {
           name: 'WEBSITES_PORT'
-          value: '8000'
+          value: '9000'
         }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
@@ -54,11 +54,23 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'HTTP_PORTS'
-          value: '8000'
+          value: '9000'
         }
         {
-          name: 'HTTPS_PORTS'
-          value: '8000'
+          name: 'PROJECT1_HTTPS'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+        }
+        {
+          name: 'services__project1__https__0'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+        }
+        {
+          name: 'PROJECT1_HTTP'
+          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+        }
+        {
+          name: 'services__project1__http__0'
+          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -66,7 +78,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'OTEL_SERVICE_NAME'
-          value: 'project1'
+          value: 'project2'
         }
         {
           name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
@@ -99,7 +111,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
   }
 }
 
-resource project1_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource project2_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
   properties: {
     principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
@@ -113,6 +125,10 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   name: 'slotConfigNames'
   properties: {
     appSettingNames: [
+      'PROJECT1_HTTPS'
+      'services__project1__https__0'
+      'PROJECT1_HTTP'
+      'services__project1__http__0'
       'OTEL_SERVICE_NAME'
     ]
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.json
@@ -1,0 +1,14 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "project1-website.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "project1_containerimage": "{project1.containerImage}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.json
@@ -1,12 +1,12 @@
 ﻿{
   "type": "azure.bicep.v0",
-  "path": "project1-website.module.bicep",
+  "path": "project2-website.module.bicep",
   "params": {
     "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
     "env_outputs_planid": "{env.outputs.planId}",
     "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
     "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
-    "project1_containerimage": "{project1.containerImage}",
+    "project2_containerimage": "{project2.containerImage}",
     "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
     "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
     "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferencesAreResolvedAcrossProjects.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferencesAreResolvedAcrossProjects.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -60,11 +60,11 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'PROJECT1_HTTP'
-          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'services__project1__http__0'
-          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'


### PR DESCRIPTION
## Description

Upgrade HTTP endpoints to HTTPS in Azure App Service, mirroring the existing behavior in Azure Container Apps (added in #14267).

Azure App Service already forces HTTP to HTTPS redirect at the platform level ([docs](https://learn.microsoft.com/azure/app-service/overview-security#data-protection)), so connection strings should use `https://` to match the actual serving scheme. Previously, HTTP endpoints kept `http://` in their connection strings, which was inconsistent with reality.

Changes:
- HTTP endpoints are now upgraded to HTTPS:443 by default
- Add `WithHttpsUpgrade(false)` to opt out at the environment level
- Consolidated HTTPS upgrade logging (one message per environment listing all affected endpoints)
- New test for opt-out behavior

This matches the ACA implementation 1:1 in API shape, naming, and behavior.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
