### PR TITLE
Add CliInstallStrategy for local E2E testing and daily smoke tests

### DIFF
--- a/.github/skills/cli-e2e-testing/SKILL.md
+++ b/.github/skills/cli-e2e-testing/SKILL.md
@@ -68,6 +68,113 @@ public sealed class SmokeTests(ITestOutputHelper output)
 }
 ```
 
+## Running Tests Locally
+
+CLI E2E tests run inside Docker containers on Linux. The workflow is: build a portable archive with `localhive`, then point the tests at it. This is the primary way to iterate on E2E tests during development.
+
+### Prerequisites
+
+- Docker Desktop running (with Linux containers)
+- .NET 10 SDK (installed via `./restore.sh` or `.\restore.cmd`)
+
+### Quick Start (macOS / Linux)
+
+```bash
+# 1. Build a portable archive with CLI + packages + bundle
+#    Use linux-arm64 on Apple Silicon, linux-x64 on Intel/Linux
+./localhive.sh -o /tmp/aspire-e2e -r linux-arm64 --archive
+
+# 2. Run a specific test
+ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e.tar.gz \
+  dotnet test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
+  -- --filter-method "*.CreateAndRunAspireStarterProject"
+
+# 3. Run all tests in a class
+ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e.tar.gz \
+  dotnet test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
+  -- --filter-class "*.SmokeTests"
+```
+
+### Quick Start (Windows / PowerShell)
+
+```powershell
+# 1. Build a portable archive (Docker Desktop uses linux-x64 via WSL2)
+.\localhive.ps1 -o C:\tmp\aspire-e2e -r linux-x64 -Archive
+
+# 2. Run a specific test
+$env:ASPIRE_E2E_ARCHIVE = "C:\tmp\aspire-e2e.tar.gz"
+dotnet test tests\Aspire.Cli.EndToEnd.Tests\Aspire.Cli.EndToEnd.Tests.csproj `
+  -- --filter-method "*.CreateAndRunAspireStarterProject"
+
+# 3. Run all tests in a class
+dotnet test tests\Aspire.Cli.EndToEnd.Tests\Aspire.Cli.EndToEnd.Tests.csproj `
+  -- --filter-class "*.SmokeTests"
+```
+
+### Choosing the Right RID
+
+The archive must match the Docker container's architecture:
+
+| Host | Docker Desktop | RID |
+|------|---------------|-----|
+| Apple Silicon Mac | Linux arm64 containers | `linux-arm64` |
+| Intel Mac | Linux x64 containers | `linux-x64` |
+| Windows (any) | WSL2 Linux x64 | `linux-x64` |
+| Linux x64 | Native | `linux-x64` |
+| Linux arm64 | Native | `linux-arm64` |
+
+### Development Workflow
+
+The typical loop when writing or debugging E2E tests:
+
+```bash
+# 1. Make your code changes (CLI, hosting, templates, etc.)
+
+# 2. Rebuild the archive (picks up all changes — ~3 min)
+./localhive.sh -o /tmp/aspire-e2e -r linux-arm64 --archive
+
+# 3. Run the specific test you're working on
+ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e.tar.gz \
+  dotnet test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
+  -- --filter-method "*.YourTestName"
+
+# 4. If it fails, check the asciinema recording
+#    Recordings are saved to $TMPDIR/aspire-cli-e2e/recordings/
+#    Play with: asciinema play /path/to/YourTestName.cast
+
+# 5. Fix and repeat from step 1 or 2
+```
+
+### Install Modes
+
+The `CliInstallStrategy` class auto-detects how to install the CLI in the test container. You can override via environment variables:
+
+| Env Var | Mode | Example |
+|---------|------|---------|
+| `ASPIRE_E2E_ARCHIVE` | LocalHive — extract archive into container | `/tmp/aspire-e2e.tar.gz` |
+| `ASPIRE_E2E_QUALITY` | Install script with quality | `dev`, `staging`, `release` |
+| `ASPIRE_E2E_VERSION` | Install script with version | `13.2.1` |
+| *(none, in CI)* | PullRequest — install from PR artifacts | Auto-detected |
+| *(none, locally)* | SourceBuild or GA fallback | Auto-detected |
+
+**LocalHive** (via `ASPIRE_E2E_ARCHIVE`) is the recommended mode for local development — it uses your locally-built CLI, packages, and bundle so you test exactly what you've changed.
+
+### Testing Against Released Versions
+
+Useful for verifying tests pass against shipped versions or catching regressions:
+
+```bash
+# Test against latest GA release
+ASPIRE_E2E_QUALITY=release dotnet test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
+  -- --filter-method "*.CreateAndRunAspireStarterProject"
+
+# Test against daily builds
+ASPIRE_E2E_QUALITY=dev dotnet test ...
+
+# Test against a specific version
+ASPIRE_E2E_VERSION=13.2.1 dotnet test ...
+```
+
 ## SequenceCounter and Prompt Detection
 
 The `SequenceCounter` class tracks the number of shell commands executed. This enables deterministic waiting for command completion via a custom shell prompt.

--- a/.github/skills/cli-e2e-testing/SKILL.md
+++ b/.github/skills/cli-e2e-testing/SKILL.md
@@ -155,7 +155,7 @@ The `CliInstallStrategy` class auto-detects how to install the CLI in the test c
 | `ASPIRE_E2E_QUALITY` | Install script with quality | `dev`, `staging`, `release` |
 | `ASPIRE_E2E_VERSION` | Install script with version | `13.2.1` |
 | *(none, in CI)* | PullRequest — install from PR artifacts | Auto-detected |
-| *(none, locally)* | SourceBuild or GA fallback | Auto-detected |
+| *(none, locally)* | InstallScript (latest GA) | Auto-detected |
 
 **LocalHive** (via `ASPIRE_E2E_ARCHIVE`) is the recommended mode for local development — it uses your locally-built CLI, packages, and bundle so you test exactly what you've changed.
 

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -1,0 +1,131 @@
+# Runs CLI E2E smoke tests against the daily build to catch regressions early.
+#
+# This workflow installs the latest daily Aspire CLI (not from source) and runs
+# a minimal set of E2E tests to verify core scenarios still work.
+#
+name: Daily CLI Smoke Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      quality:
+        description: 'Install quality (dev, staging, release)'
+        required: false
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - staging
+          - release
+
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+
+jobs:
+  smoke-test:
+    name: CLI Smoke Test (${{ inputs.quality || 'dev' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: ./restore.sh
+
+      - name: Build E2E test project
+        run: dotnet build tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+
+      - name: Run smoke tests against daily build
+        env:
+          ASPIRE_E2E_QUALITY: ${{ inputs.quality || 'dev' }}
+        run: |
+          dotnet test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
+            --no-build \
+            -- \
+            --filter-class "*.SmokeTests" \
+            --filter-not-trait "quarantined=true" \
+            --filter-not-trait "outerloop=true" \
+            --hangdump --hangdump-timeout 15m
+
+      - name: Upload test recordings
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: smoke-test-recordings-${{ inputs.quality || 'dev' }}
+          path: |
+            testresults/recordings/*.cast
+            **/TestResults/**/*.log
+          if-no-files-found: ignore
+
+  create-issue-on-failure:
+    name: Create Issue on Failure
+    needs: [smoke-test]
+    runs-on: ubuntu-latest
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    permissions:
+      issues: write
+    steps:
+      - name: Create GitHub Issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const date = new Date().toISOString().split('T')[0];
+
+            const issueTitle = `[Daily Smoke] CLI smoke test failure - ${date}`;
+            const issueBody = `## Daily CLI Smoke Test Failure
+
+            The daily CLI smoke tests failed on ${date}.
+
+            **Workflow Run:** ${runUrl}
+            **Quality:** dev (daily build)
+
+            ### Next Steps
+            1. Check the workflow run for detailed error logs
+            2. Download test recordings from artifacts
+            3. Compare with the latest daily build changes
+            4. Investigate and fix the regression
+
+            This issue was automatically created by the daily CLI smoke test workflow.
+            `;
+
+            // Check if a similar issue already exists (created today)
+            const existingIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'area-cli,failing-test',
+              per_page: 10
+            });
+
+            const todayIssue = existingIssues.data.find(issue =>
+              issue.title.includes(date) && issue.title.includes('[Daily Smoke]')
+            );
+
+            if (todayIssue) {
+              console.log(`Issue already exists for today: ${todayIssue.html_url}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: todayIssue.number,
+                body: `Another failure occurred. See: ${runUrl}`
+              });
+            } else {
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: ['area-cli', 'failing-test']
+              });
+              console.log(`Created issue: ${issue.data.html_url}`);
+            }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -165,6 +165,11 @@ internal static class CliE2EAutomatorHelpers
             default:
                 throw new ArgumentOutOfRangeException(nameof(strategy), strategy.Mode, "Unknown install mode");
         }
