### PR TITLE
Dashboard: Show latest telemetry timestamp in Manage logs and telemetry dialog

### DIFF
--- a/playground/Stress/Stress.TelemetryService/Program.cs
+++ b/playground/Stress/Stress.TelemetryService/Program.cs
@@ -7,6 +7,7 @@ var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddHostedService<TelemetryStresser>();
 builder.Services.AddHostedService<GaugeMetrics>();
 builder.Services.AddHostedService<CounterMetrics>();
+builder.Services.AddHostedService<StaggeredTelemetrySender>();
 
 builder.AddServiceDefaults();
 builder.Logging.SetMinimumLevel(LogLevel.Trace);

--- a/playground/Stress/Stress.TelemetryService/StaggeredTelemetrySender.cs
+++ b/playground/Stress/Stress.TelemetryService/StaggeredTelemetrySender.cs
@@ -1,0 +1,236 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Grpc.Core;
+using Grpc.Net.Client;
+using OpenTelemetry.Proto.Collector.Logs.V1;
+using OpenTelemetry.Proto.Collector.Metrics.V1;
+using OpenTelemetry.Proto.Collector.Trace.V1;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Resource.V1;
+using OpenTelemetry.Proto.Trace.V1;
+
+namespace Stress.TelemetryService;
+
+/// <summary>
+/// Sends OTLP telemetry from multiple simulated service instances with different
+/// signal permutations and staggered stop times. Useful for manually testing the
+/// Manage Data dialog timestamp column.
+///
+/// Instance layout:
+///   - staggered-svc / logs-traces   → sends logs + traces, stops after 10s
+///   - staggered-svc / metrics-only  → sends metrics only, stops after 30s
+///   - staggered-svc / logs-only     → sends logs only, stops after 20s
+///   - staggered-svc / all-active    → sends logs + traces + metrics, never stops
+/// </summary>
+public class StaggeredTelemetrySender(ILogger<StaggeredTelemetrySender> logger, IConfiguration config) : BackgroundService
+{
+    [Flags]
+    private enum SignalKind
+    {
+        Logs = 1,
+        Traces = 2,
+        Metrics = 4
+    }
+
+    private sealed record InstanceConfig(string InstanceId, SignalKind Signals, TimeSpan? StopAfter);
+
+    private static readonly InstanceConfig[] s_instances =
+    [
+        new("logs-traces", SignalKind.Logs | SignalKind.Traces, TimeSpan.FromSeconds(10)),
+        new("metrics-only", SignalKind.Metrics, TimeSpan.FromSeconds(30)),
+        new("logs-only", SignalKind.Logs, TimeSpan.FromSeconds(20)),
+        new("all-active", SignalKind.Logs | SignalKind.Traces | SignalKind.Metrics, null)
+    ];
+
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var address = config["OTEL_EXPORTER_OTLP_ENDPOINT"]!;
+        var channel = GrpcChannel.ForAddress(address);
+        var logClient = new LogsService.LogsServiceClient(channel);
+        var traceClient = new TraceService.TraceServiceClient(channel);
+        var metricsClient = new MetricsService.MetricsServiceClient(channel);
+        var otlpApiKey = config["OTEL_EXPORTER_OTLP_HEADERS"]!.Split('=')[1];
+        var metadata = new Metadata { { "x-otlp-api-key", otlpApiKey } };
+
+        var tasks = s_instances.Select(inst => RunInstanceAsync(inst, logClient, traceClient, metricsClient, metadata, cancellationToken));
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task RunInstanceAsync(
+        InstanceConfig inst,
+        LogsService.LogsServiceClient logClient,
+        TraceService.TraceServiceClient traceClient,
+        MetricsService.MetricsServiceClient metricsClient,
+        Metadata metadata,
+        CancellationToken cancellationToken)
+    {
+        using var linkedCts = inst.StopAfter is not null
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+            : null;
+
+        if (linkedCts is not null && inst.StopAfter is { } delay)
+        {
+            linkedCts.CancelAfter(delay);
+        }
+
+        var token = linkedCts?.Token ?? cancellationToken;
+        var resource = CreateResource("staggered-svc", inst.InstanceId);
+        var iteration = 0;
+
+        logger.LogInformation("Staggered instance {InstanceId} starting — signals: {Signals}, stops after: {StopAfter}",
+            inst.InstanceId, inst.Signals, inst.StopAfter?.ToString() ?? "never");
+
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                iteration++;
+
+                if (inst.Signals.HasFlag(SignalKind.Logs))
+                {
+                    await SendLogAsync(logClient, resource, inst.InstanceId, iteration, metadata, token);
+                }
+
+                if (inst.Signals.HasFlag(SignalKind.Traces))
+                {
+                    await SendTraceAsync(traceClient, resource, inst.InstanceId, metadata, token);
+                }
+
+                if (inst.Signals.HasFlag(SignalKind.Metrics))
+                {
+                    await SendMetricAsync(metricsClient, resource, inst.InstanceId, iteration, metadata, token);
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(2), token);
+            }
+        }
+        catch (OperationCanceledException) when (inst.StopAfter is not null)
+        {
+            logger.LogInformation("Staggered instance {InstanceId} stopped after {StopAfter}", inst.InstanceId, inst.StopAfter);
+        }
+    }
+
+    private static async Task SendLogAsync(
+        LogsService.LogsServiceClient client, Resource resource,
+        string instanceId, int iteration, Metadata metadata, CancellationToken token)
+    {
+        var request = new ExportLogsServiceRequest
+        {
+            ResourceLogs =
+            {
+                new ResourceLogs
+                {
+                    Resource = resource,
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            Scope = new InstrumentationScope { Name = "StaggeredLogger" },
+                            LogRecords =
+                            {
+                                new LogRecord
+                                {
+                                    TimeUnixNano = TelemetryStresser.DateTimeToUnixNanoseconds(DateTime.UtcNow),
+                                    SeverityNumber = SeverityNumber.Info,
+                                    Body = new AnyValue { StringValue = $"[{instanceId}] heartbeat #{iteration}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await client.ExportAsync(request, headers: metadata, cancellationToken: token);
+    }
+
+    private static async Task SendTraceAsync(
+        TraceService.TraceServiceClient client, Resource resource,
+        string instanceId, Metadata metadata, CancellationToken token)
+    {
+        var now = DateTime.UtcNow;
+        var request = new ExportTraceServiceRequest
+        {
+            ResourceSpans =
+            {
+                new ResourceSpans
+                {
+                    Resource = resource,
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Scope = new InstrumentationScope { Name = "StaggeredTracer" },
+                            Spans =
+                            {
+                                new Span
+                                {
+                                    TraceId = GenerateId(16),
+                                    SpanId = GenerateId(8),
+                                    Name = $"heartbeat-{instanceId}",
+                                    Kind = Span.Types.SpanKind.Internal,
+                                    StartTimeUnixNano = TelemetryStresser.DateTimeToUnixNanoseconds(now),
+                                    EndTimeUnixNano = TelemetryStresser.DateTimeToUnixNanoseconds(now.AddMilliseconds(5)),
+                                    Status = new OpenTelemetry.Proto.Trace.V1.Status { Code = OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode.Ok }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await client.ExportAsync(request, headers: metadata, cancellationToken: token);
+    }
+
+    private static async Task SendMetricAsync(
+        MetricsService.MetricsServiceClient client, Resource resource,
+        string instanceId, int value, Metadata metadata, CancellationToken token)
+    {
+        var request = new ExportMetricsServiceRequest
+        {
+            ResourceMetrics =
+            {
+                new ResourceMetrics
+                {
+                    Resource = resource,
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = new InstrumentationScope { Name = "StaggeredMeter" },
+                            Metrics =
+                            {
+                                TelemetryStresser.CreateSumMetric($"staggered-counter-{instanceId}", DateTime.UtcNow, value: value)
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await client.ExportAsync(request, headers: metadata, cancellationToken: token);
+    }
+
+    private static Resource CreateResource(string name, string instanceId)
+    {
+        return new Resource
+        {
+            Attributes =
+            {
+                new KeyValue { Key = "service.name", Value = new AnyValue { StringValue = name } },
+                new KeyValue { Key = "service.instance.id", Value = new AnyValue { StringValue = instanceId } }
+            }
+        };
+    }
+
+    private static Google.Protobuf.ByteString GenerateId(int byteCount)
+    {
+        var bytes = new byte[byteCount];
+        Random.Shared.NextBytes(bytes);
+        return Google.Protobuf.ByteString.CopyFrom(bytes);
+    }
+}

--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -393,7 +393,8 @@ internal sealed class TelemetryApiService(
                 DisplayName = r.ResourceKey.GetCompositeName(),
                 HasLogs = r.HasLogs,
                 HasTraces = r.HasTraces,
-                HasMetrics = r.HasMetrics
+                HasMetrics = r.HasMetrics,
+                LatestTelemetryTimestamp = telemetryRepository.GetLatestTelemetryTimestamp(r.ResourceKey)
             })
             .ToArray();
     }

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -13,7 +13,7 @@
                     ItemSize="46"
                     Virtualize="true"
                     GenerateHeader="GenerateHeaderOption.Sticky"
-                    GridTemplateColumns="2fr 1fr"
+                    GridTemplateColumns="2fr 1.5fr 1.25fr"
                     TGridItem="ManageDataGridItem"
                     OnRowClick="@OnRowClicked"
                     ShowHover="true"
@@ -30,7 +30,12 @@
                                               OnClick="OnSelectAllClicked"
                                               Disabled="@(_resourceDataRows.Count == 0)"
                                               style="margin-right: 8px;" />
-                                @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
+                                <FluentButton Appearance="Appearance.Lightweight"
+                                              Class="manage-data-sort-button"
+                                              IconEnd="@GetSortIcon(ManageDataSortColumn.Name)"
+                                              OnClick="OnNameHeaderClicked">
+                                    @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
+                                </FluentButton>
                             </div>
                         </div>
                     </div>
@@ -93,10 +98,28 @@
                     </span>
                 </ChildContent>
             </TemplateColumn>
+            <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]">
+                <HeaderCellItemTemplate>
+                    <div style="display: flex; justify-content: flex-start; width: 100%;">
+                        <FluentButton Appearance="Appearance.Lightweight"
+                                      Class="manage-data-sort-button"
+                                      IconEnd="@GetSortIcon(ManageDataSortColumn.Timestamp)"
+                                      OnClick="OnTimestampHeaderClicked">
+                            @ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]
+                        </FluentButton>
+                    </div>
+                </HeaderCellItemTemplate>
+                <ChildContent>
+                    @if (context.IsResourceRow && context.ResourceRow is not null)
+                    {
+                        <span class="manage-data-timestamp">@GetTimestampText(context.ResourceRow)</span>
+                    }
+                </ChildContent>
+            </TemplateColumn>
             <TemplateColumn Title="@Loc[nameof(Dialogs.ManageDataSummaryColumnHeader)]">
                 @if (context.IsResourceRow && context.ResourceRow is not null)
                 {
-                    <span @onclick:stopPropagation="true">
+                    <span @onclick:stopPropagation="true" class="manage-data-summary">
                         @foreach (var dataRow in context.ResourceRow.TelemetryData)
                         {
                             <FluentButton Appearance="Appearance.Lightweight"

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Globalization;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.ManageData;
@@ -60,6 +61,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     private readonly Dictionary<string, ResourceDataRow> _resourceDataRows = new(StringComparers.ResourceName);
     private readonly HashSet<string> _expandedResourceNames = new(StringComparers.ResourceName);
     private readonly HashSet<(string ResourceName, AspireDataType DataType)> _selectedRows = [];
+    private readonly Dictionary<string, DateTime?> _timestampSortSnapshots = new(StringComparers.ResourceName);
     private readonly CancellationTokenSource _cts = new();
     private readonly Icon _iconUnselectedMultiple = new Icons.Regular.Size20.CheckboxUnchecked().WithColor(Color.FillInverse);
     private readonly Icon _iconSelectedMultiple = new Icons.Filled.Size20.CheckboxChecked();
@@ -70,12 +72,20 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     private bool _isRemoving;
     private string? _errorMessage;
     private bool _isImporting;
+    private Subscription? _logsSubscription;
+    private Subscription? _metricsSubscription;
     private Subscription? _resourcesSubscription;
+    private Subscription? _tracesSubscription;
+    private ManageDataSortColumn _sortColumn = ManageDataSortColumn.Name;
+    private bool _sortDescending;
 
     protected override async Task OnInitializedAsync()
     {
         // Subscribe to telemetry changes
         _resourcesSubscription = TelemetryRepository.OnNewResources(OnTelemetryChangedAsync);
+        _logsSubscription = TelemetryRepository.OnNewLogs(resourceKey: null, SubscriptionType.Other, OnTelemetryChangedAsync);
+        _metricsSubscription = TelemetryRepository.OnNewMetrics(resourceKey: null, SubscriptionType.Other, OnTelemetryChangedAsync);
+        _tracesSubscription = TelemetryRepository.OnNewTraces(resourceKey: null, SubscriptionType.Other, OnTelemetryChangedAsync);
 
         if (DashboardClient.IsEnabled)
         {
@@ -148,6 +158,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
         // Remove selections for resources that no longer exist
         _selectedRows.RemoveWhere(r => !_resourceDataRows.ContainsKey(r.ResourceName));
+        RemoveMissingTimestampSnapshots();
     }
 
     private async Task SubscribeResourcesAsync()
@@ -225,11 +236,14 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
             Resource = resource,
             OtlpResource = otlpResource,
             Name = resource.Name,
-            TelemetryData = data
+            TelemetryData = data,
+            LatestTelemetryTimestamp = otlpResource is not null
+                ? TelemetryRepository.GetLatestTelemetryTimestamp(otlpResource.ResourceKey)
+                : TelemetryRepository.GetLatestTelemetryTimestamp(new ResourceKey(resource.Name, InstanceId: null))
         };
     }
 
-    private static ResourceDataRow CreateTelemetryOnlyResourceDataRow(OtlpResource otlpResource)
+    private ResourceDataRow CreateTelemetryOnlyResourceDataRow(OtlpResource otlpResource)
     {
         var data = new List<TelemetryDataRow>();
         var resourceName = otlpResource.ResourceKey.GetCompositeName();
@@ -240,7 +254,8 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
             Resource = null,
             OtlpResource = otlpResource,
             Name = otlpResource.ResourceKey.GetCompositeName(),
-            TelemetryData = data
+            TelemetryData = data,
+            LatestTelemetryTimestamp = TelemetryRepository.GetLatestTelemetryTimestamp(otlpResource.ResourceKey)
         };
     }
 
@@ -279,8 +294,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     {
         var items = new List<ManageDataGridItem>();
 
-        // Sort by display name (works for both ResourceViewModel resources and telemetry-only resources)
-        foreach (var resourceRow in _resourceDataRows.Values.OrderBy(r => r.Name, StringComparers.ResourceName))
+        foreach (var resourceRow in GetSortedResourceRows())
         {
             // Add the resource row
             items.Add(new ManageDataGridItem
@@ -305,6 +319,119 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
         }
 
         return items.AsQueryable();
+    }
+
+    private IEnumerable<ResourceDataRow> GetSortedResourceRows()
+    {
+        // Sort by latest telemetry timestamp, if sort column has a value, then sorts by display name
+        return _sortColumn switch
+        {
+            ManageDataSortColumn.Timestamp when _sortDescending => _resourceDataRows.Values
+                .OrderBy(r => GetTimestampSortValue(r) is null ? 1 : 0)
+                .ThenByDescending(GetTimestampSortValue)
+                .ThenBy(r => r.Name, StringComparers.ResourceName),
+            ManageDataSortColumn.Timestamp => _resourceDataRows.Values
+                .OrderBy(r => GetTimestampSortValue(r) is null ? 1 : 0)
+                .ThenBy(GetTimestampSortValue)
+                .ThenBy(r => r.Name, StringComparers.ResourceName),
+            _ when _sortDescending => _resourceDataRows.Values.OrderByDescending(r => r.Name, StringComparers.ResourceName),
+            _ => _resourceDataRows.Values.OrderBy(r => r.Name, StringComparers.ResourceName)
+        };
+    }
+
+    private DateTime? GetTimestampSortValue(ResourceDataRow row)
+    {
+        if (_timestampSortSnapshots.TryGetValue(row.Name, out var snapshot))
+        {
+            return snapshot;
+        }
+
+        return row.LatestTelemetryTimestamp;
+    }
+
+    private void ToggleNameSort()
+    {
+        if (_sortColumn == ManageDataSortColumn.Name)
+        {
+            _sortDescending = !_sortDescending;
+        }
+        else
+        {
+            _sortColumn = ManageDataSortColumn.Name;
+            _sortDescending = false;
+        }
+    }
+
+    private void ToggleTimestampSort()
+    {
+        RefreshTimestampSortSnapshots();
+
+        if (_sortColumn == ManageDataSortColumn.Timestamp)
+        {
+            _sortDescending = !_sortDescending;
+        }
+        else
+        {
+            _sortColumn = ManageDataSortColumn.Timestamp;
+            _sortDescending = true;
+        }
+    }
+
+    private void RefreshTimestampSortSnapshots()
+    {
+        _timestampSortSnapshots.Clear();
+
+        foreach (var (resourceName, resourceRow) in _resourceDataRows)
+        {
+            _timestampSortSnapshots[resourceName] = resourceRow.LatestTelemetryTimestamp;
+        }
+    }
+
+    private void RemoveMissingTimestampSnapshots()
+    {
+        var missingNames = _timestampSortSnapshots.Keys
+            .Where(name => !_resourceDataRows.ContainsKey(name))
+            .ToList();
+
+        foreach (var name in missingNames)
+        {
+            _timestampSortSnapshots.Remove(name);
+        }
+
+        foreach (var (resourceName, resourceRow) in _resourceDataRows)
+        {
+            _timestampSortSnapshots.TryAdd(resourceName, resourceRow.LatestTelemetryTimestamp);
+        }
+    }
+
+    private void OnNameHeaderClicked()
+    {
+        ToggleNameSort();
+    }
+
+    private void OnTimestampHeaderClicked()
+    {
+        ToggleTimestampSort();
+    }
+
+    private Icon? GetSortIcon(ManageDataSortColumn column)
+    {
+        if (_sortColumn != column)
+        {
+            return null;
+        }
+
+        return _sortDescending ? new Icons.Regular.Size12.ChevronDown() : new Icons.Regular.Size12.ChevronUp();
+    }
+
+    private string GetTimestampText(ResourceDataRow resourceRow)
+    {
+        if (resourceRow.LatestTelemetryTimestamp is not { } timestamp)
+        {
+            return string.Empty;
+        }
+
+        return FormatHelpers.FormatDateTime(TimeProvider, timestamp, MillisecondsDisplay.None, CultureInfo.CurrentCulture);
     }
 
     private void OnRowClicked(FluentDataGridRow<ManageDataGridItem> row)
@@ -663,7 +790,10 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     public async ValueTask DisposeAsync()
     {
+        _logsSubscription?.Dispose();
+        _metricsSubscription?.Dispose();
         _resourcesSubscription?.Dispose();
+        _tracesSubscription?.Dispose();
 
         await _cts.CancelAsync();
 
@@ -680,5 +810,11 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
         }
 
         _cts.Dispose();
+    }
+
+    private enum ManageDataSortColumn
+    {
+        Name,
+        Timestamp
     }
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
@@ -14,6 +14,21 @@
     display: inline-flex;
 }
 
+::deep .manage-data-sort-button {
+    font-weight: 600;
+    padding: 0;
+}
+
+::deep .manage-data-timestamp {
+    white-space: nowrap;
+}
+
+::deep .manage-data-summary {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow: visible;
+}
+
 .button-container {
     display: grid;
     grid-template-columns: 1fr auto;

--- a/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
@@ -31,6 +31,11 @@ public sealed class ResourceDataRow
     public List<TelemetryDataRow> TelemetryData { get; set; } = [];
 
     /// <summary>
+    /// Gets the latest telemetry timestamp for this resource row.
+    /// </summary>
+    public DateTime? LatestTelemetryTimestamp { get; init; }
+
+    /// <summary>
     /// Gets whether this resource is telemetry-only (no corresponding ResourceViewModel).
     /// </summary>
     public bool IsTelemetryOnly => Resource is null && OtlpResource is not null;

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -57,8 +57,10 @@ public class OtlpResource : IOtlpResource
         Context = context;
     }
 
-    public void AddMetrics(AddContext context, RepeatedField<ScopeMetrics> scopeMetrics)
+    public DateTime? AddMetrics(AddContext context, RepeatedField<ScopeMetrics> scopeMetrics)
     {
+        DateTime? latestTimestamp = null;
+
         _metricsLock.EnterWriteLock();
 
         try
@@ -117,7 +119,11 @@ public class OtlpResource : IOtlpResource
                         continue;
                     }
 
-                    AddMetrics(instrument, metric, context, ref tempAttributes);
+                    var metricMaxTs = AddMetrics(instrument, metric, context, ref tempAttributes);
+                    if (metricMaxTs is not null && (latestTimestamp is null || metricMaxTs.Value > latestTimestamp.Value))
+                    {
+                        latestTimestamp = metricMaxTs;
+                    }
                 }
             }
         }
@@ -125,6 +131,8 @@ public class OtlpResource : IOtlpResource
         {
             _metricsLock.ExitWriteLock();
         }
+
+        return latestTimestamp;
     }
 
     private static int GetMetricDataPointCount(Metric metric)
@@ -140,8 +148,10 @@ public class OtlpResource : IOtlpResource
         };
     }
 
-    private void AddMetrics(OtlpInstrument instrument, Metric metric, AddContext context, ref KeyValuePair<string, string>[]? tempAttributes)
+    private DateTime? AddMetrics(OtlpInstrument instrument, Metric metric, AddContext context, ref KeyValuePair<string, string>[]? tempAttributes)
     {
+        DateTime? maxTimestamp = null;
+
         switch (metric.DataCase)
         {
             case Metric.DataOneofCase.Gauge:
@@ -150,6 +160,7 @@ public class OtlpResource : IOtlpResource
                     try
                     {
                         instrument.FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Context);
+                        UpdateMaxTimestamp(OtlpHelpers.UnixNanoSecondsToDateTime(d.TimeUnixNano), ref maxTimestamp);
                         context.SuccessCount++;
                     }
                     catch (Exception ex)
@@ -165,6 +176,7 @@ public class OtlpResource : IOtlpResource
                     try
                     {
                         instrument.FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Context);
+                        UpdateMaxTimestamp(OtlpHelpers.UnixNanoSecondsToDateTime(d.TimeUnixNano), ref maxTimestamp);
                         context.SuccessCount++;
                     }
                     catch (Exception ex)
@@ -180,6 +192,7 @@ public class OtlpResource : IOtlpResource
                     try
                     {
                         instrument.FindScope(d.Attributes, ref tempAttributes).AddHistogramValue(d, Context);
+                        UpdateMaxTimestamp(OtlpHelpers.UnixNanoSecondsToDateTime(d.TimeUnixNano), ref maxTimestamp);
                         context.SuccessCount++;
                     }
                     catch (Exception ex)
@@ -197,6 +210,16 @@ public class OtlpResource : IOtlpResource
                 context.FailureCount += metric.ExponentialHistogram.DataPoints.Count;
                 Context.Logger.LogInformation("Error adding exponential histogram metrics. Exponential histogram is not supported.");
                 break;
+        }
+
+        return maxTimestamp;
+
+        static void UpdateMaxTimestamp(DateTime candidate, ref DateTime? max)
+        {
+            if (max is null || candidate > max.Value)
+            {
+                max = candidate;
+            }
         }
     }
 
@@ -267,6 +290,40 @@ public class OtlpResource : IOtlpResource
                 instruments.Add(instrument.Value.Summary);
             }
             return instruments;
