### PR TITLE
Fix deployment E2E nightly failures

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
@@ -100,9 +100,12 @@ public sealed class AcaCompactNamingUpgradeDeploymentTests(ITestOutputHelper out
             output.WriteLine("Step 5: Creating single-file AppHost with GA CLI...");
             await auto.TypeAsync("aspire init");
             await auto.EnterAsync();
+            // Wait for and dismiss the language selection (auto-selected or prompt)
             await auto.WaitAsync(TimeSpan.FromSeconds(5));
             await auto.EnterAsync();
-            await auto.WaitUntilTextAsync("Aspire initialization complete", timeout: TimeSpan.FromMinutes(2));
+            // The CLI may show a "Select a template version" prompt — dismiss it
+            await auto.WaitUntilTextAsync("based on NuGet.config", timeout: TimeSpan.FromSeconds(60));
+            await auto.EnterAsync();
             await auto.DeclineAgentInitPromptAsync(counter);
 
             // Step 6: Add ACA package using GA CLI (uses GA NuGet packages)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
@@ -98,15 +98,107 @@ public sealed class AcaCompactNamingUpgradeDeploymentTests(ITestOutputHelper out
 
             // Step 5: Create single-file AppHost with GA CLI
             output.WriteLine("Step 5: Creating single-file AppHost with GA CLI...");
+            var waitingForLanguageSelectionPrompt = new CellPatternSearcher()
+                .Find("Which language would you like to use?");
+            var waitingForTemplateVersionPrompt = new CellPatternSearcher()
+                .Find("NuGet.config");
+            var waitingForAgentInitPrompt = new CellPatternSearcher()
+                .Find("configure AI agent environments");
+            var waitingForSuccessPrompt = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+
             await auto.TypeAsync("aspire init");
             await auto.EnterAsync();
-            // Wait for and dismiss the language selection (auto-selected or prompt)
-            await auto.WaitAsync(TimeSpan.FromSeconds(5));
-            await auto.EnterAsync();
-            // The CLI may show a "Select a template version" prompt — dismiss it
-            await auto.WaitUntilTextAsync("based on NuGet.config", timeout: TimeSpan.FromSeconds(60));
-            await auto.EnterAsync();
-            await auto.DeclineAgentInitPromptAsync(counter);
+
+            var initState = "success";
+            await auto.WaitUntilAsync(s =>
+            {
+                if (waitingForLanguageSelectionPrompt.Search(s).Count > 0)
+                {
+                    initState = "language";
+                    return true;
+                }
+
+                if (waitingForTemplateVersionPrompt.Search(s).Count > 0)
+                {
+                    initState = "template-version";
+                    return true;
+                }
+
+                if (waitingForAgentInitPrompt.Search(s).Count > 0)
+                {
+                    initState = "agent-init";
+                    return true;
+                }
+
+                if (waitingForSuccessPrompt.Search(s).Count > 0)
+                {
+                    initState = "success";
+                    return true;
+                }
+
+                return false;
+            }, timeout: TimeSpan.FromMinutes(2), description: "language prompt, template version prompt, agent init prompt, or init success prompt");
+
+            if (initState == "language")
+            {
+                await auto.EnterAsync();
+
+                await auto.WaitUntilAsync(s =>
+                {
+                    if (waitingForTemplateVersionPrompt.Search(s).Count > 0)
+                    {
+                        initState = "template-version";
+                        return true;
+                    }
+
+                    if (waitingForAgentInitPrompt.Search(s).Count > 0)
+                    {
+                        initState = "agent-init";
+                        return true;
+                    }
+
+                    if (waitingForSuccessPrompt.Search(s).Count > 0)
+                    {
+                        initState = "success";
+                        return true;
+                    }
+
+                    return false;
+                }, timeout: TimeSpan.FromMinutes(2), description: "template version prompt, agent init prompt, or init success prompt");
+            }
+
+            if (initState == "template-version")
+            {
+                await auto.EnterAsync();
+
+                await auto.WaitUntilAsync(s =>
+                {
+                    if (waitingForAgentInitPrompt.Search(s).Count > 0)
+                    {
+                        initState = "agent-init";
+                        return true;
+                    }
+
+                    if (waitingForSuccessPrompt.Search(s).Count > 0)
+                    {
+                        initState = "success";
+                        return true;
+                    }
+
+                    return false;
+                }, timeout: TimeSpan.FromMinutes(2), description: "agent init prompt or init success prompt");
+            }
+
+            if (initState == "agent-init")
+            {
+                await auto.DeclineAgentInitPromptAsync(counter);
+            }
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter);
+            }
 
             // Step 6: Add ACA package using GA CLI (uses GA NuGet packages)
             output.WriteLine("Step 6: Adding Azure Container Apps package (GA)...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaManagedRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaManagedRedisDeploymentTests.cs
@@ -75,7 +75,7 @@ public sealed class AcaManagedRedisDeploymentTests(ITestOutputHelper output)
                 .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
 
             var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
+                .Find("Enter the output path");
 
             var waitingForUrlsPrompt = new CellPatternSearcher()
                 .Find("Use *.dev.localhost URLs");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
@@ -74,10 +74,17 @@ public sealed class AcrPurgeTaskDeploymentTests(ITestOutputHelper output)
             await auto.PrepareEnvironmentAsync(workspace, counter);
 
             // Step 2: Set up CLI environment (in CI)
+            // Python apphosts need the full bundle because
+            // the prebuilt AppHost server is required for aspire new with Python templates.
             if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                output.WriteLine("Step 2: Using pre-installed Aspire CLI from local build...");
-                await auto.SourceAspireCliEnvironmentAsync(counter);
+                var prNumber = DeploymentE2ETestHelpers.GetPrNumber();
+                if (prNumber > 0)
+                {
+                    output.WriteLine($"Step 2: Installing Aspire bundle from PR #{prNumber}...");
+                    await auto.InstallAspireBundleFromPullRequestAsync(prNumber, counter);
+                }
+                await auto.SourceAspireBundleEnvironmentAsync(counter);
             }
 
             // Step 3: Create Python FastAPI project using aspire new
