### PR TITLE
Surface build output on failure for Docker, Podman, and dotnet publish

### DIFF
--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -67,7 +67,7 @@ internal static partial class ProcessUtil
                 return;
             }
 
-            if (String.IsNullOrEmpty(e.Data))
+            if (string.IsNullOrEmpty(e.Data))
             {
                 return;
             }
@@ -85,7 +85,7 @@ internal static partial class ProcessUtil
                 return;
             }
 
-            if (String.IsNullOrEmpty(e.Data))
+            if (string.IsNullOrEmpty(e.Data))
             {
                 return;
             }

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -54,34 +54,44 @@ internal static partial class ProcessUtil
         // See https://github.com/dotnet/runtime/issues/29232#issuecomment-1451584094 for how this might affect waiting for process exit.
         // We are going to discard that (grandchild) output by checking process.HasExited.
 
-        if (processSpec.OnOutputData != null)
+        var stdoutComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stderrComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        process.OutputDataReceived += (_, e) =>
         {
-            process.OutputDataReceived += (_, e) =>
+            startupComplete.Wait();
+
+            if (e.Data is null)
             {
-                startupComplete.Wait();
+                stdoutComplete.TrySetResult();
+                return;
+            }
 
-                if (String.IsNullOrEmpty(e.Data))
-                {
-                    return;
-                }
+            if (String.IsNullOrEmpty(e.Data))
+            {
+                return;
+            }
 
-                processSpec.OnOutputData.Invoke(e.Data);
-            };
-        }
+            processSpec.OnOutputData?.Invoke(e.Data);
+        };
 
-        if (processSpec.OnErrorData != null)
+        process.ErrorDataReceived += (_, e) =>
         {
-            process.ErrorDataReceived += (_, e) =>
-            {
-                startupComplete.Wait();
-                if (String.IsNullOrEmpty(e.Data))
-                {
-                    return;
-                }
+            startupComplete.Wait();
 
-                processSpec.OnErrorData.Invoke(e.Data);
-            };
-        }
+            if (e.Data is null)
+            {
+                stderrComplete.TrySetResult();
+                return;
+            }
+
+            if (String.IsNullOrEmpty(e.Data))
+            {
+                return;
+            }
+
+            processSpec.OnErrorData?.Invoke(e.Data);
+        };
 
         var processLifetimeTcs = new TaskCompletionSource<ProcessResult>();
 
@@ -106,20 +116,32 @@ internal static partial class ProcessUtil
             process.BeginErrorReadLine();
             processSpec.OnStart?.Invoke(process.Id);
 
-            process.WaitForExitAsync().ContinueWith(t =>
+            _ = Task.Run(async () =>
             {
                 startupComplete.Wait();
 
-                if (processSpec.ThrowOnNonZeroReturnCode && process.ExitCode != 0)
+                try
                 {
-                    processLifetimeTcs.TrySetException(new InvalidOperationException(
-                        $"Command {processSpec.ExecutablePath} {processSpec.Arguments} returned non-zero exit code {process.ExitCode}"));
+                    await process.WaitForExitAsync().ConfigureAwait(false);
+                    await Task.WhenAll(stdoutComplete.Task, stderrComplete.Task).ConfigureAwait(false);
+
+                    processSpec.OnStop?.Invoke(process.ExitCode);
+
+                    if (processSpec.ThrowOnNonZeroReturnCode && process.ExitCode != 0)
+                    {
+                        processLifetimeTcs.TrySetException(new InvalidOperationException(
+                            $"Command {processSpec.ExecutablePath} {processSpec.Arguments} returned non-zero exit code {process.ExitCode}"));
+                    }
+                    else
+                    {
+                        processLifetimeTcs.TrySetResult(new ProcessResult(process.ExitCode));
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    processLifetimeTcs.TrySetResult(new ProcessResult(process.ExitCode));
+                    processLifetimeTcs.TrySetException(ex);
                 }
-            }, TaskScheduler.Default);
+            });
         }
         finally
         {

--- a/src/Aspire.Hosting/Publishing/BuildOutputCapture.cs
+++ b/src/Aspire.Hosting/Publishing/BuildOutputCapture.cs
@@ -40,4 +40,44 @@ internal sealed class BuildOutputCapture(int maxRetainedLineCount = 256)
             return [.. _retainedLines];
         }
     }
+
+    /// <summary>
+    /// Returns the last <paramref name="maxLines"/> lines of output formatted for display.
+    /// </summary>
+    /// <param name="maxLines">The maximum number of lines to include.</param>
+    /// <param name="outputDescription">The label used when the output is truncated.</param>
+    /// <returns>The formatted output.</returns>
+    public string GetFormattedOutput(int maxLines = 50, string outputDescription = "Build output")
+    {
+        return FormatOutput(ToArray(), TotalLineCount, maxLines, outputDescription);
+    }
+
+    /// <summary>
+    /// Formats retained output lines for display.
+    /// </summary>
+    /// <param name="output">The retained output lines.</param>
+    /// <param name="totalLineCount">The total number of lines observed.</param>
+    /// <param name="maxLines">The maximum number of lines to include.</param>
+    /// <param name="outputDescription">The label used when the output is truncated.</param>
+    /// <returns>The formatted output.</returns>
+    internal static string FormatOutput(IReadOnlyList<string> output, int totalLineCount, int maxLines = 50, string outputDescription = "Build output")
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxLines);
+
+        if (output.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var linesShown = Math.Min(maxLines, output.Count);
+        IEnumerable<string> lines = output.Skip(output.Count - linesShown);
+        var formattedOutput = string.Join(Environment.NewLine, lines);
+
+        if (totalLineCount > linesShown)
+        {
+            return $"{outputDescription} truncated: showing last {linesShown} of {totalLineCount} lines.{Environment.NewLine}{formattedOutput}";
+        }
+
+        return formattedOutput;
+    }
 }