+        }
+        finally
+        {
+            _metricsLock.ExitReadLock();
+        }
+    }
+
+    internal DateTime? GetLatestMetricTimestamp()
+    {
+        _metricsLock.EnterReadLock();
+
+        try
+        {
+            DateTime? latest = null;
+
+            foreach (var instrument in _instruments.Values)
+            {
+                foreach (var dimension in instrument.Dimensions.Values)
+                {
+                    var values = dimension.Values;
+                    if (values.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    var candidate = values[^1].End;
+                    if (latest is null || candidate > latest.Value)
+                    {
+                        latest = candidate;
+                    }
+                }
+            }
+
+            return latest;
         }
         finally
         {

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -160,7 +160,7 @@ public class OtlpResource : IOtlpResource
                     try
                     {
                         instrument.FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Context);
-                        UpdateMaxTimestamp(OtlpHelpers.UnixNanoSecondsToDateTime(d.TimeUnixNano), ref maxTimestamp);
+                        UpdateMaxTimestamp(d.TimeUnixNano, ref maxTimestamp);
                         context.SuccessCount++;
                     }
                     catch (Exception ex)
@@ -176,7 +176,7 @@ public class OtlpResource : IOtlpResource
                     try
                     {
                         instrument.FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Context);
-                        UpdateMaxTimestamp(OtlpHelpers.UnixNanoSecondsToDateTime(d.TimeUnixNano), ref maxTimestamp);
+                        UpdateMaxTimestamp(d.TimeUnixNano, ref maxTimestamp);
                         context.SuccessCount++;
                     }
                     catch (Exception ex)
@@ -192,7 +192,7 @@ public class OtlpResource : IOtlpResource
                     try
                     {
                         instrument.FindScope(d.Attributes, ref tempAttributes).AddHistogramValue(d, Context);
-                        UpdateMaxTimestamp(OtlpHelpers.UnixNanoSecondsToDateTime(d.TimeUnixNano), ref maxTimestamp);
+                        UpdateMaxTimestamp(d.TimeUnixNano, ref maxTimestamp);
                         context.SuccessCount++;
                     }
                     catch (Exception ex)
@@ -214,8 +214,14 @@ public class OtlpResource : IOtlpResource
 
         return maxTimestamp;
 
-        static void UpdateMaxTimestamp(DateTime candidate, ref DateTime? max)
+        static void UpdateMaxTimestamp(ulong timeUnixNano, ref DateTime? max)
         {
+            if (timeUnixNano == 0)
+            {
+                return;
+            }
+
+            var candidate = OtlpHelpers.UnixNanoSecondsToDateTime(timeUnixNano);
             if (max is null || candidate > max.Value)
             {
                 max = candidate;

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -51,6 +51,9 @@ public sealed partial class TelemetryRepository : IDisposable
     private readonly HashSet<(OtlpResource Resource, string PropertyKey)> _logPropertyKeys = new();
     private readonly HashSet<(OtlpResource Resource, string PropertyKey)> _tracePropertyKeys = new();
     private readonly Dictionary<ResourceKey, int> _resourceUnviewedErrorLogs = new();
+    private readonly ConcurrentDictionary<ResourceKey, DateTime> _latestLogTimestamps = new();
+    private readonly ConcurrentDictionary<ResourceKey, DateTime> _latestTraceTimestamps = new();
+    private readonly ConcurrentDictionary<ResourceKey, DateTime> _latestMetricTimestamps = new();
 
     private readonly ReaderWriterLockSlim _tracesLock = new();
     private readonly Dictionary<string, OtlpScope> _traceScopes = new();
@@ -178,6 +181,45 @@ public sealed partial class TelemetryRepository : IDisposable
         finally
         {
             _logsLock.ExitReadLock();
+        }
+    }
+
+    public DateTime? GetLatestTelemetryTimestamp(ResourceKey key)
+    {
+        var resources = GetResources(key, includeUninstrumentedPeers: true);
+        if (resources.Count == 0)
+        {
+            return null;
+        }
+
+        DateTime? latest = null;
+
+        foreach (var resource in resources)
+        {
+            if (_latestLogTimestamps.TryGetValue(resource.ResourceKey, out var logTs))
+            {
+                UpdateLatest(logTs, ref latest);
+            }
+
+            if (_latestTraceTimestamps.TryGetValue(resource.ResourceKey, out var traceTs))
+            {
+                UpdateLatest(traceTs, ref latest);
+            }
+
+            if (_latestMetricTimestamps.TryGetValue(resource.ResourceKey, out var metricTs))
+            {
+                UpdateLatest(metricTs, ref latest);
+            }
+        }
+
+        return latest;
+
+        static void UpdateLatest(DateTime candidate, ref DateTime? latest)
+        {
+            if (latest is null || candidate > latest.Value)
+            {
+                latest = candidate;
+            }
         }
     }
 
@@ -411,9 +453,21 @@ public sealed partial class TelemetryRepository : IDisposable
             _logsLock.ExitWriteLock();
         }
 
-        // Push logs to watchers outside the lock
+        // Track latest log timestamp for this resource
         if (addedLogs is not null)
         {
+            var maxLogTs = addedLogs[0].TimeStamp;
+            for (var i = 1; i < addedLogs.Count; i++)
+            {
+                if (addedLogs[i].TimeStamp > maxLogTs)
+                {
+                    maxLogTs = addedLogs[i].TimeStamp;
+                }
+            }
+
+            _latestLogTimestamps.AddOrUpdate(resourceView.ResourceKey, maxLogTs, (_, existing) => maxLogTs > existing ? maxLogTs : existing);
+
+            // Push logs to watchers outside the lock
             PushLogsToWatchers(addedLogs, resourceView.ResourceKey);
         }
     }
