### PR TITLE
Add 'privileged' flag for docker-compose publishing

### DIFF
--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Service.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Service.cs
@@ -253,6 +253,13 @@ public sealed class Service : NamedComposeMember
     public string? Pid { get; set; }
 
     /// <summary>
+    /// Indicates whether the container should run in privileged mode.
+    /// When set to true, the container is granted extended Linux capabilities and device access.
+    /// </summary>
+    [YamlMember(Alias = "privileged")]
+    public bool? Privileged { get; set; }
+
+    /// <summary>
     /// Specifies a list of Linux capabilities to add to the container.
     /// </summary>
     /// <remarks>

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -406,6 +406,36 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DockerComposeSetsServicePrivilegedManually()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+
+        builder.AddDockerComposeEnvironment("docker-compose")
+            .WithDashboard(false);
+
+        builder.AddContainer("api", "my-api:latest")
+            .PublishAsDockerComposeService((_, composeService) =>
+            {
+                composeService.Privileged = true;
+            });
+
+        var app = builder.Build();
+        app.Run();
+
+        var composePath = Path.Combine(tempDir.Path, "docker-compose.yaml");
+        Assert.True(File.Exists(composePath));
+
+        var composeContent = File.ReadAllText(composePath);
+
+        Assert.Contains("privileged: true", composeContent);
+
+        await Verify(composeContent, "yaml");
+    }
+
+    [Fact]
     public async Task PublishAsync_WithDashboardEnabled_IncludesDashboardService()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeSetsServicePrivilegedManually.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeSetsServicePrivilegedManually.verified.yaml
@@ -1,0 +1,9 @@
+﻿services:
+  api:
+    image: "my-api:latest"
+    networks:
+      - "aspire"
+    privileged: true
+networks:
+  aspire:
+    driver: "bridge"


### PR DESCRIPTION
## Description

Added the docker-compose "privileged" flag for services during publish.

Working on an embedded project that is using Aspire to generate our docker-compose file. We have services that need to run as privileged to communicate with various devices.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
