### PR TITLE
Add ANSI text colors to CLI emoji for monochrome terminal rendering

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -328,7 +328,7 @@ internal sealed class AppHostLauncher(
             }
         }
 
-        interactionService.DisplayMessage(KnownEmojis.MagnifyingGlassTiltedRight, string.Format(
+        interactionService.DisplayMessage(KnownEmojis.MagnifyingGlassTiltedLeft, string.Format(
             CultureInfo.CurrentCulture,
             RunCommandStrings.CheckLogsForDetails,
             childLogFile));

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -129,7 +129,7 @@ internal sealed class DoctorCommand : BaseCommand
     private void OutputCheckResult(EnvironmentCheckResult result)
     {
         var (icon, color) = GetStatusIconAndColor(result.Status);
-        var iconPrefix = ConsoleHelpers.FormatEmojiPrefix(icon, _ansiConsole);
+        var iconPrefix = ConsoleHelpers.FormatEmojiPrefix(icon, _ansiConsole, suppressColor: true);
 
         // Primary grid: icon + message (wrapped lines stay aligned with message text)
         var messageGrid = new Grid();

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -31,6 +31,7 @@ internal sealed class RenderCommand : BaseCommand
     private static readonly Dictionary<string, string> s_choices = new()
     {
         ["displaymessage"] = "Display message (all emojis)",
+        ["displaystyles"] = "Display error, success, subtle, and cancellation messages",
         ["showstatus"] = "Show status spinner (first 5 emojis)",
         ["showstatus-markup"] = "Show status with markup rendered",
         ["showstatus-escaped"] = "Show status with markup escaped",
@@ -136,6 +137,8 @@ internal sealed class RenderCommand : BaseCommand
             {
                 case "displaymessage":
                     return TestDisplayMessage();
+                case "displaystyles":
+                    return TestDisplayStyles();
                 case "showstatus":
                     return await TestShowStatusAsync(cancellationToken);
                 case "showstatus-markup":
@@ -188,6 +191,15 @@ internal sealed class RenderCommand : BaseCommand
             InteractionService.DisplayMessage(emoji, $"DisplayMessage with {emoji.Name}");
         }
 
+        return ExitCodeConstants.Success;
+    }
+
+    private int TestDisplayStyles()
+    {
+        InteractionService.DisplayError("This is an error message.");
+        InteractionService.DisplaySuccess("Operation completed successfully.");
+        InteractionService.DisplaySubtleMessage("This is a subtle hint.");
+        InteractionService.DisplayCancellationMessage();
         return ExitCodeConstants.Success;
     }
 

--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -126,7 +126,7 @@ internal sealed class SdkDumpCommand : BaseCommand
         return await InteractionService.ShowStatusAsync(
             "Scanning capabilities...",
             async () => await DumpCapabilitiesAsync(integrations, outputFile, format, cancellationToken),
-            emoji: KnownEmojis.MagnifyingGlassTiltedRight);
+            emoji: KnownEmojis.MagnifyingGlassTiltedLeft);
     }
 
     private async Task<int> DumpCapabilitiesAsync(

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -29,7 +29,7 @@ internal readonly struct KnownEmoji(string name, string? textColor = null)
 /// </summary>
 internal static class KnownEmojis
 {
-    public static readonly KnownEmoji Bug = new("bug", "green");
+    public static readonly KnownEmoji Bug = new("bug", "red");
     public static readonly KnownEmoji CheckMark = new("check_mark", "green");
     public static readonly KnownEmoji CheckMarkButton = new("check_mark_button", "green");
     public static readonly KnownEmoji CrossMark = new("cross_mark", "red");

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -51,7 +51,7 @@ internal static class KnownEmojis
     public static readonly KnownEmoji Rocket = new("rocket", "darkorange");
     public static readonly KnownEmoji RunningShoe = new("running_shoe", "green");
     public static readonly KnownEmoji StopSign = new("stop_sign", "red");
-    public static readonly KnownEmoji UpButton = new("up_button", "green");
+    public static readonly KnownEmoji UpButton = new("up_button", "blue");
     public static readonly KnownEmoji Warning = new("warning", "yellow");
     public static readonly KnownEmoji Wrench = new("wrench");
 }

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -33,7 +33,6 @@ internal static class KnownEmojis
     public static readonly KnownEmoji CheckMark = new("check_mark", "green");
     public static readonly KnownEmoji CheckMarkButton = new("check_mark_button", "green");
     public static readonly KnownEmoji CrossMark = new("cross_mark", "red");
-    public static readonly KnownEmoji FileCabinet = new("file_cabinet");
     public static readonly KnownEmoji FileFolder = new("file_folder", "yellow");
     public static readonly KnownEmoji FloppyDisk = new("floppy_disk", "blue");
     public static readonly KnownEmoji Gear = new("gear");
@@ -47,7 +46,7 @@ internal static class KnownEmojis
     public static readonly KnownEmoji MagnifyingGlassTiltedLeft = new("magnifying_glass_tilted_left", "blue");
     public static readonly KnownEmoji Microscope = new("microscope", "blue");
     public static readonly KnownEmoji Package = new("package", "yellow");
-    public static readonly KnownEmoji PageFacingUp = new("page_facing_up");
+    public static readonly KnownEmoji PageFacingUp = new("page_facing_up", "white");
     public static readonly KnownEmoji Rocket = new("rocket", "darkorange");
     public static readonly KnownEmoji RunningShoe = new("running_shoe", "green");
     public static readonly KnownEmoji StopSign = new("stop_sign", "red");

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -4,14 +4,22 @@
 namespace Aspire.Cli.Interaction;
 
 /// <summary>
-/// Represents an emoji by its Spectre.Console name.
+/// Represents an emoji by its Spectre.Console name, with a fallback color
+/// for terminals that render the emoji as a monochrome text character.
 /// </summary>
-internal readonly struct KnownEmoji(string name)
+internal readonly struct KnownEmoji(string name, string textColor)
 {
     /// <summary>
     /// Gets the Spectre.Console emoji name (e.g. "rocket", "check_mark").
     /// </summary>
     public string Name { get; } = name;
+
+    /// <summary>
+    /// Gets the Spectre.Console color name applied when the emoji is rendered as a
+    /// monochrome text character. ANSI foreground color is ignored by terminals that
+    /// render full-color emoji glyphs, so this is always safe to apply.
+    /// </summary>
+    public string TextColor { get; } = textColor;
 }
 
 /// <summary>
@@ -20,30 +28,30 @@ internal readonly struct KnownEmoji(string name)
 /// </summary>
 internal static class KnownEmojis
 {
-    public static readonly KnownEmoji Bug = new("bug");
-    public static readonly KnownEmoji CheckMark = new("check_mark");
-    public static readonly KnownEmoji CheckMarkButton = new("check_mark_button");
-    public static readonly KnownEmoji CrossMark = new("cross_mark");
-    public static readonly KnownEmoji FileCabinet = new("file_cabinet");
-    public static readonly KnownEmoji FileFolder = new("file_folder");
-    public static readonly KnownEmoji FloppyDisk = new("floppy_disk");
-    public static readonly KnownEmoji Gear = new("gear");
-    public static readonly KnownEmoji Hammer = new("hammer");
-    public static readonly KnownEmoji Ice = new("ice");
-    public static readonly KnownEmoji HammerAndWrench = new("hammer_and_wrench");
-    public static readonly KnownEmoji Information = new("information");
-    public static readonly KnownEmoji Key = new("key");
-    public static readonly KnownEmoji LinkedPaperclips = new("linked_paperclips");
-    public static readonly KnownEmoji LockedWithKey = new("locked_with_key");
-    public static readonly KnownEmoji MagnifyingGlassTiltedLeft = new("magnifying_glass_tilted_left");
-    public static readonly KnownEmoji MagnifyingGlassTiltedRight = new("magnifying_glass_tilted_right");
-    public static readonly KnownEmoji Microscope = new("microscope");
-    public static readonly KnownEmoji Package = new("package");
-    public static readonly KnownEmoji PageFacingUp = new("page_facing_up");
-    public static readonly KnownEmoji Rocket = new("rocket");
-    public static readonly KnownEmoji RunningShoe = new("running_shoe");
-    public static readonly KnownEmoji StopSign = new("stop_sign");
-    public static readonly KnownEmoji UpButton = new("up_button");
-    public static readonly KnownEmoji Warning = new("warning");
-    public static readonly KnownEmoji Wrench = new("wrench");
+    public static readonly KnownEmoji Bug = new("bug", "red");
+    public static readonly KnownEmoji CheckMark = new("check_mark", "green");
+    public static readonly KnownEmoji CheckMarkButton = new("check_mark_button", "green");
+    public static readonly KnownEmoji CrossMark = new("cross_mark", "red");
+    public static readonly KnownEmoji FileCabinet = new("file_cabinet", "grey");
+    public static readonly KnownEmoji FileFolder = new("file_folder", "yellow");
+    public static readonly KnownEmoji FloppyDisk = new("floppy_disk", "blue");
+    public static readonly KnownEmoji Gear = new("gear", "grey");
+    public static readonly KnownEmoji Hammer = new("hammer", "grey");
+    public static readonly KnownEmoji Ice = new("ice", "cyan");
+    public static readonly KnownEmoji HammerAndWrench = new("hammer_and_wrench", "grey");
+    public static readonly KnownEmoji Information = new("information", "blue");
+    public static readonly KnownEmoji Key = new("key", "yellow");
+    public static readonly KnownEmoji LinkedPaperclips = new("linked_paperclips", "grey");
+    public static readonly KnownEmoji LockedWithKey = new("locked_with_key", "yellow");
+    public static readonly KnownEmoji MagnifyingGlassTiltedLeft = new("magnifying_glass_tilted_left", "blue");
+    public static readonly KnownEmoji MagnifyingGlassTiltedRight = new("magnifying_glass_tilted_right", "blue");
+    public static readonly KnownEmoji Microscope = new("microscope", "blue");
+    public static readonly KnownEmoji Package = new("package", "yellow");
+    public static readonly KnownEmoji PageFacingUp = new("page_facing_up", "grey");
+    public static readonly KnownEmoji Rocket = new("rocket", "darkorange");
+    public static readonly KnownEmoji RunningShoe = new("running_shoe", "green");
+    public static readonly KnownEmoji StopSign = new("stop_sign", "red");
+    public static readonly KnownEmoji UpButton = new("up_button", "green");
+    public static readonly KnownEmoji Warning = new("warning", "yellow");
+    public static readonly KnownEmoji Wrench = new("wrench", "grey");
 }

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -4,10 +4,10 @@
 namespace Aspire.Cli.Interaction;
 
 /// <summary>
-/// Represents an emoji by its Spectre.Console name, with a fallback color
+/// Represents an emoji by its Spectre.Console name, with an optional fallback color
 /// for terminals that render the emoji as a monochrome text character.
 /// </summary>
-internal readonly struct KnownEmoji(string name, string textColor)
+internal readonly struct KnownEmoji(string name, string? textColor = null)
 {
     /// <summary>
     /// Gets the Spectre.Console emoji name (e.g. "rocket", "check_mark").
@@ -18,8 +18,9 @@ internal readonly struct KnownEmoji(string name, string textColor)
     /// Gets the Spectre.Console color name applied when the emoji is rendered as a
     /// monochrome text character. ANSI foreground color is ignored by terminals that
     /// render full-color emoji glyphs, so this is always safe to apply.
+    /// When <see langword="null"/>, no color is applied.
     /// </summary>
-    public string TextColor { get; } = textColor;
+    public string? TextColor { get; } = textColor;
 }
 
 /// <summary>
@@ -28,30 +29,29 @@ internal readonly struct KnownEmoji(string name, string textColor)
 /// </summary>
 internal static class KnownEmojis
 {
-    public static readonly KnownEmoji Bug = new("bug", "red");
+    public static readonly KnownEmoji Bug = new("bug", "green");
     public static readonly KnownEmoji CheckMark = new("check_mark", "green");
     public static readonly KnownEmoji CheckMarkButton = new("check_mark_button", "green");
     public static readonly KnownEmoji CrossMark = new("cross_mark", "red");
-    public static readonly KnownEmoji FileCabinet = new("file_cabinet", "grey");
+    public static readonly KnownEmoji FileCabinet = new("file_cabinet");
     public static readonly KnownEmoji FileFolder = new("file_folder", "yellow");
     public static readonly KnownEmoji FloppyDisk = new("floppy_disk", "blue");
-    public static readonly KnownEmoji Gear = new("gear", "grey");
-    public static readonly KnownEmoji Hammer = new("hammer", "grey");
+    public static readonly KnownEmoji Gear = new("gear");
+    public static readonly KnownEmoji Hammer = new("hammer");
     public static readonly KnownEmoji Ice = new("ice", "cyan");
-    public static readonly KnownEmoji HammerAndWrench = new("hammer_and_wrench", "grey");
+    public static readonly KnownEmoji HammerAndWrench = new("hammer_and_wrench");
     public static readonly KnownEmoji Information = new("information", "blue");
     public static readonly KnownEmoji Key = new("key", "yellow");
-    public static readonly KnownEmoji LinkedPaperclips = new("linked_paperclips", "grey");
+    public static readonly KnownEmoji LinkedPaperclips = new("linked_paperclips");
     public static readonly KnownEmoji LockedWithKey = new("locked_with_key", "yellow");
     public static readonly KnownEmoji MagnifyingGlassTiltedLeft = new("magnifying_glass_tilted_left", "blue");
-    public static readonly KnownEmoji MagnifyingGlassTiltedRight = new("magnifying_glass_tilted_right", "blue");
     public static readonly KnownEmoji Microscope = new("microscope", "blue");
     public static readonly KnownEmoji Package = new("package", "yellow");
-    public static readonly KnownEmoji PageFacingUp = new("page_facing_up", "grey");
+    public static readonly KnownEmoji PageFacingUp = new("page_facing_up");
     public static readonly KnownEmoji Rocket = new("rocket", "darkorange");
     public static readonly KnownEmoji RunningShoe = new("running_shoe", "green");
     public static readonly KnownEmoji StopSign = new("stop_sign", "red");
     public static readonly KnownEmoji UpButton = new("up_button", "green");
     public static readonly KnownEmoji Warning = new("warning", "yellow");
-    public static readonly KnownEmoji Wrench = new("wrench", "grey");
+    public static readonly KnownEmoji Wrench = new("wrench");
 }

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -479,7 +479,7 @@ internal sealed class ProjectLocator(
 
         var relativeSettingsFilePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, settingsFile.FullName).Replace(Path.DirectorySeparatorChar, '/');
         var message = fileExisted ? InteractionServiceStrings.UpdatedSettingsFile : InteractionServiceStrings.CreatedSettingsFile;
-        interactionService.DisplayMessage(KnownEmojis.FileCabinet, string.Format(CultureInfo.CurrentCulture, message, $"[bold]'{relativeSettingsFilePath.EscapeMarkup()}'[/]"), allowMarkup: true);
+        interactionService.DisplayMessage(KnownEmojis.FloppyDisk, string.Format(CultureInfo.CurrentCulture, message, $"[bold]'{relativeSettingsFilePath.EscapeMarkup()}'[/]"), allowMarkup: true);
     }
 
     private FileInfo GetOrCreateLocalAspireConfigFile()

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -226,17 +226,17 @@ internal sealed class ConsoleActivityLogger
                 : string.Format(CultureInfo.CurrentCulture, ConsoleActivityLoggerStrings.SummaryStepsSucceeded, succeededSteps);
             if (_enableColor)
             {
-                summaryParts.Add($"[green]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.CheckMarkButton, _console)}{succeededSegment}[/]");
+                summaryParts.Add($"[green]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.CheckMarkButton, _console, suppressColor: true)}{succeededSegment}[/]");
                 if (warningSteps > 0)
                 {
                     var warningText = warningSteps == 1
                         ? string.Format(CultureInfo.CurrentCulture, ConsoleActivityLoggerStrings.SummaryWarningsSingular, warningSteps)
                         : string.Format(CultureInfo.CurrentCulture, ConsoleActivityLoggerStrings.SummaryWarningsPlural, warningSteps);
-                    summaryParts.Add($"[yellow]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.Warning, _console)}{warningText}[/]");
+                    summaryParts.Add($"[yellow]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.Warning, _console, suppressColor: true)}{warningText}[/]");
                 }
                 if (failedSteps > 0)
                 {
-                    summaryParts.Add($"[red]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.CrossMark, _console)}{string.Format(CultureInfo.CurrentCulture, ConsoleActivityLoggerStrings.SummaryFailed, failedSteps)}[/]");
+                    summaryParts.Add($"[red]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.CrossMark, _console, suppressColor: true)}{string.Format(CultureInfo.CurrentCulture, ConsoleActivityLoggerStrings.SummaryFailed, failedSteps)}[/]");
                 }
             }
             else
@@ -333,13 +333,13 @@ internal sealed class ConsoleActivityLogger
         if (succeeded)
         {
             _finalStatusHeader = _enableColor
-                ? $"[green]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.CheckMarkButton, _console)}{ConsoleActivityLoggerStrings.PipelineSucceeded}[/]"
+                ? $"[green]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.CheckMarkButton, _console, suppressColor: true)}{ConsoleActivityLoggerStrings.PipelineSucceeded}[/]"
                 : $"{SuccessSymbol} {ConsoleActivityLoggerStrings.PipelineSucceeded}";
         }
         else
         {
             _finalStatusHeader = _enableColor
-                ? $"[red]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.CrossMark, _console)}{ConsoleActivityLoggerStrings.PipelineFailed}[/]"
+                ? $"[red]{ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.CrossMark, _console, suppressColor: true)}{ConsoleActivityLoggerStrings.PipelineFailed}[/]"
                 : $"{FailureSymbol} {ConsoleActivityLoggerStrings.PipelineFailed}";
         }
     }

