### PR TITLE
Fix CodeQL pipeline to build all code without publishing

### DIFF
--- a/eng/pipelines/azure-pipelines-codeql.yml
+++ b/eng/pipelines/azure-pipelines-codeql.yml
@@ -33,9 +33,7 @@ schedules:
     branches:
       include:
       - main
-      - release/*
-      exclude:
-      - "*preview*"
+      - release/13.2
     always: true
 
 jobs:
@@ -52,14 +50,41 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  # Install Node.js, yarn, and vsce so the VS Code extension can be built
+  - task: NodeTool@0
+    displayName: Install node.js
+    inputs:
+      versionSpec: '20.x'
+
+  - task: PowerShell@2
+    displayName: Install yarn
+    inputs:
+      targetType: 'inline'
+      script: |
+        npm install -g yarn@1.22.22
+        yarn --version
+      workingDirectory: '$(Build.SourcesDirectory)'
+
+  - task: PowerShell@2
+    displayName: Install vsce
+    inputs:
+      targetType: 'inline'
+      script: |
+        npm install -g @vscode/vsce@3.7.1
+        vsce --version
+      workingDirectory: '$(Build.SourcesDirectory)'
+
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
 
-  - script: eng\common\cibuild.cmd
+  - script: build.cmd
+      -restore -build
       -configuration $(_BuildConfig)
       -prepareMachine
-      /p:Test=false
-    displayName: Windows Build
+      -ci
+      /p:BuildExtension=true
+      /p:SkipNativeBuild=true
+    displayName: Build
 
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize


### PR DESCRIPTION
## Summary

The CodeQL pipeline (definition 1599) has been failing on \main\ for several weeks. This PR fixes it.

## Root Causes

1. **VSIX validation error** (April 6 & 13): \cibuild.cmd\ hardwires \-publish\, which triggers publish validation in \Publishing.props\ that expects exactly 1 \.vsix\ file. Since \BuildExtension\ defaults to \alse\, no VSIX was ever built.

2. **SDK resolution error** (March 16–30): Stale \elease/*\ branches referenced unavailable SDK versions.

## Changes

- **Replace \cibuild.cmd\ with \uild.cmd -restore -build\** — only restores and builds, no test execution, signing, packing, or publishing. All code (src, tests, playground, extension) is compiled so CodeQL can analyze it.
- **Add \/p:BuildExtension=true\** + Node.js/yarn/vsce prerequisites — includes the VS Code extension in the build for CodeQL TypeScript analysis.
- **Add \/p:SkipNativeBuild=true\** — skips native AOT CLI compilation (slow and not useful for CodeQL C#/TS analysis).
- **Narrow scheduled branches** to \main\ and \elease/13.2\ only (other release branches are stale).