### PR TITLE
Add --list-steps flag to aspire do command

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
@@ -24,6 +24,7 @@ internal interface IAppHostCliBackchannel
     Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     Task UpdatePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     IAsyncEnumerable<CommandOutput> ExecAsync(CancellationToken cancellationToken);
+    Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken);
 }
 
 internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logger, AspireCliTelemetry telemetry) : IAppHostCliBackchannel
@@ -478,6 +479,23 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
         {
             yield return commandOutput;
         }
+    }
+
+    public async Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken)
+    {
+        using var activity = telemetry.StartDiagnosticActivity();
+        var rpc = await GetRpcTaskAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        logger.LogDebug("Requesting pipeline steps.");
+
+        var steps = await rpc.InvokeWithCancellationAsync<PipelineStepInfo[]>(
+            "GetPipelineStepsAsync",
+            [],
+            cancellationToken).ConfigureAwait(false);
+
+        logger.LogDebug("Received {StepCount} pipeline steps.", steps.Length);
+
+        return steps;
     }
 
 }

--- a/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
@@ -24,7 +24,7 @@ internal interface IAppHostCliBackchannel
     Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     Task UpdatePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     IAsyncEnumerable<CommandOutput> ExecAsync(CancellationToken cancellationToken);
-    Task<GetPipelineStepsResponse> GetPipelineStepsAsync(CancellationToken cancellationToken);
+    Task<GetPipelineStepsResponse> GetPipelineStepsAsync(string? step, CancellationToken cancellationToken);
 }
 
 internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logger, AspireCliTelemetry telemetry) : IAppHostCliBackchannel
@@ -481,7 +481,7 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
         }
     }
 
-    public async Task<GetPipelineStepsResponse> GetPipelineStepsAsync(CancellationToken cancellationToken)
+    public async Task<GetPipelineStepsResponse> GetPipelineStepsAsync(string? step, CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity();
         var rpc = await GetRpcTaskAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -490,7 +490,7 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
 
         var response = await rpc.InvokeWithCancellationAsync<GetPipelineStepsResponse>(
             "GetPipelineStepsAsync",
-            [new GetPipelineStepsRequest()],
+            [new GetPipelineStepsRequest { Step = step }],
             cancellationToken).ConfigureAwait(false);
 
         logger.LogDebug("Received {StepCount} pipeline steps.", response.Steps.Length);

--- a/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
@@ -24,7 +24,7 @@ internal interface IAppHostCliBackchannel
     Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     Task UpdatePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     IAsyncEnumerable<CommandOutput> ExecAsync(CancellationToken cancellationToken);
-    Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken);
+    Task<GetPipelineStepsResponse> GetPipelineStepsAsync(CancellationToken cancellationToken);
 }
 
 internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logger, AspireCliTelemetry telemetry) : IAppHostCliBackchannel
@@ -481,21 +481,21 @@ internal sealed class AppHostCliBackchannel(ILogger<AppHostCliBackchannel> logge
         }
     }
 
-    public async Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken)
+    public async Task<GetPipelineStepsResponse> GetPipelineStepsAsync(CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity();
         var rpc = await GetRpcTaskAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
 
         logger.LogDebug("Requesting pipeline steps.");
 
-        var steps = await rpc.InvokeWithCancellationAsync<PipelineStepInfo[]>(
+        var response = await rpc.InvokeWithCancellationAsync<GetPipelineStepsResponse>(
             "GetPipelineStepsAsync",
-            [],
+            [new GetPipelineStepsRequest()],
             cancellationToken).ConfigureAwait(false);
 
-        logger.LogDebug("Received {StepCount} pipeline steps.", steps.Length);
+        logger.LogDebug("Received {StepCount} pipeline steps.", response.Steps.Length);
 
-        return steps;
+        return response;
     }
 
 }

--- a/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
@@ -78,6 +78,8 @@ namespace Aspire.Cli.Backchannel;
 [JsonSerializable(typeof(WaitForResourceResponse))]
 [JsonSerializable(typeof(PipelineStepInfo))]
 [JsonSerializable(typeof(PipelineStepInfo[]))]
+[JsonSerializable(typeof(GetPipelineStepsRequest))]
+[JsonSerializable(typeof(GetPipelineStepsResponse))]
 internal partial class BackchannelJsonSerializerContext : JsonSerializerContext
 {
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Using the Json source generator.")]

--- a/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
@@ -76,6 +76,8 @@ namespace Aspire.Cli.Backchannel;
 [JsonSerializable(typeof(ExecuteResourceCommandResponse))]
 [JsonSerializable(typeof(WaitForResourceRequest))]
 [JsonSerializable(typeof(WaitForResourceResponse))]
+[JsonSerializable(typeof(PipelineStepInfo))]
+[JsonSerializable(typeof(PipelineStepInfo[]))]
 internal partial class BackchannelJsonSerializerContext : JsonSerializerContext
 {
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Using the Json source generator.")]

--- a/src/Aspire.Cli/Commands/DeployCommand.cs
+++ b/src/Aspire.Cli/Commands/DeployCommand.cs
@@ -77,6 +77,8 @@ internal sealed class DeployCommand : PipelineCommandBase
 
     protected override string GetCanceledMessage() => DeployCommandStrings.DeploymentCanceled;
 
+    protected override string? GetTargetStepName(ParseResult parseResult) => "deploy";
+
     protected override string GetProgressMessage(ParseResult parseResult)
     {
         return "Executing step deploy";

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -30,6 +30,16 @@ internal sealed class DoCommand : PipelineCommandBase
             Arity = ArgumentArity.ZeroOrOne
         };
         Arguments.Add(_stepArgument);
+
+        Validators.Add(result =>
+        {
+            var step = result.GetValue(_stepArgument);
+            var listSteps = result.GetValue(s_listStepsOption);
+            if (string.IsNullOrEmpty(step) && !listSteps && !ExtensionHelper.IsExtensionHost(interactionService, out _, out _))
+            {
+                result.AddError("The 'step' argument is required when not using --list-steps.");
+            }
+        });
     }
 
     protected override string OperationCompletedPrefix => DoCommandStrings.OperationCompletedPrefix;
@@ -53,12 +63,6 @@ internal sealed class DoCommand : PipelineCommandBase
                 DoCommandStrings.StepArgumentDescription,
                 required: true,
                 cancellationToken: cancellationToken);
-        }
-
-        // Step is required when not using --list-steps
-        if (string.IsNullOrEmpty(step) && !parseResult.GetValue(s_listStepsOption))
-        {
-            throw new InvalidOperationException("The 'step' argument is required when not using --list-steps.");
         }
 
         if (!string.IsNullOrEmpty(step))

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -24,11 +24,10 @@ internal sealed class DoCommand : PipelineCommandBase
     public DoCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, IConfiguration configuration, ILogger<DoCommand> logger, IAnsiConsole ansiConsole)
         : base("do", DoCommandStrings.Description, runner, interactionService, projectLocator, telemetry, features, updateNotifier, executionContext, hostEnvironment, projectFactory, configuration, logger, ansiConsole)
     {
-        var isExtensionHost = ExtensionHelper.IsExtensionHost(interactionService, out _, out _);
         _stepArgument = new Argument<string>("step")
         {
             Description = DoCommandStrings.StepArgumentDescription,
-            Arity = isExtensionHost ? ArgumentArity.ZeroOrOne : ArgumentArity.ExactlyOne
+            Arity = ArgumentArity.ZeroOrOne
         };
         Arguments.Add(_stepArgument);
     }
