### PR TITLE
Add clickable dashboard hyperlinks to CLI telemetry commands

### DIFF
--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Dashboard.Utils;
 using Aspire.Shared;
 using Aspire.Shared.Model.Serialization;
 using Microsoft.Extensions.Logging;
@@ -186,7 +187,7 @@ internal sealed class DescribeCommand : BaseCommand
         }
         else
         {
-            DisplayResourcesTable(snapshots);
+            DisplayResourcesTable(snapshots, dashboardBaseUrl);
         }
 
         return ExitCodeConstants.Success;
@@ -259,7 +260,7 @@ internal sealed class DescribeCommand : BaseCommand
         return ExitCodeConstants.Success;
     }
 
-    private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots)
+    private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots, string? dashboardBaseUrl)
     {
         if (snapshots.Count == 0)
         {
@@ -290,7 +291,14 @@ internal sealed class DescribeCommand : BaseCommand
             var stateText = ColorState(snapshot.State);
             var healthText = ColorHealth(snapshot.HealthStatus?.EscapeMarkup() ?? "-");
 
-            table.AddRow(ColorResourceName(displayName, displayName.EscapeMarkup()), type, stateText, healthText, endpoints);
+            var nameMarkup = ColorResourceName(displayName, displayName.EscapeMarkup());
+            if (!string.IsNullOrEmpty(dashboardBaseUrl))
+            {
+                var resourceUrl = DashboardUrls.CombineUrl(dashboardBaseUrl, DashboardUrls.ResourcesUrl(resource: snapshot.Name));
+                nameMarkup = $"[link={resourceUrl}]{nameMarkup}[/]";
+            }
+
+            table.AddRow(nameMarkup, type, stateText, healthText, endpoints);
         }
 
         _interactionService.DisplayRenderable(table);

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -404,8 +404,9 @@ internal static class TelemetryCommandHelpers
     /// <param name="dashboardUrl">The base dashboard URL.</param>
     /// <param name="traceId">The trace ID.</param>
     /// <param name="displayText">The text to display (defaults to shortened trace ID).</param>
+    /// <param name="spanId">Optional span ID to highlight in the trace detail view.</param>
     /// <returns>A Spectre markup string with hyperlink, or plain text if dashboardUrl is null.</returns>
-    public static string FormatTraceLink(string? dashboardUrl, string traceId, string? displayText = null)
+    public static string FormatTraceLink(string? dashboardUrl, string traceId, string? displayText = null, string? spanId = null)
     {
         var text = displayText ?? OtlpHelpers.ToShortenedId(traceId);
         if (string.IsNullOrEmpty(dashboardUrl))
@@ -414,7 +415,7 @@ internal static class TelemetryCommandHelpers
         }
 
         // Dashboard trace detail URL: /traces/detail/{traceId}
-        var url = DashboardUrls.CombineUrl(dashboardUrl, DashboardUrls.TraceDetailUrl(traceId));
+        var url = DashboardUrls.CombineUrl(dashboardUrl, DashboardUrls.TraceDetailUrl(traceId, spanId));
         return $"[link={url}]{text}[/]";
     }
 

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -409,7 +409,7 @@ internal static class TelemetryCommandHelpers
     public static string FormatTraceLink(string? dashboardUrl, string traceId, string? displayText = null, string? spanId = null)
     {
         var text = displayText ?? OtlpHelpers.ToShortenedId(traceId);
-        if (string.IsNullOrEmpty(dashboardUrl))
+        if (string.IsNullOrEmpty(dashboardUrl) || string.IsNullOrEmpty(traceId))
         {
             return text;
         }

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -100,7 +100,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             return dashboardApi.ExitCode;
         }
 
-        return await FetchSpansAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, hasError, limit, follow, format, dashboardOnly: dashboardUrl is not null, cancellationToken);
+        return await FetchSpansAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, hasError, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, cancellationToken);
     }
 
     private async Task<int> FetchSpansAsync(
@@ -113,6 +113,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         bool follow,
         OutputFormat format,
         bool dashboardOnly,
+        string dashboardUrl,
         CancellationToken cancellationToken)
     {
         using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
@@ -142,11 +143,11 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         {
             if (follow)
             {
-                return await StreamSpansAsync(client, url, format, allOtlpResources, cancellationToken);
+                return await StreamSpansAsync(client, url, format, allOtlpResources, dashboardUrl, cancellationToken);
             }
             else
             {
-                return await GetSpansSnapshotAsync(client, url, format, allOtlpResources, cancellationToken);
+                return await GetSpansSnapshotAsync(client, url, format, allOtlpResources, dashboardUrl, cancellationToken);
             }
         }
         catch (HttpRequestException ex)
@@ -158,7 +159,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         }
     }
 