@@ -809,12 +863,18 @@ public sealed partial class TelemetryRepository : IDisposable
                 foreach (var resource in resources)
                 {
                     SetResourceHasTraces(resource, false);
+                    _latestTraceTimestamps.TryRemove(resource.ResourceKey, out _);
                 }
             }
         }
         finally
         {
             _tracesLock.ExitWriteLock();
+        }
+
+        if (resources is null || resources.Count == 0)
+        {
+            _latestTraceTimestamps.Clear();
         }
 
         RaiseSubscriptionChanged(_tracesSubscriptions);
@@ -853,12 +913,18 @@ public sealed partial class TelemetryRepository : IDisposable
                 {
                     SetResourceHasLogs(resource, false);
                     _resourceUnviewedErrorLogs.Remove(resource.ResourceKey);
+                    _latestLogTimestamps.TryRemove(resource.ResourceKey, out _);
                 }
             }
         }
         finally
         {
             _logsLock.ExitWriteLock();
+        }
+
+        if (resources is null || resources.Count == 0)
+        {
+            _latestLogTimestamps.Clear();
         }
 
         RaiseSubscriptionChanged(_logSubscriptions);
@@ -868,6 +934,9 @@ public sealed partial class TelemetryRepository : IDisposable
     {
         if (_resources.TryRemove(resourceKey, out _))
         {
+            _latestLogTimestamps.TryRemove(resourceKey, out _);
+            _latestTraceTimestamps.TryRemove(resourceKey, out _);
+            _latestMetricTimestamps.TryRemove(resourceKey, out _);
             RaiseSubscriptionChanged(_resourceSubscriptions);
         }
     }