@@ -54,6 +53,12 @@ internal sealed class DoCommand : PipelineCommandBase
                 DoCommandStrings.StepArgumentDescription,
                 required: true,
                 cancellationToken: cancellationToken);
+        }
+
+        // Step is required when not using --list-steps
+        if (string.IsNullOrEmpty(step) && !parseResult.GetValue(s_listStepsOption))
+        {
+            throw new InvalidOperationException("The 'step' argument is required when not using --list-steps.");
         }
 
         if (!string.IsNullOrEmpty(step))
@@ -94,6 +99,11 @@ internal sealed class DoCommand : PipelineCommandBase
 
     protected override string GetProgressMessage(ParseResult parseResult)
     {
+        if (parseResult.GetValue(s_listStepsOption))
+        {
+            return "Listing pipeline steps";
+        }
+
         var step = parseResult.GetValue(_stepArgument);
         return $"Executing step {step}";
     }

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -97,6 +97,8 @@ internal sealed class DoCommand : PipelineCommandBase
 
     protected override string GetCanceledMessage() => DoCommandStrings.OperationCanceled;
 
+    protected override string? GetTargetStepName(ParseResult parseResult) => parseResult.GetValue(_stepArgument);
+
     protected override string GetProgressMessage(ParseResult parseResult)
     {
         if (parseResult.GetValue(s_listStepsOption))

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -413,9 +413,10 @@ internal abstract class PipelineCommandBase : BaseCommand
                     var connector = hasTags ? "├" : "└";
                     var continuation = hasTags ? "│" : " ";
                     var firstLinePrefix = $"   {connector}─ [blue]Depends on:[/] ";
-                    // Continuation aligns items under the first dep value:
-                    // "   ├─ Depends on: " = 19 visible chars
-                    var continuationPrefix = $"   {continuation}                 ";
+                    // Build continuation prefix that aligns wrapped items under the first dep value.
+                    // Replace the connector with the continuation char and pad the rest with spaces.
+                    var visibleWidth = StripMarkup(firstLinePrefix).Length;
+                    var continuationPrefix = "   " + continuation + new string(' ', visibleWidth - 4);
                     var wrappedDeps = FormatWithHangingIndent(step.DependsOn, firstLinePrefix, continuationPrefix);
                     _ansiConsole.MarkupLine(wrappedDeps);
                 }

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -397,7 +397,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             var step = steps[i];
 
-            _ansiConsole.MarkupLine($"[bold green]{i + 1}.[/] [bold]{step.Name.EscapeMarkup()}[/]");
+            _ansiConsole.MarkupLine($"[bold green]{i + 1}.[/] [cyan]{step.Name.EscapeMarkup()}[/]");
 
             var hasDeps = step.DependsOn.Length > 0;
             var hasTags = step.Tags.Length > 0;
@@ -412,9 +412,11 @@ internal abstract class PipelineCommandBase : BaseCommand
                 {
                     var connector = hasTags ? "├" : "└";
                     var continuation = hasTags ? "│" : " ";
-                    // "   ├─ Depends on: " is 19 chars; hanging indent aligns continuation items
-                    const string hangingIndent = "                   ";
-                    var wrappedDeps = FormatWithHangingIndent(step.DependsOn, $"   {connector}─ [blue]Depends on:[/] ", $"   {continuation}  {hangingIndent}");
+                    var firstLinePrefix = $"   {connector}─ [blue]Depends on:[/] ";
+                    // Continuation aligns items under the first dep value:
+                    // "   ├─ Depends on: " = 19 visible chars
+                    var continuationPrefix = $"   {continuation}                 ";
+                    var wrappedDeps = FormatWithHangingIndent(step.DependsOn, firstLinePrefix, continuationPrefix);
                     _ansiConsole.MarkupLine(wrappedDeps);
                 }
 

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -263,8 +263,17 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 StopTerminalProgressBar();
 
-                var steps = await backchannel.GetPipelineStepsAsync(cancellationToken);
-                PrintPipelineSteps(steps);
+                // Check that the AppHost supports this capability before calling
+                var capabilities = await backchannel.GetCapabilitiesAsync(cancellationToken);
+                if (!capabilities.Contains("pipeline-steps.v1"))
+                {
+                    throw new AppHostIncompatibleException(
+                        "The AppHost does not support --list-steps. Update the AppHost to a newer version of Aspire.",
+                        "pipeline-steps.v1");
+                }
+
+                var response = await backchannel.GetPipelineStepsAsync(cancellationToken);
+                PrintPipelineSteps(response.Steps);
 
                 await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
                 await pendingRun;

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -60,6 +60,11 @@ internal abstract class PipelineCommandBase : BaseCommand
         Description = PublishCommandStrings.NoBuildArgumentDescription
     };
 
+    protected static readonly Option<bool> s_listStepsOption = new("--list-steps")
+    {
+        Description = "List the pipeline steps that would be executed, without running them."
+    };
+
     protected abstract string OperationCompletedPrefix { get; }
     protected abstract string OperationFailedPrefix { get; }
 
@@ -95,6 +100,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         Options.Add(s_environmentOption);
         Options.Add(s_includeExceptionDetailsOption);
         Options.Add(s_noBuildOption);
+        Options.Add(s_listStepsOption);
 
         if (ExtensionHelper.IsExtensionHost(interactionService, out _, out _))
         {
@@ -250,6 +256,20 @@ internal abstract class PipelineCommandBase : BaseCommand
                 throw new InvalidOperationException("Run completed without returning a backchannel.", innerException);
             }, emoji: KnownEmojis.HammerAndWrench);
 
+            // If --list-steps was specified, get pipeline steps and print them instead of executing
+            var listSteps = parseResult.GetValue(s_listStepsOption);
+            if (listSteps)
+            {
+                StopTerminalProgressBar();
+
+                var steps = await backchannel.GetPipelineStepsAsync(cancellationToken);
+                PrintPipelineSteps(steps);
+
+                await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
+                await pendingRun;
+                return ExitCodeConstants.Success;
+            }
+
             var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
 
             // Check if debug or trace logging is enabled
@@ -358,6 +378,53 @@ internal abstract class PipelineCommandBase : BaseCommand
                 InteractionService.DisplayLines(outputCollector.GetLines());
             }
             return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+    }
+
+    /// <summary>
+    /// Prints pipeline steps in a numbered tree format showing dependencies and tags.
+    /// </summary>
+    internal void PrintPipelineSteps(PipelineStepInfo[] steps)
+    {
+        if (steps.Length == 0)
+        {
+            _ansiConsole.MarkupLine("[dim]No pipeline steps found.[/]");
+            return;
+        }
+
+        for (var i = 0; i < steps.Length; i++)
+        {
+            var step = steps[i];
+
+            _ansiConsole.MarkupLine($"[bold]{i + 1}. {step.Name.EscapeMarkup()}[/]");
+
+            var hasDeps = step.DependsOn.Length > 0;
+            var hasTags = step.Tags.Length > 0;
+
+            if (!hasDeps && !hasTags)
+            {
+                _ansiConsole.MarkupLine("   └─ No dependencies");
+            }
+            else
+            {
+                if (hasDeps)
+                {
+                    var depsText = string.Join(", ", step.DependsOn);
+                    var connector = hasTags ? "├" : "└";
+                    _ansiConsole.MarkupLine($"   {connector}─ Depends on: {depsText.EscapeMarkup()}");
+                }
+
+                if (hasTags)
+                {
+                    var tagsText = string.Join(", ", step.Tags);
+                    _ansiConsole.MarkupLine($"   └─ Tags: {tagsText.EscapeMarkup()}");
+                }
+            }
+
+            if (i < steps.Length - 1)
+            {
+                _ansiConsole.WriteLine();
+            }
         }
     }
 

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
@@ -396,28 +397,31 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             var step = steps[i];
 