--- a/src/Aspire.Hosting/Publishing/BuildOutputCapture.cs
+++ b/src/Aspire.Hosting/Publishing/BuildOutputCapture.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Publishing;
+
+/// <summary>
+/// Retains a bounded tail of build output while tracking the total number of lines observed.
+/// </summary>
+internal sealed class BuildOutputCapture(int maxRetainedLineCount = 256)
+{
+    private readonly object _lock = new();
+    private readonly CircularBuffer<string> _retainedLines = new(maxRetainedLineCount);
+
+    /// <summary>
+    /// Gets the total number of stdout and stderr lines observed.
+    /// </summary>
+    public int TotalLineCount { get; private set; }
+
+    /// <summary>
+    /// Adds a line of build output to the retained tail.
+    /// </summary>
+    /// <param name="line">The output line.</param>
+    public void Add(string line)
+    {
+        lock (_lock)
+        {
+            TotalLineCount++;
+            _retainedLines.Add(line);
+        }
+    }
+
+    /// <summary>
+    /// Returns the retained output lines in order.
+    /// </summary>
+    /// <returns>The retained output lines.</returns>
+    public string[] ToArray()
+    {
+        lock (_lock)
+        {
+            return [.. _retainedLines];
+        }
+    }
+}

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -140,7 +140,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     /// <param name="exceptionMessageTemplate">Exception message template (must include {ExitCode} placeholder).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="logArguments">Arguments to pass to the log templates.</param>
-    private async Task ExecuteContainerCommandAsync(
+    protected async Task ExecuteContainerCommandAsync(
         string arguments,
         string errorLogTemplate,
         string successLogTemplate,
@@ -148,7 +148,8 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         CancellationToken cancellationToken,
         params object[] logArguments)
     {
-        var spec = CreateProcessSpec(arguments);
+        var outputBuffer = new BuildOutputCapture();
+        var spec = CreateProcessSpec(arguments, outputBuffer);
 
         _logger.LogDebug("Running {RuntimeName} with arguments: {ArgumentList}", Name, spec.Arguments);
         var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
@@ -163,7 +164,14 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
             {
                 var errorArgs = logArguments.Concat(new object[] { processResult.ExitCode }).ToArray();
                 _logger.LogError(errorLogTemplate, errorArgs);
-                throw new DistributedApplicationException(string.Format(System.Globalization.CultureInfo.InvariantCulture, exceptionMessageTemplate, processResult.ExitCode));
+
+                var message = string.Format(System.Globalization.CultureInfo.InvariantCulture, exceptionMessageTemplate, processResult.ExitCode);
+                if (outputBuffer.TotalLineCount > 0)
+                {
+                    message = $"{message}{Environment.NewLine}{outputBuffer.GetFormattedOutput(outputDescription: "Command output")}";
+                }
+
+                throw new DistributedApplicationException(message);
             }
 
             _logger.LogInformation(successLogTemplate, logArguments);
@@ -274,16 +282,6 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     protected static string BuildStageString(string? stage)
     {
         return !string.IsNullOrEmpty(stage) ? $" --target \"{stage}\"" : string.Empty;
-    }
-
-    /// <summary>
-    /// Creates a ProcessSpec for executing container runtime commands.
-    /// </summary>
-    /// <param name="arguments">The command arguments.</param>
-    /// <returns>A configured ProcessSpec instance.</returns>
-    private ProcessSpec CreateProcessSpec(string arguments)
-    {
-        return CreateProcessSpec(arguments, outputBuffer: null);
     }
 
     private ProcessSpec CreateProcessSpec(string arguments, BuildOutputCapture? outputBuffer)

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREPIPELINES003
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
@@ -179,6 +180,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="logArguments">Arguments to pass to the log templates.</param>
     /// <param name="environmentVariables">Optional environment variables to set for the process.</param>
+    /// <param name="outputBuffer">Optional buffer to collect stdout/stderr lines.</param>
     /// <returns>The exit code of the process.</returns>
     protected async Task<int> ExecuteContainerCommandWithExitCodeAsync(
         string arguments,
@@ -186,9 +188,10 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         string successLogTemplate,
         CancellationToken cancellationToken,
         object[] logArguments,
-        Dictionary<string, string>? environmentVariables = null)
+        Dictionary<string, string>? environmentVariables = null,
+        ConcurrentQueue<string>? outputBuffer = null)
     {
-        var spec = CreateProcessSpec(arguments);
+        var spec = CreateProcessSpec(arguments, outputBuffer);
 
         // Add environment variables if provided
         if (environmentVariables is not null)
@@ -281,16 +284,23 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     /// <returns>A configured ProcessSpec instance.</returns>
     private ProcessSpec CreateProcessSpec(string arguments)
     {
+        return CreateProcessSpec(arguments, outputBuffer: null);
+    }
+
+    private ProcessSpec CreateProcessSpec(string arguments, ConcurrentQueue<string>? outputBuffer)
+    {
         return new ProcessSpec(RuntimeExecutable)
         {
             Arguments = arguments,
             OnOutputData = output =>
             {
                 _logger.LogDebug("{RuntimeName} (stdout): {Output}", RuntimeExecutable, output);
+                outputBuffer?.Enqueue(output);
             },
             OnErrorData = error =>
             {
                 _logger.LogDebug("{RuntimeName} (stderr): {Error}", RuntimeExecutable, error);
+                outputBuffer?.Enqueue(error);
             },
             ThrowOnNonZeroReturnCode = false,
             InheritEnv = true

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -4,7 +4,6 @@
 #pragma warning disable ASPIREPIPELINES003
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
-using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
@@ -180,7 +179,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="logArguments">Arguments to pass to the log templates.</param>
     /// <param name="environmentVariables">Optional environment variables to set for the process.</param>
-    /// <param name="outputBuffer">Optional buffer to collect stdout/stderr lines.</param>
+    /// <param name="outputBuffer">Optional buffer to retain stdout/stderr lines.</param>
     /// <returns>The exit code of the process.</returns>
     protected async Task<int> ExecuteContainerCommandWithExitCodeAsync(
         string arguments,
@@ -189,7 +188,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         CancellationToken cancellationToken,
         object[] logArguments,
         Dictionary<string, string>? environmentVariables = null,
-        ConcurrentQueue<string>? outputBuffer = null)
+        BuildOutputCapture? outputBuffer = null)
     {
         var spec = CreateProcessSpec(arguments, outputBuffer);
 
@@ -287,7 +286,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         return CreateProcessSpec(arguments, outputBuffer: null);
     }
 
-    private ProcessSpec CreateProcessSpec(string arguments, ConcurrentQueue<string>? outputBuffer)
+    private ProcessSpec CreateProcessSpec(string arguments, BuildOutputCapture? outputBuffer)
     {
         return new ProcessSpec(RuntimeExecutable)
         {
@@ -295,12 +294,12 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
             OnOutputData = output =>
             {
                 _logger.LogDebug("{RuntimeName} (stdout): {Output}", RuntimeExecutable, output);
-                outputBuffer?.Enqueue(output);
+                outputBuffer?.Add(output);
             },
             OnErrorData = error =>
             {
                 _logger.LogDebug("{RuntimeName} (stderr): {Error}", RuntimeExecutable, error);
-                outputBuffer?.Enqueue(error);
+                outputBuffer?.Add(error);
             },
             ThrowOnNonZeroReturnCode = false,
             InheritEnv = true

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -4,7 +4,6 @@
 #pragma warning disable ASPIREPIPELINES003
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
-using System.Collections.Concurrent;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
 
@@ -97,7 +96,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
                 }
             }
 
-            var buildOutput = new ConcurrentQueue<string>();
+            var buildOutput = new BuildOutputCapture();
 
             var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
                 arguments,
@@ -110,7 +109,11 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
 
             if (exitCode != 0)
             {
-                throw new ProcessFailedException($"Docker build failed with exit code {exitCode}.", exitCode, buildOutput.ToArray());
+                throw new ProcessFailedException(
+                    $"Docker build failed with exit code {exitCode}.",
+                    exitCode,
+                    buildOutput.ToArray(),
+                    buildOutput.TotalLineCount);
             }
         }
         finally
@@ -191,7 +194,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
     private async Task CreateBuildkitInstanceAsync(string builderName, CancellationToken cancellationToken)
     {
         var arguments = $"buildx create --name \"{builderName}\" --driver docker-container";
-        var buildOutput = new ConcurrentQueue<string>();
+        var buildOutput = new BuildOutputCapture();
 
         var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
             arguments,
@@ -206,7 +209,8 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
             throw new ProcessFailedException(
                 $"Failed to create buildkit instance '{builderName}' with exit code {exitCode}.",
                 exitCode,
-                buildOutput.ToArray());
+                buildOutput.ToArray(),
+                buildOutput.TotalLineCount);
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -4,8 +4,8 @@
 #pragma warning disable ASPIREPIPELINES003
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
+using System.Collections.Concurrent;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Dcp.Process;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Publishing;
@@ -18,7 +18,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
 
     protected override string RuntimeExecutable => "docker";
     public override string Name => "Docker";
-    private async Task<int> RunDockerBuildAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
+    private async Task RunDockerBuildAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
     {
         var imageName = !string.IsNullOrEmpty(options?.Tag)
             ? $"{options.ImageName}:{options.Tag}"
@@ -37,13 +37,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
             }
 
             builderName = $"{resourceName}-builder";
-            var createBuilderResult = await CreateBuildkitInstanceAsync(builderName, cancellationToken).ConfigureAwait(false);
-
-            if (createBuilderResult != 0)
-            {
-                Logger.LogError("Failed to create buildkit instance {BuilderName} with exit code {ExitCode}.", builderName, createBuilderResult);
-                return createBuilderResult;
-            }
+            await CreateBuildkitInstanceAsync(builderName, cancellationToken).ConfigureAwait(false);
         }
 
         try
@@ -93,47 +87,30 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
 
             arguments += $" \"{contextPath}\"";
 
-            var spec = new ProcessSpec("docker")
-            {
-                Arguments = arguments,
-                OnOutputData = output =>
-                {
-                    Logger.LogDebug("docker buildx (stdout): {Output}", output);
-                },
-                OnErrorData = error =>
-                {
-                    Logger.LogDebug("docker buildx (stderr): {Error}", error);
-                },
-                ThrowOnNonZeroReturnCode = false,
-                InheritEnv = true,
-            };
-
-            // Add build secrets as environment variables (only for environment-type secrets)
+            // Prepare environment variables for build secrets
+            var environmentVariables = new Dictionary<string, string>();
             foreach (var buildSecret in buildSecrets)
             {
                 if (buildSecret.Value.Type == BuildImageSecretType.Environment && buildSecret.Value.Value is not null)
                 {
-                    spec.EnvironmentVariables[buildSecret.Key.ToUpperInvariant()] = buildSecret.Value.Value;
+                    environmentVariables[buildSecret.Key.ToUpperInvariant()] = buildSecret.Value.Value;
                 }
             }
 
-            Logger.LogDebug("Running Docker CLI with arguments: {ArgumentList}", spec.Arguments);
-            var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+            var buildOutput = new ConcurrentQueue<string>();
 
-            await using (processDisposable)
+            var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
+                arguments,
+                "Docker build for {ImageName} failed with exit code {ExitCode}.",
+                "Docker build for {ImageName} succeeded.",
+                cancellationToken,
+                new object[] { imageName },
+                environmentVariables,
+                buildOutput).ConfigureAwait(false);
+
+            if (exitCode != 0)
             {
-                var processResult = await pendingProcessResult
-                    .WaitAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (processResult.ExitCode != 0)
-                {
-                    Logger.LogError("docker buildx for {ImageName} failed with exit code {ExitCode}.", imageName, processResult.ExitCode);
-                    return processResult.ExitCode;
-                }
-
-                Logger.LogInformation("docker buildx for {ImageName} succeeded.", imageName);
-                return processResult.ExitCode;
+                throw new ProcessFailedException($"Docker build failed with exit code {exitCode}.", exitCode, buildOutput.ToArray());
             }
         }
         finally