-    private async Task<int> GetSpansSnapshotAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, CancellationToken cancellationToken)
+    private async Task<int> GetSpansSnapshotAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl, CancellationToken cancellationToken)
     {
         var response = await client.GetAsync(url, cancellationToken);
         TelemetryCommandHelpers.EnsureTelemetryApiResponse(response);
@@ -172,13 +173,13 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         }
         else
         {
-            DisplaySpansSnapshot(json, allResources);
+            DisplaySpansSnapshot(json, allResources, dashboardUrl);
         }
 
         return ExitCodeConstants.Success;
     }
 
-    private async Task<int> StreamSpansAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, CancellationToken cancellationToken)
+    private async Task<int> StreamSpansAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl, CancellationToken cancellationToken)
     {
         using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         TelemetryCommandHelpers.EnsureTelemetryApiResponse(response);
@@ -195,14 +196,14 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             }
             else
             {
-                DisplaySpansStreamLine(line, allResources);
+                DisplaySpansStreamLine(line, allResources, dashboardUrl);
             }
         }
 
         return ExitCodeConstants.Success;
     }
 
-    private void DisplaySpansSnapshot(string json, IReadOnlyList<IOtlpResource> allResources)
+    private void DisplaySpansSnapshot(string json, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl)
     {
         var response = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
         var resourceSpans = response?.Data?.ResourceSpans;
@@ -213,16 +214,16 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             return;
         }
 
-        DisplayResourceSpans(resourceSpans, allResources);
+        DisplayResourceSpans(resourceSpans, allResources, dashboardUrl);
     }
 
-    private void DisplaySpansStreamLine(string json, IReadOnlyList<IOtlpResource> allResources)
+    private void DisplaySpansStreamLine(string json, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl)
     {
         var request = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpExportTraceServiceRequestJson);
-        DisplayResourceSpans(request?.ResourceSpans ?? [], allResources);
+        DisplayResourceSpans(request?.ResourceSpans ?? [], allResources, dashboardUrl);
     }
 
-    private void DisplayResourceSpans(IEnumerable<OtlpResourceSpansJson> resourceSpans, IReadOnlyList<IOtlpResource> allResources)
+    private void DisplayResourceSpans(IEnumerable<OtlpResourceSpansJson> resourceSpans, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl)
     {
         var allSpans = new List<(string ResourceName, OtlpSpanJson Span)>();
 
@@ -241,16 +242,17 @@ internal sealed class TelemetrySpansCommand : BaseCommand
 
         foreach (var (resourceName, span) in allSpans.OrderBy(s => s.Span.StartTimeUnixNano ?? 0))
         {
-            DisplaySpanEntry(resourceName, span);
+            DisplaySpanEntry(resourceName, span, dashboardUrl);
         }
     }
 
     // Using simple text lines instead of Spectre.Console Table for streaming support.
     // Tables require knowing all data upfront, but streaming mode displays spans as they arrive.
-    private void DisplaySpanEntry(string resourceName, OtlpSpanJson span)
+    private void DisplaySpanEntry(string resourceName, OtlpSpanJson span, string dashboardUrl)
     {
         var name = span.Name ?? "";
         var spanId = span.SpanId ?? "";
+        var traceId = span.TraceId ?? "";
         var duration = OtlpHelpers.CalculateDuration(span.StartTimeUnixNano, span.EndTimeUnixNano);
         var hasError = span.Status?.Code == 2; // ERROR status
 
@@ -261,10 +263,11 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             ? FormatHelpers.FormatConsoleTime(_timeProvider, OtlpHelpers.UnixNanoSecondsToDateTime(span.StartTimeUnixNano.Value))
             : "";
         var shortSpanId = OtlpHelpers.ToShortenedId(spanId);
+        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, $"[grey]{shortSpanId}[/]", spanId: spanId);
         var durationStr = TelemetryCommandHelpers.FormatDuration(duration);
         var resourceColor = _resourceColorMap.GetColor(resourceName);
 
         var escapedName = name.EscapeMarkup();