-            _ansiConsole.MarkupLine($"[bold]{i + 1}. {step.Name.EscapeMarkup()}[/]");
+            _ansiConsole.MarkupLine($"[bold green]{i + 1}.[/] [bold]{step.Name.EscapeMarkup()}[/]");
 
             var hasDeps = step.DependsOn.Length > 0;
             var hasTags = step.Tags.Length > 0;
 
             if (!hasDeps && !hasTags)
             {
-                _ansiConsole.MarkupLine("   └─ No dependencies");
+                _ansiConsole.MarkupLine("[dim]   └─ No dependencies[/]");
             }
             else
             {
                 if (hasDeps)
                 {
-                    var depsText = string.Join(", ", step.DependsOn);
                     var connector = hasTags ? "├" : "└";
-                    _ansiConsole.MarkupLine($"   {connector}─ Depends on: {depsText.EscapeMarkup()}");
+                    var continuation = hasTags ? "│" : " ";
+                    // "   ├─ Depends on: " is 19 chars; hanging indent aligns continuation items
+                    const string hangingIndent = "                   ";
+                    var wrappedDeps = FormatWithHangingIndent(step.DependsOn, $"   {connector}─ [blue]Depends on:[/] ", $"   {continuation}  {hangingIndent}");
+                    _ansiConsole.MarkupLine(wrappedDeps);
                 }
 
                 if (hasTags)
                 {
                     var tagsText = string.Join(", ", step.Tags);
-                    _ansiConsole.MarkupLine($"   └─ Tags: {tagsText.EscapeMarkup()}");
+                    _ansiConsole.MarkupLine($"   └─ [yellow]Tags:[/] {tagsText.EscapeMarkup()}");
                 }
             }
 
@@ -426,6 +430,50 @@ internal abstract class PipelineCommandBase : BaseCommand
                 _ansiConsole.WriteLine();
             }
         }
+    }
+
+    /// <summary>
+    /// Formats a list of items with a prefix on the first line and hanging indent on continuation lines.
+    /// Items are comma-separated and wrapped so each line stays readable.
+    /// </summary>
+    private static string FormatWithHangingIndent(string[] items, string firstLinePrefix, string continuationPrefix, int maxLineLength = 100)
+    {
+        if (items.Length == 0)
+        {
+            return firstLinePrefix;
+        }
+
+        var sb = new StringBuilder();
+        sb.Append(firstLinePrefix);
+
+        // Track visible length (without markup tags) for line wrapping
+        var visiblePrefixLength = StripMarkup(firstLinePrefix).Length;
+        var currentLineLength = visiblePrefixLength;
+
+        for (var i = 0; i < items.Length; i++)
+        {
+            var item = items[i].EscapeMarkup();
+            var separator = i < items.Length - 1 ? ", " : "";
+            var chunk = item + separator;
+
+            if (i > 0 && currentLineLength + chunk.Length > maxLineLength)
+            {
+                sb.AppendLine();
+                sb.Append(continuationPrefix);
+                currentLineLength = StripMarkup(continuationPrefix).Length;
+            }
+
+            sb.Append(chunk);
+            currentLineLength += chunk.Length;
+        }
+
+        return sb.ToString();
+    }
+
+    private static string StripMarkup(string text)
+    {
+        // Remove Spectre markup tags like [bold], [/], [blue], etc.
+        return System.Text.RegularExpressions.Regex.Replace(text, @"\[/?[^\]]*\]", "");
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -123,6 +123,12 @@ internal abstract class PipelineCommandBase : BaseCommand
     protected abstract string GetProgressMessage(ParseResult parseResult);
 
     /// <summary>
+    /// Gets the target pipeline step name for this command, used for --list-steps filtering.
+    /// Returns null to show all steps.
+    /// </summary>
+    protected virtual string? GetTargetStepName(ParseResult parseResult) => null;
+
+    /// <summary>
     /// Gets command-specific arguments to forward when starting a debug session from the extension context.
     /// Subclasses should override to include their specific positional arguments.
     /// Unmatched tokens are always included automatically.
@@ -272,7 +278,8 @@ internal abstract class PipelineCommandBase : BaseCommand
                         "pipeline-steps.v1");
                 }
 
-                var response = await backchannel.GetPipelineStepsAsync(cancellationToken);
+                var targetStep = GetTargetStepName(parseResult);
+                var response = await backchannel.GetPipelineStepsAsync(targetStep, cancellationToken);
                 PrintPipelineSteps(response.Steps);
 
                 await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -85,5 +85,7 @@ internal sealed class PublishCommand : PipelineCommandBase
 
     protected override string GetCanceledMessage() => InteractionServiceStrings.OperationCancelled;
 
