### PR TITLE
Add E2E test for aspire otel logs structured logs

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
@@ -45,8 +45,9 @@ public sealed class OtelLogsTests(ITestOutputHelper output)
         await auto.AspireStartAsync(counter);
 
         // Wait for the apiservice resource to be running before querying logs
-        await auto.TypeAsync("aspire wait apiservice --status up");
+        await auto.TypeAsync("aspire wait apiservice --status up --timeout 300");
         await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("is up (running).", timeout: TimeSpan.FromMinutes(6));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Run aspire otel logs and capture output to a file

--- a/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
@@ -21,7 +21,7 @@ public sealed class OtelLogsTests(ITestOutputHelper output)
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
 
-        var workspace = TemporaryWorkspace.Create(output);
+        using var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
 
@@ -44,8 +44,8 @@ public sealed class OtelLogsTests(ITestOutputHelper output)
         // Start the AppHost in the background
         await auto.AspireStartAsync(counter);
 
-        // Wait for resources to produce structured logs
-        await auto.TypeAsync("sleep 15");
+        // Wait for the apiservice resource to be running before querying logs
+        await auto.TypeAsync("aspire wait apiservice --status up");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -54,21 +54,15 @@ public sealed class OtelLogsTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Verify the output contains structured log entries (not "No logs found")
+        // Verify the output contains structured log entries with apiservice content
         await auto.TypeAsync("cat otel_logs.txt | head -20");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Assert that logs were found by checking absence of "No logs found"
-        await auto.TypeAsync("grep -c 'No logs found' otel_logs.txt && echo 'NO_LOGS_DETECTED' || echo 'STRUCTURED_LOGS_PRESENT'");
+        // Assert structured logs are present and contain apiservice entries
+        await auto.TypeAsync("if [ ! -r otel_logs.txt ]; then echo 'OTEL_LOGS_FILE_UNREADABLE'; elif grep -q 'apiservice' otel_logs.txt; then echo 'STRUCTURED_LOGS_PRESENT'; else echo 'STRUCTURED_LOGS_MISSING'; fi");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("STRUCTURED_LOGS_PRESENT", timeout: TimeSpan.FromSeconds(10));
-        await auto.WaitForAnyPromptAsync(counter);
-
-        // Verify the output contains entries from the apiservice resource
-        await auto.TypeAsync("grep -q 'apiservice' otel_logs.txt && echo 'APISERVICE_LOGS_FOUND' || echo 'APISERVICE_LOGS_MISSING'");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("APISERVICE_LOGS_FOUND", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForAnyPromptAsync(counter);
 
         // Also verify JSON format works and contains structured data

--- a/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for the aspire otel logs command with structured logs.
+/// Each test class runs as a separate CI job for parallelization.
+/// </summary>
+public sealed class OtelLogsTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task OtelLogsReturnsStructuredLogsFromStarterApp()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        // Create a new Starter project (includes an ASP.NET Core apiservice)
+        await auto.AspireNewAsync("AspireOtelLogsApp", counter);
+
+        // Navigate to the AppHost directory
+        await auto.TypeAsync("cd AspireOtelLogsApp/AspireOtelLogsApp.AppHost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Start the AppHost in the background
+        await auto.AspireStartAsync(counter);
+
+        // Wait for resources to produce structured logs
+        await auto.TypeAsync("sleep 15");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Run aspire otel logs and capture output to a file
+        await auto.TypeAsync("aspire otel logs > otel_logs.txt 2>&1");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Verify the output contains structured log entries (not "No logs found")
+        await auto.TypeAsync("cat otel_logs.txt | head -20");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Assert that logs were found by checking absence of "No logs found"
+        await auto.TypeAsync("grep -c 'No logs found' otel_logs.txt && echo 'NO_LOGS_DETECTED' || echo 'STRUCTURED_LOGS_PRESENT'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("STRUCTURED_LOGS_PRESENT", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Verify the output contains entries from the apiservice resource
+        await auto.TypeAsync("grep -q 'apiservice' otel_logs.txt && echo 'APISERVICE_LOGS_FOUND' || echo 'APISERVICE_LOGS_MISSING'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("APISERVICE_LOGS_FOUND", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Also verify JSON format works and contains structured data
+        await auto.TypeAsync("aspire otel logs --format json > otel_logs_json.txt 2>&1");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Verify JSON output contains resourceLogs key
+        await auto.TypeAsync("grep -q 'resourceLogs' otel_logs_json.txt && echo 'JSON_STRUCTURED_LOGS_PRESENT' || echo 'JSON_STRUCTURED_LOGS_MISSING'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("JSON_STRUCTURED_LOGS_PRESENT", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Stop the AppHost
+        await auto.AspireStopAsync(counter);
+
+        // Exit the shell
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}


### PR DESCRIPTION
## Description

Add an E2E test (`OtelLogsTests.OtelLogsReturnsStructuredLogsFromStarterApp`) that verifies the `aspire otel logs` command returns structured logs from a running Aspire Starter project.

The test:
1. Creates a new Starter project (which includes an ASP.NET Core `apiservice`)
2. Starts it with `aspire start`
3. Waits for resources to produce structured logs
4. Runs `aspire otel logs` and asserts that structured logs are present (not "No logs found") and contain entries from the `apiservice` resource
5. Runs `aspire otel logs --format json` and asserts the JSON output contains `resourceLogs`
6. Stops the AppHost and exits cleanly

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