@@ -888,6 +957,12 @@ public sealed partial class TelemetryRepository : IDisposable
         {
             resource.ClearMetrics();
             SetResourceHasMetrics(resource, false);
+            _latestMetricTimestamps.TryRemove(resource.ResourceKey, out _);
+        }
+
+        if (!resourceKey.HasValue)
+        {
+            _latestMetricTimestamps.Clear();
         }
 
         RaiseSubscriptionChanged(_metricsSubscriptions);
@@ -1071,8 +1146,13 @@ public sealed partial class TelemetryRepository : IDisposable
                 continue;
             }
 
-            resourceView.Resource.AddMetrics(context, rm.ScopeMetrics);
+            var latestMetricTs = resourceView.Resource.AddMetrics(context, rm.ScopeMetrics);
             SetResourceHasMetrics(resourceView.Resource, true);
+
+            if (latestMetricTs is { } metricTs)
+            {
+                _latestMetricTimestamps.AddOrUpdate(resourceView.ResourceKey, metricTs, (_, existing) => metricTs > existing ? metricTs : existing);
+            }
         }
 
         RaiseSubscriptionChanged(_metricsSubscriptions);
@@ -1285,9 +1365,22 @@ public sealed partial class TelemetryRepository : IDisposable
             _tracesLock.ExitWriteLock();
         }
 