+    protected override string? GetTargetStepName(ParseResult parseResult) => "publish";
+
     protected override string GetProgressMessage(ParseResult parseResult) => "Executing step publish";
 }

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -209,8 +209,6 @@ internal class AppHostRpcTarget(
 
     public async Task<GetPipelineStepsResponse> GetPipelineStepsAsync(GetPipelineStepsRequest? request = null, CancellationToken cancellationToken = default)
     {
-        _ = request; // Reserved for future filtering options
-
         logger.LogDebug("Resolving pipeline steps for list-steps request.");
 
 #pragma warning disable ASPIREPIPELINES001
@@ -223,6 +221,23 @@ internal class AppHostRpcTarget(
         var pipelineContext = new PipelineContext(model, executionContext, serviceProvider, logger, cancellationToken);
 
         var resolvedSteps = await pipeline.ResolveStepsAsync(pipelineContext).ConfigureAwait(false);
+
+        // If a target step is specified, filter to its transitive dependencies
+        if (!string.IsNullOrEmpty(request?.Step))
+        {
+            var stepsByName = resolvedSteps.ToDictionary(s => s.Name, StringComparer.Ordinal);
+            if (stepsByName.TryGetValue(request.Step, out var targetStep))
+            {
+                resolvedSteps = DistributedApplicationPipeline.ComputeTransitiveDependencies(targetStep, stepsByName);
+            }
+            else
+            {
+                var availableSteps = string.Join(", ", resolvedSteps.Select(s => $"'{s.Name}'"));
+                throw new InvalidOperationException(
+                    $"Step '{request.Step}' not found in pipeline. Available steps: {availableSteps}");
+            }
+        }
+
         var orderedSteps = DistributedApplicationPipeline.GetTopologicalOrder(resolvedSteps);
 #pragma warning restore ASPIREPIPELINES001
 

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Exec;
@@ -191,7 +193,8 @@ internal class AppHostRpcTarget(
 
         _ = cancellationToken;
         return Task.FromResult(new string[] {
-            "baseline.v2"
+            "baseline.v2",
+            "pipeline-steps.v1"
             });
     }
 #pragma warning restore CA1822
@@ -204,5 +207,30 @@ internal class AppHostRpcTarget(
     public async Task UpdatePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken = default)
     {
         await activityReporter.CompleteInteractionAsync(promptId, answers, updateResponse: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Resolving pipeline steps for list-steps request.");
+
+        var pipeline = serviceProvider.GetRequiredService<IDistributedApplicationPipeline>() as DistributedApplicationPipeline
+            ?? throw new InvalidOperationException("Pipeline is not a DistributedApplicationPipeline.");
+
+        var model = serviceProvider.GetRequiredService<DistributedApplicationModel>();
+        var executionContext = serviceProvider.GetRequiredService<DistributedApplicationExecutionContext>();
+
+        var pipelineContext = new PipelineContext(model, executionContext, serviceProvider, logger, cancellationToken);
+
+        var resolvedSteps = await pipeline.ResolveStepsAsync(pipelineContext).ConfigureAwait(false);
+        var orderedSteps = DistributedApplicationPipeline.GetTopologicalOrder(resolvedSteps);
+
+        return orderedSteps.Select(step => new PipelineStepInfo
+        {
+            Name = step.Name,
+            Description = step.Description,
+            DependsOn = [.. step.DependsOnSteps],
+            Tags = [.. step.Tags],
+            ResourceName = step.Resource?.Name
+        }).ToArray();
     }
 }

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Exec;
@@ -209,10 +207,13 @@ internal class AppHostRpcTarget(
         await activityReporter.CompleteInteractionAsync(promptId, answers, updateResponse: true, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken)
+    public async Task<GetPipelineStepsResponse> GetPipelineStepsAsync(GetPipelineStepsRequest? request = null, CancellationToken cancellationToken = default)
     {
+        _ = request; // Reserved for future filtering options
+
         logger.LogDebug("Resolving pipeline steps for list-steps request.");
 
+#pragma warning disable ASPIREPIPELINES001
         var pipeline = serviceProvider.GetRequiredService<IDistributedApplicationPipeline>() as DistributedApplicationPipeline
             ?? throw new InvalidOperationException("Pipeline is not a DistributedApplicationPipeline.");
 
@@ -223,14 +224,18 @@ internal class AppHostRpcTarget(
 
         var resolvedSteps = await pipeline.ResolveStepsAsync(pipelineContext).ConfigureAwait(false);
         var orderedSteps = DistributedApplicationPipeline.GetTopologicalOrder(resolvedSteps);
+#pragma warning restore ASPIREPIPELINES001
 
-        return orderedSteps.Select(step => new PipelineStepInfo
+        return new GetPipelineStepsResponse
         {
-            Name = step.Name,
-            Description = step.Description,
-            DependsOn = [.. step.DependsOnSteps],
-            Tags = [.. step.Tags],
-            ResourceName = step.Resource?.Name
-        }).ToArray();
+            Steps = orderedSteps.Select(step => new PipelineStepInfo
+            {
+                Name = step.Name,
+                Description = step.Description,
+                DependsOn = [.. step.DependsOnSteps],
+                Tags = [.. step.Tags],
+                ResourceName = step.Resource?.Name
+            }).ToArray()
+        };
     }
 }

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -720,6 +720,22 @@ internal sealed class PipelineStepInfo
 }
 
 /// <summary>
+/// Request for getting pipeline step metadata.
+/// </summary>
+internal sealed class GetPipelineStepsRequest { }
+
+/// <summary>
+/// Response containing pipeline step metadata.
+/// </summary>
+internal sealed class GetPipelineStepsResponse
+{
+    /// <summary>
+    /// Gets the pipeline steps in topological (execution) order.
+    /// </summary>
+    public required PipelineStepInfo[] Steps { get; init; }
+}
+
+/// <summary>
 /// Represents the connection information for the Dashboard MCP server.
 /// </summary>
 internal sealed class DashboardMcpConnectionInfo

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -689,6 +689,37 @@ internal class PublishingPromptInputAnswer
 }
 
 /// <summary>
+/// Represents metadata about a pipeline step for display purposes (e.g., --list-steps).
+/// </summary>
+internal sealed class PipelineStepInfo
+{
+    /// <summary>
+    /// Gets the unique name of the step.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the description of the step.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the names of steps that this step depends on.
+    /// </summary>
+    public string[] DependsOn { get; init; } = [];
+
+    /// <summary>
+    /// Gets the tags that categorize this step.
+    /// </summary>
+    public string[] Tags { get; init; } = [];
+
+    /// <summary>
+    /// Gets the name of the resource this step is associated with, if any.
+    /// </summary>
+    public string? ResourceName { get; init; }
+}
+
+/// <summary>
 /// Represents the connection information for the Dashboard MCP server.
 /// </summary>
 internal sealed class DashboardMcpConnectionInfo

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -722,7 +722,14 @@ internal sealed class PipelineStepInfo
 /// <summary>
 /// Request for getting pipeline step metadata.
 /// </summary>
-internal sealed class GetPipelineStepsRequest { }
+internal sealed class GetPipelineStepsRequest
+{
+    /// <summary>
+    /// Gets or sets the target step name to filter to (including transitive dependencies).
+    /// When null, all steps are returned.
+    /// </summary>
+    public string? Step { get; init; }
+}
 
 /// <summary>
 /// Response containing pipeline step metadata.

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -395,8 +395,9 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
 
     /// <summary>
     /// Resolves all pipeline steps (from built-in steps and resource annotations),
-    /// normalizes dependencies, validates, and returns the steps in topological order
-    /// without executing them.
+    /// normalizes RequiredBy relationships to DependsOn, and validates the steps
+    /// without executing them. The returned list is in collection order; use
+    /// <see cref="GetTopologicalOrder"/> to obtain execution order.
     /// </summary>
     internal async Task<List<PipelineStep>> ResolveStepsAsync(PipelineContext context)
     {

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -380,6 +380,26 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
 
     public async Task ExecuteAsync(PipelineContext context)
     {
+        var allSteps = await ResolveStepsAsync(context).ConfigureAwait(false);
+
+        if (allSteps.Count == 0)
+        {
+            return;
+        }
+
+        var (stepsToExecute, stepsByName) = FilterStepsForExecution(allSteps, context);
+
+        // Build dependency graph and execute with readiness-based scheduler
+        await ExecuteStepsAsTaskDag(stepsToExecute, stepsByName, context).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves all pipeline steps (from built-in steps and resource annotations),
+    /// normalizes dependencies, validates, and returns the steps in topological order
+    /// without executing them.
+    /// </summary>
+    internal async Task<List<PipelineStep>> ResolveStepsAsync(PipelineContext context)
+    {
         var annotationSteps = await CollectStepsFromAnnotationsAsync(context).ConfigureAwait(false);
         var allSteps = _steps.Concat(annotationSteps).ToList();
 
@@ -389,7 +409,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
 
         if (allSteps.Count == 0)
         {
-            return;
+            return allSteps;
         }
 
         ValidateSteps(allSteps);
@@ -401,10 +421,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
         // Capture resolved pipeline data for diagnostics (before filtering)
         _lastResolvedSteps = allSteps;
 
-        var (stepsToExecute, stepsByName) = FilterStepsForExecution(allSteps, context);
-
-        // Build dependency graph and execute with readiness-based scheduler
-        await ExecuteStepsAsTaskDag(stepsToExecute, stepsByName, context).ConfigureAwait(false);
+        return allSteps;
     }
 
     /// <summary>
@@ -1199,7 +1216,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
     /// <summary>
     /// Gets the topological order of steps for execution.
     /// </summary>
-    private static List<PipelineStep> GetTopologicalOrder(List<PipelineStep> steps)
+    internal static List<PipelineStep> GetTopologicalOrder(List<PipelineStep> steps)
     {
         var stepsByName = steps.ToDictionary(s => s.Name, StringComparer.Ordinal);
         var visited = new HashSet<string>(StringComparer.Ordinal);

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -482,7 +482,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
         return (stepsToExecute, filteredStepsByName);
     }
 
-    private static List<PipelineStep> ComputeTransitiveDependencies(
+    internal static List<PipelineStep> ComputeTransitiveDependencies(
         PipelineStep step,
         Dictionary<string, PipelineStep> stepsByName)
     {

--- a/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for the aspire do --list-steps feature.
+/// Verifies that the CLI can list pipeline steps without executing them.
+/// </summary>
+public sealed class ListStepsTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task DoListStepsShowsPipelineSteps()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        // Create a new Aspire project
+        await auto.AspireNewAsync("ListStepsApp", counter);
+
+        // Navigate to the AppHost project
+        await auto.TypeAsync("cd ListStepsApp/ListStepsApp.AppHost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Run aspire do deploy --list-steps
+        await auto.TypeAsync("aspire do deploy --list-steps");
+        await auto.EnterAsync();
+
+        // Wait for the output to contain step information
+        // The output should contain numbered steps with dependencies
+        await auto.WaitUntilAsync(s =>
+            s.ContainsText("Depends on:") || s.ContainsText("No dependencies"),
+            timeout: TimeSpan.FromMinutes(3),
+            description: "waiting for --list-steps output with step dependency information");
+
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Exit the terminal
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Cli.Commands;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Backchannel;
 using Microsoft.Extensions.DependencyInjection;
 using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -279,5 +280,231 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+    }
+
+    [Fact]
+    public async Task DoCommandWithListStepsReturnsZero()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var requestStopCalled = new TaskCompletionSource();
+        var getPipelineStepsCalled = new TaskCompletionSource();
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
+
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, true, VersionHelper.GetDefaultTemplateVersion());
+                    },
+
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        var backchannel = new TestAppHostBackchannel
+                        {
+                            RequestStopAsyncCalled = requestStopCalled,
+                            GetPipelineStepsAsyncCalled = getPipelineStepsCalled
+                        };
+                        backchannelCompletionSource?.SetResult(backchannel);
+                        await requestStopCalled.Task.DefaultTimeout();
+                        return 0;
+                    }
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Act - no step argument needed with --list-steps
+        var result = command.Parse("do --list-steps");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.True(getPipelineStepsCalled.Task.IsCompleted, "GetPipelineStepsAsync should have been called");
+        Assert.True(requestStopCalled.Task.IsCompleted, "RequestStopAsync should have been called");
+    }
+
+    [Fact]
+    public async Task DoCommandWithListStepsAndStepArgumentReturnsZero()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var requestStopCalled = new TaskCompletionSource();
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
+
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, true, VersionHelper.GetDefaultTemplateVersion());
+                    },
+
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        var backchannel = new TestAppHostBackchannel
+                        {
+                            RequestStopAsyncCalled = requestStopCalled
+                        };
+                        backchannelCompletionSource?.SetResult(backchannel);
+                        await requestStopCalled.Task.DefaultTimeout();
+                        return 0;
+                    }
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Act - step argument with --list-steps
+        var result = command.Parse("do deploy --list-steps");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        // Assert
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task DoCommandWithListStepsDoesNotExecutePipeline()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var publishingActivitiesRequested = false;
+        var requestStopCalled = new TaskCompletionSource();
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
+
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, true, VersionHelper.GetDefaultTemplateVersion());
+                    },
+
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        var backchannel = new TestAppHostBackchannel
+                        {
+                            RequestStopAsyncCalled = requestStopCalled,
+                            GetPublishingActivitiesAsyncCallback = (ct) =>
+                            {
+                                publishingActivitiesRequested = true;
+                                return AsyncEnumerable.Empty<PublishingActivity>();
+                            }
+                        };
+                        backchannelCompletionSource?.SetResult(backchannel);
+                        await requestStopCalled.Task.DefaultTimeout();
+                        return 0;
+                    }
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse("do --list-steps");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        // Assert - pipeline should NOT have been executed
+        Assert.Equal(0, exitCode);
+        Assert.False(publishingActivitiesRequested, "Publishing activities should not be requested when --list-steps is used");
+    }
+
+    [Fact]
+    public async Task DoCommandListStepsDisplaysCustomSteps()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var requestStopCalled = new TaskCompletionSource();
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
+
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, true, VersionHelper.GetDefaultTemplateVersion());
+                    },
+
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        var backchannel = new TestAppHostBackchannel
+                        {
+                            RequestStopAsyncCalled = requestStopCalled,
+                            GetPipelineStepsAsyncCallback = (ct) => Task.FromResult(new PipelineStepInfo[]
+                            {
+                                new() { Name = "parameter-prompt" },
+                                new() { Name = "provision-redis-infra", DependsOn = ["parameter-prompt"], Tags = ["provision-infra"] },
+                                new() { Name = "build-webapi", DependsOn = ["parameter-prompt"], Tags = ["build-compute"] },
+                                new() { Name = "deploy-webapi", DependsOn = ["provision-redis-infra", "build-webapi"], Tags = ["deploy-compute"] }
+                            })
+                        };
+                        backchannelCompletionSource?.SetResult(backchannel);
+                        await requestStopCalled.Task.DefaultTimeout();
+                        return 0;
+                    }
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse("do --list-steps");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task DoCommandWithHelpShowsListStepsOption()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("do --help");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, exitCode);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -466,12 +466,14 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
                         var backchannel = new TestAppHostBackchannel
                         {
                             RequestStopAsyncCalled = requestStopCalled,
-                            GetPipelineStepsAsyncCallback = (ct) => Task.FromResult(new PipelineStepInfo[]
+                            GetPipelineStepsAsyncCallback = (ct) => Task.FromResult(new GetPipelineStepsResponse
                             {
-                                new() { Name = "parameter-prompt" },
-                                new() { Name = "provision-redis-infra", DependsOn = ["parameter-prompt"], Tags = ["provision-infra"] },
-                                new() { Name = "build-webapi", DependsOn = ["parameter-prompt"], Tags = ["build-compute"] },
-                                new() { Name = "deploy-webapi", DependsOn = ["provision-redis-infra", "build-webapi"], Tags = ["deploy-compute"] }
+                                Steps = [
+                                    new() { Name = "parameter-prompt" },
+                                    new() { Name = "provision-redis-infra", DependsOn = ["parameter-prompt"], Tags = ["provision-infra"] },
+                                    new() { Name = "build-webapi", DependsOn = ["parameter-prompt"], Tags = ["build-compute"] },
+                                    new() { Name = "deploy-webapi", DependsOn = ["provision-redis-infra", "build-webapi"], Tags = ["deploy-compute"] }
+                                ]
                             })
                         };
                         backchannelCompletionSource?.SetResult(backchannel);

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -466,7 +466,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
                         var backchannel = new TestAppHostBackchannel
                         {
                             RequestStopAsyncCalled = requestStopCalled,
-                            GetPipelineStepsAsyncCallback = (ct) => Task.FromResult(new GetPipelineStepsResponse
+                            GetPipelineStepsAsyncCallback = (step, ct) => Task.FromResult(new GetPipelineStepsResponse
                             {
                                 Steps = [
                                     new() { Name = "parameter-prompt" },

--- a/tests/Aspire.Cli.Tests/Commands/PipelineCommandListStepsTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PipelineCommandListStepsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.RegularExpressions;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Tests.Utils;
@@ -9,8 +10,13 @@ using Spectre.Console;
 
 namespace Aspire.Cli.Tests.Commands;
 
-public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
+public partial class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
 {
+    [GeneratedRegex(@"\x1B\[[0-9;]*m")]
+    private static partial Regex AnsiEscapeRegex();
+
+    private static string StripAnsi(string text) => AnsiEscapeRegex().Replace(text, "");
+
     [Fact]
     public void PrintPipelineSteps_WithNoDependencies_ShowsNoDependencies()
     {
@@ -18,7 +24,7 @@ public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
 
         command.PrintPipelineSteps([new PipelineStepInfo { Name = "parameter-prompt" }]);
 
-        var output = writer.ToString();
+        var output = StripAnsi(writer.ToString());
         Assert.Contains("1. parameter-prompt", output);
         Assert.Contains("No dependencies", output);
     }
@@ -33,7 +39,7 @@ public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
             new PipelineStepInfo { Name = "build-webapi", DependsOn = ["parameter-prompt"] }
         ]);
 
-        var output = writer.ToString();
+        var output = StripAnsi(writer.ToString());
         Assert.Contains("2. build-webapi", output);
         Assert.Contains("Depends on: parameter-prompt", output);
     }
@@ -47,7 +53,7 @@ public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
             new PipelineStepInfo { Name = "deploy-webapi", DependsOn = ["build-webapi", "provision-redis"] }
         ]);
 
-        var output = writer.ToString();
+        var output = StripAnsi(writer.ToString());
         Assert.Contains("Depends on: build-webapi, provision-redis", output);
     }
 
@@ -60,7 +66,7 @@ public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
             new PipelineStepInfo { Name = "build-webapi", DependsOn = ["parameter-prompt"], Tags = ["build-compute"] }
         ]);
 