+
+        // Log the installed version for debugging — visible in asciinema recordings
+        await auto.TypeAsync("aspire --version");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -125,15 +125,6 @@ internal static class CliE2EAutomatorHelpers
                 await auto.WaitForSuccessPromptAsync(counter);
                 break;
 
-            case CliInstallMode.SourceBuild:
-                await auto.TypeAsync("mkdir -p ~/.aspire/bin && cp /opt/aspire-cli/aspire ~/.aspire/bin/aspire && chmod +x ~/.aspire/bin/aspire");
-                await auto.EnterAsync();
-                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
-                await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
-                await auto.EnterAsync();
-                await auto.WaitForSuccessPromptAsync(counter);
-                break;
-
             case CliInstallMode.PullRequest:
                 var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
                 await auto.TypeAsync($"/opt/aspire-scripts/get-aspire-cli-pr.sh {prNumber}");

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -119,6 +119,10 @@ internal static class CliE2EAutomatorHelpers
                 await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
                 await auto.EnterAsync();
                 await auto.WaitForSuccessPromptAsync(counter);
+                // Set the channel to 'local' so the CLI finds the hive packages
+                await auto.TypeAsync("aspire config set channel local -g");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter);
                 break;
 
             case CliInstallMode.SourceBuild:

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -102,7 +102,7 @@ internal static class CliE2EAutomatorHelpers
 
     /// <summary>
     /// Installs the Aspire CLI inside a Docker container using the given install strategy.
