### PR TITLE
Clarify dashboard clear telemetry labels

### DIFF
--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -223,7 +223,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove all.
+        ///   Looks up a localized string similar to Remove all telemetry.
         /// </summary>
         public static string ClearAllResources {
             get {
@@ -232,7 +232,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove for resource.
+        ///   Looks up a localized string similar to Remove telemetry for resource.
         /// </summary>
         public static string ClearPendingSelectedResource {
             get {
@@ -241,7 +241,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove for {0}.
+        ///   Looks up a localized string similar to Remove telemetry for {0}.
         /// </summary>
         public static string ClearSelectedResource {
             get {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -428,13 +428,13 @@
     <value>Mount type</value>
   </data>
   <data name="ClearAllResources" xml:space="preserve">
-    <value>Remove all</value>
+    <value>Remove all telemetry</value>
   </data>
   <data name="ClearSelectedResource" xml:space="preserve">
-    <value>Remove for {0}</value>
+    <value>Remove telemetry for {0}</value>
   </data>
   <data name="ClearPendingSelectedResource" xml:space="preserve">
-    <value>Remove for resource</value>
+    <value>Remove telemetry for resource</value>
   </data>
   <data name="ChartContainerOverflowDescription" xml:space="preserve">
     <value>Some dimensions for the metric have been dropped by the OpenTelemetry SDK.</value>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Odebrat vše</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Odebrat vše</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Odebrat pro prostředek</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Odebrat pro prostředek</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Odebrat pro {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Odebrat pro {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Alle entfernen</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Alle entfernen</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Für Ressource entfernen</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Für Ressource entfernen</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Für {0} entfernen</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Für {0} entfernen</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Quitar todo</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Quitar todo</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Quitar para el recurso</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Quitar para el recurso</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Quitar para {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Quitar para {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Supprimer tout</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Supprimer tout</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Supprimer pour la ressource</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Supprimer pour la ressource</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Supprimer pour {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Supprimer pour {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Rimuovi tutto</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Rimuovi tutto</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Rimuovi per la risorsa</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Rimuovi per la risorsa</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Rimuovi per {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Rimuovi per {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">すべて削除</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">すべて削除</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">リソースの削除</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">リソースの削除</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">{0} の削除</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">{0} の削除</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">모두 제거</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">모두 제거</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">리소스 제거</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">리소스 제거</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">{0} 제거</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">{0} 제거</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Usuń wszystko</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Usuń wszystko</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Usuń dla zasobu</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Usuń dla zasobu</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Usuń dla {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Usuń dla {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Remover tudo</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Remover tudo</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Remover para o recurso</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Remover para o recurso</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Remover para {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Remover para {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Удалить все</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Удалить все</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Удалить для ресурса</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Удалить для ресурса</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Удалить для {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Удалить для {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">Tümünü kaldır</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">Tümünü kaldır</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">Kaynak için kaldır</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">Kaynak için kaldır</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">Bu işlem için {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">Bu işlem için {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">全部移除</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">全部移除</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">删除资源</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">删除资源</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">删除 {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">删除 {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -93,18 +93,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ClearAllResources">
-        <source>Remove all</source>
-        <target state="translated">全部移除</target>
+        <source>Remove all telemetry</source>
+        <target state="needs-review-translation">全部移除</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearPendingSelectedResource">
-        <source>Remove for resource</source>
-        <target state="translated">拿掉資源</target>
+        <source>Remove telemetry for resource</source>
+        <target state="needs-review-translation">拿掉資源</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSelectedResource">
-        <source>Remove for {0}</source>
-        <target state="translated">拿掉 {0}</target>
+        <source>Remove telemetry for {0}</source>
+        <target state="needs-review-translation">拿掉 {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearSignalsButtonTitle">


### PR DESCRIPTION
## Description

Clarifies the dashboard clear-signals actions by adding "telemetry" to the names. ie, `Remove all` -> `Remove all telemetry`

Updates the generic clear-all label and the resource-specific clear labels in the dashboard resources, then regenerates the localized XLF files.

Closes https://github.com/microsoft/aspire/issues/9040

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No