### PR TITLE
Use display name in lifecycle command response messages

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -27,7 +27,7 @@ internal static class CommandsConfigurationExtensions
                 var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStarted, context.ResourceName) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStarted, GetResolvedResourceName(resource, context)) };
             },
             updateState: context =>
             {
@@ -60,7 +60,7 @@ internal static class CommandsConfigurationExtensions
                 var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStopped, context.ResourceName) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStopped, GetResolvedResourceName(resource, context)) };
             },
             updateState: context =>
             {
@@ -100,7 +100,7 @@ internal static class CommandsConfigurationExtensions
 
                 await orchestrator.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceRestarted, context.ResourceName) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceRestarted, GetResolvedResourceName(resource, context)) };
             },
             updateState: context =>
             {
@@ -139,6 +139,11 @@ internal static class CommandsConfigurationExtensions
         static bool IsBuilding(string? state) => state == KnownResourceStates.Building;
         static bool IsRuntimeUnhealthy(string? state) => state == KnownResourceStates.RuntimeUnhealthy;
         static bool HasNoState(string? state) => string.IsNullOrEmpty(state);
+    }
+
+    private static string GetResolvedResourceName(IResource resource, ExecuteCommandContext context)
+    {
+        return resource.GetReplicaCount() > 1 ? context.ResourceName : resource.Name;
     }
 
     private static void AddRebuildCommand(ProjectResource projectResource)


### PR DESCRIPTION
## Description

Lifecycle command response messages (start, stop, restart) were using the internal DCP resource ID (e.g., `apiservice-abcdefgh`) instead of the friendly resource name. This caused the Notification Center in the Dashboard to display messages like `Successfully stopped 'apiservice-abcdefgh'` instead of `Successfully stopped 'apiservice'`.

Added a `GetResolvedResourceName` helper that returns `resource.Name` for single-instance resources and `context.ResourceName` (the full DCP ID) for replicated resources, matching the existing display name resolution pattern used elsewhere in the codebase.

Fixes https://github.com/microsoft/aspire/issues/16141

After:
<img width="454" height="468" alt="image" src="https://github.com/user-attachments/assets/c67d9cd8-c277-4668-bc21-db72aacfcc93" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
