### PR TITLE
Improve CLI deployment rendering: symbol fixes, log level helper, render scenarios

### DIFF
--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -412,27 +412,14 @@ internal abstract class PipelineCommandBase : BaseCommand
             else if (activity.Type == PublishingActivityTypes.Log)
             {
                 // Log activity - display the log message
-                var logLevel = activity.Data.LogLevel ?? "Information";
+                var (parsedLogLevel, logPrefix) = ParseLogLevel(activity.Data.LogLevel);
                 var message = ConvertTextWithMarkdownFlag(activity.Data.StatusText, activity.Data);
                 var timestamp = activity.Data.Timestamp?.ToString("HH:mm:ss", CultureInfo.InvariantCulture) ?? DateTimeOffset.UtcNow.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
 
-                // Use 3-letter prefixes for log levels
-                var logPrefix = logLevel.ToUpperInvariant() switch
-                {
-                    "DEBUG" => "DBG",
-                    "TRACE" => "TRC",
-                    "INFORMATION" => "INF",
-                    "WARNING" => "WRN",
-                    "ERROR" => "ERR",
-                    "CRITICAL" => "CRT",
-                    _ => "INF"
-                };
-
                 // Make debug and trace logs more subtle
-                var formattedMessage = logLevel.ToUpperInvariant() switch
+                var formattedMessage = parsedLogLevel switch
                 {
-                    "DEBUG" => $"[[{timestamp}]] [dim][[{logPrefix}]] {message}[/]",
-                    "TRACE" => $"[[{timestamp}]] [dim][[{logPrefix}]] {message}[/]",
+                    LogLevel.Debug or LogLevel.Trace => $"[[{timestamp}]] [dim][[{logPrefix}]] {message}[/]",
                     _ => $"[[{timestamp}]] [[{logPrefix}]] {message}"
                 };
 
@@ -550,42 +537,27 @@ internal abstract class PipelineCommandBase : BaseCommand
                     var stepId = activity.Data.StepId;
                     if (stepId != null && steps.TryGetValue(stepId, out var stepInfo))
                     {
-                        var logLevel = activity.Data.LogLevel ?? "Information";
+                        var (parsedLogLevel, logPrefix) = ParseLogLevel(activity.Data.LogLevel);
                         var message = ConvertTextWithMarkdownFlag(activity.Data.StatusText, activity.Data);
-
-                        // Add 3-letter prefix to message for consistency
-                        var logPrefix = logLevel.ToUpperInvariant() switch
-                        {
-                            "DEBUG" => "DBG",
-                            "TRACE" => "TRC",
-                            "INFORMATION" => "INF",
-                            "WARNING" => "WRN",
-                            "ERROR" => "ERR",
-                            "CRITICAL" => "CRT",
-                            _ => "INF"
-                        };
 
                         var prefixedMessage = $"[[{logPrefix}]] {message}";
 
-                        // Map log levels to appropriate console logger methods
-                        switch (logLevel.ToUpperInvariant())
+                        switch (parsedLogLevel)
                         {
-                            case "ERROR":
-                            case "CRITICAL":
+                            case LogLevel.Error:
+                            case LogLevel.Critical:
                                 logger.Failure(stepInfo.Id, prefixedMessage);
                                 break;
-                            case "WARNING":
-                            case "WARN":
+                            case LogLevel.Warning:
                                 logger.Warning(stepInfo.Id, prefixedMessage);
                                 break;
-                            case "DEBUG":
-                            case "TRACE":
+                            case LogLevel.Debug:
+                            case LogLevel.Trace:
                                 // Use a more subtle approach for debug/trace - prefix with dim formatting
                                 var subtleMessage = $"[dim]{prefixedMessage}[/]";
                                 logger.Info(stepInfo.Id, subtleMessage);
                                 break;
-                            case "INFORMATION":
-                            case "INFO":
+                            case LogLevel.Information:
                             default:
                                 logger.Info(stepInfo.Id, prefixedMessage);
                                 break;
@@ -907,6 +879,17 @@ internal abstract class PipelineCommandBase : BaseCommand
     {
         return bool.TryParse(value, out var result) && result;
     }
+
+    private static (LogLevel Level, string Prefix) ParseLogLevel(string? logLevel) => logLevel?.ToUpperInvariant() switch
+    {
+        "TRACE" => (LogLevel.Trace, "TRC"),
+        "DEBUG" => (LogLevel.Debug, "DBG"),
+        "INFORMATION" or "INFO" => (LogLevel.Information, "INF"),
+        "WARNING" or "WARN" => (LogLevel.Warning, "WRN"),
+        "ERROR" => (LogLevel.Error, "ERR"),
+        "CRITICAL" => (LogLevel.Critical, "CRT"),
+        null or _ => (LogLevel.Information, "INF")
+    };
 
     private class StepInfo
     {

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -333,8 +333,8 @@ internal sealed class RenderCommand : BaseCommand
         "publish-summary-markup" => new(
             "Markup characters in names and failures",
             [
-                new("root", "Build [web] frontend", ConsoleActivityLogger.ActivityState.Success, TimeSpan.FromMilliseconds(120), null, null, 0, 1, TimeSpan.Zero, TimeSpan.FromMilliseconds(120)),
-                new("child", "Deploy [api] service", ConsoleActivityLogger.ActivityState.Failure, TimeSpan.FromMilliseconds(35), "Failure while parsing [resource] => {bad}", "root", 1, 2, TimeSpan.FromMilliseconds(60), TimeSpan.FromMilliseconds(95)),
+                new("root", "Build [[web]] frontend", ConsoleActivityLogger.ActivityState.Success, TimeSpan.FromMilliseconds(120), null, null, 0, 1, TimeSpan.Zero, TimeSpan.FromMilliseconds(120)),
+                new("child", "Deploy [[api]] service", ConsoleActivityLogger.ActivityState.Failure, TimeSpan.FromMilliseconds(35), "Failure while parsing [[resource]] => {bad}", "root", 1, 2, TimeSpan.FromMilliseconds(60), TimeSpan.FromMilliseconds(95)),
                 new("sibling", "Notify [[observers]]", ConsoleActivityLogger.ActivityState.Warning, TimeSpan.FromMilliseconds(12), null, "root", 1, 3, TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(112)),
             ], false),
         "publish-summary-mixed-hierarchy" => new(
@@ -344,7 +344,8 @@ internal sealed class RenderCommand : BaseCommand
                 new("orphan", "Orphaned child falls back to root ordering", ConsoleActivityLogger.ActivityState.Success, TimeSpan.FromSeconds(2), null, "missing-parent", 1, 2, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3)),
                 new("root-b", "Publish", ConsoleActivityLogger.ActivityState.Warning, TimeSpan.FromSeconds(4), null, null, 0, 3, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(9)),
                 new("child-b", "Package", ConsoleActivityLogger.ActivityState.Success, TimeSpan.FromSeconds(1), null, "root-b", 1, 4, TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(7)),
-                new("root-c", "Validate", ConsoleActivityLogger.ActivityState.Success, TimeSpan.FromSeconds(2), null, null, 0, 5, TimeSpan.FromSeconds(9), TimeSpan.FromSeconds(11)),
+                new("info-step", "Using cached configuration", ConsoleActivityLogger.ActivityState.Info, TimeSpan.FromSeconds(0), null, "root-b", 1, 5, TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(7)),
+                new("root-c", "Validate", ConsoleActivityLogger.ActivityState.Success, TimeSpan.FromSeconds(2), null, null, 0, 6, TimeSpan.FromSeconds(9), TimeSpan.FromSeconds(11)),
             ]),
         "publish-summary-duration-extremes" => new(
             "Duration extremes",

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -333,9 +333,9 @@ internal sealed class RenderCommand : BaseCommand
         "publish-summary-markup" => new(
             "Markup characters in names and failures",
             [
-                new("root", "Build [[web]] frontend", ConsoleActivityLogger.ActivityState.Success, TimeSpan.FromMilliseconds(120), null, null, 0, 1, TimeSpan.Zero, TimeSpan.FromMilliseconds(120)),
-                new("child", "Deploy [[api]] service", ConsoleActivityLogger.ActivityState.Failure, TimeSpan.FromMilliseconds(35), "Failure while parsing [[resource]] => {bad}", "root", 1, 2, TimeSpan.FromMilliseconds(60), TimeSpan.FromMilliseconds(95)),
-                new("sibling", "Notify [[observers]]", ConsoleActivityLogger.ActivityState.Warning, TimeSpan.FromMilliseconds(12), null, "root", 1, 3, TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(112)),
+                new("root", "Build [web] frontend", ConsoleActivityLogger.ActivityState.Success, TimeSpan.FromMilliseconds(120), null, null, 0, 1, TimeSpan.Zero, TimeSpan.FromMilliseconds(120)),
+                new("child", "Deploy [api] service", ConsoleActivityLogger.ActivityState.Failure, TimeSpan.FromMilliseconds(35), "Failure while parsing [[resource]] => [bold]{bad}[/]", "root", 1, 2, TimeSpan.FromMilliseconds(60), TimeSpan.FromMilliseconds(95)),
+                new("sibling", "Notify [observers]", ConsoleActivityLogger.ActivityState.Warning, TimeSpan.FromMilliseconds(12), null, "root", 1, 3, TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(112)),
             ], false),
         "publish-summary-mixed-hierarchy" => new(
             "Mixed roots and orphaned parents",

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -47,10 +47,11 @@ internal sealed class ConsoleActivityLogger
 
     // No raw ANSI escape codes; rely on Spectre.Console markup tokens.
 
-    private const string SuccessSymbol = "✓\uFE0E";
-    private const string FailureSymbol = "✗\uFE0E";
+    private const string SuccessSymbol = "✓";
+    private const string FailureSymbol = "✗";
+    // The warning symbol is intentionally not ⚠ because that character can be displayed as an emoji in some terminals, causing rendering issues.
     private const string WarningSymbol = "△";
-    private const string InProgressSymbol = "→\uFE0E";
+    private const string InProgressSymbol = "→";
     private const string InfoSymbol = "i";
     private const int SummaryTimelineWidth = 28;
     private const int SummaryTimelineTicks = 4;

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -403,13 +403,15 @@ internal sealed class ConsoleActivityLogger
         foreach (var rec in orderedRecords)
         {
             var durStr = FormatSummaryDuration(rec.Duration, totalTimeline).PadLeft(durationWidth);
-            var symbol = rec.State switch
+            var stateSymbol = rec.State switch
             {
-                ActivityState.Success => _enableColor ? "[green]" + SuccessSymbol + "[/]" : SuccessSymbol,
-                ActivityState.Warning => _enableColor ? "[yellow]" + WarningSymbol + "[/]" : WarningSymbol,
-                ActivityState.Failure => _enableColor ? "[red]" + FailureSymbol + "[/]" : FailureSymbol,
-                _ => _enableColor ? "[cyan]" + InProgressSymbol + "[/]" : InProgressSymbol
+                ActivityState.Success => SuccessSymbol,
+                ActivityState.Warning => WarningSymbol,
+                ActivityState.Failure => FailureSymbol,
+                ActivityState.Info => InfoSymbol,
+                _ => InProgressSymbol
             };
+            var symbol = _enableColor ? $"[{GetStateColor(rec.State)}]{stateSymbol}[/]" : stateSymbol;
             var displayName = GetIndentedDisplayName(rec);
             var name = (renderTimeline ? displayName.PadRight(nameWidth) : displayName).EscapeMarkup();
 
@@ -642,13 +644,7 @@ internal sealed class ConsoleActivityLogger
             return escapedBar;
         }
 
-        return state switch
-        {
-            ActivityState.Success => $"[green]{escapedBar}[/]",
-            ActivityState.Warning => $"[yellow]{escapedBar}[/]",
-            ActivityState.Failure => $"[red]{escapedBar}[/]",
-            _ => $"[cyan]{escapedBar}[/]"
-        };
+        return $"[{GetStateColor(state)}]{escapedBar}[/]";
     }
 
     private void WriteCompletion(string taskKey, string symbol, string message, ActivityState state, double? seconds)
@@ -725,15 +721,17 @@ internal sealed class ConsoleActivityLogger
         }
     }
 
-    private static string ColorizeSymbol(string symbol, ActivityState state) => state switch
+    private static string GetStateColor(ActivityState state) => state switch
     {
-        ActivityState.Success => $"[green]{symbol}[/]",
-        ActivityState.Warning => $"[yellow]{symbol}[/]",
-        ActivityState.Failure => $"[red]{symbol}[/]",
-        ActivityState.InProgress => $"[cyan]{symbol}[/]",
-        ActivityState.Info => $"[dim]{symbol}[/]",
-        _ => symbol
+        ActivityState.Success => "green",
+        ActivityState.Warning => "yellow",
+        ActivityState.Failure => "red",
+        ActivityState.Info => "blue",
+        _ => "cyan"
     };
+
+    private static string ColorizeSymbol(string symbol, ActivityState state) =>
+        $"[{GetStateColor(state)}]{symbol}[/]";
 
     // Messages are already converted from Markdown to Spectre markup in PipelineCommandBase.
     // When interactive output is not supported, we need to convert Spectre link markup

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -47,10 +47,10 @@ internal sealed class ConsoleActivityLogger
 
     // No raw ANSI escape codes; rely on Spectre.Console markup tokens.
 
-    private const string SuccessSymbol = "✓";
-    private const string FailureSymbol = "✗";
-    private const string WarningSymbol = "⚠";
-    private const string InProgressSymbol = "→";
+    private const string SuccessSymbol = "✓\uFE0E";
+    private const string FailureSymbol = "✗\uFE0E";
+    private const string WarningSymbol = "△";
+    private const string InProgressSymbol = "→\uFE0E";
     private const string InfoSymbol = "i";
     private const int SummaryTimelineWidth = 28;
     private const int SummaryTimelineTicks = 4;
@@ -410,10 +410,10 @@ internal sealed class ConsoleActivityLogger
                 ActivityState.Failure => _enableColor ? "[red]" + FailureSymbol + "[/]" : FailureSymbol,
                 _ => _enableColor ? "[cyan]" + InProgressSymbol + "[/]" : InProgressSymbol
             };
