### PR TITLE
Fix language dropdown arrow-key behavior and duplicate zh-CN entry in dashboard settings

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html lang="en">
+<html lang="@System.Globalization.CultureInfo.CurrentUICulture.Name">
 
 <head>
     <meta charset="utf-8" />

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -19,10 +19,11 @@
         <div class="input-container">
             <FluentSelect
                 TOption="CultureInfo"
-                Immediate="true"
+                ChangeOnEnterOnly="true"
                 Position="SelectPosition.Below"
                 Label="@Loc[nameof(Dialogs.SettingsDialogLanguage)]"
                 Items="@_languageOptions"
+                OptionValue="@(c => c!.Name)"
                 OptionText="@(c => c!.NativeName.Humanize())"
                 ValueChanged="@ValueChanged"
                 @bind-SelectedOption="@_selectedUiCulture"

--- a/src/Shared/LocaleHelpers.cs
+++ b/src/Shared/LocaleHelpers.cs
@@ -9,6 +9,8 @@ namespace Aspire.Shared;
 
 internal static class LocaleHelpers
 {
+    private const int MaxCultureParentDepth = 5;
+
     // our localization list comes from https://github.com/dotnet/arcade/blob/89008f339a79931cc49c739e9dbc1a27c608b379/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props#L22
     public static readonly string[] SupportedLocales = ["en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant"];
 
@@ -54,7 +56,7 @@ internal static class LocaleHelpers
         // For example, zh-CN's parent is zh-Hans which is supported.
         var current = cultureInfo.Parent;
         var depth = 0;
-        while (current != CultureInfo.InvariantCulture && depth < 5)
+        while (current != CultureInfo.InvariantCulture && current != current.Parent && depth < MaxCultureParentDepth)
         {
             if (SupportedLocales.Contains(current.Name))
             {

--- a/src/Shared/LocaleHelpers.cs
+++ b/src/Shared/LocaleHelpers.cs
@@ -10,7 +10,7 @@ namespace Aspire.Shared;
 internal static class LocaleHelpers
 {
     // our localization list comes from https://github.com/dotnet/arcade/blob/89008f339a79931cc49c739e9dbc1a27c608b379/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props#L22
-    public static readonly string[] SupportedLocales = ["en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-Hans", "zh-Hant"];
+    public static readonly string[] SupportedLocales = ["en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant"];
 
     public static SetLocaleResult TrySetLocaleOverride(string localeOverride)
     {
@@ -24,8 +24,7 @@ internal static class LocaleHelpers
         try
         {
             var cultureInfo = new CultureInfo(localeOverride);
-            if (SupportedLocales.Contains(cultureInfo.Name) ||
-                SupportedLocales.Contains(cultureInfo.TwoLetterISOLanguageName))
+            if (IsSupportedCulture(cultureInfo))
             {
                 CultureInfo.CurrentUICulture = cultureInfo;
                 CultureInfo.CurrentCulture = cultureInfo;
@@ -40,6 +39,32 @@ internal static class LocaleHelpers
         {
             return SetLocaleResult.InvalidLocale;
         }
+    }
+
+    private static bool IsSupportedCulture(CultureInfo cultureInfo)
+    {
+        // Check exact name and two-letter ISO language name first.
+        if (SupportedLocales.Contains(cultureInfo.Name) ||
+            SupportedLocales.Contains(cultureInfo.TwoLetterISOLanguageName))
+        {
+            return true;
+        }
+
+        // Walk the parent chain to find a supported culture.
+        // For example, zh-CN's parent is zh-Hans which is supported.
+        var current = cultureInfo.Parent;
+        var depth = 0;
+        while (current != CultureInfo.InvariantCulture && depth < 5)
+        {
+            if (SupportedLocales.Contains(current.Name))
+            {
+                return true;
+            }
+            current = current.Parent;
+            depth++;
+        }
+
+        return false;
     }
 
     private static bool IsKnownCulture(string cultureName)

--- a/tests/Aspire.Dashboard.Tests/GlobalizationHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/GlobalizationHelpersTests.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Aspire.Dashboard.Utils;
+using Humanizer;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests;
@@ -28,6 +29,16 @@ public class GlobalizationHelpersTests
         Assert.Contains("en-GB", supportedCultures);
         Assert.Contains("fr-CA", supportedCultures);
         Assert.Contains("zh-CN", supportedCultures);
+    }
+
+    [Fact]
+    public void OrderedLocalizedCultures_HasUniqueDisplayNames()
+    {
+        var displayNames = GlobalizationHelpers.OrderedLocalizedCultures
+            .Select(c => c.NativeName.Humanize())
+            .ToList();
+
+        Assert.Equal(displayNames.Count, displayNames.Distinct().Count());
     }
 
     [Theory]
@@ -71,6 +82,8 @@ public class GlobalizationHelpersTests
     [InlineData("en", "en-XX", "en")]
     [InlineData("de", "en-US", null)]
     [InlineData("zh-Hans", "en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7", "zh-CN")]
+    [InlineData("zh-Hans", "zh-CN", "zh-CN")]
+    [InlineData("zh-Hans", "zh-CN,zh;q=0.9", "zh-CN")]
     public async Task ResolveSetCultureToAcceptedCultureAsync_MatchRequestToResult(string requestedLanguage, string acceptLanguage, string? result)
     {
         // Arrange


### PR DESCRIPTION
## Description

Fixes the language dropdown in the dashboard settings and zh-CN locale handling.

### Changes

- **Fix dropdown arrow-key behavior**: Replace `Immediate="true"` with `ChangeOnEnterOnly="true"` on the language `FluentSelect` so that arrow-key navigation no longer immediately commits the language change and closes the settings dialog. Users can now browse languages with arrow keys and confirm with Enter/Space/Escape.
- **Remove duplicate zh-CN entry**: Remove `zh-CN` from `SupportedLocales` since it's a child culture of `zh-Hans` (which is already listed). This eliminates the duplicate "中文 中国" option in the language dropdown.
- **Add `OptionValue` binding**: Add `OptionValue="@(c => c!.Name)"` to the `FluentSelect` to ensure correct value matching by culture name.
- **Walk parent culture chain**: Add `IsSupportedCulture` method that walks the culture parent chain so `zh-CN` (and similar regional variants) are still recognized as supported via their parent `zh-Hans`.
- **Set dynamic `lang` attribute**: Change `<html lang="en">` to `<html lang="@System.Globalization.CultureInfo.CurrentUICulture.Name">` so the HTML lang attribute reflects the actual UI culture.
- **Add tests**: New tests for unique display names, zh-CN resolution, and Accept-Language header matching.

<img width="1280" height="900" alt="language-dropdown-open" src="https://github.com/user-attachments/assets/852e28a6-9424-4f41-9892-01a500310069" />

https://github.com/user-attachments/assets/f99df93c-aeeb-4056-8497-94e36b58dd03


Fixes #12479
Fixes #15897