-        // Push spans to watchers outside the lock
+        // Track latest trace timestamp for this resource using the span's actual end time,
+        // not trace.LastUpdatedDate which is DateTime.UtcNow (receipt time, not signal time).
         if (addedSpans is not null)
         {
+            var maxTraceTs = DateTime.MinValue;
+            foreach (var span in addedSpans)
+            {
+                if (span.EndTime > maxTraceTs)
+                {
+                    maxTraceTs = span.EndTime;
+                }
+            }
+
+            _latestTraceTimestamps.AddOrUpdate(resourceView.ResourceKey, maxTraceTs, (_, existing) => maxTraceTs > existing ? maxTraceTs : existing);
+
+            // Push spans to watchers outside the lock
             PushSpansToWatchers(addedSpans, resourceView.ResourceKey);
         }
 

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -54,6 +54,7 @@ public sealed partial class TelemetryRepository : IDisposable
     private readonly ConcurrentDictionary<ResourceKey, DateTime> _latestLogTimestamps = new();
     private readonly ConcurrentDictionary<ResourceKey, DateTime> _latestTraceTimestamps = new();
     private readonly ConcurrentDictionary<ResourceKey, DateTime> _latestMetricTimestamps = new();
+    private readonly object _metricsWriteLock = new();
 
     private readonly ReaderWriterLockSlim _tracesLock = new();
     private readonly Dictionary<string, OtlpScope> _traceScopes = new();
