### PR TITLE
Add analyzer for duplicate polyglot instance method names

### DIFF
--- a/src/Aspire.Hosting.Integration.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Aspire.Hosting.Integration.Analyzers/AnalyzerReleases.Unshipped.md
@@ -17,3 +17,4 @@ ASPIREEXPORT009 | Design | Warning | AspireExportAnalyzer, [Documentation](https
 ASPIREEXPORT010 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT010)
 ASPIREEXPORT011 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT011)
 ASPIREEXPORT012 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT012)
+ASPIREEXPORT013 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT013)

--- a/src/Aspire.Hosting.Integration.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Aspire.Hosting.Integration.Analyzers/AnalyzerReleases.Unshipped.md
@@ -19,3 +19,4 @@ ASPIREEXPORT011 | Design | Warning | AspireExportAnalyzer, [Documentation](https
 ASPIREEXPORT012 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT012)
 ASPIREEXPORT013 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT013)
 ASPIREEXPORT014 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT014)
+ASPIREEXPORT015 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT015)

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
@@ -131,6 +131,17 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{CallbackContextTypeMissingExportId}");
 
+        private const string DuplicateInstanceMethodNameId = "ASPIREEXPORT013";
+        internal static readonly DiagnosticDescriptor s_duplicateInstanceMethodName = new(
+            id: DuplicateInstanceMethodNameId,
+            title: "Exported instance methods must have unique polyglot names",
+            messageFormat: "Exported instance method '{0}' on type '{1}' maps to polyglot method name '{2}', which is already used by another exported instance method. Use [AspireExportIgnore] on unsupported overloads or assign a unique [AspireExport(\"...\")] ID.",
+            category: "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: $"https://aka.ms/aspire/diagnostics/{DuplicateInstanceMethodNameId}",
+            customTags: [WellKnownDiagnosticTags.CompilationEnd]);
+
         public static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics = ImmutableArray.Create(
             s_exportMethodMustBeStatic,
             s_invalidExportIdFormat,
@@ -143,7 +154,8 @@ public partial class AspireExportAnalyzer
             s_exportNameShouldBeUnique,
             s_exportedSyncDelegateInvokedInline,
             s_redundantExportId,
-            s_callbackContextTypeMissingExport
+            s_callbackContextTypeMissingExport,
+            s_duplicateInstanceMethodName
         );
     }
 }

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
@@ -154,10 +154,14 @@ public partial class AspireExportAnalyzer
             customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 
         private const string DuplicateInstanceMethodNameId = "ASPIREEXPORT015";
+        // Severity is Warning (not Error like ASPIREEXPORT014) because the collision is
+        // resolvable through well-known escape hatches: applying [AspireExportIgnore] to
+        // unsupported overloads or assigning a unique [AspireExport("...")] ID. Promoting
+        // this to Error would break existing assemblies on the first release of the rule.
         internal static readonly DiagnosticDescriptor s_duplicateInstanceMethodName = new(
             id: DuplicateInstanceMethodNameId,
             title: "Exported instance methods must have unique polyglot names",
-            messageFormat: "Exported instance method '{0}' on type '{1}' maps to polyglot method name '{2}', which is already used by another exported instance method. Use [AspireExportIgnore] on unsupported overloads or assign a unique [AspireExport(\"...\")] ID.",
+            messageFormat: "Exported instance method '{0}' on type '{1}' maps to polyglot method name '{2}', which is shared by multiple exported instance methods: {3}. Use [AspireExportIgnore] on unsupported overloads or assign a unique [AspireExport(\"...\")] ID.",
             category: "Design",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
@@ -153,6 +153,17 @@ public partial class AspireExportAnalyzer
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{DuplicateGeneratedMethodNameId}",
             customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 
+        private const string DuplicateInstanceMethodNameId = "ASPIREEXPORT015";
+        internal static readonly DiagnosticDescriptor s_duplicateInstanceMethodName = new(
+            id: DuplicateInstanceMethodNameId,
+            title: "Exported instance methods must have unique polyglot names",
+            messageFormat: "Exported instance method '{0}' on type '{1}' maps to polyglot method name '{2}', which is already used by another exported instance method. Use [AspireExportIgnore] on unsupported overloads or assign a unique [AspireExport(\"...\")] ID.",
+            category: "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: $"https://aka.ms/aspire/diagnostics/{DuplicateInstanceMethodNameId}",
+            customTags: [WellKnownDiagnosticTags.CompilationEnd]);
+
         public static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics = ImmutableArray.Create(
             s_exportMethodMustBeStatic,
             s_invalidExportIdFormat,
@@ -167,7 +178,8 @@ public partial class AspireExportAnalyzer
             s_redundantExportId,
             s_callbackContextTypeMissingExport,
             s_duplicatePolyglotCapabilityId,
-            s_duplicateGeneratedMethodName
+            s_duplicateGeneratedMethodName,
+            s_duplicateInstanceMethodName
         );
     }
 }

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -75,13 +75,18 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // Collection for ASPIREEXPORT007: track export IDs to detect duplicates
         // Key: (exportId, targetTypeFullName), Value: list of (method, location)
         var exportsByKey = new ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>>();