@@ -151,7 +128,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
         // Normalize the context path to handle trailing slashes and relative paths
         var normalizedContextPath = Path.GetFullPath(contextPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
-        var exitCode = await RunDockerBuildAsync(
+        await RunDockerBuildAsync(
             normalizedContextPath,
             dockerfilePath,
             options,
@@ -159,11 +136,6 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
             buildSecrets,
             stage,
             cancellationToken).ConfigureAwait(false);
-
-        if (exitCode != 0)
-        {
-            throw new DistributedApplicationException($"Docker build failed with exit code {exitCode}.");
-        }
     }
 
     public override async Task<bool> CheckIfRunningAsync(CancellationToken cancellationToken)
@@ -216,16 +188,26 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
         }
     }
 
-    private async Task<int> CreateBuildkitInstanceAsync(string builderName, CancellationToken cancellationToken)
+    private async Task CreateBuildkitInstanceAsync(string builderName, CancellationToken cancellationToken)
     {
         var arguments = $"buildx create --name \"{builderName}\" --driver docker-container";
+        var buildOutput = new ConcurrentQueue<string>();
 
-        return await ExecuteContainerCommandWithExitCodeAsync(
+        var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
             arguments,
             "Failed to create buildkit instance {BuilderName} with exit code {ExitCode}.",
             "Successfully created buildkit instance {BuilderName}.",
             cancellationToken,
-            new object[] { builderName }).ConfigureAwait(false);
+            new object[] { builderName },
+            outputBuffer: buildOutput).ConfigureAwait(false);
+
+        if (exitCode != 0)
+        {
+            throw new ProcessFailedException(
+                $"Failed to create buildkit instance '{builderName}' with exit code {exitCode}.",
+                exitCode,
+                buildOutput.ToArray());
+        }
     }
 
     private async Task<int> RemoveBuildkitInstanceAsync(string builderName, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREPIPELINES003
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.Dcp.Process;
@@ -140,7 +141,7 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
             Publishers = g.Value
         }).ToList();
     }
