### PR TITLE
Add regression coverage for TS SDK refresh after aspire add

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
+using Hex1b;
 using Hex1b.Automation;
 using Xunit;
 
@@ -19,13 +20,18 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
     public async Task RestoreRefreshesGeneratedSdkAfterAddingIntegration()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
         var workspace = TemporaryWorkspace.Create(output);
 
         // Use the DotNet container variant even for the TypeScript AppHost so local LocalHive
         // repros still have dotnet available for package/add flows while remaining outside the repo,
         // which keeps the AppHost on the PrebuiltAppHostServer path instead of in-repo dev mode.
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.DotNet, workspace: workspace);
+        using var terminal = CreateDockerTestTerminal(
+            repoRoot,
+            workspace,
+            variant: CliE2ETestHelpers.DockerfileVariant.DotNet,
+            mountDockerSocket: false,
+            out var strategy,
+            out var installMode);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -34,7 +40,7 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
-        await auto.InstallAspireCliAsync(strategy, counter);
+        await InstallAspireCliAsync(auto, counter, strategy, installMode);
 
         // Step 1: Create a TypeScript AppHost and verify the baseline generated SDK.
         await auto.TypeAsync("aspire init --language typescript --non-interactive");
@@ -135,17 +141,22 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
     public async Task UnAwaitedChainsCompileWithAutoResolvePromises()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CreateDockerTestTerminal(
+            repoRoot,
+            workspace,
+            variant: CliE2ETestHelpers.DockerfileVariant.DotNet,
+            mountDockerSocket: true,
+            out var strategy,
+            out var installMode);
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
         var counter = new SequenceCounter();
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
-        await auto.InstallAspireCliAsync(strategy, counter);
+        await InstallAspireCliAsync(auto, counter, strategy, installMode);
 
         await auto.TypeAsync("aspire init --language typescript --non-interactive");
         await auto.EnterAsync();
@@ -213,5 +224,68 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
         await auto.EnterAsync();
 
         await pendingRun;
+    }
+
+    private Hex1bTerminal CreateDockerTestTerminal(
+        string repoRoot,
+        TemporaryWorkspace workspace,
+        CliE2ETestHelpers.DockerfileVariant variant,
+        bool mountDockerSocket,
+        out CliInstallStrategy? strategy,
+        out CliE2ETestHelpers.DockerInstallMode? installMode)
+    {
+        if (ShouldUseCliInstallStrategy())
+        {
+            strategy = CliInstallStrategy.Detect();
+            installMode = null;
+
+            return CliE2ETestHelpers.CreateDockerTestTerminal(
+                repoRoot,
+                strategy,
+                output,
+                variant: variant,
+                mountDockerSocket: mountDockerSocket,
+                workspace: workspace);
+        }
+
+        strategy = null;
+        installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+
+        return CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot,
+            installMode.Value,
+            output,
+            variant: variant,
+            mountDockerSocket: mountDockerSocket,
+            workspace: workspace);
+    }
+
+    private static async Task InstallAspireCliAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        CliInstallStrategy? strategy,
+        CliE2ETestHelpers.DockerInstallMode? installMode)
+    {
+        if (strategy is not null)
+        {
+            await auto.InstallAspireCliAsync(strategy, counter);
+            return;
+        }
+
+        if (installMode is not null)
+        {
+            await auto.InstallAspireCliInDockerAsync(installMode.Value, counter);
+            return;
+        }
+
+        throw new InvalidOperationException("Either a CLI install strategy or Docker install mode must be provided.");
+    }
+
+    private static bool ShouldUseCliInstallStrategy()
+    {
+        return CliE2ETestHelpers.IsRunningInCI ||
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPIRE_E2E_ARCHIVE")) ||
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPIRE_E2E_QUALITY")) ||
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION"));
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -9,20 +9,23 @@ using Xunit;
 namespace Aspire.Cli.EndToEnd.Tests;
 
 /// <summary>
-/// End-to-end test that validates the <c>aspire restore</c> command by creating a
-/// TypeScript AppHost with two integrations and verifying the generated SDK files
-/// are produced in the <c>.modules/</c> directory.
+/// End-to-end tests that validate TypeScript SDK generation for guest AppHosts,
+/// including refreshing the generated SDK after adding integrations.
 /// </summary>
 public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
 {
     [Fact]
-    public async Task RestoreGeneratesSdkFiles()
+    [CaptureWorkspaceOnFailure]
+    public async Task RestoreRefreshesGeneratedSdkAfterAddingIntegration()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var strategy = CliInstallStrategy.Detect();
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, variant: CliE2ETestHelpers.DockerfileVariant.Polyglot, workspace: workspace);
+        // Use the DotNet container variant even for the TypeScript AppHost so local LocalHive
+        // repros still have dotnet available for package/add flows while remaining outside the repo,
+        // which keeps the AppHost on the PrebuiltAppHostServer path instead of in-repo dev mode.
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.DotNet, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -31,38 +34,48 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
-        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+        await auto.InstallAspireCliAsync(strategy, counter);
 
-        // Step 1: Create a TypeScript AppHost
+        // Step 1: Create a TypeScript AppHost and verify the baseline generated SDK.
         await auto.TypeAsync("aspire init --language typescript --non-interactive");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Step 2: Add two integrations
-        await auto.TypeAsync("aspire add Aspire.Hosting.Redis");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("The package Aspire.Hosting.", timeout: TimeSpan.FromMinutes(2));
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        await auto.TypeAsync("aspire add Aspire.Hosting.SqlServer");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("The package Aspire.Hosting.", timeout: TimeSpan.FromMinutes(2));
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Step 3: Run aspire restore and verify success
-        await auto.TypeAsync("aspire restore");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Step 4: Verify generated SDK files exist
         var modulesDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".modules");
         if (!Directory.Exists(modulesDir))
         {
             throw new InvalidOperationException($".modules directory was not created at {modulesDir}");
         }
 