+        var instanceMethodsByPublicName = new ConcurrentDictionary<(string ContainingType, string PublicMethodName), ConcurrentBag<(IMethodSymbol Method, Location Location)>>();
 
         context.RegisterSymbolAction(
-            c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, currentAssemblyExportedTypes, exportsByKey),
+            c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, currentAssemblyExportedTypes, exportsByKey, instanceMethodsByPublicName),
             SymbolKind.Method);
 
         // At the end of compilation, report duplicate export IDs
-        context.RegisterCompilationEndAction(c => ReportDuplicateExports(c, exportsByKey));
+        context.RegisterCompilationEndAction(c =>
+        {
+            ReportDuplicateExports(c, exportsByKey);
+            ReportDuplicateInstanceMethodNames(c, instanceMethodsByPublicName);
+        });
 
         // Warn when exported builder methods invoke synchronous callback delegates inline. Deferred callbacks
         // that are stored for later execution are fine, and exports that opt into background-thread dispatch
@@ -123,7 +128,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol? aspireExportIgnoreAttribute,
         INamedTypeSymbol? aspireUnionAttribute,
         HashSet<ITypeSymbol> currentAssemblyExportedTypes,
-        ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>> exportsByKey)
+        ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>> exportsByKey,
+        ConcurrentDictionary<(string ContainingType, string PublicMethodName), ConcurrentBag<(IMethodSymbol Method, Location Location)>> instanceMethodsByPublicName)
     {
         var method = (IMethodSymbol)context.Symbol;
 
@@ -161,6 +167,16 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        var containingTypeExportAttribute = GetContainingTypeAspireExportAttribute(method.ContainingType, aspireExportAttribute);
+
+        TrackExportedInstanceMethodName(
+            method,
+            exportAttribute,
+            containingTypeExportAttribute,
+            hasExportIgnore,
+            containingTypeHasExportIgnore,
+            instanceMethodsByPublicName);
+
         // ASPIREEXPORT008: Check for missing export attributes on builder extension methods
         if (exportAttribute is null && !hasExportIgnore && !containingTypeHasExportIgnore && !isObsolete)
         {
@@ -174,7 +190,6 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         var attributeSyntax = exportAttribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken);
         var location = attributeSyntax?.GetLocation() ?? method.Locations.FirstOrDefault() ?? Location.None;
-        var containingTypeExportAttribute = GetContainingTypeAspireExportAttribute(method.ContainingType, aspireExportAttribute);
 
         // Rule 1: Method must be static
         if (!method.IsStatic && containingTypeExportAttribute is null)
@@ -952,6 +967,98 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    private static void ReportDuplicateInstanceMethodNames(
+        CompilationAnalysisContext context,
+        ConcurrentDictionary<(string ContainingType, string PublicMethodName), ConcurrentBag<(IMethodSymbol Method, Location Location)>> instanceMethodsByPublicName)
+    {
+        foreach (var kvp in instanceMethodsByPublicName)
+        {
+            var methods = kvp.Value.ToArray();
+            if (methods.Length <= 1)
+            {
+                continue;
+            }
+
+            foreach (var (method, location) in methods)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.s_duplicateInstanceMethodName,
+                    location,
+                    method.Name,
+                    kvp.Key.ContainingType,
+                    kvp.Key.PublicMethodName));
+            }
+        }
+    }
+
+    private static void TrackExportedInstanceMethodName(
+        IMethodSymbol method,
+        AttributeData? exportAttribute,
+        AttributeData? containingTypeExportAttribute,
+        bool hasExportIgnore,
+        bool containingTypeHasExportIgnore,
+        ConcurrentDictionary<(string ContainingType, string PublicMethodName), ConcurrentBag<(IMethodSymbol Method, Location Location)>> instanceMethodsByPublicName)
+    {
+        if (hasExportIgnore ||
+            containingTypeHasExportIgnore ||
+            !TryGetExportedInstanceMethodPublicName(method, exportAttribute, containingTypeExportAttribute, out var publicMethodName))
+        {
+            return;
+        }
+
+        var key = (method.ContainingType.ToDisplayString(), publicMethodName);
+        var location = method.Locations.FirstOrDefault() ?? Location.None;
+        var bag = instanceMethodsByPublicName.GetOrAdd(key, _ => new ConcurrentBag<(IMethodSymbol, Location)>());
+        bag.Add((method, location));
+    }
+
+    private static bool TryGetExportedInstanceMethodPublicName(
+        IMethodSymbol method,
+        AttributeData? exportAttribute,
+        AttributeData? containingTypeExportAttribute,
+        out string publicMethodName)
+    {
+        publicMethodName = string.Empty;
+
+        if (containingTypeExportAttribute is null ||
+            method.IsStatic ||
+            method.IsImplicitlyDeclared ||
+            method.MethodKind != MethodKind.Ordinary ||
+            method.IsGenericMethod ||
+            method.Name is "GetType" or "ToString" or "Equals" or "GetHashCode")
+        {
+            return false;
+        }
+
+        var isExplicitlyExported = exportAttribute is not null;
+        var isAutoExported = IsExposeMethodsEnabled(containingTypeExportAttribute) && method.DeclaredAccessibility == Accessibility.Public;
+        if (!isExplicitlyExported && !isAutoExported)
+        {
+            return false;
+        }
+
+        var explicitId = exportAttribute is not null ? GetExportId(exportAttribute) : null;
+        if (explicitId is not null)
+        {
+            if (!s_exportIdPattern.IsMatch(explicitId))
+            {
+                return false;
+            }
+
+            publicMethodName = GetPublicExportMethodName(explicitId);
+            return true;
+        }
+
+        var derivedExportId = GetDerivedExportId(method, containingTypeExportAttribute);
+        if (derivedExportId is null)
+        {
+            return false;
+        }
+
+        publicMethodName = GetPublicExportMethodName(derivedExportId);
+        return true;
+    }
+
     private static string? GetExportId(AttributeData attribute)
     {
         if (attribute.ConstructorArguments.Length > 0 &&
@@ -960,6 +1067,12 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             return id;
         }
         return null;
+    }
+
+    private static string GetPublicExportMethodName(string exportId)
+    {
+        var dotIndex = exportId.LastIndexOf('.');
+        return dotIndex >= 0 ? exportId.Substring(dotIndex + 1) : exportId;
     }
 
     private static string? GetDerivedExportId(IMethodSymbol method, AttributeData? containingTypeExportAttribute)

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -94,6 +94,46 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    private readonly struct InstanceMethodNameExport : IEquatable<InstanceMethodNameExport>
+    {
+        public InstanceMethodNameExport(string methodName, string source, Location location, string effectiveExportId)
+        {
+            MethodName = methodName;
+            Source = source;
+            Location = location;
+            EffectiveExportId = effectiveExportId;
+        }
+
+        public string MethodName { get; }
+
+        public string Source { get; }
+
+        public Location Location { get; }
+
+        public string EffectiveExportId { get; }
+
+        public bool Equals(InstanceMethodNameExport other)
+        {
+            return MethodName == other.MethodName &&
+                Source == other.Source &&
+                Location.Equals(other.Location) &&
+                EffectiveExportId == other.EffectiveExportId;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InstanceMethodNameExport other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return StringComparer.Ordinal.GetHashCode(MethodName) ^
+                StringComparer.Ordinal.GetHashCode(Source) ^
+                Location.GetHashCode() ^
+                StringComparer.Ordinal.GetHashCode(EffectiveExportId);
+        }
+    }
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => Diagnostics.SupportedDiagnostics;
 
     public override void Initialize(AnalysisContext context)