-        var output = writer.ToString();
+        var output = StripAnsi(writer.ToString());
         Assert.Contains("Tags: build-compute", output);
     }
 
@@ -73,7 +79,7 @@ public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
             new PipelineStepInfo { Name = "provision-redis-infra", DependsOn = ["parameter-prompt"], Tags = ["provision-infra"] }
         ]);
 
-        var output = writer.ToString();
+        var output = StripAnsi(writer.ToString());
         Assert.Contains("Depends on: parameter-prompt", output);
         Assert.Contains("Tags: provision-infra", output);
     }
@@ -85,7 +91,7 @@ public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
 
         command.PrintPipelineSteps([]);
 
-        var output = writer.ToString();
+        var output = StripAnsi(writer.ToString());
         Assert.Contains("No pipeline steps found", output);
     }
 
@@ -100,7 +106,7 @@ public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
             new PipelineStepInfo { Name = "step-c" }
         ]);
 
-        var output = writer.ToString();
+        var output = StripAnsi(writer.ToString());
         Assert.Contains("1. step-a", output);
         Assert.Contains("2. step-b", output);
         Assert.Contains("3. step-c", output);
@@ -121,7 +127,7 @@ public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
             new PipelineStepInfo { Name = "deploy-frontend", DependsOn = ["build-frontend", "deploy-webapi"], Tags = ["deploy-compute"] },
         ]);
 