+        var aspireModulePath = Path.Combine(modulesDir, "aspire.ts");
+        if (!File.Exists(aspireModulePath))
+        {
+            throw new InvalidOperationException($"Expected generated file not found: {aspireModulePath}");
+        }
+
+        var initialAspireTs = File.ReadAllText(aspireModulePath);
+        if (!initialAspireTs.Contains("createBuilder"))
+        {
+            throw new InvalidOperationException("aspire.ts did not contain the expected base exports before adding a new integration.");
+        }
+
+        var codegenHashPath = Path.Combine(modulesDir, ".codegen-hash");
+        var initialCodegenHash = File.Exists(codegenHashPath) ? File.ReadAllText(codegenHashPath) : null;
+
+        // Step 2: Add a new integration that is not present in the initial generated SDK.
+        await auto.TypeAsync("aspire add Aspire.Hosting.Redis");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("The package Aspire.Hosting.", timeout: TimeSpan.FromMinutes(2));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Step 3: Run aspire restore and verify the generated SDK picks up the new exports.
+        await auto.TypeAsync("aspire restore");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Step 4: Verify generated SDK files exist and were refreshed.
         var expectedFiles = new[] { "aspire.ts", "base.ts", "transport.ts" };
         foreach (var file in expectedFiles)
         {
@@ -79,16 +92,37 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
             }
         }
 
-        // Verify aspire.ts contains symbols from both integrations
-        var aspireTs = File.ReadAllText(Path.Combine(modulesDir, "aspire.ts"));
-        if (!aspireTs.Contains("addRedis"))
+        var restoredAspireTs = File.ReadAllText(aspireModulePath);
+        if (!restoredAspireTs.Contains("createBuilder"))
         {
-            throw new InvalidOperationException("aspire.ts does not contain addRedis from Aspire.Hosting.Redis");
+            throw new InvalidOperationException("aspire.ts no longer contains the original base exports after restore.");
         }
-        if (!aspireTs.Contains("addSqlServer"))
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+        var configJson = File.ReadAllText(configPath);
+        if (!configJson.Contains("\"Aspire.Hosting.Redis\""))
         {
-            throw new InvalidOperationException("aspire.ts does not contain addSqlServer from Aspire.Hosting.SqlServer");
+            throw new InvalidOperationException("aspire.config.json did not record Aspire.Hosting.Redis after aspire add.");
         }