-    /// Handles all modes: LocalHive, SourceBuild, PullRequest, and InstallScript.
+    /// Handles all modes: LocalHive, PullRequest, and InstallScript.
     /// </summary>
     internal static async Task InstallAspireCliAsync(
         this Hex1bTerminalAutomator auto,
@@ -139,7 +139,7 @@ internal static class CliE2EAutomatorHelpers
                 var scriptArgs = "";
                 if (strategy.Quality is not null)
                 {
-                    scriptArgs = $" --quality {strategy.Quality}";
+                    scriptArgs = $" --quality {strategy.Quality.Value.ToString().ToLowerInvariant()}";
                 }
                 else if (strategy.Version is not null)
                 {

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -101,6 +101,69 @@ internal static class CliE2EAutomatorHelpers
     }
 
     /// <summary>
+    /// Installs the Aspire CLI inside a Docker container using the given install strategy.
+    /// Handles all modes: LocalHive, SourceBuild, PullRequest, and InstallScript.
+    /// </summary>
+    internal static async Task InstallAspireCliAsync(
+        this Hex1bTerminalAutomator auto,
+        CliInstallStrategy strategy,
+        SequenceCounter counter)
+    {
+        switch (strategy.Mode)
+        {
+            case CliInstallMode.LocalHive:
+                // Extract the localhive archive into ~/.aspire
+                await auto.TypeAsync("mkdir -p ~/.aspire && tar -xzf /tmp/aspire-localhive.tar.gz -C ~/.aspire");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+                await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter);
+                break;
+
+            case CliInstallMode.SourceBuild:
+                await auto.TypeAsync("mkdir -p ~/.aspire/bin && cp /opt/aspire-cli/aspire ~/.aspire/bin/aspire && chmod +x ~/.aspire/bin/aspire");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+                await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter);
+                break;
+
+            case CliInstallMode.PullRequest:
+                var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+                await auto.TypeAsync($"/opt/aspire-scripts/get-aspire-cli-pr.sh {prNumber}");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
+                await auto.TypeAsync("export PATH=~/.aspire/bin:~/.aspire:$PATH");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter);
+                break;
+
+            case CliInstallMode.InstallScript:
+                var scriptArgs = "";
+                if (strategy.Quality is not null)
+                {
+                    scriptArgs = $" --quality {strategy.Quality}";
+                }
+                else if (strategy.Version is not null)
+                {
+                    scriptArgs = $" --version {strategy.Version}";
+                }
+                await auto.TypeAsync($"/opt/aspire-scripts/get-aspire-cli.sh{scriptArgs}");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(120));
+                await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(strategy), strategy.Mode, "Unknown install mode");
+        }
+    }
+
+    /// <summary>
     /// Mounts the workspace-local Aspire package hive into the standard local hive path inside Docker.
     /// Used for SourceBuild E2E runs where the CLI binary is local but package resolution still needs
     /// locally packed Aspire packages.

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -292,6 +292,81 @@ internal static class CliE2ETestHelpers
         return builder.Build();
     }
 
+    /// <summary>
+    /// Creates a Hex1b terminal that runs inside a Docker container, configured using the
+    /// given <see cref="CliInstallStrategy"/> for CLI installation.
+    /// </summary>
+    internal static Hex1bTerminal CreateDockerTestTerminal(
+        string repoRoot,
+        CliInstallStrategy strategy,
+        ITestOutputHelper output,
+        DockerfileVariant variant = DockerfileVariant.DotNet,
+        bool mountDockerSocket = false,
+        TemporaryWorkspace? workspace = null,
+        IEnumerable<string>? additionalVolumes = null,
+        int width = 160,
+        int height = 48,
+        [CallerMemberName] string testName = "")
+    {
+        var recordingPath = GetTestResultsRecordingPath(testName);
+        var dockerfileName = variant switch
+        {
+            DockerfileVariant.DotNet => "Dockerfile.e2e",
+            DockerfileVariant.Polyglot => "Dockerfile.e2e-polyglot-base",
+            DockerfileVariant.PolyglotJava => "Dockerfile.e2e-polyglot-java",
+            _ => throw new ArgumentOutOfRangeException(nameof(variant)),
+        };
+        var dockerfilePath = Path.Combine(repoRoot, "tests", "Shared", "Docker", dockerfileName);
+
+        if (variant is DockerfileVariant.PolyglotJava)
+        {
+            EnsurePolyglotBaseImage(repoRoot, output);
+        }
+
+        output.WriteLine($"Creating Docker test terminal:");
+        output.WriteLine($"  Test name:      {testName}");
+        output.WriteLine($"  Strategy:       {strategy}");
+        output.WriteLine($"  Variant:        {variant}");
+        output.WriteLine($"  Dockerfile:     {dockerfilePath}");
+        output.WriteLine($"  Workspace:      {workspace?.WorkspaceRoot.FullName ?? "(none)"}");
+        output.WriteLine($"  Docker socket:  {mountDockerSocket}");
+        output.WriteLine($"  Dimensions:     {width}x{height}");
+        output.WriteLine($"  Recording:      {recordingPath}");
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(width, height)
+            .WithAsciinemaRecording(recordingPath)
+            .WithDockerContainer(c =>
+            {
+                c.DockerfilePath = dockerfilePath;
+                c.BuildContext = repoRoot;
+
+                if (mountDockerSocket)
+                {
+                    c.MountDockerSocket = true;
+                }
+
+                if (workspace is not null)
+                {
+                    c.Volumes.Add($"{workspace.WorkspaceRoot.FullName}:/workspace/{workspace.WorkspaceRoot.Name}");
+                }
+
+                if (additionalVolumes is not null)
+                {
+                    foreach (var volume in additionalVolumes)
+                    {
+                        c.Volumes.Add(volume);
+                    }
+                }
+
+                // Delegate all mode-specific Docker config to the strategy
+                strategy.ConfigureContainer(c);
+            });
+
+        return builder.Build();
+    }
+
     private static void EnsurePolyglotBaseImage(string repoRoot, ITestOutputHelper output)
     {
         lock (s_polyglotBaseImageLock)

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategy.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategy.cs
@@ -105,9 +105,9 @@ internal sealed class CliInstallStrategy
     ///   1. ASPIRE_E2E_ARCHIVE → LocalHive
     ///   2. ASPIRE_E2E_QUALITY → InstallScript with quality
     ///   3. ASPIRE_E2E_VERSION → InstallScript with version
-    ///   4. CI (GITHUB_PR_NUMBER) → PullRequest
-    ///   4. CI (GITHUB_PR_NUMBER) → PullRequest
-    ///   5. Fallback → InstallScript (latest GA)
+    ///   4. CI with PR (GITHUB_PR_NUMBER) → PullRequest
+    ///   5. CI without PR (main branch, scheduled) → InstallScript (dev/daily)
+    ///   6. Local fallback → InstallScript (latest GA)
     /// </summary>
     public static CliInstallStrategy Detect()
     {
@@ -132,13 +132,20 @@ internal sealed class CliInstallStrategy
             return FromVersion(version);
         }
 
-        // 4. CI — install from PR artifacts
+        // 4. CI with PR number — install from PR artifacts
         if (CliE2ETestHelpers.IsRunningInCI)
         {
             return new CliInstallStrategy(CliInstallMode.PullRequest);
         }
 
-        // 5. Fallback — latest GA
+        // 5. CI without PR (main branch push, scheduled) — use daily build
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")) ||
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")))
+        {
+            return FromQuality("dev");
+        }
+
+        // 6. Local fallback — latest GA
         return LatestGa();
     }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategy.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategy.cs