@@ -154,8 +194,11 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         var generatedMethodNames = new ConcurrentDictionary<(string MethodName, string TargetType), ConcurrentBag<GeneratedMethodNameExport>>();
         AnalyzeAssemblyExportedTypes(context.Compilation, aspireExportAttribute, aspireExportIgnoreAttribute, capabilityIds, generatedMethodNames, context.CancellationToken);
 
+        // Collection for ASPIREEXPORT015: track instance method names per containing type.
+        var instanceMethodsByPublicName = new ConcurrentDictionary<(string ContainingType, string PublicMethodName), ConcurrentBag<InstanceMethodNameExport>>();
+
         context.RegisterSymbolAction(
-            c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, currentAssemblyExportedTypes, exportsByKey, capabilityIds, generatedMethodNames),
+            c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, currentAssemblyExportedTypes, exportsByKey, capabilityIds, generatedMethodNames, instanceMethodsByPublicName),
             SymbolKind.Method);
 
         context.RegisterSymbolAction(
@@ -166,6 +209,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationEndAction(c => ReportDuplicateExports(c, exportsByKey));
         context.RegisterCompilationEndAction(c => ReportDuplicateCapabilityIds(c, capabilityIds));
         context.RegisterCompilationEndAction(c => ReportDuplicateGeneratedMethodNames(c, generatedMethodNames));
+        context.RegisterCompilationEndAction(c => ReportDuplicateInstanceMethodNames(c, instanceMethodsByPublicName));
 
         // Warn when exported builder methods invoke synchronous callback delegates inline. Deferred callbacks
         // that are stored for later execution are fine, and exports that opt into background-thread dispatch
@@ -209,7 +253,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         HashSet<ITypeSymbol> currentAssemblyExportedTypes,
         ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>> exportsByKey,
         ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>> capabilityIds,
-        ConcurrentDictionary<(string MethodName, string TargetType), ConcurrentBag<GeneratedMethodNameExport>> generatedMethodNames)
+        ConcurrentDictionary<(string MethodName, string TargetType), ConcurrentBag<GeneratedMethodNameExport>> generatedMethodNames,
+        ConcurrentDictionary<(string ContainingType, string PublicMethodName), ConcurrentBag<InstanceMethodNameExport>> instanceMethodsByPublicName)
     {
         var method = (IMethodSymbol)context.Symbol;
 
@@ -247,6 +292,16 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        var containingTypeExportAttribute = GetContainingTypeAspireExportAttribute(method.ContainingType, aspireExportAttribute);
+
+        TrackExportedInstanceMethodName(
+            method,
+            exportAttribute,
+            containingTypeExportAttribute,
+            hasExportIgnore,
+            containingTypeHasExportIgnore,
+            instanceMethodsByPublicName);
+
         // ASPIREEXPORT008: Check for missing export attributes on builder extension methods
         if (exportAttribute is null && !hasExportIgnore && !containingTypeHasExportIgnore && !isObsolete)
         {
@@ -260,7 +315,6 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         var attributeSyntax = exportAttribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken);
         var location = attributeSyntax?.GetLocation() ?? method.Locations.FirstOrDefault() ?? Location.None;
-        var containingTypeExportAttribute = GetContainingTypeAspireExportAttribute(method.ContainingType, aspireExportAttribute);
 
         // Rule 1: Method must be static
         if (!method.IsStatic && containingTypeExportAttribute is null)
@@ -1373,6 +1427,108 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         bag.Add(new GeneratedMethodNameExport(source, location, effectiveExportId, canShareGeneratedName));
     }
 