-        var output = writer.ToString();
+        var output = StripAnsi(writer.ToString());
         Assert.Contains("1. parameter-prompt", output);
         Assert.Contains("7. deploy-frontend", output);
         Assert.Contains("No dependencies", output);

--- a/tests/Aspire.Cli.Tests/Commands/PipelineCommandListStepsTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PipelineCommandListStepsTests.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class PipelineCommandListStepsTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void PrintPipelineSteps_WithNoDependencies_ShowsNoDependencies()
+    {
+        var (command, writer) = CreateCommandWithCapturedOutput();
+
+        command.PrintPipelineSteps([new PipelineStepInfo { Name = "parameter-prompt" }]);
+
+        var output = writer.ToString();
+        Assert.Contains("1. parameter-prompt", output);
+        Assert.Contains("No dependencies", output);
+    }
+
+    [Fact]
+    public void PrintPipelineSteps_WithDependencies_ShowsDependsOn()
+    {
+        var (command, writer) = CreateCommandWithCapturedOutput();
+
+        command.PrintPipelineSteps([
+            new PipelineStepInfo { Name = "parameter-prompt" },
+            new PipelineStepInfo { Name = "build-webapi", DependsOn = ["parameter-prompt"] }
+        ]);
+
+        var output = writer.ToString();
+        Assert.Contains("2. build-webapi", output);
+        Assert.Contains("Depends on: parameter-prompt", output);
+    }
+
+    [Fact]
+    public void PrintPipelineSteps_WithMultipleDependencies_ShowsAllDependencies()
+    {
+        var (command, writer) = CreateCommandWithCapturedOutput();
+
+        command.PrintPipelineSteps([
+            new PipelineStepInfo { Name = "deploy-webapi", DependsOn = ["build-webapi", "provision-redis"] }
+        ]);
+
+        var output = writer.ToString();
+        Assert.Contains("Depends on: build-webapi, provision-redis", output);
+    }
+
+    [Fact]
+    public void PrintPipelineSteps_WithTags_ShowsTags()
+    {
+        var (command, writer) = CreateCommandWithCapturedOutput();
+
+        command.PrintPipelineSteps([
+            new PipelineStepInfo { Name = "build-webapi", DependsOn = ["parameter-prompt"], Tags = ["build-compute"] }
+        ]);
+
+        var output = writer.ToString();
+        Assert.Contains("Tags: build-compute", output);
+    }
+
+    [Fact]
+    public void PrintPipelineSteps_WithDepsAndTags_ShowsBothConnectors()
+    {
+        var (command, writer) = CreateCommandWithCapturedOutput();
+
+        command.PrintPipelineSteps([
+            new PipelineStepInfo { Name = "provision-redis-infra", DependsOn = ["parameter-prompt"], Tags = ["provision-infra"] }
+        ]);
+
+        var output = writer.ToString();
+        Assert.Contains("Depends on: parameter-prompt", output);
+        Assert.Contains("Tags: provision-infra", output);
+    }
+
+    [Fact]
+    public void PrintPipelineSteps_WithEmptySteps_ShowsNoStepsMessage()
+    {
+        var (command, writer) = CreateCommandWithCapturedOutput();
+
+        command.PrintPipelineSteps([]);
+
+        var output = writer.ToString();
+        Assert.Contains("No pipeline steps found", output);
+    }
+
+    [Fact]
+    public void PrintPipelineSteps_NumbersStepsSequentially()
+    {
+        var (command, writer) = CreateCommandWithCapturedOutput();
+
+        command.PrintPipelineSteps([
+            new PipelineStepInfo { Name = "step-a" },
+            new PipelineStepInfo { Name = "step-b" },
+            new PipelineStepInfo { Name = "step-c" }
+        ]);
+
+        var output = writer.ToString();
+        Assert.Contains("1. step-a", output);
+        Assert.Contains("2. step-b", output);
+        Assert.Contains("3. step-c", output);
+    }
+
+    [Fact]
+    public void PrintPipelineSteps_FullPipelineOutput()
+    {
+        var (command, writer) = CreateCommandWithCapturedOutput();
+
+        command.PrintPipelineSteps([
+            new PipelineStepInfo { Name = "parameter-prompt" },
+            new PipelineStepInfo { Name = "provision-redis-infra", DependsOn = ["parameter-prompt"], Tags = ["provision-infra"] },
+            new PipelineStepInfo { Name = "provision-postgres-infra", DependsOn = ["parameter-prompt"], Tags = ["provision-infra"] },
+            new PipelineStepInfo { Name = "build-webapi", DependsOn = ["parameter-prompt"], Tags = ["build-compute"] },
+            new PipelineStepInfo { Name = "build-frontend", DependsOn = ["parameter-prompt"], Tags = ["build-compute"] },
+            new PipelineStepInfo { Name = "deploy-webapi", DependsOn = ["provision-redis-infra", "provision-postgres-infra", "build-webapi"], Tags = ["deploy-compute"] },
+            new PipelineStepInfo { Name = "deploy-frontend", DependsOn = ["build-frontend", "deploy-webapi"], Tags = ["deploy-compute"] },
+        ]);
+
+        var output = writer.ToString();
+        Assert.Contains("1. parameter-prompt", output);
+        Assert.Contains("7. deploy-frontend", output);
+        Assert.Contains("No dependencies", output);
+        Assert.Contains("Depends on: provision-redis-infra, provision-postgres-infra, build-webapi", output);
+        Assert.Contains("Tags: provision-infra", output);
+        Assert.Contains("Tags: build-compute", output);
+        Assert.Contains("Tags: deploy-compute", output);
+    }
+
+    private (PipelineCommandBase Command, StringWriter Writer) CreateCommandWithCapturedOutput()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+        var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+            Ansi = AnsiSupport.No,
+            Interactive = InteractionSupport.No
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
+        services.AddSingleton<IAnsiConsole>(console);
+        var provider = services.BuildServiceProvider();
+        return (provider.GetRequiredService<DoCommand>(), writer);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -838,7 +838,7 @@ internal sealed class TestPromptBackchannel : IAppHostCliBackchannel
         yield break;
     }
 