-        _interactionService.DisplayMarkupLine($"[grey]{timestamp}[/] [{statusColor}]{statusText}[/] [white]{durationStr,8}[/] [{resourceColor}]{resourceName.EscapeMarkup()}[/]: {escapedName} [grey]{shortSpanId}[/]");
+        _interactionService.DisplayMarkupLine($"[grey]{timestamp}[/] [{statusColor}]{statusText}[/] [white]{durationStr,8}[/] [{resourceColor}]{resourceName.EscapeMarkup()}[/]: {escapedName} {spanIdLink}");
     }
 }

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -102,11 +102,11 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         {
             if (!string.IsNullOrEmpty(traceId))
             {
-                return await FetchSingleTraceAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, traceId, format, cancellationToken);
+                return await FetchSingleTraceAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, traceId, format, dashboardApi.DashboardUrl!, cancellationToken);
             }
             else
             {
-                return await FetchTracesAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, hasError, limit, format, cancellationToken);
+                return await FetchTracesAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, hasError, limit, format, dashboardApi.DashboardUrl!, cancellationToken);
             }
         }
         catch (HttpRequestException ex)
@@ -123,6 +123,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         string apiToken,
         string traceId,
         OutputFormat format,
+        string dashboardUrl,
         CancellationToken cancellationToken)
     {
         using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
@@ -157,7 +158,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
         else
         {
-            DisplayTraceDetails(json, traceId, allOtlpResources);
+            DisplayTraceDetails(json, traceId, allOtlpResources, dashboardUrl);
         }
 
         return ExitCodeConstants.Success;
@@ -170,6 +171,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         bool? hasError,
         int? limit,
         OutputFormat format,
+        string dashboardUrl,
         CancellationToken cancellationToken)
     {
         using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
@@ -205,13 +207,13 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
         else
         {
-            DisplayTracesTable(json, allOtlpResources);
+            DisplayTracesTable(json, allOtlpResources, dashboardUrl);
         }
 
         return ExitCodeConstants.Success;
     }
 
-    private void DisplayTracesTable(string json, IReadOnlyList<IOtlpResource> allResources)
+    private void DisplayTracesTable(string json, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl)
     {
         var response = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
         var resourceSpans = response?.Data?.ResourceSpans;
@@ -276,15 +278,16 @@ internal sealed class TelemetryTracesCommand : BaseCommand
                 ? FormatHelpers.FormatConsoleTime(_timeProvider, OtlpHelpers.UnixNanoSecondsToDateTime(info.StartTimeNano.Value))
                 : "";
             var shortTraceId = OtlpHelpers.ToShortenedId(info.TraceId);
-            var nameMarkup = $"[{resourceColor}]{info.Resource.EscapeMarkup()}[/]: {info.FirstSpanName.EscapeMarkup()} [grey]{shortTraceId}[/]";
-            table.AddRow(timestamp, nameMarkup, info.SpanCount.ToString(CultureInfo.InvariantCulture), durationStr, statusText);
+            var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, info.TraceId, $"[grey]{shortTraceId}[/]");
+            var nameColumn = $"[{resourceColor}]{info.Resource.EscapeMarkup()}[/]: {info.FirstSpanName.EscapeMarkup()} {traceLink}";
+            table.AddRow(timestamp, nameColumn, info.SpanCount.ToString(CultureInfo.InvariantCulture), durationStr, statusText);
         }
 
         _interactionService.DisplayRenderable(table);
         _interactionService.DisplayMarkupLine($"[grey]Showing {traceInfos.Count} of {response?.TotalCount ?? traceInfos.Count} traces[/]");
     }
 
-    private void DisplayTraceDetails(string json, string traceId, IReadOnlyList<IOtlpResource> allResources)
+    private void DisplayTraceDetails(string json, string traceId, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl)
     {
         var response = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
         var resourceSpans = response?.Data?.ResourceSpans;
@@ -324,15 +327,16 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var totalDuration = rootSpans.Count > 0 ? rootSpans.Max(s => s.Duration) : spans.Max(s => s.Duration);
 
         // Header
-        _interactionService.DisplayMarkupLine($"[bold]Trace:[/] {traceId}");
+        var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, traceId);
+        _interactionService.DisplayMarkupLine($"[bold]Trace:[/] {traceLink}");
         _interactionService.DisplayMarkupLine($"[bold]Duration:[/] {TelemetryCommandHelpers.FormatDuration(totalDuration)}  [bold]Spans:[/] {spans.Count}");
         _interactionService.DisplayEmptyLine();
 
         // Build tree and display
-        DisplaySpanTree(spans);
+        DisplaySpanTree(spans, dashboardUrl, traceId);
     }
 
