### PR TITLE
Less frantic polling for results during CLI tests

### DIFF
--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -36,7 +36,14 @@ internal static partial class ProcessSignaler
         if (process is { })
         {
             logger.LogDebug("Killing process {Pid}...", pid);
-            process.Kill(entireProcessTree: false);
+            try
+            {
+                process.Kill(entireProcessTree: false);
+            }
+            catch(InvalidOperationException)
+            {
+                // Process already exited.
+            }
         }
     }
 

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -40,7 +40,7 @@ internal static partial class ProcessSignaler
             {
                 process.Kill(entireProcessTree: false);
             }
-            catch(InvalidOperationException)
+            catch (InvalidOperationException)
             {
                 // Process already exited.
             }

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -158,7 +158,19 @@ internal static class Hex1bAutomatorTestHelpers
 
             if (firstOutputMatched)
             {
-                return;
+                return; // success
+            }
+
+             remaining = effectiveTimeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                break;
+            }
+
+            var delayBeforeRetry = remaining < effectiveRetryInterval ? remaining : effectiveRetryInterval;
+            if (delayBeforeRetry > TimeSpan.FromMilliseconds(1))
+            {
+                await auto.WaitAsync(delayBeforeRetry);
             }
         }
 

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -161,7 +161,7 @@ internal static class Hex1bAutomatorTestHelpers
                 return; // success
             }
 
-             remaining = effectiveTimeout - stopwatch.Elapsed;
+            remaining = effectiveTimeout - stopwatch.Elapsed;
             if (remaining <= TimeSpan.Zero)
             {
                 break;


### PR DESCRIPTION
Should fix https://github.com/microsoft/aspire/issues/16076