+    private static void ReportDuplicateInstanceMethodNames(
+        CompilationAnalysisContext context,
+        ConcurrentDictionary<(string ContainingType, string PublicMethodName), ConcurrentBag<InstanceMethodNameExport>> instanceMethodsByPublicName)
+    {
+        foreach (var kvp in instanceMethodsByPublicName.OrderBy(kvp => kvp.Key.ContainingType, StringComparer.Ordinal).ThenBy(kvp => kvp.Key.PublicMethodName, StringComparer.Ordinal))
+        {
+            var exports = kvp.Value
+                .Distinct()
+                .OrderBy(static e => e.Location.SourceSpan.Start)
+                .ThenBy(static e => e.Source, StringComparer.Ordinal)
+                .ToArray();
+
+            if (exports.Length <= 1 ||
+                exports.Select(static e => e.EffectiveExportId).Distinct(StringComparer.Ordinal).Count() <= 1)
+            {
+                continue;
+            }
+
+            foreach (var export in exports)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.s_duplicateInstanceMethodName,
+                    export.Location,
+                    export.MethodName,
+                    kvp.Key.ContainingType,
+                    kvp.Key.PublicMethodName));
+            }
+        }
+    }
+
+    private static void TrackExportedInstanceMethodName(
+        IMethodSymbol method,
+        AttributeData? exportAttribute,
+        AttributeData? containingTypeExportAttribute,
+        bool hasExportIgnore,
+        bool containingTypeHasExportIgnore,
+        ConcurrentDictionary<(string ContainingType, string PublicMethodName), ConcurrentBag<InstanceMethodNameExport>> instanceMethodsByPublicName)
+    {
+        if (hasExportIgnore ||
+            containingTypeHasExportIgnore ||
+            !TryGetExportedInstanceMethodPublicName(method, exportAttribute, containingTypeExportAttribute, out var publicMethodName, out var effectiveExportId))
+        {
+            return;
+        }
+
+        var key = (method.ContainingType.ToDisplayString(), publicMethodName);
+        var location = method.Locations.FirstOrDefault() ?? Location.None;
+        var bag = instanceMethodsByPublicName.GetOrAdd(key, _ => []);
+        bag.Add(new InstanceMethodNameExport(method.Name, GetMethodDisplayString(method), location, effectiveExportId));
+    }
+
+    private static bool TryGetExportedInstanceMethodPublicName(
+        IMethodSymbol method,
+        AttributeData? exportAttribute,
+        AttributeData? containingTypeExportAttribute,
+        out string publicMethodName,
+        out string effectiveExportId)
+    {
+        publicMethodName = string.Empty;
+        effectiveExportId = string.Empty;
+
+        if (containingTypeExportAttribute is null ||
+            method.IsStatic ||
+            method.IsImplicitlyDeclared ||
+            method.MethodKind != MethodKind.Ordinary ||
+            method.IsGenericMethod ||
+            method.Name is "GetType" or "ToString" or "Equals" or "GetHashCode")
+        {
+            return false;
+        }
+
+        var isExplicitlyExported = exportAttribute is not null;
+        var isAutoExported = IsExposeMethodsEnabled(containingTypeExportAttribute) && method.DeclaredAccessibility == Accessibility.Public;
+        if (!isExplicitlyExported && !isAutoExported)
+        {
+            return false;
+        }
+
+        var explicitId = exportAttribute is not null ? GetExportId(exportAttribute) : null;
+        if (explicitId is not null)
+        {
+            if (!s_exportIdPattern.IsMatch(explicitId))
+            {
+                return false;
+            }
+
+            effectiveExportId = explicitId;
+            publicMethodName = GetPublicExportMethodName(effectiveExportId);
+            return true;
+        }
+
+        var derivedExportId = GetDerivedExportId(method, containingTypeExportAttribute);
+        if (derivedExportId is null)
+        {
+            return false;
+        }
+
+        effectiveExportId = derivedExportId;
+        publicMethodName = GetPublicExportMethodName(effectiveExportId);
+        return true;
+    }
+
     private static string? GetExportId(AttributeData attribute)
     {
         if (attribute.ConstructorArguments.Length > 0 &&
@@ -1381,6 +1537,12 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             return id;
         }
         return null;
+    }
+
+    private static string GetPublicExportMethodName(string exportId)
+    {
+        var dotIndex = exportId.LastIndexOf('.');
+        return dotIndex >= 0 ? exportId.Substring(dotIndex + 1) : exportId;
     }
 
     private static string? GetDerivedExportId(IMethodSymbol method, AttributeData? containingTypeExportAttribute)

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -1439,12 +1439,17 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                 .ThenBy(static e => e.Source, StringComparer.Ordinal)
                 .ToArray();
 