+
+        var restoredCodegenHash = File.Exists(codegenHashPath) ? File.ReadAllText(codegenHashPath) : null;
+        if (initialCodegenHash == restoredCodegenHash)
+        {
+            throw new InvalidOperationException(".modules/.codegen-hash did not change after adding Aspire.Hosting.Redis and running aspire restore.");
+        }
+
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts");
+        File.WriteAllText(appHostPath, """
+            import { createBuilder } from './.modules/aspire.js';
+
+            const builder = await createBuilder();
+            await builder.addRedis("cache");
+            await builder.build().run();
+            """);
+
+        await auto.TypeAsync("npx tsc --noEmit --project tsconfig.apphost.json");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(2));
 
         await auto.TypeAsync("exit");
         await auto.EnterAsync();
@@ -101,17 +135,17 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
     public async Task UnAwaitedChainsCompileWithAutoResolvePromises()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var strategy = CliInstallStrategy.Detect();
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
         var counter = new SequenceCounter();
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
-        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+        await auto.InstallAspireCliAsync(strategy, counter);
 
         await auto.TypeAsync("aspire init --language typescript --non-interactive");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -42,10 +42,15 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
 
         await InstallAspireCliAsync(auto, counter, strategy, installMode);
 
-        // Step 1: Create a TypeScript AppHost and verify the baseline generated SDK.
+        // Step 1: Create a TypeScript AppHost, restore it, and verify the baseline generated SDK.
         await auto.TypeAsync("aspire init --language typescript --non-interactive");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire restore");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
         await auto.WaitForSuccessPromptAsync(counter);
 
         var modulesDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".modules");

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b;
@@ -69,6 +71,11 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
         if (!initialAspireTs.Contains("createBuilder"))
         {
             throw new InvalidOperationException("aspire.ts did not contain the expected base exports before adding a new integration.");
+        }
+
+        if (Regex.IsMatch(initialAspireTs, @"(?m)^\s*(?![*/])\S.*\baddRedis\s*\("))
+        {
+            throw new InvalidOperationException("Baseline SDK already exposes an addRedis API; test cannot verify refresh behavior after adding Redis.");
         }
 
         var codegenHashPath = Path.Combine(modulesDir, ".codegen-hash");
@@ -237,7 +244,8 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
         CliE2ETestHelpers.DockerfileVariant variant,
         bool mountDockerSocket,
         out CliInstallStrategy? strategy,
-        out CliE2ETestHelpers.DockerInstallMode? installMode)
+        out CliE2ETestHelpers.DockerInstallMode? installMode,
+        [CallerMemberName] string testName = "")
     {
         if (ShouldUseCliInstallStrategy())
         {
@@ -250,7 +258,8 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
                 output,
                 variant: variant,
                 mountDockerSocket: mountDockerSocket,
-                workspace: workspace);
+                workspace: workspace,
+                testName: testName);
         }
 
         strategy = null;
@@ -262,7 +271,8 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
             output,
             variant: variant,
             mountDockerSocket: mountDockerSocket,
-            workspace: workspace);
+            workspace: workspace,
+            testName: testName);
     }
 
     private static async Task InstallAspireCliAsync(


### PR DESCRIPTION
## Description

Adds CLI E2E coverage for the TypeScript guest AppHost flow behind issue #15785. The new test creates an app outside the repo so it uses `PrebuiltAppHostServer`, installs Aspire through `CliInstallStrategy`, adds `Aspire.Hosting.Redis`, runs `aspire restore`, and then compiles an `apphost.ts` that calls `builder.addRedis("cache")`.

This keeps the regression focused on the packaged/prebuilt path where stale SDK output was reported, and avoids false positives from string matching generated docs by proving the export is actually consumable from TypeScript. No product code changed because the refreshed SDK path passed once the scenario was modeled accurately.

Fixes #15785

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No