-    private async Task<int> RunPodmanBuildAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
+    private async Task RunPodmanBuildAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
     {
         var imageName = !string.IsNullOrEmpty(options?.Tag)
             ? $"{options.ImageName}:{options.Tag}"
@@ -195,18 +196,26 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
             }
         }
 
-        return await ExecuteContainerCommandWithExitCodeAsync(
+        var buildOutput = new ConcurrentQueue<string>();
+
+        var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
             arguments,
             "Podman build for {ImageName} failed with exit code {ExitCode}.",
             "Podman build for {ImageName} succeeded.",
             cancellationToken,
             new object[] { imageName },
-            environmentVariables).ConfigureAwait(false);
+            environmentVariables,
+            buildOutput).ConfigureAwait(false);
+
+        if (exitCode != 0)
+        {
+            throw new ProcessFailedException($"Podman build failed with exit code {exitCode}.", exitCode, buildOutput.ToArray());
+        }
     }
 
     public override async Task BuildImageAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
     {
-        var exitCode = await RunPodmanBuildAsync(
+        await RunPodmanBuildAsync(
             contextPath,
             dockerfilePath,
             options,
@@ -214,11 +223,6 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
             buildSecrets,
             stage,
             cancellationToken).ConfigureAwait(false);
-
-        if (exitCode != 0)
-        {
-            throw new DistributedApplicationException($"Podman build failed with exit code {exitCode}.");
-        }
     }
 
     public override async Task<bool> CheckIfRunningAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -4,7 +4,6 @@
 #pragma warning disable ASPIREPIPELINES003
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
-using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.Dcp.Process;
@@ -196,7 +195,7 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
             }
         }
 
-        var buildOutput = new ConcurrentQueue<string>();
+        var buildOutput = new BuildOutputCapture();
 
         var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
             arguments,