+            // Skip when all duplicates share the same effective export ID — that case is
+            // already covered by ASPIREEXPORT013 (duplicate polyglot capability ID).
+            // ASPIREEXPORT015 only fires when *different* effective IDs collapse to the
+            // same trailing polyglot method name.
             if (exports.Length <= 1 ||
                 exports.Select(static e => e.EffectiveExportId).Distinct(StringComparer.Ordinal).Count() <= 1)
             {
                 continue;
             }
 
+            var sources = string.Join(", ", exports.Select(static e => e.Source).Distinct(StringComparer.Ordinal));
             foreach (var export in exports)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
@@ -1452,7 +1457,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                     export.Location,
                     export.MethodName,
                     kvp.Key.ContainingType,
-                    kvp.Key.PublicMethodName));
+                    kvp.Key.PublicMethodName,
+                    sources));
             }
         }
     }

--- a/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
+++ b/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
@@ -32,6 +32,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="namespace">The namespace name.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Use the exported withNamespace union helper instead.")]
     public HelmChartOptions WithNamespace(string @namespace)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
@@ -47,6 +48,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="namespace">A parameter resource builder for the namespace value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Use the exported withNamespace union helper instead.")]
     public HelmChartOptions WithNamespace(IResourceBuilder<ParameterResource> @namespace)
     {
         ArgumentNullException.ThrowIfNull(@namespace);
@@ -56,11 +58,22 @@ public sealed partial class HelmChartOptions
         return this;
     }
 