--- a/src/Aspire.Cli/Utils/ConsoleHelpers.cs
+++ b/src/Aspire.Cli/Utils/ConsoleHelpers.cs
@@ -30,9 +30,9 @@ internal static class ConsoleHelpers
         // Wrap in a color tag so monochrome text-presentation glyphs get a visible tint.
         // Terminals that render full-color emoji glyphs ignore ANSI foreground color, so this is always safe.
         // There is an option to suppress it in scenarios where the emoji is added to text inside an existing color.
-        if (!suppressColor)
+        if (!suppressColor && emoji.TextColor is { } color)
         {
-            return $"[{emoji.TextColor}]{spectreEmojiText}[/]" + new string(' ', padding);
+            return $"[{color}]{spectreEmojiText}[/]" + new string(' ', padding);
         }
 
         return spectreEmojiText + new string(' ', padding);

--- a/src/Aspire.Cli/Utils/ConsoleHelpers.cs
+++ b/src/Aspire.Cli/Utils/ConsoleHelpers.cs
@@ -14,13 +14,27 @@ internal static class ConsoleHelpers
     /// <summary>
     /// Formats an emoji prefix with trailing space for aligned console output.
     /// </summary>
-    public static string FormatEmojiPrefix(KnownEmoji emoji, IAnsiConsole console, bool replaceEmoji = false)
+    public static string FormatEmojiPrefix(KnownEmoji emoji, IAnsiConsole console, bool replaceEmoji = false, bool suppressColor = false)
     {
         const int emojiTargetWidth = 3; // 2 for emoji and 1 trailing space
 
         var cellLength = EmojiWidth.GetCachedCellWidth(emoji.Name, console);
         var padding = Math.Max(1, emojiTargetWidth - cellLength);
         var spectreEmojiText = $":{emoji.Name}:";
-        return (replaceEmoji ? Emoji.Replace(spectreEmojiText) : spectreEmojiText) + new string(' ', padding);
+
+        if (replaceEmoji)
+        {
+            return Emoji.Replace(spectreEmojiText) + new string(' ', padding);
+        }
+
+        // Wrap in a color tag so monochrome text-presentation glyphs get a visible tint.
+        // Terminals that render full-color emoji glyphs ignore ANSI foreground color, so this is always safe.
+        // There is an option to suppress it in scenarios where the emoji is added to text inside an existing color.
+        if (!suppressColor)
+        {
+            return $"[{emoji.TextColor}]{spectreEmojiText}[/]" + new string(' ', padding);
+        }
+
+        return spectreEmojiText + new string(' ', padding);
     }
 }


### PR DESCRIPTION
## Description

Add ANSI text colors to CLI emoji so they look better on terminals that render them as monochrome text characters instead of full-color emoji glyphs.

**Changes:**
- Add `TextColor` property to `KnownEmoji` struct — a Spectre.Console color name applied as ANSI foreground color. Terminals rendering full-color emoji glyphs ignore foreground color, so this is always safe to apply.
- Assign text colors to all 26 known emojis (green for success, red for errors, yellow for warnings, blue for info/search, grey for tools, etc.)
- Update `FormatEmojiPrefix` to wrap emoji markup in color tags, with a new `suppressColor` parameter for call sites already inside a color wrapper.
- Consolidate `MagnifyingGlassTiltedRight` usages to `MagnifyingGlassTiltedLeft` (the universally standard search icon).

Before:
<img width="632" height="553" alt="image" src="https://github.com/user-attachments/assets/99de3c4f-fa8d-42cc-aa8c-481730604768" />

After:
<img width="626" height="580" alt="image" src="https://github.com/user-attachments/assets/3c4f821d-df85-4e8c-aacc-06302b40c7cd" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