@@ -209,7 +208,11 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
 
         if (exitCode != 0)
         {
-            throw new ProcessFailedException($"Podman build failed with exit code {exitCode}.", exitCode, buildOutput.ToArray());
+            throw new ProcessFailedException(
+                $"Podman build failed with exit code {exitCode}.",
+                exitCode,
+                buildOutput.ToArray(),
+                buildOutput.TotalLineCount);
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/ProcessFailedException.cs
+++ b/src/Aspire.Hosting/Publishing/ProcessFailedException.cs
@@ -48,22 +48,6 @@ internal sealed class ProcessFailedException : DistributedApplicationException
     /// </summary>
     public string GetFormattedOutput(int maxLines = 50)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxLines);
-
-        if (BuildOutput.Count == 0)
-        {
-            return string.Empty;
-        }
-
-        var linesShown = Math.Min(maxLines, BuildOutput.Count);
-        IEnumerable<string> lines = BuildOutput.Skip(BuildOutput.Count - linesShown);
-        var formattedOutput = string.Join(Environment.NewLine, lines);
-
-        if (TotalBuildOutputLineCount > linesShown)
-        {
-            return $"Build output truncated: showing last {linesShown} of {TotalBuildOutputLineCount} lines.{Environment.NewLine}{formattedOutput}";
-        }
-
-        return formattedOutput;
+        return BuildOutputCapture.FormatOutput(BuildOutput, TotalBuildOutputLineCount, maxLines);
     }
 }

--- a/src/Aspire.Hosting/Publishing/ProcessFailedException.cs
+++ b/src/Aspire.Hosting/Publishing/ProcessFailedException.cs
@@ -6,19 +6,21 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Exception thrown when a container image build or dotnet publish operation fails.
 /// </summary>
-internal sealed class ProcessFailedException : Exception
+internal sealed class ProcessFailedException : DistributedApplicationException
 {
     /// <summary>
     /// Initializes a new instance of <see cref="ProcessFailedException"/>.
     /// </summary>
     /// <param name="message">A summary of the failure (e.g., "Docker build failed with exit code 1.").</param>
     /// <param name="exitCode">The process exit code.</param>
-    /// <param name="buildOutput">The captured stdout/stderr lines from the build process.</param>
-    public ProcessFailedException(string message, int exitCode, IReadOnlyList<string> buildOutput)
+    /// <param name="buildOutput">The retained stdout/stderr lines from the build process.</param>
+    /// <param name="totalBuildOutputLineCount">The total number of stdout/stderr lines observed.</param>
+    public ProcessFailedException(string message, int exitCode, IReadOnlyList<string> buildOutput, int? totalBuildOutputLineCount = null)
         : base(message)
     {
         ExitCode = exitCode;
         BuildOutput = buildOutput;
+        TotalBuildOutputLineCount = totalBuildOutputLineCount ?? buildOutput.Count;
     }
 
     /// <summary>
@@ -27,9 +29,14 @@ internal sealed class ProcessFailedException : Exception
     public int ExitCode { get; }
 
     /// <summary>
-    /// The captured stdout/stderr lines from the build process.
+    /// The retained stdout/stderr lines from the build process.
     /// </summary>
     public IReadOnlyList<string> BuildOutput { get; }
+
+    /// <summary>
+    /// The total number of stdout/stderr lines observed for the failed process.
+    /// </summary>
+    public int TotalBuildOutputLineCount { get; }
 
     /// <inheritdoc/>
     public override string Message => BuildOutput.Count > 0
@@ -41,15 +48,22 @@ internal sealed class ProcessFailedException : Exception
     /// </summary>
     public string GetFormattedOutput(int maxLines = 50)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxLines);
+
         if (BuildOutput.Count == 0)
         {
             return string.Empty;
         }
 
-        IEnumerable<string> lines = BuildOutput.Count > maxLines
-            ? BuildOutput.Skip(BuildOutput.Count - maxLines)
-            : BuildOutput;
+        var linesShown = Math.Min(maxLines, BuildOutput.Count);
+        IEnumerable<string> lines = BuildOutput.Skip(BuildOutput.Count - linesShown);
+        var formattedOutput = string.Join(Environment.NewLine, lines);
 
-        return string.Join(Environment.NewLine, lines);
+        if (TotalBuildOutputLineCount > linesShown)
+        {
+            return $"Build output truncated: showing last {linesShown} of {TotalBuildOutputLineCount} lines.{Environment.NewLine}{formattedOutput}";
+        }
+
+        return formattedOutput;
     }
 }