-    public Task<GetPipelineStepsResponse> GetPipelineStepsAsync(CancellationToken cancellationToken) =>
+    public Task<GetPipelineStepsResponse> GetPipelineStepsAsync(string? step, CancellationToken cancellationToken) =>
         Task.FromResult(new GetPipelineStepsResponse { Steps = [] });
 }
 

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -838,8 +838,8 @@ internal sealed class TestPromptBackchannel : IAppHostCliBackchannel
         yield break;
     }
 
-    public Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken) =>
-        Task.FromResult(Array.Empty<PipelineStepInfo>());
+    public Task<GetPipelineStepsResponse> GetPipelineStepsAsync(CancellationToken cancellationToken) =>
+        Task.FromResult(new GetPipelineStepsResponse { Steps = [] });
 }
 
 // Data structures for tracking prompts

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -837,6 +837,9 @@ internal sealed class TestPromptBackchannel : IAppHostCliBackchannel
         await Task.CompletedTask; // Suppress CS1998
         yield break;
     }
+
+    public Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken) =>
+        Task.FromResult(Array.Empty<PipelineStepInfo>());
 }
 
 // Data structures for tracking prompts

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
@@ -30,7 +30,7 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
     public Func<CancellationToken, Task<string[]>>? GetCapabilitiesAsyncCallback { get; set; }
 
     public TaskCompletionSource? GetPipelineStepsAsyncCalled { get; set; }
-    public Func<CancellationToken, Task<PipelineStepInfo[]>>? GetPipelineStepsAsyncCallback { get; set; }
+    public Func<CancellationToken, Task<GetPipelineStepsResponse>>? GetPipelineStepsAsyncCallback { get; set; }
 
     public Task RequestStopAsync(CancellationToken cancellationToken)
     {
@@ -222,7 +222,7 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
         }
         else
         {
-            return ["baseline.v2"];
+            return ["baseline.v2", "pipeline-steps.v1"];
         }
     }
 
@@ -254,7 +254,7 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
         yield return new CommandOutput { Text = "test", IsErrorMessage = false, LineNumber = 0 };
     }
 
-    public async Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken)
+    public async Task<GetPipelineStepsResponse> GetPipelineStepsAsync(CancellationToken cancellationToken)
     {
         GetPipelineStepsAsyncCalled?.SetResult();
         if (GetPipelineStepsAsyncCallback is not null)
@@ -262,10 +262,13 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
             return await GetPipelineStepsAsyncCallback(cancellationToken).ConfigureAwait(false);
         }
 
-        return [
-            new PipelineStepInfo { Name = "process-parameters", Description = "Prompts for parameter values" },
-            new PipelineStepInfo { Name = "build-webapi", DependsOn = ["process-parameters"], Tags = ["build-compute"] },
-            new PipelineStepInfo { Name = "deploy-webapi", DependsOn = ["build-webapi"], Tags = ["deploy-compute"] }
-        ];
+        return new GetPipelineStepsResponse
+        {
+            Steps = [
+                new PipelineStepInfo { Name = "process-parameters", Description = "Prompts for parameter values" },
+                new PipelineStepInfo { Name = "build-webapi", DependsOn = ["process-parameters"], Tags = ["build-compute"] },
+                new PipelineStepInfo { Name = "deploy-webapi", DependsOn = ["build-webapi"], Tags = ["deploy-compute"] }
+            ]
+        };
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
@@ -30,7 +30,7 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
     public Func<CancellationToken, Task<string[]>>? GetCapabilitiesAsyncCallback { get; set; }
 
     public TaskCompletionSource? GetPipelineStepsAsyncCalled { get; set; }
-    public Func<CancellationToken, Task<GetPipelineStepsResponse>>? GetPipelineStepsAsyncCallback { get; set; }
+    public Func<string?, CancellationToken, Task<GetPipelineStepsResponse>>? GetPipelineStepsAsyncCallback { get; set; }
 
     public Task RequestStopAsync(CancellationToken cancellationToken)
     {
@@ -254,12 +254,12 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
         yield return new CommandOutput { Text = "test", IsErrorMessage = false, LineNumber = 0 };
     }
 
