### PR TITLE
Fix AcrPurgeTask deployment test TypeScript API calls

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
@@ -128,8 +128,8 @@ public sealed class AcrPurgeTaskDeploymentTests(ITestOutputHelper output)
 // Add Azure Container App Environment and configure ACR purge task
 const infra = await builder.addAzureContainerAppEnvironment("infra");
 // Schedule once a month so it never fires during the test; the task is triggered manually via az acr task run
-const acr = await infra.getAzureContainerRegistry();
-await acr.withPurgeTask("0 0 1 * *", undefined, undefined, 1);
+await infra.getAzureContainerRegistry()
+    .withPurgeTask("0 0 1 * *", { keep: 1 });
 
 await builder.build().run();
 """);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
@@ -126,10 +126,10 @@ public sealed class AcrPurgeTaskDeploymentTests(ITestOutputHelper output)
                 "await builder.build().run();",
                 """
 // Add Azure Container App Environment and configure ACR purge task
-const infra = builder.addAzureContainerAppEnvironment("infra");
+const infra = await builder.addAzureContainerAppEnvironment("infra");
 // Schedule once a month so it never fires during the test; the task is triggered manually via az acr task run
-infra.getAzureContainerRegistry()
-    .withPurgeTask("0 0 1 * *", { keep: 1 });
+const acr = await infra.getAzureContainerRegistry();
+await acr.withPurgeTask("0 0 1 * *", undefined, undefined, 1);
 
 await builder.build().run();
 """);


### PR DESCRIPTION
## Description

Fix the AcrPurgeTask deployment E2E test's TypeScript AppHost code to use proper `await` and positional parameters.

The test modifies `apphost.ts` to add an Azure Container App Environment with a purge task. The TypeScript SDK methods return Promises and need `await`, and `withPurgeTask()` uses positional args (not an options object).

### Changes
- Add `await` on `addAzureContainerAppEnvironment()` and `getAzureContainerRegistry()` calls
- Use positional args for `withPurgeTask(schedule, filter, ago, keep)` instead of `{ keep: 1 }`

### Verified
- Audited all other deployment tests using `apphost.ts` -- they all use `await` correctly
- Tests using `apphost.cs` (C# AppHost via `aspire init`) are unaffected

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No (this IS a test fix)
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No