### PR TITLE
Rename describe endpoints column to URLs

### DIFF
--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -278,7 +278,7 @@ internal sealed class DescribeCommand : BaseCommand
         table.AddBoldColumn(DescribeCommandStrings.HeaderType);
         table.AddBoldColumn(DescribeCommandStrings.HeaderState);
         table.AddBoldColumn(DescribeCommandStrings.HeaderHealth);
-        table.AddBoldColumn(DescribeCommandStrings.HeaderEndpoints);
+        table.AddBoldColumn(DescribeCommandStrings.HeaderURLs);
 
         foreach (var (snapshot, displayName) in orderedItems)
         {

--- a/src/Aspire.Cli/Resources/DescribeCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DescribeCommandStrings.Designer.cs
@@ -111,9 +111,9 @@ namespace Aspire.Cli.Resources {
             }
         }
 
-        public static string HeaderEndpoints {
+        public static string HeaderURLs {
             get {
-                return ResourceManager.GetString("HeaderEndpoints", resourceCulture);
+                return ResourceManager.GetString("HeaderURLs", resourceCulture);
             }
         }
     }

--- a/src/Aspire.Cli/Resources/DescribeCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DescribeCommandStrings.resx
@@ -150,7 +150,7 @@
   <data name="HeaderHealth" xml:space="preserve">
     <value>Health</value>
   </data>
-  <data name="HeaderEndpoints" xml:space="preserve">
-    <value>Endpoints</value>
+  <data name="HeaderURLs" xml:space="preserve">
+    <value>URLs</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.cs.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Koncové body</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Stav</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Typ</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.de.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Endpunkte</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Integrität</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Typ</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.es.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Puntos de conexión</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Mantenimiento</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Tipo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.fr.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Points de terminaison</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Intégrité</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.it.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Endpoint</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Integrità</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Tipo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ja.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">エンドポイント</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">正常性</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ko.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">엔드포인트</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">상태</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">형식</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.pl.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Punkty końcowe</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Kondycja</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Typ</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Pontos de extremidade</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Integridade</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Tipo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ru.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Конечные точки</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Работоспособность</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Тип</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.tr.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">Uç noktalar</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">Sistem Durumu</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">Tür</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">终结点</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">运行状况</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">类型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="new">Continuously stream resource state changes</target>
         <note />
       </trans-unit>
-      <trans-unit id="HeaderEndpoints">
-        <source>Endpoints</source>
-        <target state="translated">端點</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HeaderHealth">
         <source>Health</source>
         <target state="translated">健康情況</target>
@@ -35,6 +30,11 @@
       <trans-unit id="HeaderType">
         <source>Type</source>
         <target state="translated">類型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderURLs">
+        <source>URLs</source>
+        <target state="new">URLs</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">


### PR DESCRIPTION
## Description

`aspire describe` has a table with an Endpoints column. PR renames it to URLs to be consistent with the dashboard.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