@@ -15,12 +15,6 @@ internal enum CliInstallMode
     LocalHive,
 
     /// <summary>
-    /// The CLI was built from source — native AOT binary is mounted from the host.
-    /// Packages come from artifacts/packages/.
-    /// </summary>
-    SourceBuild,
-
-    /// <summary>
     /// Install from PR build artifacts using get-aspire-cli-pr.sh.
     /// Used in CI when GITHUB_PR_NUMBER is set.
     /// </summary>
@@ -51,11 +45,6 @@ internal sealed class CliInstallStrategy
     public string? ArchivePath { get; }
 
     /// <summary>
-    /// For SourceBuild: the path to the native AOT CLI publish directory on the host.
-    /// </summary>
-    public string? CliBinaryDir { get; }
-
-    /// <summary>
     /// For InstallScript: the quality level (e.g., "dev", "staging", "release").
     /// </summary>
     public string? Quality { get; }
@@ -65,11 +54,10 @@ internal sealed class CliInstallStrategy
     /// </summary>
     public string? Version { get; }
 
-    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, string? cliBinaryDir = null, string? quality = null, string? version = null)
+    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, string? quality = null, string? version = null)
     {
         Mode = mode;
         ArchivePath = archivePath;
-        CliBinaryDir = cliBinaryDir;
         Quality = quality;
         Version = version;
     }
@@ -118,10 +106,10 @@ internal sealed class CliInstallStrategy
     ///   2. ASPIRE_E2E_QUALITY → InstallScript with quality
     ///   3. ASPIRE_E2E_VERSION → InstallScript with version
     ///   4. CI (GITHUB_PR_NUMBER) → PullRequest
-    ///   5. Native AOT binary exists → SourceBuild
-    ///   6. Fallback → InstallScript (latest GA)
+    ///   4. CI (GITHUB_PR_NUMBER) → PullRequest
+    ///   5. Fallback → InstallScript (latest GA)
     /// </summary>
-    public static CliInstallStrategy Detect(string repoRoot)
+    public static CliInstallStrategy Detect()
     {
         // 1. Explicit archive override
         var archivePath = Environment.GetEnvironmentVariable("ASPIRE_E2E_ARCHIVE");
@@ -150,14 +138,7 @@ internal sealed class CliInstallStrategy
             return new CliInstallStrategy(CliInstallMode.PullRequest);
         }
 
-        // 5. Local source build — native AOT binary exists
-        var cliBinaryDir = CliE2ETestHelpers.FindLocalCliBinary(repoRoot);
-        if (cliBinaryDir is not null)
-        {
-            return new CliInstallStrategy(CliInstallMode.SourceBuild, cliBinaryDir: cliBinaryDir);
-        }
-
-        // 6. Fallback — latest GA
+        // 5. Fallback — latest GA
         return LatestGa();
     }
 
@@ -175,11 +156,6 @@ internal sealed class CliInstallStrategy
             case CliInstallMode.LocalHive:
                 // Mount the archive into the container
                 config.Volumes.Add($"{ArchivePath}:/tmp/aspire-localhive.tar.gz:ro");
-                break;
-
-            case CliInstallMode.SourceBuild:
-                // Mount the locally-built CLI binary
-                config.Volumes.Add($"{CliBinaryDir}:/opt/aspire-cli:ro");
                 break;
 
             case CliInstallMode.PullRequest:
@@ -207,7 +183,6 @@ internal sealed class CliInstallStrategy
         return Mode switch
         {
             CliInstallMode.LocalHive => $"LocalHive ({ArchivePath})",
-            CliInstallMode.SourceBuild => $"SourceBuild ({CliBinaryDir})",
             CliInstallMode.PullRequest => $"PullRequest (PR #{Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER")})",
             CliInstallMode.InstallScript when Quality is not null => $"InstallScript (--quality {Quality})",
             CliInstallMode.InstallScript when Version is not null => $"InstallScript (--version {Version})",

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategy.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategy.cs
@@ -1,0 +1,218 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.EndToEnd.Tests.Helpers;
+
+/// <summary>
+/// Specifies how the Aspire CLI should be installed in the E2E test container.
+/// </summary>
+internal enum CliInstallMode
+{
+    /// <summary>
+    /// Extract a localhive archive (.tar.gz) into the container.
+    /// Set via ASPIRE_E2E_ARCHIVE env var.
+    /// </summary>
+    LocalHive,
+
+    /// <summary>
+    /// The CLI was built from source — native AOT binary is mounted from the host.
+    /// Packages come from artifacts/packages/.
+    /// </summary>
+    SourceBuild,
+
+    /// <summary>
+    /// Install from PR build artifacts using get-aspire-cli-pr.sh.
+    /// Used in CI when GITHUB_PR_NUMBER is set.
+    /// </summary>
+    PullRequest,
+
+    /// <summary>
+    /// Install via get-aspire-cli.sh with optional --quality or --version.
+    /// Covers GA releases, daily builds, preview, etc.
+    /// </summary>
+    InstallScript,
+}
+
+/// <summary>
+/// Encapsulates how the Aspire CLI is detected, configured, and installed
+/// inside an E2E test Docker container. Replaces the scattered DockerInstallMode
+/// branching across CliE2ETestHelpers and CliE2EAutomatorHelpers.
+/// </summary>
+internal sealed class CliInstallStrategy
+{
+    /// <summary>
+    /// The install mode.
+    /// </summary>
+    public CliInstallMode Mode { get; }
+
+    /// <summary>
+    /// For LocalHive: the path to the .tar.gz archive on the host.
+    /// </summary>
+    public string? ArchivePath { get; }
+
+    /// <summary>
+    /// For SourceBuild: the path to the native AOT CLI publish directory on the host.
+    /// </summary>
+    public string? CliBinaryDir { get; }
+
+    /// <summary>
+    /// For InstallScript: the quality level (e.g., "dev", "staging", "release").
+    /// </summary>
+    public string? Quality { get; }
+
+    /// <summary>
+    /// For InstallScript: a specific version (e.g., "13.2.1").
+    /// </summary>
+    public string? Version { get; }
+
+    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, string? cliBinaryDir = null, string? quality = null, string? version = null)
+    {
+        Mode = mode;
+        ArchivePath = archivePath;
+        CliBinaryDir = cliBinaryDir;
+        Quality = quality;
+        Version = version;
+    }
+
+    /// <summary>
+    /// Creates a LocalHive strategy from an archive path.
+    /// </summary>
+    public static CliInstallStrategy FromLocalHive(string archivePath)
+    {
+        if (!File.Exists(archivePath))
+        {
+            throw new FileNotFoundException($"LocalHive archive not found: {archivePath}");
+        }
+
+        return new CliInstallStrategy(CliInstallMode.LocalHive, archivePath: archivePath);
+    }
+
+    /// <summary>
+    /// Creates an InstallScript strategy targeting a quality level (e.g., "dev" for daily builds).
+    /// </summary>
+    public static CliInstallStrategy FromQuality(string quality)
+    {
+        return new CliInstallStrategy(CliInstallMode.InstallScript, quality: quality);
+    }
+
+    /// <summary>
+    /// Creates an InstallScript strategy targeting a specific version.
+    /// </summary>
+    public static CliInstallStrategy FromVersion(string version)
+    {
+        return new CliInstallStrategy(CliInstallMode.InstallScript, version: version);
+    }
+
+    /// <summary>
+    /// Creates an InstallScript strategy for the latest GA release.
+    /// </summary>
+    public static CliInstallStrategy LatestGa()
+    {
+        return new CliInstallStrategy(CliInstallMode.InstallScript);
+    }
+
+    /// <summary>
+    /// Auto-detect the install strategy from the environment and local build artifacts.
+    /// Priority:
+    ///   1. ASPIRE_E2E_ARCHIVE → LocalHive
+    ///   2. ASPIRE_E2E_QUALITY → InstallScript with quality
+    ///   3. ASPIRE_E2E_VERSION → InstallScript with version
+    ///   4. CI (GITHUB_PR_NUMBER) → PullRequest
+    ///   5. Native AOT binary exists → SourceBuild
+    ///   6. Fallback → InstallScript (latest GA)
+    /// </summary>
+    public static CliInstallStrategy Detect(string repoRoot)
+    {
+        // 1. Explicit archive override
+        var archivePath = Environment.GetEnvironmentVariable("ASPIRE_E2E_ARCHIVE");
+        if (!string.IsNullOrEmpty(archivePath))
+        {
+            return FromLocalHive(archivePath);
+        }
+
+        // 2. Explicit quality override (daily, staging, etc.)
+        var quality = Environment.GetEnvironmentVariable("ASPIRE_E2E_QUALITY");
+        if (!string.IsNullOrEmpty(quality))
+        {
+            return FromQuality(quality);
+        }
+
+        // 3. Explicit version override
+        var version = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
+        if (!string.IsNullOrEmpty(version))
+        {
+            return FromVersion(version);
+        }
+
+        // 4. CI — install from PR artifacts
+        if (CliE2ETestHelpers.IsRunningInCI)
+        {
+            return new CliInstallStrategy(CliInstallMode.PullRequest);
+        }
+
+        // 5. Local source build — native AOT binary exists
+        var cliBinaryDir = CliE2ETestHelpers.FindLocalCliBinary(repoRoot);
+        if (cliBinaryDir is not null)
+        {
+            return new CliInstallStrategy(CliInstallMode.SourceBuild, cliBinaryDir: cliBinaryDir);
+        }
+
+        // 6. Fallback — latest GA
+        return LatestGa();
+    }
+
+    /// <summary>
+    /// Configures the Docker container builder with the appropriate volumes, build args,
+    /// and environment variables for this install mode.
+    /// </summary>
+    public void ConfigureContainer(Hex1b.DockerContainerOptions config)
+    {
+        // Always skip the expensive source build inside Docker.
+        config.BuildArgs["SKIP_SOURCE_BUILD"] = "true";
+
+        switch (Mode)
+        {
+            case CliInstallMode.LocalHive:
+                // Mount the archive into the container
+                config.Volumes.Add($"{ArchivePath}:/tmp/aspire-localhive.tar.gz:ro");
+                break;
+
+            case CliInstallMode.SourceBuild:
+                // Mount the locally-built CLI binary
+                config.Volumes.Add($"{CliBinaryDir}:/opt/aspire-cli:ro");
+                break;
+
+            case CliInstallMode.PullRequest:
+                var ghToken = Environment.GetEnvironmentVariable("GH_TOKEN");
+                if (!string.IsNullOrEmpty(ghToken))
+                {
+                    config.Environment["GH_TOKEN"] = ghToken;
+                }
+
+                config.Environment["GITHUB_PR_NUMBER"] = Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER") ?? "";
+                config.Environment["GITHUB_PR_HEAD_SHA"] = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA") ?? "";
+                break;
+
+            case CliInstallMode.InstallScript:
+                // No special Docker config needed — install script runs inside container
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Returns a description of this strategy for test output logging.
+    /// </summary>
+    public override string ToString()
+    {
+        return Mode switch
+        {
+            CliInstallMode.LocalHive => $"LocalHive ({ArchivePath})",
+            CliInstallMode.SourceBuild => $"SourceBuild ({CliBinaryDir})",
+            CliInstallMode.PullRequest => $"PullRequest (PR #{Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER")})",
+            CliInstallMode.InstallScript when Quality is not null => $"InstallScript (--quality {Quality})",
+            CliInstallMode.InstallScript when Version is not null => $"InstallScript (--version {Version})",
+            CliInstallMode.InstallScript => "InstallScript (latest GA)",
+            _ => Mode.ToString(),
+        };
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategy.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategy.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.RegularExpressions;
+
 namespace Aspire.Cli.EndToEnd.Tests.Helpers;
 
 /// <summary>