-    private void DisplaySpanTree(List<SpanInfo> spans)
+    private void DisplaySpanTree(List<SpanInfo> spans, string dashboardUrl, string traceId)
     {
         // Build a lookup of children by parent ID
         var childrenByParent = spans
@@ -352,7 +356,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
 
         foreach (var root in rootSpans)
         {
-            DisplaySpanNode(root, childrenByParent, "", true, ref lastResource);
+            DisplaySpanNode(root, childrenByParent, "", true, dashboardUrl, traceId, ref lastResource);
         }
     }
 
@@ -361,6 +365,8 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         Dictionary<string, List<SpanInfo>> childrenByParent,
         string indent,
         bool isLast,
+        string dashboardUrl,
+        string traceId,
         ref string? lastResource)
     {
         // Show resource name when it changes (indicates cross-service call)
@@ -384,6 +390,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var statusText = span.HasError ? "ERR" : "OK";
         var durationStr = TelemetryCommandHelpers.FormatDuration(span.Duration).PadLeft(8);
         var shortenedSpanId = OtlpHelpers.ToShortenedId(span.SpanId);
+        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, $"[dim]{shortenedSpanId}[/]", spanId: span.SpanId);
         var escapedName = span.Name.EscapeMarkup();
 
         // Truncate long names
@@ -392,14 +399,14 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             ? escapedName[..(maxNameLength - 3)] + "..."
             : escapedName;
 
-        _interactionService.DisplayMarkupLine($"{indent}{connector} [dim]{shortenedSpanId}[/] {displayName} [{statusColor}]{statusText}[/] [dim]{durationStr}[/]");
+        _interactionService.DisplayMarkupLine($"{indent}{connector} {spanIdLink} {displayName} [{statusColor}]{statusText}[/] [dim]{durationStr}[/]");
 
         // Render children
         if (childrenByParent.TryGetValue(span.SpanId, out var children))
         {
             for (var i = 0; i < children.Count; i++)
             {
-                DisplaySpanNode(children[i], childrenByParent, childIndent, i == children.Count - 1, ref lastResource);
+                DisplaySpanNode(children[i], childrenByParent, childIndent, i == children.Count - 1, dashboardUrl, traceId, ref lastResource);
             }
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -608,7 +608,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             }
 
             // Navigate to remove ?resource=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
-            await Task.Delay(200);
+            await Task.Delay(200, _watchTaskCancellationTokenSource.Token);
 
             NavigationManager.NavigateTo(DashboardUrls.ResourcesUrl(), new NavigationOptions { ReplaceHistoryEntry = true });
         }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -113,7 +113,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private ResourceViewModel? SelectedResource { get; set; }
 
-    private readonly CancellationTokenSource _watchTaskCancellationTokenSource = new();
+    private readonly CancellationTokenSource _cts = new();
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private readonly HashSet<string> _collapsedResourceNames = new(StringComparers.ResourceName);
     private readonly TaskCompletionSource _loadingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -292,7 +292,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         async Task SubscribeResourcesAsync()
         {
-            var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_watchTaskCancellationTokenSource.Token);
+            var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_cts.Token);
 
             // Apply snapshot.
             foreach (var resource in snapshot)
@@ -307,7 +307,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             // Listen for updates and apply.
             _resourceSubscriptionTask = Task.Run(async () =>
             {
-                await foreach (var changes in subscription.WithCancellation(_watchTaskCancellationTokenSource.Token).ConfigureAwait(false))
+                await foreach (var changes in subscription.WithCancellation(_cts.Token).ConfigureAwait(false))
                 {
                     var selectedResourceHasChanged = false;
 
@@ -608,7 +608,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             }
 
             // Navigate to remove ?resource=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
-            await Task.Delay(200, _watchTaskCancellationTokenSource.Token);
+            await Task.Delay(200, _cts.Token);
 
             NavigationManager.NavigateTo(DashboardUrls.ResourcesUrl(), new NavigationOptions { ReplaceHistoryEntry = true });
         }
@@ -987,7 +987,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         _aiContext?.Dispose();
 
         _resourcesInteropReference?.Dispose();
-        _watchTaskCancellationTokenSource.Cancel();
+        _cts.Cancel();
         _logsSubscription?.Dispose();
         TelemetryContext.Dispose();
         await JSInteropHelpers.SafeDisposeAsync(_jsModule);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -607,7 +607,9 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 Logger.LogDebug("Can't navigate to {ResourceName} from URL. Resource not found.", ResourceName);
             }
 