+    [AspireExport("withNamespace", Description = "Sets the target Kubernetes namespace for deployment from a string or parameter resource.")]
+    internal HelmChartOptions WithNamespaceCore(
+        [AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object @namespace)
+        => @namespace switch
+        {
+            string value => WithNamespace(value),
+            IResourceBuilder<ParameterResource> parameter => WithNamespace(parameter),
+            _ => throw new ArgumentException($"Unexpected namespace type: {@namespace.GetType().Name}", nameof(@namespace))
+        };
+
     /// <summary>
     /// Sets the Helm release name for deployment.
     /// </summary>
     /// <param name="releaseName">The release name.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Use the exported withReleaseName union helper instead.")]
     public HelmChartOptions WithReleaseName(string releaseName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(releaseName);
@@ -76,6 +89,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="releaseName">A parameter resource builder for the release name value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Use the exported withReleaseName union helper instead.")]
     public HelmChartOptions WithReleaseName(IResourceBuilder<ParameterResource> releaseName)
     {
         ArgumentNullException.ThrowIfNull(releaseName);
@@ -85,11 +99,22 @@ public sealed partial class HelmChartOptions
         return this;
     }
 
+    [AspireExport("withReleaseName", Description = "Sets the Helm release name for deployment from a string or parameter resource.")]
+    internal HelmChartOptions WithReleaseNameCore(
+        [AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object releaseName)
+        => releaseName switch
+        {
+            string value => WithReleaseName(value),
+            IResourceBuilder<ParameterResource> parameter => WithReleaseName(parameter),
+            _ => throw new ArgumentException($"Unexpected release name type: {releaseName.GetType().Name}", nameof(releaseName))
+        };
+
     /// <summary>
     /// Sets the Helm chart version for deployment.
     /// </summary>
     /// <param name="version">The chart version (e.g., "1.0.0").</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Use the exported withChartVersion union helper instead.")]
     public HelmChartOptions WithChartVersion(string version)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
@@ -105,6 +130,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="version">A parameter resource builder for the chart version value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Use the exported withChartVersion union helper instead.")]
     public HelmChartOptions WithChartVersion(IResourceBuilder<ParameterResource> version)
     {
         ArgumentNullException.ThrowIfNull(version);
@@ -113,6 +139,16 @@ public sealed partial class HelmChartOptions
         EnvironmentBuilder.WithAnnotation(new HelmChartVersionAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
         return this;
     }
+
+    [AspireExport("withChartVersion", Description = "Sets the Helm chart version for deployment from a string or parameter resource.")]
+    internal HelmChartOptions WithChartVersionCore(
+        [AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object version)
+        => version switch
+        {
+            string value => WithChartVersion(value),
+            IResourceBuilder<ParameterResource> parameter => WithChartVersion(parameter),
+            _ => throw new ArgumentException($"Unexpected chart version type: {version.GetType().Name}", nameof(version))
+        };
 
     private static void ValidateDnsLabel(string value, string target, int maxLength, string paramName)
     {

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -1908,4 +1908,72 @@ public class AspireExportAnalyzerTests
 
         await test.RunAsync();
     }
+
+    [Fact]
+    public async Task AutoExportedInstanceMethodOverloads_ReportsASPIREEXPORT013()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateInstanceMethodName;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExport(ExposeMethods = true)]
+            public interface IYarpConfigurationBuilder
+            {
+                string AddCluster(string endpoint);
+                string AddCluster(int port);
+            }
+            """,
+            [
+                new DiagnosticResult(diagnostic).WithLocation(8, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster"),
+                new DiagnosticResult(diagnostic).WithLocation(9, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster")
+            ]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task AutoExportedInstanceMethodOverloads_WithAspireExportIgnore_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExport(ExposeMethods = true)]
+            public interface IYarpConfigurationBuilder
+            {
+                [AspireExportIgnore(Reason = "Use addClusterFromEndpoint instead.")]
+                string AddCluster(string endpoint);
+
+                string AddCluster(int port);
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task AutoExportedInstanceMethodOverloads_WithUniqueExplicitIds_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExport(ExposeMethods = true)]
+            public interface IYarpConfigurationBuilder
+            {
+                [AspireExport("addClusterFromEndpoint")]
+                string AddCluster(string endpoint);
+
+                [AspireExport("addClusterWithPort")]
+                string AddCluster(int port);
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
 }

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -2203,6 +2203,7 @@ public class AspireExportAnalyzerTests
     public async Task ExplicitInstanceMethodAliasesWithSamePublicName_ReportsASPIREEXPORT015()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateInstanceMethodName;
+        var sources = "IYarpConfigurationBuilder.AddCluster(string), IYarpConfigurationBuilder.AddCluster(int)";
 
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
             using Aspire.Hosting;
@@ -2220,8 +2221,36 @@ public class AspireExportAnalyzerTests
             }
             """,
             [
-                new DiagnosticResult(diagnostic).WithLocation(9, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster"),
-                new DiagnosticResult(diagnostic).WithLocation(12, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster")
+                new DiagnosticResult(diagnostic).WithLocation(9, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster", sources),
+                new DiagnosticResult(diagnostic).WithLocation(12, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster", sources)
+            ]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExplicitAndAutoDerivedInstanceMethodsCollidingOnPublicName_ReportsASPIREEXPORT015()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateInstanceMethodName;
+        var sources = "IYarpConfigurationBuilder.AddCluster(string), IYarpConfigurationBuilder.AddCluster(int)";
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExport(ExposeMethods = true)]
+            public interface IYarpConfigurationBuilder
+            {
+                [AspireExport("clusters.addCluster")]
+                string AddCluster(string endpoint);
+
+                string AddCluster(int port);
+            }
+            """,
+            [
+                new DiagnosticResult(diagnostic).WithLocation(9, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster", sources),
+                new DiagnosticResult(diagnostic).WithLocation(11, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster", sources)
             ]);
 
         await test.RunAsync();

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -2198,4 +2198,75 @@ public class AspireExportAnalyzerTests
 
         await test.RunAsync();
     }
+
+    [Fact]
+    public async Task ExplicitInstanceMethodAliasesWithSamePublicName_ReportsASPIREEXPORT015()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateInstanceMethodName;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExport(ExposeMethods = true)]
+            public interface IYarpConfigurationBuilder
+            {
+                [AspireExport("clusters.addCluster")]
+                string AddCluster(string endpoint);
+
+                [AspireExport("ports.addCluster")]
+                string AddCluster(int port);
+            }
+            """,
+            [
+                new DiagnosticResult(diagnostic).WithLocation(9, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster"),
+                new DiagnosticResult(diagnostic).WithLocation(12, 12).WithArguments("AddCluster", "IYarpConfigurationBuilder", "addCluster")
+            ]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task AutoExportedInstanceMethodOverloads_WithAspireExportIgnore_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExport(ExposeMethods = true)]
+            public interface IYarpConfigurationBuilder
+            {
+                [AspireExportIgnore(Reason = "Use addClusterFromEndpoint instead.")]
+                string AddCluster(string endpoint);
+
+                string AddCluster(int port);
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task AutoExportedInstanceMethodOverloads_WithUniqueExplicitIds_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExport(ExposeMethods = true)]
+            public interface IYarpConfigurationBuilder
+            {
+                [AspireExport("addClusterFromEndpoint")]
+                string AddCluster(string endpoint);
+
+                [AspireExport("addClusterWithPort")]
+                string AddCluster(int port);
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.CodeGeneration.Python\Aspire.Hosting.CodeGeneration.Python.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.CodeGeneration.Rust\Aspire.Hosting.CodeGeneration.Rust.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.CodeGeneration.TypeScript\Aspire.Hosting.CodeGeneration.TypeScript.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Kubernetes\Aspire.Hosting.Kubernetes.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.RemoteHost\Aspire.Hosting.RemoteHost.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Yarp\Aspire.Hosting.Yarp.csproj" />

--- a/tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj
@@ -12,7 +12,6 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.CodeGeneration.Python\Aspire.Hosting.CodeGeneration.Python.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.CodeGeneration.Rust\Aspire.Hosting.CodeGeneration.Rust.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.CodeGeneration.TypeScript\Aspire.Hosting.CodeGeneration.TypeScript.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Kubernetes\Aspire.Hosting.Kubernetes.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.RemoteHost\Aspire.Hosting.RemoteHost.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Yarp\Aspire.Hosting.Yarp.csproj" />

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -424,6 +424,37 @@ public class AtsCapabilityScannerTests
     }
 
     [Fact]
+    public void ScanAssembly_HelmChartOptions_ExportsUnionHelpers()
+    {
+        var kubernetesAssembly = typeof(global::Aspire.Hosting.Kubernetes.HelmChartOptions).Assembly;
+
+        var result = AtsCapabilityScanner.ScanAssembly(kubernetesAssembly);
+
+        static void AssertUnionCapability(
+            AtsCapabilityScanner.ScanResult scanResult,
+            string capabilityId,
+            string parameterName,
+            string expectedMethodName)
+        {
+            var capability = Assert.Single(scanResult.Capabilities, c => c.CapabilityId == capabilityId);
+            var parameter = Assert.Single(capability.Parameters, p => p.Name == parameterName);
+
+            Assert.NotNull(parameter.Type);
+            Assert.Equal(AtsTypeCategory.Union, parameter.Type.Category);
+            Assert.NotNull(parameter.Type.UnionTypes);
+            Assert.Contains(parameter.Type.UnionTypes, t => t.TypeId == "string");
+            Assert.Contains(parameter.Type.UnionTypes, t => t.TypeId == AtsTypeMapping.DeriveTypeId(typeof(ParameterResource)));
+
+            var method = Assert.Single(scanResult.Methods, m => m.Key == capabilityId).Value;
+            Assert.Equal(expectedMethodName, method.Name);
+        }
+
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withNamespace", "namespace", "WithNamespaceCore");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withReleaseName", "releaseName", "WithReleaseNameCore");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withChartVersion", "version", "WithChartVersionCore");
+    }
+
+    [Fact]
     public void ScanAssembly_ClassLevelBackgroundThreadOptIn_AppliesToExportedMethods()
     {
         var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -425,6 +425,37 @@ public class AtsCapabilityScannerTests
     }
 
     [Fact]
+    public void ScanAssembly_HelmChartOptions_ExportsUnionHelpers()
+    {
+        var kubernetesAssembly = typeof(global::Aspire.Hosting.Kubernetes.HelmChartOptions).Assembly;
+
+        var result = AtsCapabilityScanner.ScanAssembly(kubernetesAssembly);
+
+        static void AssertUnionCapability(
+            AtsCapabilityScanner.ScanResult scanResult,
+            string capabilityId,
+            string parameterName,
+            string expectedMethodName)
+        {
+            var capability = Assert.Single(scanResult.Capabilities, c => c.CapabilityId == capabilityId);
+            var parameter = Assert.Single(capability.Parameters, p => p.Name == parameterName);
+
+            Assert.NotNull(parameter.Type);
+            Assert.Equal(AtsTypeCategory.Union, parameter.Type.Category);
+            Assert.NotNull(parameter.Type.UnionTypes);
+            Assert.Contains(parameter.Type.UnionTypes, t => t.TypeId == "string");
+            Assert.Contains(parameter.Type.UnionTypes, t => t.TypeId == AtsTypeMapping.DeriveTypeId(typeof(ParameterResource)));
+
+            var method = Assert.Single(scanResult.Methods, m => m.Key == capabilityId).Value;
+            Assert.Equal(expectedMethodName, method.Name);
+        }
+
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withNamespace", "namespace", "WithNamespace");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withReleaseName", "releaseName", "WithReleaseName");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withChartVersion", "version", "WithChartVersion");
+    }
+
+    [Fact]
     public void ScanAssembly_ClassLevelBackgroundThreadOptIn_AppliesToExportedMethods()
     {
         var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -450,9 +450,9 @@ public class AtsCapabilityScannerTests
             Assert.Equal(expectedMethodName, method.Name);
         }
 
-        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withNamespace", "namespace", "WithNamespace");
-        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withReleaseName", "releaseName", "WithReleaseName");
-        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/withChartVersion", "version", "WithChartVersion");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withNamespace", "namespace", "WithNamespace");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withReleaseName", "releaseName", "WithReleaseName");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withChartVersion", "version", "WithChartVersion");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -425,6 +425,37 @@ public class AtsCapabilityScannerTests
     }
 
     [Fact]
+    public void ScanAssembly_HelmChartOptions_ExportsUnionHelpers()
+    {
+        var kubernetesAssembly = typeof(global::Aspire.Hosting.Kubernetes.HelmChartOptions).Assembly;
+
+        var result = AtsCapabilityScanner.ScanAssembly(kubernetesAssembly);
+
+        static void AssertUnionCapability(
+            AtsCapabilityScanner.ScanResult scanResult,
+            string capabilityId,
+            string parameterName,
+            string expectedMethodName)
+        {
+            var capability = Assert.Single(scanResult.Capabilities, c => c.CapabilityId == capabilityId);
+            var parameter = Assert.Single(capability.Parameters, p => p.Name == parameterName);
+
+            Assert.NotNull(parameter.Type);
+            Assert.Equal(AtsTypeCategory.Union, parameter.Type.Category);
+            Assert.NotNull(parameter.Type.UnionTypes);
+            Assert.Contains(parameter.Type.UnionTypes, t => t.TypeId == "string");
+            Assert.Contains(parameter.Type.UnionTypes, t => t.TypeId == AtsTypeMapping.DeriveTypeId(typeof(ParameterResource)));
+
+            var method = Assert.Single(scanResult.Methods, m => m.Key == capabilityId).Value;
+            Assert.Equal(expectedMethodName, method.Name);
+        }
+
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withNamespace", "namespace", "WithNamespace");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withReleaseName", "releaseName", "WithReleaseName");
+        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withChartVersion", "version", "WithChartVersion");
+    }
+
+    [Fact]
     public void ScanAssembly_ClassLevelBackgroundThreadOptIn_AppliesToExportedMethods()
     {
         var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -425,37 +425,6 @@ public class AtsCapabilityScannerTests
     }
 
     [Fact]
-    public void ScanAssembly_HelmChartOptions_ExportsUnionHelpers()
-    {
-        var kubernetesAssembly = typeof(global::Aspire.Hosting.Kubernetes.HelmChartOptions).Assembly;
-
-        var result = AtsCapabilityScanner.ScanAssembly(kubernetesAssembly);
-
-        static void AssertUnionCapability(
-            AtsCapabilityScanner.ScanResult scanResult,
-            string capabilityId,
-            string parameterName,
-            string expectedMethodName)
-        {
-            var capability = Assert.Single(scanResult.Capabilities, c => c.CapabilityId == capabilityId);
-            var parameter = Assert.Single(capability.Parameters, p => p.Name == parameterName);
-
-            Assert.NotNull(parameter.Type);
-            Assert.Equal(AtsTypeCategory.Union, parameter.Type.Category);
-            Assert.NotNull(parameter.Type.UnionTypes);
-            Assert.Contains(parameter.Type.UnionTypes, t => t.TypeId == "string");
-            Assert.Contains(parameter.Type.UnionTypes, t => t.TypeId == AtsTypeMapping.DeriveTypeId(typeof(ParameterResource)));
-
-            var method = Assert.Single(scanResult.Methods, m => m.Key == capabilityId).Value;
-            Assert.Equal(expectedMethodName, method.Name);
-        }
-
-        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withNamespace", "namespace", "WithNamespace");
-        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withReleaseName", "releaseName", "WithReleaseName");
-        AssertUnionCapability(result, "Aspire.Hosting.Kubernetes/HelmChartOptions.withChartVersion", "version", "WithChartVersion");
-    }
-
-    [Fact]
     public void ScanAssembly_ClassLevelBackgroundThreadOptIn_AppliesToExportedMethods()
     {
         var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);


### PR DESCRIPTION
Fixes #15120.

## Summary
- add ASPIREEXPORT013 for exported instance methods that collapse to the same polyglot method name
- match the check to the generated TypeScript surface rather than raw export IDs
- cover the YARP-style addCluster overload case plus the ignore and unique-id escape hatches

## Testing
- `$env:DOTNET_ROLL_FORWARD='Major'; dotnet test tests\Aspire.Hosting.Analyzers.Tests\Aspire.Hosting.Analyzers.Tests.csproj -- --filter-class "*.AspireExportAnalyzerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