@@ -28,6 +30,19 @@ internal enum CliInstallMode
 }
 
 /// <summary>
+/// Quality levels for the Aspire CLI install script.
+/// </summary>
+internal enum CliInstallQuality
+{
+    /// <summary>Daily development builds.</summary>
+    Dev,
+    /// <summary>Staging/preview builds.</summary>
+    Staging,
+    /// <summary>Official release builds.</summary>
+    Release,
+}
+
+/// <summary>
 /// Encapsulates how the Aspire CLI is detected, configured, and installed
 /// inside an E2E test Docker container. Replaces the scattered DockerInstallMode
 /// branching across CliE2ETestHelpers and CliE2EAutomatorHelpers.
@@ -45,16 +60,18 @@ internal sealed class CliInstallStrategy
     public string? ArchivePath { get; }
 
     /// <summary>
-    /// For InstallScript: the quality level (e.g., "dev", "staging", "release").
+    /// For InstallScript: the quality level.
     /// </summary>
-    public string? Quality { get; }
+    public CliInstallQuality? Quality { get; }
 
     /// <summary>
     /// For InstallScript: a specific version (e.g., "13.2.1").
     /// </summary>
     public string? Version { get; }
 
-    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, string? quality = null, string? version = null)
+    private static readonly Regex s_versionPattern = new(@"^[0-9A-Za-z.\-]+$", RegexOptions.Compiled);
+
+    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, CliInstallQuality? quality = null, string? version = null)
     {
         Mode = mode;
         ArchivePath = archivePath;
@@ -76,9 +93,9 @@ internal sealed class CliInstallStrategy
     }
 
     /// <summary>
-    /// Creates an InstallScript strategy targeting a quality level (e.g., "dev" for daily builds).
+    /// Creates an InstallScript strategy targeting a quality level.
     /// </summary>
-    public static CliInstallStrategy FromQuality(string quality)
+    public static CliInstallStrategy FromQuality(CliInstallQuality quality)
     {
         return new CliInstallStrategy(CliInstallMode.InstallScript, quality: quality);
     }
@@ -88,6 +105,11 @@ internal sealed class CliInstallStrategy
     /// </summary>
     public static CliInstallStrategy FromVersion(string version)
     {
+        if (!s_versionPattern.IsMatch(version))
+        {
+            throw new ArgumentException($"Invalid version format: '{version}'. Must contain only alphanumeric characters, dots, and dashes.", nameof(version));
+        }
+
         return new CliInstallStrategy(CliInstallMode.InstallScript, version: version);
     }
 
@@ -105,7 +127,7 @@ internal sealed class CliInstallStrategy
     ///   1. ASPIRE_E2E_ARCHIVE → LocalHive
     ///   2. ASPIRE_E2E_QUALITY → InstallScript with quality
     ///   3. ASPIRE_E2E_VERSION → InstallScript with version
-    ///   4. CI with PR (GITHUB_PR_NUMBER) → PullRequest
+    ///   4. CI with PR (GITHUB_PR_NUMBER + GITHUB_PR_HEAD_SHA) → PullRequest
     ///   5. CI without PR (main branch, scheduled) → InstallScript (dev/daily)
     ///   6. Local fallback → InstallScript (latest GA)
     /// </summary>