@@ -95,7 +102,7 @@ public sealed class AcrPurgeTaskDeploymentTests(ITestOutputHelper output)
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
 
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI && DeploymentE2ETestHelpers.GetPrNumber() <= 0)
             {
                 await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
                 await auto.EnterAsync();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
@@ -76,10 +76,17 @@ public sealed class AppServicePythonDeploymentTests(ITestOutputHelper output)
             await auto.PrepareEnvironmentAsync(workspace, counter);
 
             // Step 2: Set up CLI environment (in CI)
+            // Python apphosts need the full bundle because
+            // the prebuilt AppHost server is required for aspire new with Python templates.
             if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                output.WriteLine("Step 2: Using pre-installed Aspire CLI from local build...");
-                await auto.SourceAspireCliEnvironmentAsync(counter);
+                var prNumber = DeploymentE2ETestHelpers.GetPrNumber();
+                if (prNumber > 0)
+                {
+                    output.WriteLine($"Step 2: Installing Aspire bundle from PR #{prNumber}...");
+                    await auto.InstallAspireBundleFromPullRequestAsync(prNumber, counter);
+                }
+                await auto.SourceAspireBundleEnvironmentAsync(counter);
             }
 
             // Step 3: Create Python FastAPI project using aspire new with interactive prompts

--- a/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
@@ -76,10 +76,17 @@ public sealed class PythonFastApiDeploymentTests(ITestOutputHelper output)
             await auto.PrepareEnvironmentAsync(workspace, counter);
 
             // Step 2: Set up CLI environment (in CI)
+            // Python apphosts need the full bundle because
+            // the prebuilt AppHost server is required for aspire new with Python templates.
             if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