@@ -380,6 +381,7 @@ public sealed partial class TelemetryRepository : IDisposable
     public void AddLogsCore(AddContext context, OtlpResourceView resourceView, RepeatedField<ScopeLogs> scopeLogs)
     {
         List<OtlpLogEntry>? addedLogs = null;
+        DateTime? maxLogTs = null;
 
         _logsLock.EnterWriteLock();
 
@@ -437,6 +439,10 @@ public sealed partial class TelemetryRepository : IDisposable
                         // Collect log for push-based streaming (lazy init to avoid allocation when no watchers)
                         addedLogs ??= new List<OtlpLogEntry>();
                         addedLogs.Add(logEntry);
+                        if (maxLogTs is null || logEntry.TimeStamp > maxLogTs.Value)
+                        {
+                            maxLogTs = logEntry.TimeStamp;
+                        }
 
                         context.SuccessCount++;
                     }
@@ -447,27 +453,20 @@ public sealed partial class TelemetryRepository : IDisposable
                     }
                 }
             }
+
+            if (maxLogTs is { } maxTimestamp)
+            {
+                _latestLogTimestamps.AddOrUpdate(resourceView.ResourceKey, maxTimestamp, (_, existing) => maxTimestamp > existing ? maxTimestamp : existing);
+            }
         }
         finally
         {
             _logsLock.ExitWriteLock();
         }
 
-        // Track latest log timestamp for this resource
+        // Push logs to watchers outside the lock.
         if (addedLogs is not null)
         {
-            var maxLogTs = addedLogs[0].TimeStamp;
-            for (var i = 1; i < addedLogs.Count; i++)
-            {
-                if (addedLogs[i].TimeStamp > maxLogTs)
-                {
-                    maxLogTs = addedLogs[i].TimeStamp;
-                }
-            }
-
-            _latestLogTimestamps.AddOrUpdate(resourceView.ResourceKey, maxLogTs, (_, existing) => maxLogTs > existing ? maxLogTs : existing);
-
-            // Push logs to watchers outside the lock
             PushLogsToWatchers(addedLogs, resourceView.ResourceKey);
         }
     }
@@ -943,26 +942,29 @@ public sealed partial class TelemetryRepository : IDisposable
 
     public void ClearMetrics(ResourceKey? resourceKey = null)
     {
-        List<OtlpResource> resources;
-        if (resourceKey.HasValue)
+        lock (_metricsWriteLock)
         {
-            resources = GetResources(resourceKey.Value);
-        }
-        else
-        {
-            resources = _resources.Values.ToList();
-        }
+            List<OtlpResource> resources;
+            if (resourceKey.HasValue)
+            {
+                resources = GetResources(resourceKey.Value);
+            }
+            else
+            {
+                resources = _resources.Values.ToList();
+            }
 
-        foreach (var resource in resources)
-        {
-            resource.ClearMetrics();
-            SetResourceHasMetrics(resource, false);
-            _latestMetricTimestamps.TryRemove(resource.ResourceKey, out _);
-        }
+            foreach (var resource in resources)
+            {
+                resource.ClearMetrics();
+                SetResourceHasMetrics(resource, false);
+                _latestMetricTimestamps.TryRemove(resource.ResourceKey, out _);
+            }
 
-        if (!resourceKey.HasValue)
-        {
-            _latestMetricTimestamps.Clear();
+            if (!resourceKey.HasValue)
+            {
+                _latestMetricTimestamps.Clear();
+            }
         }
 
         RaiseSubscriptionChanged(_metricsSubscriptions);
@@ -1146,12 +1148,15 @@ public sealed partial class TelemetryRepository : IDisposable
                 continue;
             }
 
-            var latestMetricTs = resourceView.Resource.AddMetrics(context, rm.ScopeMetrics);
-            SetResourceHasMetrics(resourceView.Resource, true);
-
-            if (latestMetricTs is { } metricTs)
+            lock (_metricsWriteLock)
             {
-                _latestMetricTimestamps.AddOrUpdate(resourceView.ResourceKey, metricTs, (_, existing) => metricTs > existing ? metricTs : existing);
+                var latestMetricTs = resourceView.Resource.AddMetrics(context, rm.ScopeMetrics);
+                SetResourceHasMetrics(resourceView.Resource, true);
+
+                if (latestMetricTs is { } metricTs)
+                {
+                    _latestMetricTimestamps.AddOrUpdate(resourceView.ResourceKey, metricTs, (_, existing) => metricTs > existing ? metricTs : existing);
+                }
             }
         }
 
@@ -1217,6 +1222,7 @@ public sealed partial class TelemetryRepository : IDisposable
     internal void AddTracesCore(AddContext context, OtlpResourceView resourceView, RepeatedField<ScopeSpans> scopeSpans)
     {
         List<OtlpSpan>? addedSpans = null;
+        DateTime? maxTraceTs = null;
 
         _tracesLock.EnterWriteLock();
 
@@ -1339,6 +1345,10 @@ public sealed partial class TelemetryRepository : IDisposable
                         // Collect span for push-based streaming (lazy init to avoid allocation when no watchers)
                         addedSpans ??= new List<OtlpSpan>();
                         addedSpans.Add(newSpan);
+                        if (maxTraceTs is null || newSpan.EndTime > maxTraceTs.Value)
+                        {
+                            maxTraceTs = newSpan.EndTime;
+                        }
 
                         context.SuccessCount++;
                     }
@@ -1359,28 +1369,20 @@ public sealed partial class TelemetryRepository : IDisposable
                     CalculateTraceUninstrumentedPeers(updatedTrace);
                 }
             }
+
+            if (maxTraceTs is { } maxTimestamp)
+            {
+                _latestTraceTimestamps.AddOrUpdate(resourceView.ResourceKey, maxTimestamp, (_, existing) => maxTimestamp > existing ? maxTimestamp : existing);
+            }
         }
         finally
         {
             _tracesLock.ExitWriteLock();
         }
 
-        // Track latest trace timestamp for this resource using the span's actual end time,
-        // not trace.LastUpdatedDate which is DateTime.UtcNow (receipt time, not signal time).
+        // Push spans to watchers outside the lock.
         if (addedSpans is not null)
         {
-            var maxTraceTs = DateTime.MinValue;
-            foreach (var span in addedSpans)
-            {
-                if (span.EndTime > maxTraceTs)
-                {
-                    maxTraceTs = span.EndTime;
-                }
-            }
-
-            _latestTraceTimestamps.AddOrUpdate(resourceView.ResourceKey, maxTraceTs, (_, existing) => maxTraceTs > existing ? maxTraceTs : existing);
-
-            // Push spans to watchers outside the lock
             PushSpansToWatchers(addedSpans, resourceView.ResourceKey);
         }
 

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -865,15 +865,15 @@ public sealed partial class TelemetryRepository : IDisposable
                     _latestTraceTimestamps.TryRemove(resource.ResourceKey, out _);
                 }
             }