@@ -119,9 +141,13 @@ internal sealed class CliInstallStrategy
         }
 
         // 2. Explicit quality override (daily, staging, etc.)
-        var quality = Environment.GetEnvironmentVariable("ASPIRE_E2E_QUALITY");
-        if (!string.IsNullOrEmpty(quality))
+        var qualityStr = Environment.GetEnvironmentVariable("ASPIRE_E2E_QUALITY");
+        if (!string.IsNullOrEmpty(qualityStr))
         {
+            if (!Enum.TryParse<CliInstallQuality>(qualityStr, ignoreCase: true, out var quality))
+            {
+                throw new ArgumentException($"Invalid ASPIRE_E2E_QUALITY value: '{qualityStr}'. Must be one of: {string.Join(", ", Enum.GetNames<CliInstallQuality>())}");
+            }
             return FromQuality(quality);
         }
 
@@ -142,7 +168,7 @@ internal sealed class CliInstallStrategy
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")) ||
             !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")))
         {
-            return FromQuality("dev");
+            return FromQuality(CliInstallQuality.Dev);
         }
 
         // 6. Local fallback — latest GA
@@ -179,6 +205,9 @@ internal sealed class CliInstallStrategy
             case CliInstallMode.InstallScript:
                 // No special Docker config needed — install script runs inside container
                 break;
+
+            default:
+                throw new InvalidOperationException($"Unknown install mode: {Mode}");
         }
     }
 
@@ -191,7 +220,7 @@ internal sealed class CliInstallStrategy
         {
             CliInstallMode.LocalHive => $"LocalHive ({ArchivePath})",
             CliInstallMode.PullRequest => $"PullRequest (PR #{Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER")})",
-            CliInstallMode.InstallScript when Quality is not null => $"InstallScript (--quality {Quality})",
+            CliInstallMode.InstallScript when Quality is not null => $"InstallScript (--quality {Quality.Value.ToString().ToLowerInvariant()})",
             CliInstallMode.InstallScript when Version is not null => $"InstallScript (--version {Version})",
             CliInstallMode.InstallScript => "InstallScript (latest GA)",
             _ => Mode.ToString(),

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -19,7 +19,7 @@ public sealed class SmokeTests(ITestOutputHelper output)
     public async Task CreateAndRunAspireStarterProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect(repoRoot);
+        var strategy = CliInstallStrategy.Detect();
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -19,11 +19,11 @@ public sealed class SmokeTests(ITestOutputHelper output)
     public async Task CreateAndRunAspireStarterProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var strategy = CliInstallStrategy.Detect(repoRoot);
 
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -34,7 +34,7 @@ public sealed class SmokeTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
         // Install the Aspire CLI
-        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+        await auto.InstallAspireCliAsync(strategy, counter);
 
         // Create a new project using aspire new
         await auto.AspireNewAsync("AspireStarterApp", counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -19,13 +19,13 @@ public sealed class StartStopTests(ITestOutputHelper output)
     public async Task CreateStartAndStopAspireProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var strategy = CliInstallStrategy.Detect();
         var projectSuffix = Guid.NewGuid().ToString("N")[..6];
         var projectName = $"StarterApp_{projectSuffix}";
 
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -36,7 +36,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
         // Install the Aspire CLI
-        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+        await auto.InstallAspireCliAsync(strategy, counter);
 
         // Create a new project using aspire new
         await auto.AspireNewAsync(projectName, counter);
@@ -74,11 +74,11 @@ public sealed class StartStopTests(ITestOutputHelper output)
     public async Task StopWithNoRunningAppHostExitsSuccessfully()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var strategy = CliInstallStrategy.Detect();
 
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -89,7 +89,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
         // Install the Aspire CLI
-        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+        await auto.InstallAspireCliAsync(strategy, counter);
 
         // Run aspire stop with no running AppHost - should exit with code 0
         await auto.TypeAsync("aspire stop");
@@ -108,11 +108,11 @@ public sealed class StartStopTests(ITestOutputHelper output)
     public async Task AddPackageWhileAppHostRunningDetached()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var strategy = CliInstallStrategy.Detect();
 
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -123,7 +123,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
         // Install the Aspire CLI
-        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+        await auto.InstallAspireCliAsync(strategy, counter);
 
         // Create a new project using aspire new
         await auto.AspireNewAsync("AspireAddTestApp", counter);
@@ -168,11 +168,11 @@ public sealed class StartStopTests(ITestOutputHelper output)
     public async Task AddPackageInteractiveWhileAppHostRunningDetached()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var strategy = CliInstallStrategy.Detect();
 
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -183,7 +183,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
         // Install the Aspire CLI
-        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+        await auto.InstallAspireCliAsync(strategy, counter);
 
         // Create a new project using aspire new
         await auto.AspireNewAsync("AspireAddInteractiveApp", counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -19,7 +19,7 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
     public async Task CreateAndRunTypeScriptStarterProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect(repoRoot);
+        var strategy = CliInstallStrategy.Detect();
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -19,18 +19,10 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
     public async Task CreateAndRunTypeScriptStarterProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var strategy = CliInstallStrategy.Detect(repoRoot);
         var workspace = TemporaryWorkspace.Create(output);
-        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, workspace, installMode);
-        var bundlePath = FindLocalBundlePath(repoRoot, installMode);
 
-        var additionalVolumes = new List<string>();
-        if (bundlePath is not null)
-        {
-            additionalVolumes.Add($"{bundlePath}:/opt/aspire-bundle:ro");
-        }
-
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace, additionalVolumes: additionalVolumes);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -38,34 +30,7 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
-        await auto.InstallAspireCliInDockerAsync(installMode, counter);
-
-        // Set up bundle layout for SourceBuild mode so the CLI can find
-        // aspire-managed and DCP relative to the CLI binary location.
-        if (bundlePath is not null)
-        {
-            await auto.TypeAsync("ln -s /opt/aspire-bundle/managed ~/.aspire/managed && ln -s /opt/aspire-bundle/dcp ~/.aspire/dcp");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter);
-        }
-
-        // Set up local channel NuGet packages for SourceBuild mode so the
-        // CLI can resolve Aspire packages during template creation.
-        if (localChannel is not null)
-        {
-            await auto.MountLocalChannelPackagesAsync(localChannel, workspace, counter);
-
-            // Set channel and SDK version globally so aspire new uses the local
-            // channel with the correct prerelease version (dev builds fall back to
-            // the last stable release by default, which won't match local packages).
-            await auto.TypeAsync("aspire config set channel local --global");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter);
-
-            await auto.TypeAsync($"aspire config set sdk.version {localChannel.SdkVersion} --global");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter);
-        }
+        await auto.InstallAspireCliAsync(strategy, counter);
 
         // Step 1: Create project using aspire new, selecting the Express/React template
         await auto.AspireNewAsync("TsStarterApp", counter, template: AspireTemplate.ExpressReact);