--- a/src/Aspire.Hosting/Publishing/ProcessFailedException.cs
+++ b/src/Aspire.Hosting/Publishing/ProcessFailedException.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Publishing;
+
+/// <summary>
+/// Exception thrown when a container image build or dotnet publish operation fails.
+/// </summary>
+internal sealed class ProcessFailedException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ProcessFailedException"/>.
+    /// </summary>
+    /// <param name="message">A summary of the failure (e.g., "Docker build failed with exit code 1.").</param>
+    /// <param name="exitCode">The process exit code.</param>
+    /// <param name="buildOutput">The captured stdout/stderr lines from the build process.</param>
+    public ProcessFailedException(string message, int exitCode, IReadOnlyList<string> buildOutput)
+        : base(message)
+    {
+        ExitCode = exitCode;
+        BuildOutput = buildOutput;
+    }
+
+    /// <summary>
+    /// The process exit code.
+    /// </summary>
+    public int ExitCode { get; }
+
+    /// <summary>
+    /// The captured stdout/stderr lines from the build process.
+    /// </summary>
+    public IReadOnlyList<string> BuildOutput { get; }
+
+    /// <inheritdoc/>
+    public override string Message => BuildOutput.Count > 0
+        ? $"{base.Message}{Environment.NewLine}{GetFormattedOutput()}"
+        : base.Message;
+
+    /// <summary>
+    /// Returns the last <paramref name="maxLines"/> lines of build output formatted for display.
+    /// </summary>
+    public string GetFormattedOutput(int maxLines = 50)
+    {
+        if (BuildOutput.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        IEnumerable<string> lines = BuildOutput.Count > maxLines
+            ? BuildOutput.Skip(BuildOutput.Count - maxLines)
+            : BuildOutput;
+
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -412,7 +412,7 @@ internal sealed class ResourceContainerImageManager(
             if (processResult.ExitCode != 0)
             {
                 throw new ProcessFailedException(
-                    $"dotnet publish for project '{projectMetadata.ProjectPath}' failed with exit code {processResult.ExitCode}.",
+                    $"Failed to build container image for resource '{resource.Name}' from project '{projectMetadata.ProjectPath}' with exit code {processResult.ExitCode}.",
                     processResult.ExitCode,
                     buildOutput.ToArray(),
                     buildOutput.TotalLineCount);

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -5,7 +5,6 @@
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
@@ -379,7 +378,7 @@ internal sealed class ResourceContainerImageManager(
         }
 #pragma warning restore ASPIREDOCKERFILEBUILDER001
 
-        var buildOutput = new ConcurrentQueue<string>();
+        var buildOutput = new BuildOutputCapture();
 
         var spec = new ProcessSpec("dotnet")
         {
@@ -388,12 +387,12 @@ internal sealed class ResourceContainerImageManager(
             OnOutputData = output =>
             {
                 logger.LogDebug("dotnet publish {ProjectPath} (stdout): {Output}", projectMetadata.ProjectPath, output);
-                buildOutput.Enqueue(output);
+                buildOutput.Add(output);
             },
             OnErrorData = error =>
             {
                 logger.LogDebug("dotnet publish {ProjectPath} (stderr): {Error}", projectMetadata.ProjectPath, error);
-                buildOutput.Enqueue(error);
+                buildOutput.Add(error);
             }
         };
 
@@ -412,7 +411,11 @@ internal sealed class ResourceContainerImageManager(
 
             if (processResult.ExitCode != 0)
             {
-                throw new ProcessFailedException($"dotnet publish for project '{projectMetadata.ProjectPath}' failed with exit code {processResult.ExitCode}.", processResult.ExitCode, buildOutput.ToArray());
+                throw new ProcessFailedException(
+                    $"dotnet publish for project '{projectMetadata.ProjectPath}' failed with exit code {processResult.ExitCode}.",
+                    processResult.ExitCode,
+                    buildOutput.ToArray(),
+                    buildOutput.TotalLineCount);
             }
             else
             {

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
@@ -304,17 +305,9 @@ internal sealed class ResourceContainerImageManager(
 
             logger.LogInformation("Building image: {ResourceName}", resource.Name);
 
-            var success = await ExecuteDotnetPublishAsync(resource, options, cancellationToken).ConfigureAwait(false);
+            await ExecuteDotnetPublishAsync(resource, options, cancellationToken).ConfigureAwait(false);
 
-            if (!success)
-            {
-                logger.LogError("Building image for {ResourceName} failed", resource.Name);
-                throw new DistributedApplicationException($"Failed to build container image for resource '{resource.Name}'.");
-            }
-            else
-            {
-                logger.LogInformation("Building image for {ResourceName} completed", resource.Name);
-            }
+            logger.LogInformation("Building image for {ResourceName} completed", resource.Name);
         }
         finally
         {
@@ -322,7 +315,7 @@ internal sealed class ResourceContainerImageManager(
         }
     }
 
-    private async Task<bool> ExecuteDotnetPublishAsync(IResource resource, ResolvedContainerBuildOptions options, CancellationToken cancellationToken)
+    private async Task ExecuteDotnetPublishAsync(IResource resource, ResolvedContainerBuildOptions options, CancellationToken cancellationToken)
     {
         // This is a resource project so we'll use the .NET SDK to build the container image.
         if (!resource.TryGetLastAnnotation<IProjectMetadata>(out var projectMetadata))
@@ -378,16 +371,21 @@ internal sealed class ResourceContainerImageManager(
         }
 #pragma warning restore ASPIREDOCKERFILEBUILDER001
 
+        var buildOutput = new ConcurrentQueue<string>();
+
         var spec = new ProcessSpec("dotnet")
         {
             Arguments = arguments,
+            ThrowOnNonZeroReturnCode = false,
             OnOutputData = output =>
             {
                 logger.LogDebug("dotnet publish {ProjectPath} (stdout): {Output}", projectMetadata.ProjectPath, output);
+                buildOutput.Enqueue(output);
             },
             OnErrorData = error =>
             {
                 logger.LogDebug("dotnet publish {ProjectPath} (stderr): {Error}", projectMetadata.ProjectPath, error);
+                buildOutput.Enqueue(error);
             }
         };
 
@@ -406,15 +404,13 @@ internal sealed class ResourceContainerImageManager(
 
             if (processResult.ExitCode != 0)
             {
-                logger.LogError("dotnet publish for project {ProjectPath} failed with exit code {ExitCode}.", projectMetadata.ProjectPath, processResult.ExitCode);
-                return false;
+                throw new ProcessFailedException($"dotnet publish for project '{projectMetadata.ProjectPath}' failed with exit code {processResult.ExitCode}.", processResult.ExitCode, buildOutput.ToArray());
             }
             else
             {
                 logger.LogDebug(
                     ".NET CLI completed with exit code: {ExitCode}",
                     processResult.ExitCode);
-                return true;
             }
         }
     }

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -302,12 +302,20 @@ internal sealed class ResourceContainerImageManager(
 
         try
         {
-
             logger.LogInformation("Building image: {ResourceName}", resource.Name);
 
             await ExecuteDotnetPublishAsync(resource, options, cancellationToken).ConfigureAwait(false);
 
             logger.LogInformation("Building image for {ResourceName} completed", resource.Name);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Building image for {ResourceName} failed", resource.Name);
+            throw;
         }
         finally
         {

--- a/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dcp.Process;
+
+namespace Aspire.Hosting.Tests.Dcp;
+
+[Trait("Partition", "4")]
+public class ProcessUtilTests
+{
+    [Fact]
+    public async Task Run_WaitsForOutputCallbacksToFinishBeforeCompleting()
+    {
+        var callbackStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var spec = CreateSingleLineOutputProcessSpec(output =>
+        {
+            Assert.Equal("final-line", output);
+            callbackStarted.TrySetResult();
+            releaseCallback.Task.GetAwaiter().GetResult();
+        });
+
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+
+        await using (processDisposable)
+        {
+            await callbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await Task.Delay(200);
+
+            Assert.False(pendingProcessResult.IsCompleted);
+
+            releaseCallback.TrySetResult();
+
+            var result = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(0, result.ExitCode);
+        }
+    }
+
+    private static ProcessSpec CreateSingleLineOutputProcessSpec(Action<string> onOutputData)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return new ProcessSpec("cmd")
+            {
+                Arguments = "/c echo final-line",
+                OnOutputData = onOutputData,
+                ThrowOnNonZeroReturnCode = false
+            };
+        }
+
+        return new ProcessSpec("sh")
+        {
+            Arguments = "-c \"echo final-line\"",
+            OnOutputData = onOutputData,
+            ThrowOnNonZeroReturnCode = false
+        };
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -11,6 +11,7 @@
 
 using Aspire.Hosting.Backchannel;
 using Aspire.Hosting.Pipelines;
+using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Publishing;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -872,6 +873,28 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         Assert.NotNull(reporter);
         Assert.Contains("failing-step", reporter.CreatedSteps);
         Assert.Contains(reporter.CompletedSteps, step => step.StepTitle == "failing-step" && step.CompletionState == CompletionState.CompletedWithError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenStepThrowsProcessFailedException_RethrowsWithoutWrapping()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: null).WithTestAndResourceLogging(testOutputHelper);
+
+        builder.Services.AddSingleton(testOutputHelper);
+        builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
+
+        var pipeline = new DistributedApplicationPipeline();
+        var expected = new ProcessFailedException("Docker build failed with exit code 1.", 1, ["output-001"]);
+
+        pipeline.AddStep("failing-step", _ => Task.FromException(expected));
+
+        var context = CreateDeployingContext(builder.Build());
+
+        var exception = await Assert.ThrowsAsync<ProcessFailedException>(() => pipeline.ExecuteAsync(context)).DefaultTimeout();
+
+        Assert.Same(expected, exception);
+        Assert.DoesNotContain("Step 'failing-step' failed:", exception.Message);
+        Assert.Contains("output-001", exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPIPELINES003
+#pragma warning disable ASPIRECONTAINERRUNTIME001
+
+using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.Tests.Publishing;
+
+[Trait("Partition", "4")]
+public class ContainerRuntimeBaseTests
+{
+    [Fact]
+    public async Task ExecuteContainerCommandAsync_IncludesCapturedOutputInFailureMessage()
+    {
+        var runtime = new TestContainerRuntime();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+            runtime.RunFailingCommandAsync()).WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.Contains("Test command failed with exit code 1.", exception.Message);
+        Assert.Contains("stdout-final-line", exception.Message);
+        Assert.Contains("stderr-final-line", exception.Message);
+    }
+
+    private sealed class TestContainerRuntime() : ContainerRuntimeBase<TestContainerRuntime>(NullLogger<TestContainerRuntime>.Instance)
+    {
+        protected override string RuntimeExecutable => OperatingSystem.IsWindows() ? "cmd" : "sh";
+
+        public override string Name => "test-runtime";
+
+        public override Task<bool> CheckIfRunningAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+
+        public override Task BuildImageAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task RunFailingCommandAsync(CancellationToken cancellationToken = default)
+        {
+            return ExecuteContainerCommandAsync(
+                OperatingSystem.IsWindows()
+                    ? "/c \"echo stdout-final-line & echo stderr-final-line 1>&2 & exit /b 1\""
+                    : "-c \"echo stdout-final-line; echo stderr-final-line 1>&2; exit 1\"",
+                "Test command failed with exit code {ExitCode}.",
+                "Test command succeeded.",
+                "Test command failed with exit code {0}.",
+                cancellationToken);
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Publishing/ProcessFailedExceptionTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ProcessFailedExceptionTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Publishing;
+
+namespace Aspire.Hosting.Tests.Publishing;
+
+[Trait("Partition", "4")]
+public class ProcessFailedExceptionTests
+{
+    [Fact]
+    public void Message_IncludesTruncationSummary_WhenOutputExceedsDefaultLimit()
+    {
+        var buildOutput = Enumerable.Range(1, 60)
+            .Select(i => $"output-{i:000}")
+            .ToArray();
+
+        var exception = new ProcessFailedException("Build failed.", 1, buildOutput, totalBuildOutputLineCount: 60);
+
+        Assert.Contains("Build failed.", exception.Message);
+        Assert.Contains("Build output truncated: showing last 50 of 60 lines.", exception.Message);
+        Assert.DoesNotContain("output-001", exception.Message);
+        Assert.Contains("output-011", exception.Message);
+        Assert.Contains("output-060", exception.Message);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -663,6 +663,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var exception = await Assert.ThrowsAsync<ProcessFailedException>(() =>
             imageBuilder.BuildImageAsync(project.Resource, cts.Token));
 
+        Assert.Contains("broken-project", exception.Message);
         Assert.Contains("missing.csproj", exception.Message);
         Assert.NotEqual(0, exception.ExitCode);
     }

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -660,10 +660,11 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         using var cts = new CancellationTokenSource(TestConstants.DefaultTimeoutTimeSpan);
         var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageManager>();
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var exception = await Assert.ThrowsAsync<ProcessFailedException>(() =>
             imageBuilder.BuildImageAsync(project.Resource, cts.Token));
 
-        Assert.Contains("broken-project", exception.Message);
+        Assert.Contains("missing.csproj", exception.Message);
+        Assert.NotEqual(0, exception.ExitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -1453,7 +1453,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         using var tempDir = new TestTempDirectory();
         var dockerfilePath = Path.Combine(tempDir.Path, "Dockerfile");
         await File.WriteAllTextAsync(dockerfilePath, """
-            FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+            FROM scratch
             COPY nonexistent-file-12345.txt /app/
             """);
 

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -1436,6 +1436,40 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         // Verify CheckIfRunningAsync was called
         Assert.Equal(1, fakeContainerRuntime.CheckIfRunningCallCount);
     }
+
+    [Fact]
+    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    public async Task DockerBuildFailureIncludesBuildOutputInException()
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
+
+        builder.Services.AddLogging(logging =>
+        {
+            logging.AddXunit(output);
+        });
+
+        // Create a Dockerfile that will fail — references a nonexistent file
+        var tempDir = new TestTempDirectory();
+        var dockerfilePath = Path.Combine(tempDir.Path, "Dockerfile");
+        await File.WriteAllTextAsync(dockerfilePath, """
+            FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+            COPY nonexistent-file-12345.txt /app/
+            """);
+
+        var container = builder.AddDockerfile("broken-container", tempDir.Path, dockerfilePath);
+
+        using var app = builder.Build();
+
+        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
+        var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageManager>();
+
+        var ex = await Assert.ThrowsAsync<ProcessFailedException>(
+            () => imageBuilder.BuildImageAsync(container.Resource, cts.Token));
+
+        Assert.NotEqual(0, ex.ExitCode);
+        Assert.NotEmpty(ex.BuildOutput);
+        Assert.Contains(ex.BuildOutput, line => line.Contains("nonexistent-file-12345.txt"));
+    }
 }
 
 file sealed class TestProjectMetadata(string projectPath) : IProjectMetadata

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -1449,7 +1449,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         });
 
         // Create a Dockerfile that will fail — references a nonexistent file
-        var tempDir = new TestTempDirectory();
+        using var tempDir = new TestTempDirectory();
         var dockerfilePath = Path.Combine(tempDir.Path, "Dockerfile");
         await File.WriteAllTextAsync(dockerfilePath, """
             FROM mcr.microsoft.com/cbl-mariner/base/core:2.0


### PR DESCRIPTION
## Description

Surface build output on failure for Docker, Podman, and dotnet publish container builds.

### Problem
When a container image build fails, users see only:
```
Docker build failed with exit code 1.
```
The actual build output (compiler errors, missing files, Dockerfile issues) is logged at Debug level only. Users have to re-run with `--log-level debug` to see what went wrong.

### Solution
Introduce `ProcessFailedException` that captures stdout/stderr from failed build processes. The exception's `Message` property includes the last 50 lines of output so it surfaces through the pipeline step reporter automatically.

### Changes
- **`ProcessFailedException`** — new internal exception type with `ExitCode`, `BuildOutput` (raw lines), and `GetFormattedOutput()`. `Message` is overridden to include formatted output.
- **Docker buildx** — deduped to use base class `ExecuteContainerCommandWithExitCodeAsync`, throws `ProcessFailedException` with captured output
- **Podman build** — throws `ProcessFailedException` with captured output
- **dotnet publish /t:PublishContainer** — throws `ProcessFailedException` with captured output
- **Buildkit instance creation** — also throws `ProcessFailedException`
- Uses `ConcurrentQueue<string>` for thread-safe output buffering (callbacks fire on different threads)
- Integration test for Docker build failure verifying exception carries output

### Before
```
(build-myapi) ✗ Docker build failed with exit code 1.
```

### After
```
(build-myapi) ✗ Docker build failed with exit code 1.
  #8 [builder 4/5] COPY nonexistent-file.txt /app/
  #8 ERROR: "/nonexistent-file.txt": not found
  Dockerfile:4
  >>> COPY nonexistent-file.txt /app/
  ERROR: failed to build: failed to compute cache key
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