+
+            if (resources is null || resources.Count == 0)
+            {
+                _latestTraceTimestamps.Clear();
+            }
         }
         finally
         {
             _tracesLock.ExitWriteLock();
-        }
-
-        if (resources is null || resources.Count == 0)
-        {
-            _latestTraceTimestamps.Clear();
         }
 
         RaiseSubscriptionChanged(_tracesSubscriptions);
@@ -915,15 +915,15 @@ public sealed partial class TelemetryRepository : IDisposable
                     _latestLogTimestamps.TryRemove(resource.ResourceKey, out _);
                 }
             }
+
+            if (resources is null || resources.Count == 0)
+            {
+                _latestLogTimestamps.Clear();
+            }
         }
         finally
         {
             _logsLock.ExitWriteLock();
-        }
-
-        if (resources is null || resources.Count == 0)
-        {
-            _latestLogTimestamps.Clear();
         }
 
         RaiseSubscriptionChanged(_logSubscriptions);

--- a/src/Shared/Otlp/Serialization/ResourceInfoJson.cs
+++ b/src/Shared/Otlp/Serialization/ResourceInfoJson.cs
@@ -48,6 +48,12 @@ internal sealed class ResourceInfoJson
     public bool HasMetrics { get; set; }
 
     /// <summary>
+    /// Gets or sets the latest timestamp observed across logs, traces, and metrics for this resource.
+    /// </summary>
+    [JsonPropertyName("latestTelemetryTimestamp")]
+    public DateTime? LatestTelemetryTimestamp { get; set; }
+
+    /// <summary>
     /// Gets the composite name by combining Name and InstanceId.
     /// </summary>
     /// <returns>The composite name (e.g., "catalogservice-abc123" or "catalogservice").</returns>

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Dashboard.Components.Dialogs;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Tests.Shared;
+using Aspire.Dashboard.Utils;
+using Bunit;
+using Google.Protobuf.Collections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Proto.Logs.V1;
+using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
+
+namespace Aspire.Dashboard.Components.Tests.Dialogs;
+
+[UseCulture("en-US")]
+public sealed class ManageDataDialogTests : DashboardTestContext
+{
+    [Fact]
+    public void RendersLatestTimestampForTelemetryOnlyResources()
+    {
+        var timeProvider = SetupManageDataServices();
+        var repository = Services.GetRequiredService<TelemetryRepository>();
+        var timestamp = new DateTime(2026, 4, 8, 10, 0, 0, DateTimeKind.Utc);
+
+        AddLog(repository, "beta", timestamp);
+
+        var cut = RenderComponent<ManageDataDialog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Timestamp", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains(FormatHelpers.FormatDateTime(timeProvider, timestamp, MillisecondsDisplay.None, CultureInfo.CurrentCulture), cut.Markup, StringComparison.Ordinal);
+            Assert.Equal(["beta"], GetResourceNames(cut));
+        });
+    }
+
+    [Fact]
+    public void TimestampSort_UsesSnapshotUntilUserChangesSort()
+    {
+        var timeProvider = SetupManageDataServices();
+        var repository = Services.GetRequiredService<TelemetryRepository>();
+        var alphaInitial = new DateTime(2026, 4, 8, 9, 0, 0, DateTimeKind.Utc);
+        var betaInitial = new DateTime(2026, 4, 8, 10, 0, 0, DateTimeKind.Utc);
+        var alphaUpdated = new DateTime(2026, 4, 8, 12, 0, 0, DateTimeKind.Utc);
+
+        AddLog(repository, "alpha", alphaInitial);
+        AddLog(repository, "beta", betaInitial);
+
+        var cut = RenderComponent<ManageDataDialog>();
+
+        cut.WaitForAssertion(() => Assert.Equal(["alpha", "beta"], GetResourceNames(cut)));
+
+        cut.FindAll(".manage-data-sort-button")[1].Click();
+
+        cut.WaitForAssertion(() => Assert.Equal(["beta", "alpha"], GetResourceNames(cut)));
+
+        AddLog(repository, "alpha", alphaUpdated);
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(["beta", "alpha"], GetResourceNames(cut));
+            Assert.Contains(FormatHelpers.FormatDateTime(timeProvider, alphaUpdated, MillisecondsDisplay.None, CultureInfo.CurrentCulture), cut.Markup, StringComparison.Ordinal);
+        });
+
+        cut.FindAll(".manage-data-sort-button")[0].Click();
+
+        cut.WaitForAssertion(() => Assert.Equal(["alpha", "beta"], GetResourceNames(cut)));
+
+        cut.FindAll(".manage-data-sort-button")[1].Click();
+
+        cut.WaitForAssertion(() => Assert.Equal(["alpha", "beta"], GetResourceNames(cut)));
+    }
+
+    private TestTimeProvider SetupManageDataServices()
+    {
+        var timeProvider = new TestTimeProvider();
+
+        FluentUISetupHelpers.SetupFluentDataGrid(this);
+        FluentUISetupHelpers.AddCommonDashboardServices(this, browserTimeProvider: timeProvider);
+
+        Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isEnabled: false));
+        Services.AddSingleton<ConsoleLogsManager>();
+        Services.AddSingleton<ConsoleLogsFetcher>();
+        Services.AddSingleton<TelemetryExportService>();
+        Services.AddSingleton<TelemetryImportService>();
+        Services.AddSingleton<IOptionsMonitor<DashboardOptions>>(new TestOptionsMonitor<DashboardOptions>(new DashboardOptions
+        {
+            UI = new UIOptions
+            {
+                DisableImport = true
+            }
+        }));
+        Services.AddSingleton<ILogger<TelemetryImportService>>(NullLogger<TelemetryImportService>.Instance);
+
+        return timeProvider;
+    }
+
+    private static void AddLog(TelemetryRepository repository, string resourceName, DateTime timestamp)
+    {
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: resourceName),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(time: timestamp, message: resourceName, severity: SeverityNumber.Info)
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    private static List<string> GetResourceNames(IRenderedComponent<ManageDataDialog> cut)
+    {
+        return cut.FindAll(".resource-name-text")
+            .Select(element => element.TextContent.Trim())
+            .ToList();
+    }
+
+    private sealed class TestOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = currentValue;
+
+        public T Get(string? name)
+        {
+            return CurrentValue;
+        }
+
+        public IDisposable? OnChange(Action<T, string?> listener)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -147,7 +147,7 @@ public class TelemetryApiServiceTests
         // Assert - should only return the non-error span
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
-        
+
         // Serialize to check content
         var json = System.Text.Json.JsonSerializer.Serialize(result.Data);
         Assert.DoesNotContain("error-span", json);
@@ -189,7 +189,7 @@ public class TelemetryApiServiceTests
         // Assert - should only return the error span
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
-        
+
         var json = System.Text.Json.JsonSerializer.Serialize(result.Data);
         Assert.Contains("error-span", json);
         Assert.DoesNotContain("ok-span", json);