-                output.WriteLine("Step 2: Using pre-installed Aspire CLI from local build...");
-                await auto.SourceAspireCliEnvironmentAsync(counter);
+                var prNumber = DeploymentE2ETestHelpers.GetPrNumber();
+                if (prNumber > 0)
+                {
+                    output.WriteLine($"Step 2: Installing Aspire bundle from PR #{prNumber}...");
+                    await auto.InstallAspireBundleFromPullRequestAsync(prNumber, counter);
+                }
+                await auto.SourceAspireBundleEnvironmentAsync(counter);
             }
 
             // Step 3: Create Python FastAPI project using aspire new with interactive prompts

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptVnetSqlServerInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptVnetSqlServerInfraDeploymentTests.cs
@@ -86,27 +86,12 @@ public sealed class TypeScriptVnetSqlServerInfraDeploymentTests(ITestOutputHelpe
             // Step 3: Create TypeScript AppHost using aspire init
             output.WriteLine("Step 3: Creating TypeScript AppHost with aspire init...");
 
-            var waitingForNuGetConfigPrompt = new CellPatternSearcher()
-                .Find("NuGet.config");
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             await auto.TypeAsync("aspire init --language typescript");
             await auto.EnterAsync();
 
-            // NuGet.config prompt may or may not appear depending on environment.
-            await auto.WaitUntilAsync(
-                s => waitingForNuGetConfigPrompt.Search(s).Count > 0
-                    || waitingForInitComplete.Search(s).Count > 0,
-                timeout: TimeSpan.FromMinutes(2),
-                description: "NuGet.config prompt or init completion");
-            await auto.EnterAsync(); // Dismiss NuGet.config prompt if present
-
-            await auto.WaitUntilAsync(
-                s => waitingForInitComplete.Search(s).Count > 0,
-                timeout: TimeSpan.FromMinutes(2),
-                description: "aspire initialization complete");
-
+            // When using bundle install, the CLI auto-selects the package version
+            // from the local hive without showing a NuGet.config prompt.
+            // Go straight to waiting for the agent init prompt / success prompt.
             await auto.DeclineAgentInitPromptAsync(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.AppContainers

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptVnetSqlServerInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptVnetSqlServerInfraDeploymentTests.cs
@@ -86,13 +86,60 @@ public sealed class TypeScriptVnetSqlServerInfraDeploymentTests(ITestOutputHelpe
             // Step 3: Create TypeScript AppHost using aspire init
             output.WriteLine("Step 3: Creating TypeScript AppHost with aspire init...");
 
+            var waitingForTemplateVersionPrompt = new CellPatternSearcher()
+                .Find("NuGet.config");
+            var waitingForAgentInitPrompt = new CellPatternSearcher()
+                .Find("configure AI agent environments");
+            var waitingForSuccessPrompt = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+
             await auto.TypeAsync("aspire init --language typescript");
             await auto.EnterAsync();
 
-            // When using bundle install, the CLI auto-selects the package version
-            // from the local hive without showing a NuGet.config prompt.
-            // Go straight to waiting for the agent init prompt / success prompt.
-            await auto.DeclineAgentInitPromptAsync(counter);
+            var sawTemplateVersionPrompt = false;
+            var sawAgentInitPrompt = false;
+            await auto.WaitUntilAsync(s =>
+            {
+                if (waitingForTemplateVersionPrompt.Search(s).Count > 0)
+                {
+                    sawTemplateVersionPrompt = true;
+                    return true;
+                }
+
+                if (waitingForAgentInitPrompt.Search(s).Count > 0)
+                {
+                    sawAgentInitPrompt = true;
+                    return true;
+                }
+
+                return waitingForSuccessPrompt.Search(s).Count > 0;
+            }, timeout: TimeSpan.FromMinutes(2), description: "template version prompt, agent init prompt, or init success prompt");
+
+            if (sawTemplateVersionPrompt)
+            {
+                await auto.EnterAsync();
+
+                await auto.WaitUntilAsync(s =>
+                {
+                    if (waitingForAgentInitPrompt.Search(s).Count > 0)
+                    {
+                        sawAgentInitPrompt = true;
+                        return true;
+                    }
+
+                    return waitingForSuccessPrompt.Search(s).Count > 0;
+                }, timeout: TimeSpan.FromMinutes(2), description: "agent init prompt or init success prompt");
+            }
+
+            if (sawAgentInitPrompt)
+            {
+                await auto.DeclineAgentInitPromptAsync(counter);
+            }
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter);
+            }
 
             // Step 4a: Add Aspire.Hosting.Azure.AppContainers
             output.WriteLine("Step 4a: Adding Azure Container Apps hosting package...");


### PR DESCRIPTION
## Summary
This addresses the deployment E2E failures reported in #16057 from the April 11, 2026 nightly run.

The failing tests were all relying on outdated CI interaction assumptions:
- Python deployment tests were sourcing only the CLI binary in CI instead of the full Aspire bundle required by Python apphost flows.
- The TypeScript VNet SQL infra test still waited for a NuGet prompt that bundle-based installs no longer show.
- The compact naming upgrade test now needs to dismiss the template-version prompt before continuing.
- The managed Redis test matched the old output-path prompt text too strictly.

## What Changed
- Switched the Python deployment CI setup paths to install/source the full Aspire bundle when running in CI.
- Updated the ACR purge task test so PR bundle installs do not re-handle the NuGet version prompt incorrectly.
- Removed the obsolete prompt wait from the TypeScript VNet SQL infra test.
- Updated the GA init flow in the compact naming upgrade test for the current CLI prompt sequence.
- Relaxed the managed Redis prompt matcher to handle the updated CLI text.

## Impact
These changes align the deployment E2E tests with the current CLI and bundle behavior so the nightly deployment workflow can complete without the false failures seen in #16057.

Fixes #16057

## Validation
- `./dotnet.sh build tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj -c Release`
- `./dotnet.sh test tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj -c Release` with writable temp XDG paths and `DOTNET_ROOT` set to the repo-local SDK
- Result: build passed; deployment E2E test assembly executed successfully in this environment with the touched tests loading and skipping because `ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION` is not configured

## Remaining Environment Limits
- Full Azure-backed deployment execution was not run here because this environment does not have the Azure deployment prerequisites configured (`ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION`, Azure auth/CLI, and usable Docker daemon access)