@@ -97,32 +62,5 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
         await auto.EnterAsync();
 
         await pendingRun;
-    }
-
-    /// <summary>
-    /// Finds the extracted bundle layout directory for SourceBuild mode.
-    /// The bundle provides the aspire-managed server and DCP needed for template creation.
-    /// Returns null for non-SourceBuild modes (CI installs the full bundle via the PR script).
-    /// </summary>
-    private static string? FindLocalBundlePath(string repoRoot, CliE2ETestHelpers.DockerInstallMode installMode)
-    {
-        if (installMode != CliE2ETestHelpers.DockerInstallMode.SourceBuild)
-        {
-            return null;
-        }
-
-        var bundlePath = Path.Combine(repoRoot, "artifacts", "bundle", "linux-x64");
-        if (!Directory.Exists(bundlePath))
-        {
-            throw new InvalidOperationException("Local source-built TypeScript E2E tests require the bundle layout. Run './build.sh --bundle' first.");
-        }
-
-        var managedPath = Path.Combine(bundlePath, "managed", "aspire-managed");
-        if (!File.Exists(managedPath))
-        {
-            throw new InvalidOperationException($"Bundle layout is missing aspire-managed at {managedPath}. Run './build.sh --bundle' first.");
-        }
-
-        return bundlePath;
     }
 }


### PR DESCRIPTION
## Description

Introduce `CliInstallStrategy` for unified CLI E2E test installation, enabling local development iteration and daily build smoke testing.

### What changed

- **`CliInstallStrategy`** — new class that encapsulates how the Aspire CLI is detected, configured, and installed inside E2E test Docker containers. Three modes:
  - **LocalHive** — extract a `localhive.sh --archive` tarball into the container (CLI + packages + managed + DCP in one step)
  - **PullRequest** — install from PR artifacts via `get-aspire-cli-pr.sh` (CI)
  - **InstallScript** — install via `get-aspire-cli.sh` with `--quality` or `--version` (daily, preview, GA, specific releases)

- **Converted tests** — `SmokeTests` and `TypeScriptStarterTemplateTests` migrated to `CliInstallStrategy`. Both verified passing locally with LocalHive mode (~34s each).

- **Removed `SourceBuild` mode** — `LocalHive` replaces the old three-mount approach (CLI binary + packages + bundle symlinks) with a single archive.

- **Version logging** — `aspire --version` is logged after install in every test, visible in asciinema recordings for debugging.

- **Daily smoke test workflow** — new `tests-daily-smoke.yml` runs `SmokeTests` against the daily build at 6 AM UTC. Supports manual dispatch with quality selection (dev/staging/release).

- **Skill doc** — comprehensive "Running Tests Locally" section added to `cli-e2e-testing` skill covering macOS, Windows, RID selection, development workflow, and testing against released versions.

### How to run E2E tests locally

```bash
# Build archive (once, ~3 min)
./localhive.sh -o /tmp/aspire-e2e -r linux-arm64 --archive

# Run a test
ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e.tar.gz \
  dotnet test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
  -- --filter-method "*.CreateAndRunAspireStarterProject"
```

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No



### Detection Logic

`CliInstallStrategy.Detect()` checks env vars top to bottom, first match wins:

| Scenario | What triggers | Mode |
|----------|--------------|------|
| Local dev with archive | `ASPIRE_E2E_ARCHIVE=/tmp/...` | LocalHive (extract archive) |
| Local dev, no env vars | Nothing set | InstallScript (latest GA) |
| PR CI | Workflow sets `GITHUB_PR_NUMBER` | PullRequest (PR artifacts) |
| Main branch CI | `GITHUB_ACTIONS=true` but no PR number | InstallScript (daily/dev) |
| Daily smoke workflow | Workflow sets `ASPIRE_E2E_QUALITY=dev` | InstallScript (daily/dev) |
| Testing specific release | `ASPIRE_E2E_VERSION=13.2.1` | InstallScript (13.2.1) |

Explicit env vars always win. CI context is the tiebreaker. Local defaults to latest GA as a safe fallback.