@@ -248,7 +248,7 @@ public class TelemetryApiServiceTests
         // Assert - should only return 1 trace (the one without errors)
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
-        
+
         // Verify with null filter returns both
         var allResult = service.GetTraces(resourceNames: null, hasError: null, limit: null);
         Assert.NotNull(allResult);
@@ -308,7 +308,7 @@ public class TelemetryApiServiceTests
         // Assert - should only return 1 trace (the one with errors)
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
-        
+
         // Verify with null filter returns both
         var allResult = service.GetTraces(resourceNames: null, hasError: null, limit: null);
         Assert.NotNull(allResult);
@@ -609,6 +609,64 @@ public class TelemetryApiServiceTests
         Assert.NotNull(result);
         Assert.Equal(totalLogs, result.TotalCount);
         Assert.Equal(totalLogs, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetResources_IncludesLatestTelemetryTimestamp()
+    {
+        var repository = CreateRepository();
+        var expectedTimestamp = s_testTime.AddMinutes(7);
+
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(time: expectedTimestamp, message: "log", severity: SeverityNumber.Info)
+                        }
+                    }
+                }
+            }
+        });
+
+        var service = CreateService(repository);
+
+        var resources = service.GetResources();
+
+        var resource = Assert.Single(resources);
+        Assert.Equal("service1", resource.Name);
+        Assert.Equal("inst1", resource.InstanceId);
+        Assert.Equal(expectedTimestamp, resource.LatestTelemetryTimestamp);
+    }
+
+    [Fact]
+    public void GetResources_ResourceWithoutSignalData_HasNullLatestTelemetryTimestamp()
+    {
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service2", instanceId: "inst2")
+            }
+        });
+
+        var service = CreateService(repository);
+
+        var resources = service.GetResources();
+
+        var resource = Assert.Single(resources);
+        Assert.Equal("service2", resource.Name);
+        Assert.Equal("inst2", resource.InstanceId);
+        Assert.Null(resource.LatestTelemetryTimestamp);
     }
 
     /// <summary>

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
@@ -4,6 +4,8 @@
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
 using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
@@ -144,6 +146,106 @@ public class ResourceTests
         // Assert
         Assert.Equal("app1-19572b19", instance1Name);
         Assert.Equal("app1-f66e2b1e", instance2Name);
+    }
+
+    [Fact]
+    public void GetLatestTelemetryTimestamp_ReturnsLatestAcrossSignals()
+    {
+        var repository = CreateRepository();
+
+        var resource = CreateResource(name: "app1", instanceId: "123");
+
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = resource,
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: new DateTime(2026, 4, 8, 10, 0, 0, DateTimeKind.Utc)) }
+                    }
+                }
+            }
+        });
+
+        repository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = resource,
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test", startTime: new DateTime(2026, 4, 8, 10, 5, 0, DateTimeKind.Utc))
+                        }
+                    }
+                }
+            }
+        });
+
+        var latest = repository.GetLatestTelemetryTimestamp(new ResourceKey("app1", "123"));
+
+        // Metric timestamp is later than log timestamp, so it wins
+        Assert.Equal(new DateTime(2026, 4, 8, 10, 5, 0, DateTimeKind.Utc), latest);
+    }
+
+    [Fact]
+    public void GetLatestTelemetryTimestamp_ReturnsNullWhenResourceHasNoSignals()
+    {
+        var repository = CreateRepository();
+
+        var latest = repository.GetLatestTelemetryTimestamp(new ResourceKey("missing", "123"));
+
+        Assert.Null(latest);
+    }
+
+    [Fact]
+    public void GetLatestTelemetryTimestamp_WithNameOnlyKeyAggregatesReplicas()
+    {
+        var repository = CreateRepository();
+
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app1", instanceId: "123"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: new DateTime(2026, 4, 8, 10, 0, 0, DateTimeKind.Utc)) }
+                    }
+                }
+            }
+        });
+
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app1", instanceId: "456"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: new DateTime(2026, 4, 8, 10, 10, 0, DateTimeKind.Utc)) }
+                    }
+                }
+            }
+        });
+
+        var latest = repository.GetLatestTelemetryTimestamp(new ResourceKey("app1", InstanceId: null));
+
+        Assert.Equal(new DateTime(2026, 4, 8, 10, 10, 0, DateTimeKind.Utc), latest);
     }
 
     private static void AddResource(TelemetryRepository repository, string name, string? instanceId = null)


### PR DESCRIPTION
## Description

Adds a **Timestamp** column to the "Manage logs and telemetry" dialog in the dashboard, showing the latest telemetry signal time (structured logs, traces, and metrics) for each resource. This helps users identify which resource instances have the most recent telemetry — particularly useful when running the dashboard standalone with multiple service instances sharing the same `service.name` but different `service.instance.id`.

<img width="773" height="424" alt="image" src="https://github.com/user-attachments/assets/bd0253ce-19dc-4684-acdc-1a0f22baa06f" />

### Changes

**Backend (TelemetryRepository)**
- Add `GetLatestTelemetryTimestamp(ResourceKey)` with O(1) per-resource lookups via incremental tracking dictionaries (`_latestLogTimestamps`, `_latestTraceTimestamps`, `_latestMetricTimestamps`)
- Track timestamps at ingestion time in `AddLogsCore`, `AddTracesCore`, and `AddMetrics` instead of scanning all data on each call
- Clear tracked timestamps in `ClearStructuredLogs`, `ClearTraces`, `ClearMetrics`, and `ClearResource`
- Use actual OTLP signal timestamps (log `TimeStamp`, span `EndTime`, metric data point `TimeUnixNano`) — not wall-clock receipt times

**OtlpResource**
- Change `AddMetrics` to return `DateTime?` (latest metric data point timestamp seen in the batch) for incremental tracking
- Add `GetLatestMetricTimestamp()` for fallback/test use

**API**
- Add `latestTelemetryTimestamp` to `ResourceInfoJson` for the `/api/telemetry/resources` endpoint
- Project the timestamp in `TelemetryApiService.GetResources()`

**Dialog UI (ManageDataDialog)**
- Add sortable Timestamp column between Name and Summary with browser-local absolute date/time formatting
- Add sort snapshot mechanism (`_timestampSortSnapshots`) to prevent row reordering during live telemetry updates — snapshots refresh only when the user explicitly changes sort
- Subscribe to log/trace/metric telemetry changes for live timestamp updates
- Add `LatestTelemetryTimestamp` to `ResourceDataRow` model
- Fix Summary column truncation (`...`) for rows with 3+ signal type icons

**Tests**
- Repository tests: cross-signal aggregation, null for missing resources, replica aggregation
- API tests: `GetResources` includes/excludes latest timestamp correctly
- Component tests: timestamp rendering, sort snapshot stability

Closes https://github.com/microsoft/aspire/issues/15957

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
