### PR TITLE
Use display name without DCP suffix in resource command error messages

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -27,7 +27,7 @@ internal static class CommandsConfigurationExtensions
                 var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStarted, GetResolvedDcpResouceName(resource, context)) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStarted, resource.GetResolvedDisplayResourceName(context.ResourceName)) };
             },
             updateState: context =>
             {
@@ -60,7 +60,7 @@ internal static class CommandsConfigurationExtensions
                 var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStopped, GetResolvedDcpResouceName(resource, context)) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStopped, resource.GetResolvedDisplayResourceName(context.ResourceName)) };
             },
             updateState: context =>
             {
@@ -100,7 +100,7 @@ internal static class CommandsConfigurationExtensions
 
                 await orchestrator.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceRestarted, GetResolvedDcpResouceName(resource, context)) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceRestarted, resource.GetResolvedDisplayResourceName(context.ResourceName)) };
             },
             updateState: context =>
             {
@@ -139,11 +139,6 @@ internal static class CommandsConfigurationExtensions
         static bool IsBuilding(string? state) => state == KnownResourceStates.Building;
         static bool IsRuntimeUnhealthy(string? state) => state == KnownResourceStates.RuntimeUnhealthy;
         static bool HasNoState(string? state) => string.IsNullOrEmpty(state);
-    }
-
-    private static string GetResolvedDcpResouceName(IResource resource, ExecuteCommandContext context)
-    {
-        return resource.GetReplicaCount() > 1 ? context.ResourceName : resource.Name;
     }
 
     private static void AddRebuildCommand(ProjectResource projectResource)

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -27,7 +27,7 @@ internal static class CommandsConfigurationExtensions
                 var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStarted, GetResolvedResourceName(resource, context)) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStarted, GetResolvedDcpResouceName(resource, context)) };
             },
             updateState: context =>
             {
@@ -60,7 +60,7 @@ internal static class CommandsConfigurationExtensions
                 var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStopped, GetResolvedResourceName(resource, context)) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStopped, GetResolvedDcpResouceName(resource, context)) };
             },
             updateState: context =>
             {
@@ -100,7 +100,7 @@ internal static class CommandsConfigurationExtensions
 
                 await orchestrator.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceRestarted, GetResolvedResourceName(resource, context)) };
+                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceRestarted, GetResolvedDcpResouceName(resource, context)) };
             },
             updateState: context =>
             {
@@ -141,7 +141,7 @@ internal static class CommandsConfigurationExtensions
         static bool HasNoState(string? state) => string.IsNullOrEmpty(state);
     }
 
-    private static string GetResolvedResourceName(IResource resource, ExecuteCommandContext context)
+    private static string GetResolvedDcpResouceName(IResource resource, ExecuteCommandContext context)
     {
         return resource.GetReplicaCount() > 1 ? context.ResourceName : resource.Name;
     }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -194,6 +194,6 @@ public class ResourceCommandService
         }
 
         logger.LogInformation("Command '{CommandName}' not available.", commandName);
-        return new ExecuteCommandResult { Success = false, Message = $"Command '{commandName}' not available for resource '{resourceId}'." };
+        return new ExecuteCommandResult { Success = false, Message = $"Command '{commandName}' not available for resource '{resource.GetResolvedDisplayResourceName(resourceId)}'." };
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1109,6 +1109,16 @@ public static class ResourceExtensions
     }
 
     /// <summary>
+    /// Returns the display name for the specified resource.
+    /// For resources with replicas, returns the full <paramref name="resourceId"/> to identify the instance.
+    /// For single-instance resources, returns the resource's display name without the DCP suffix.
+    /// </summary>
+    internal static string GetResolvedDisplayResourceName(this IResource resource, string resourceId)
+    {
+        return resource.GetReplicaCount() > 1 ? resourceId : resource.Name;
+    }
+
+    /// <summary>
     /// Attempts to get the DCP instances for the specified resource.
     /// </summary>
     /// <param name="resource">The resource to get the DCP instances from.</param>

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -72,6 +72,47 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task ExecuteCommandAsync_NoMatchingCommand_SingleInstance_MessageUsesDisplayName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myResource-abcdwxyz", "abcdwxyz", 0)
+            ]));
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(custom.Resource, "NotFound");
+
+        Assert.False(result.Success);
+        Assert.Equal("Command 'NotFound' not available for resource 'myResource'.", result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_NoMatchingCommand_HasReplicas_MessageUsesResourceId()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myResource-abcdwxyz", "abcdwxyz", 0),
+            new DcpInstance("myResource-efghwxyz", "efghwxyz", 1)
+            ]));
+        custom.WithAnnotation(new ReplicaAnnotation(2));
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(custom.Resource, "NotFound");
+
+        Assert.False(result.Success);
+        Assert.Contains("'myResource-abcdwxyz'", result.Message);
+        Assert.Contains("'myResource-efghwxyz'", result.Message);
+    }
+
+    [Fact]
     public async Task ExecuteCommandAsync_ResourceNameMultipleMatches_Success()
     {
         // Arrange


### PR DESCRIPTION
## Description

Resource command error messages previously included the full DCP resource ID (e.g., `cache-abcdwxyz`) even for single-instance resources. This is confusing because users know the resource by its display name (`cache`).

This PR:
- Adds `GetResolvedDisplayResourceName` extension method on `IResource` that returns the display name for single-instance resources and the full DCP resource ID for resources with replicas.
- Uses it in `ResourceCommandService.ExecuteCommandCoreAsync` for the "command not available" error message.
- Renames the existing private helper in `CommandsConfigurationExtensions` to `GetResolvedDcpResouceName` to distinguish it from the new method.
- Adds two tests verifying the error message format for both single-instance and replica scenarios.

Before:
<img width="1421" height="137" alt="image" src="https://github.com/user-attachments/assets/d69d5cb9-12f3-4d4d-ace7-49391763040e" />

After:
<img width="1320" height="137" alt="image" src="https://github.com/user-attachments/assets/d3c07c19-2d6a-4a79-a70f-ffdcfe5972e9" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