-            // DisplayName and FailureReason are already Spectre-safe (pre-processed
-            // through ConvertTextWithMarkdownFlag which escapes or converts markdown).
             var displayName = GetIndentedDisplayName(rec);
             var name = (renderTimeline ? displayName.PadRight(nameWidth) : displayName).EscapeMarkup();
+
+            // FailureReason is already Spectre-safe (pre-processed through ConvertTextWithMarkdownFlag which escapes or converts markdown).
             var reason = rec.State == ActivityState.Failure && !string.IsNullOrEmpty(rec.FailureReason)
                 ? (_enableColor ? $" [red]— {HighlightMessage(rec.FailureReason!)}[/]" : $" — {rec.FailureReason!}")
                 : string.Empty;


### PR DESCRIPTION
## Description

Improve CLI deployment rendering with several small fixes:

- **Symbol rendering**: Append VS15 (`\uFE0E`) to `✓`, `✗`, and `→` to force text presentation on all platforms. Replace `⚠` with `△` (U+25B3) since VS15 didn't reliably suppress emoji rendering for that character.
- **Log level helper**: Extract a shared `ParseLogLevel` helper method that returns both the `LogLevel` enum value and its 3-letter prefix (e.g. `"TRC"`, `"DBG"`, `"INF"`). Replaces duplicated switch expressions in both the debug and non-debug processing paths. Also handles `"INFO"` and `"WARN"` short forms, and maps `null` to `LogLevel.Information`.
- **Render scenarios**: Escape Spectre markup brackets in the `publish-summary-markup` scenario data. Add an `Info`-state step to the `publish-summary-mixed-hierarchy` scenario to exercise the `InfoSymbol`.

Before (warning is emoji instead of text):
<img width="1121" height="356" alt="image" src="https://github.com/user-attachments/assets/8f0d703e-d30c-4613-8023-08db4dd15ddf" />

After (warning is text):
<img width="1130" height="389" alt="image" src="https://github.com/user-attachments/assets/0d2e8350-1026-418c-a41f-fdc05f578bf9" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