-            // Navigate to remove ?resource=xxx in the URL.
+            // Navigate to remove ?resource=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
+            await Task.Delay(200);
+
             NavigationManager.NavigateTo(DashboardUrls.ResourcesUrl(), new NavigationOptions { ReplaceHistoryEntry = true });
         }
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -41,6 +41,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private List<OtlpResource> _resources = default!;
     private List<SelectViewModel<ResourceTypeDetails>> _resourceViewModels = default!;
     private List<SelectViewModel<LogLevel?>> _logLevels = default!;
+    private readonly CancellationTokenSource _cts = new();
     private Subscription? _resourcesSubscription;
     private Subscription? _logsSubscription;
     private bool _resourceChanged;
@@ -267,7 +268,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             }
 
             // Navigate to remove ?logEntryId=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
-            await Task.Delay(200);
+            await Task.Delay(200, _cts.Token);
 
             NavigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(), new NavigationOptions { ReplaceHistoryEntry = true });
         }
@@ -480,6 +481,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     public void Dispose()
     {
+        _cts.Cancel();
         _aiContext?.Dispose();
         _resourcesSubscription?.Dispose();
         _logsSubscription?.Dispose();

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -266,7 +266,9 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
                 await OnShowPropertiesAsync(logEntryId, buttonId: null);
             }
 
-            // Navigate to remove ?logEntryId=xxx in the URL.
+            // Navigate to remove ?logEntryId=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
+            await Task.Delay(200);
+
             NavigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(), new NavigationOptions { ReplaceHistoryEntry = true });
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -31,6 +31,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     private const string ActionsColumn = nameof(ActionsColumn);
     private const int RootSpanDepth = 1;
 
+    private readonly CancellationTokenSource _cts = new();
     private readonly List<IDisposable> _peerChangesSubscriptions = new();
     private OtlpTrace? _trace;
     private Subscription? _tracesSubscription;
@@ -243,7 +244,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             }
 
             // Navigate to remove ?spanId=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
-            await Task.Delay(200);
+            await Task.Delay(200, _cts.Token);
 
             NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(TraceId), new NavigationOptions { ReplaceHistoryEntry = true });
         }
@@ -572,6 +573,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     public void Dispose()
     {
+        _cts.Cancel();
         _aiContext?.Dispose();
         foreach (var subscription in _peerChangesSubscriptions)
         {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -242,7 +242,9 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
                 await OnShowPropertiesAsync(spanVm, buttonId: null);
             }
 
-            // Navigate to remove ?spanId=xxx in the URL.
+            // Navigate to remove ?spanId=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
+            await Task.Delay(200);
+
             NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(TraceId), new NavigationOptions { ReplaceHistoryEntry = true });
         }
     }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -300,6 +300,8 @@ internal sealed class CliServiceCollectionTestOptions
         {
             // Use a large width to prevent Spectre.Console from word-wrapping output lines.
             console.Profile.Width = int.MaxValue;
+            // Disable link capabilities to prevent OSC 8 hyperlink sequences in output.
+            console.Profile.Capabilities.Links = false;
         }
         return console;
     }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -293,7 +293,8 @@ internal sealed class CliServiceCollectionTestOptions
             Ansi = ansi ? AnsiSupport.Yes : AnsiSupport.No,
             Interactive = InteractionSupport.Yes,
             ColorSystem = ansi ? ColorSystemSupport.Standard : ColorSystemSupport.NoColors,
-            Out = new AnsiConsoleOutput(textWriter)
+            Out = new AnsiConsoleOutput(textWriter),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
         };
         var console = AnsiConsole.Create(settings);
         if (!ansi)


### PR DESCRIPTION
## Description

Add clickable dashboard hyperlinks to CLI telemetry commands. When using the CLI to view traces, spans, or resources, IDs and resource names are now rendered as clickable terminal hyperlinks that open the corresponding dashboard page in the browser.

### Changes

- **TelemetryTracesCommand**: Short trace IDs link to the trace detail page; span IDs in the tree view link to the trace detail page with the span highlighted
- **TelemetrySpansCommand**: Short span IDs link to the trace detail page with the span highlighted
- **DescribeCommand**: Resource names link to the dashboard resource page
- **TelemetryCommandHelpers**: Added `FormatTraceLink` helper with optional `spanId` parameter; extract dashboard base URL from AppHost info
- **TraceDetail.razor.cs**: Fix blank page when navigating with `spanId` query parameter by yielding before `NavigateTo`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