-    public async Task<GetPipelineStepsResponse> GetPipelineStepsAsync(CancellationToken cancellationToken)
+    public async Task<GetPipelineStepsResponse> GetPipelineStepsAsync(string? step, CancellationToken cancellationToken)
     {
         GetPipelineStepsAsyncCalled?.SetResult();
         if (GetPipelineStepsAsyncCallback is not null)
         {
-            return await GetPipelineStepsAsyncCallback(cancellationToken).ConfigureAwait(false);
+            return await GetPipelineStepsAsyncCallback(step, cancellationToken).ConfigureAwait(false);
         }
 
         return new GetPipelineStepsResponse

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
@@ -29,6 +29,9 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
     public TaskCompletionSource? GetCapabilitiesAsyncCalled { get; set; }
     public Func<CancellationToken, Task<string[]>>? GetCapabilitiesAsyncCallback { get; set; }
 
+    public TaskCompletionSource? GetPipelineStepsAsyncCalled { get; set; }
+    public Func<CancellationToken, Task<PipelineStepInfo[]>>? GetPipelineStepsAsyncCallback { get; set; }
+
     public Task RequestStopAsync(CancellationToken cancellationToken)
     {
         RequestStopAsyncCalled?.SetResult();
@@ -249,5 +252,20 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
     {
         await Task.Delay(1, cancellationToken).ConfigureAwait(false);
         yield return new CommandOutput { Text = "test", IsErrorMessage = false, LineNumber = 0 };
+    }
+
+    public async Task<PipelineStepInfo[]> GetPipelineStepsAsync(CancellationToken cancellationToken)
+    {
+        GetPipelineStepsAsyncCalled?.SetResult();
+        if (GetPipelineStepsAsyncCallback is not null)
+        {
+            return await GetPipelineStepsAsyncCallback(cancellationToken).ConfigureAwait(false);
+        }
+
+        return [
+            new PipelineStepInfo { Name = "process-parameters", Description = "Prompts for parameter values" },
+            new PipelineStepInfo { Name = "build-webapi", DependsOn = ["process-parameters"], Tags = ["build-compute"] },
+            new PipelineStepInfo { Name = "deploy-webapi", DependsOn = ["build-webapi"], Tags = ["deploy-compute"] }
+        ];
     }
 }

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -2269,4 +2269,127 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
     private sealed class CustomResource(string name) : Resource(name)
     {
     }
+
+    [Fact]
+    public async Task ResolveStepsAsync_ReturnsAllSteps()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: null).WithTestAndResourceLogging(testOutputHelper);
+        builder.Services.AddSingleton(testOutputHelper);
+        builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
+
+        var pipeline = new DistributedApplicationPipeline();
+        pipeline.AddStep("custom-step", _ => Task.CompletedTask);
+
+        var context = CreateDeployingContext(builder.Build());
+        var steps = await pipeline.ResolveStepsAsync(context).DefaultTimeout();
+
+        // Should include built-in steps + our custom step
+        Assert.Contains(steps, s => s.Name == "custom-step");
+        Assert.Contains(steps, s => s.Name == "deploy");
+        Assert.Contains(steps, s => s.Name == "process-parameters");
+    }
+
+    [Fact]
+    public async Task ResolveStepsAsync_NormalizesRequiredByToDependsOn()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: null).WithTestAndResourceLogging(testOutputHelper);
+        builder.Services.AddSingleton(testOutputHelper);
+        builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
+
+        var pipeline = new DistributedApplicationPipeline();
+        var step = new PipelineStep
+        {
+            Name = "my-step",
+            Action = _ => Task.CompletedTask,
+        };
+        step.RequiredBy("deploy");
+        pipeline.AddStep(step);
+
+        var context = CreateDeployingContext(builder.Build());
+        var steps = await pipeline.ResolveStepsAsync(context).DefaultTimeout();
+
+        // "deploy" should now depend on "my-step" due to RequiredBy normalization
+        var deployStep = steps.Single(s => s.Name == "deploy");
+        Assert.Contains("my-step", deployStep.DependsOnSteps);
+    }
+
+    [Fact]
+    public async Task ResolveStepsAsync_PreservesTags()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: null).WithTestAndResourceLogging(testOutputHelper);
+        builder.Services.AddSingleton(testOutputHelper);
+        builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
+
+        var pipeline = new DistributedApplicationPipeline();
+        pipeline.AddStep(new PipelineStep
+        {
+            Name = "tagged-step",
+            Action = _ => Task.CompletedTask,
+            Tags = ["build-compute", "custom-tag"]
+        });
+
+        var context = CreateDeployingContext(builder.Build());
+        var steps = await pipeline.ResolveStepsAsync(context).DefaultTimeout();
+
+        var taggedStep = steps.Single(s => s.Name == "tagged-step");
+        Assert.Contains("build-compute", taggedStep.Tags);
+        Assert.Contains("custom-tag", taggedStep.Tags);
+    }
+
+    [Fact]
+    public async Task ResolveStepsAsync_DoesNotExecuteStepActions()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: null).WithTestAndResourceLogging(testOutputHelper);
+        builder.Services.AddSingleton(testOutputHelper);
+        builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
+
+        var stepExecuted = false;
+        var pipeline = new DistributedApplicationPipeline();
+        pipeline.AddStep("should-not-execute", _ =>
+        {
+            stepExecuted = true;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateDeployingContext(builder.Build());
+        await pipeline.ResolveStepsAsync(context).DefaultTimeout();
+
+        Assert.False(stepExecuted, "Step action should not be executed during resolution");
+    }
+
+    [Fact]
+    public void GetTopologicalOrder_ReturnsStepsInDependencyOrder()
+    {
+        var steps = new List<PipelineStep>
+        {
+            new() { Name = "deploy", Action = _ => Task.CompletedTask, DependsOnSteps = { "build" } },
+            new() { Name = "build", Action = _ => Task.CompletedTask, DependsOnSteps = { "init" } },
+            new() { Name = "init", Action = _ => Task.CompletedTask }
+        };
+
+        var ordered = DistributedApplicationPipeline.GetTopologicalOrder(steps);
+
+        var initIndex = ordered.FindIndex(s => s.Name == "init");
+        var buildIndex = ordered.FindIndex(s => s.Name == "build");
+        var deployIndex = ordered.FindIndex(s => s.Name == "deploy");
+
+        Assert.True(initIndex < buildIndex, "init should come before build");
+        Assert.True(buildIndex < deployIndex, "build should come before deploy");
+    }
+
+    [Fact]
+    public void GetTopologicalOrder_IsDeterministic()
+    {
+        var steps = new List<PipelineStep>
+        {
+            new() { Name = "c-step", Action = _ => Task.CompletedTask },
+            new() { Name = "a-step", Action = _ => Task.CompletedTask },
+            new() { Name = "b-step", Action = _ => Task.CompletedTask }
+        };
+
+        var ordered1 = DistributedApplicationPipeline.GetTopologicalOrder(steps);
+        var ordered2 = DistributedApplicationPipeline.GetTopologicalOrder(steps);
+
+        Assert.Equal(ordered1.Select(s => s.Name), ordered2.Select(s => s.Name));
+    }
 }


### PR DESCRIPTION
## Description

Adds support for `aspire do --list-steps` flag that prints the pipeline steps that would be executed, in topological (execution) order, along with their dependencies and tags — without actually running them.

### Problem

Users need a simple way to inspect what pipeline steps will run for a given target. The existing `aspire do diagnostics` output is too verbose and technical for typical users (see [issue discussion](https://github.com/microsoft/aspire/issues/12376#issuecomment-3638917856)).

### Approach

The implementation spans the AppHost (Aspire.Hosting) and CLI (Aspire.Cli), connected via the backchannel RPC:

**AppHost side:**
- New `PipelineStepInfo` DTO in `BackchannelDataTypes.cs` (source-shared between CLI and AppHost)
- New `ResolveStepsAsync()` on `DistributedApplicationPipeline` that resolves all steps (collects from annotations, normalizes RequiredBy→DependsOn, validates) without executing them
- New `GetPipelineStepsAsync()` RPC method on `AppHostRpcTarget` with `pipeline-steps.v1` capability

**CLI side:**
- `--list-steps` option added to `PipelineCommandBase` (available on `do`, `publish`, `deploy`)
- After backchannel connects, calls `GetPipelineStepsAsync` instead of streaming publishing activities
- Formats output as a numbered tree, then calls `RequestStopAsync` to shut down the AppHost immediately

**Example output:**
```
1. parameter-prompt
   └─ No dependencies

2. provision-redis-infra
   ├─ Depends on: parameter-prompt
   └─ Tags: provision-infra

3. build-webapi
   ├─ Depends on: parameter-prompt
   └─ Tags: build-compute

4. deploy-webapi
   ├─ Depends on: provision-redis-infra, build-webapi
   └─ Tags: deploy-compute
```

### Validation
- All 2009 existing CLI tests pass (0 failures)
- 5 new DoCommand integration tests (exit code, RPC calls, no pipeline execution)
- 9 new PrintPipelineSteps formatting tests (dependencies, tags, connectors, numbering, empty steps, full pipeline)
- 6 new pipeline resolution tests (ResolveStepsAsync, GetTopologicalOrder)
- 1 new E2E CLI test using Hex1b terminal automation

Fixes #12376

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
