### PR TITLE
Warn when guest AppHost packages add no SDK surface

### DIFF
--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1350,7 +1350,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             .Where(integration => ShouldCheckForGeneratedSdkWarning(integration, codeGenerationPackageName))
             .OrderBy(integration => integration.Name, StringComparer.OrdinalIgnoreCase))
         {
-            var capabilities = await rpcClient.GetCapabilitiesForAssembliesAsync([integration.Name], cancellationToken);
+            var capabilities = await rpcClient.GetCapabilitiesForAssembliesAsync(new[] { integration.Name }, cancellationToken);
             if (HasGeneratedSdkSurface(capabilities))
             {
                 continue;

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Net.Sockets;
 using System.Text.Json;
+using Aspire.Cli.Commands.Sdk;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Configuration;
@@ -1321,11 +1323,62 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             await File.WriteAllTextAsync(filePath, content, cancellationToken);
         }
 
+        await WarnAboutPackagesWithoutGeneratedSdkAsync(
+            languageDisplayName: DisplayName,
+            codeGenerationPackageName: _resolvedLanguage.PackageName,
+            interactionService: _interactionService,
+            rpcClient: rpcClient,
+            integrations: integrationsList,
+            cancellationToken: cancellationToken);
+
         // Write generation hash for caching
         SaveGenerationHash(outputPath, integrationsList);
 
         _logger.LogInformation("Generated {Count} {CodeGenerator} files in {Path}",
             files.Count, codeGenerator, outputPath);
+    }
+
+    internal static async Task WarnAboutPackagesWithoutGeneratedSdkAsync(
+        string languageDisplayName,
+        string codeGenerationPackageName,
+        IInteractionService interactionService,
+        IAppHostRpcClient rpcClient,
+        IEnumerable<IntegrationReference> integrations,
+        CancellationToken cancellationToken)
+    {
+        foreach (var integration in integrations
+            .Where(integration => ShouldCheckForGeneratedSdkWarning(integration, codeGenerationPackageName))
+            .OrderBy(integration => integration.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            var capabilities = await rpcClient.GetCapabilitiesForAssembliesAsync([integration.Name], cancellationToken);
+            if (HasGeneratedSdkSurface(capabilities))
+            {
+                continue;
+            }
+
+            interactionService.DisplayMessage(
+                KnownEmojis.Warning,
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ErrorStrings.PackageDoesNotExposeGuestAppHostApis,
+                    integration.Name,
+                    languageDisplayName));
+        }
+    }
+
+    internal static bool HasGeneratedSdkSurface(CapabilitiesInfo capabilities)
+    {
+        return capabilities.Capabilities.Count > 0
+            || capabilities.HandleTypes.Count > 0
+            || capabilities.DtoTypes.Count > 0
+            || capabilities.EnumTypes.Count > 0;
+    }
+
+    private static bool ShouldCheckForGeneratedSdkWarning(IntegrationReference integration, string codeGenerationPackageName)
+    {
+        return integration.IsPackageReference
+            && !string.Equals(integration.Name, "Aspire.Hosting", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(integration.Name, codeGenerationPackageName, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1346,7 +1346,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             .Where(integration => ShouldCheckForGeneratedSdkWarning(integration, codeGenerationPackageName))
             .OrderBy(integration => integration.Name, StringComparer.OrdinalIgnoreCase))
         {
-            var capabilities = await rpcClient.GetCapabilitiesForAssembliesAsync([integration.Name], cancellationToken);
+            var capabilities = await rpcClient.GetCapabilitiesForAssembliesAsync(new[] { integration.Name }, cancellationToken);
             if (HasGeneratedSdkSurface(capabilities))
             {
                 continue;

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Net.Sockets;
 using System.Text.Json;
+using Aspire.Cli.Commands.Sdk;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Configuration;
@@ -1317,11 +1319,62 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             await File.WriteAllTextAsync(filePath, content, cancellationToken);
         }
 
+        await WarnAboutPackagesWithoutGeneratedSdkAsync(
+            languageDisplayName: DisplayName,
+            codeGenerationPackageName: _resolvedLanguage.PackageName,
+            interactionService: _interactionService,
+            rpcClient: rpcClient,
+            integrations: integrationsList,
+            cancellationToken: cancellationToken);
+
         // Write generation hash for caching
         SaveGenerationHash(outputPath, integrationsList);
 
         _logger.LogInformation("Generated {Count} {CodeGenerator} files in {Path}",
             files.Count, codeGenerator, outputPath);
+    }
+
+    internal static async Task WarnAboutPackagesWithoutGeneratedSdkAsync(
+        string languageDisplayName,
+        string codeGenerationPackageName,
+        IInteractionService interactionService,
+        IAppHostRpcClient rpcClient,
+        IEnumerable<IntegrationReference> integrations,
+        CancellationToken cancellationToken)
+    {
+        foreach (var integration in integrations
+            .Where(integration => ShouldCheckForGeneratedSdkWarning(integration, codeGenerationPackageName))
+            .OrderBy(integration => integration.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            var capabilities = await rpcClient.GetCapabilitiesForAssembliesAsync([integration.Name], cancellationToken);
+            if (HasGeneratedSdkSurface(capabilities))
+            {
+                continue;
+            }
+
+            interactionService.DisplayMessage(
+                KnownEmojis.Warning,
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ErrorStrings.PackageDoesNotExposeGuestAppHostApis,
+                    integration.Name,
+                    languageDisplayName));
+        }
+    }
+
+    internal static bool HasGeneratedSdkSurface(CapabilitiesInfo capabilities)
+    {
+        return capabilities.Capabilities.Count > 0
+            || capabilities.HandleTypes.Count > 0
+            || capabilities.DtoTypes.Count > 0
+            || capabilities.EnumTypes.Count > 0;
+    }
+
+    private static bool ShouldCheckForGeneratedSdkWarning(IntegrationReference integration, string codeGenerationPackageName)
+    {
+        return integration.IsPackageReference
+            && !string.Equals(integration.Name, "Aspire.Hosting", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(integration.Name, codeGenerationPackageName, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -355,6 +355,13 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ProjectFilesCreatedButNodeToolsNotFound", resourceCulture);
             }
         }
+        public static string PackageDoesNotExposeGuestAppHostApis
+        {
+            get
+            {
+                return ResourceManager.GetString("PackageDoesNotExposeGuestAppHostApis", resourceCulture);
+            }
+        }
         public static string AppHostsMayNotBeBuildable
         {
             get

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -315,6 +315,13 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ProjectFilesCreatedButNodeToolsNotFound", resourceCulture);
             }
         }
+        public static string PackageDoesNotExposeGuestAppHostApis
+        {
+            get
+            {
+                return ResourceManager.GetString("PackageDoesNotExposeGuestAppHostApis", resourceCulture);
+            }
+        }
         public static string AppHostsMayNotBeBuildable
         {
             get

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -237,6 +237,10 @@
     <value>Project files were created, but Aspire could not run '{0}' automatically because the required JavaScript tooling was not found on PATH. You may see missing package errors or red squiggles in your IDE until you install {1} and run '{0}' in the project directory.</value>
     <comment>{0} is the install command, such as 'npm install', 'bun install', 'yarn install', or 'pnpm install'. {1} is the toolchain display name, such as 'Node.js', 'Bun', 'Yarn', or 'pnpm'. Do not translate 'PATH'.</comment>
   </data>
+  <data name="PackageDoesNotExposeGuestAppHostApis" xml:space="preserve">
+    <value>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</value>
+    <comment>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</comment>
+  </data>
   <data name="AppHostsMayNotBeBuildable" xml:space="preserve">
     <value>No buildable AppHosts were found, but there may have been unbuildable AppHosts.</value>
   </data>

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -221,6 +221,10 @@
     <value>Project files were created, but Aspire could not run 'npm install' automatically because the required Node.js tools were not found on PATH. You may see missing package errors or red squiggles in your IDE until you install Node.js and run 'npm install' in the project directory.</value>
     <comment>Do not translate 'npm install', 'Node.js', or 'PATH'.</comment>
   </data>
+  <data name="PackageDoesNotExposeGuestAppHostApis" xml:space="preserve">
+    <value>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</value>
+    <comment>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</comment>
+  </data>
   <data name="AppHostsMayNotBeBuildable" xml:space="preserve">
     <value>No buildable AppHosts were found, but there may have been unbuildable AppHosts.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Pro výzvu {0} byl požadován vstup, ale nebyl zadán.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Projekt se nepodařilo analyzovat kvůli chybě sestavení. Protokoly najdete na {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Pro výzvu {0} byl požadován vstup, ale nebyl zadán.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Projekt se nepodařilo analyzovat kvůli chybě sestavení. Protokoly najdete na {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Für die Eingabeaufforderung „{0}“ war eine Eingabe erforderlich, wurde jedoch nicht angegeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Das Projekt konnte aufgrund eines Buildfehlers nicht analysiert werden. Protokolle unter {0} anzeigen.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Für die Eingabeaufforderung „{0}“ war eine Eingabe erforderlich, wurde jedoch nicht angegeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Das Projekt konnte aufgrund eines Buildfehlers nicht analysiert werden. Protokolle unter {0} anzeigen.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Se requiere una entrada para la solicitud '{0}', pero no se ha proporcionado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">No se pudo analizar el proyecto debido a un error de compilación. Consulte los registros en {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Se requiere una entrada para la solicitud '{0}', pero no se ha proporcionado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">No se pudo analizar el proyecto debido a un error de compilación. Consulte los registros en {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Une entrée était requise pour l’invite '{0}', mais elle n’a pas été fournie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Impossible d’analyser le projet en raison d’une erreur de build. Consultez les journaux à l’emplacement {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Une entrée était requise pour l’invite '{0}', mais elle n’a pas été fournie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Impossible d’analyser le projet en raison d’une erreur de build. Consultez les journaux à l’emplacement {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -167,6 +167,11 @@
         <target state="translated">L'input necessario per la richiesta '{0}' non è stato fornito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Non è possibile analizzare il progetto a causa di un errore di compilazione. Consultare i log in {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -142,6 +142,11 @@
         <target state="translated">L'input necessario per la richiesta '{0}' non è stato fornito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Non è possibile analizzare il progetto a causa di un errore di compilazione. Consultare i log in {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -167,6 +167,11 @@
         <target state="translated">プロンプト '{0}' には入力が必要でしたが、提供されていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">ビルド エラーのため、プロジェクトを分析できませんでした。{0} でログを表示する</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -142,6 +142,11 @@
         <target state="translated">プロンプト '{0}' には入力が必要でしたが、提供されていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">ビルド エラーのため、プロジェクトを分析できませんでした。{0} でログを表示する</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -167,6 +167,11 @@
         <target state="translated">프롬프트 '{0}'에 대한 입력이 필요하지만 제공되지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">빌드 오류로 인해 프로젝트를 분석할 수 없습니다. {0}에서 로그 보기</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -142,6 +142,11 @@
         <target state="translated">프롬프트 '{0}'에 대한 입력이 필요하지만 제공되지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">빌드 오류로 인해 프로젝트를 분석할 수 없습니다. {0}에서 로그 보기</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Dane wejściowe były wymagane dla monitu „{0}”, ale nie zostały podane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Nie można przeanalizować projektu z powodu błędu kompilacji. Zobacz dzienniki pod adresem {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Dane wejściowe były wymagane dla monitu „{0}”, ale nie zostały podane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Nie można przeanalizować projektu z powodu błędu kompilacji. Zobacz dzienniki pod adresem {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -167,6 +167,11 @@
         <target state="translated">A entrada era necessária para a solicitação "{0}", mas não foi fornecida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Não foi possível analisar o projeto devido a um erro de compilação. Ver logs em {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="translated">A entrada era necessária para a solicitação "{0}", mas não foi fornecida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Não foi possível analisar o projeto devido a um erro de compilação. Ver logs em {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Для запроса "{0}" требовались входные данные, но они не были предоставлены.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Не удалось проанализировать проект из-за ошибки сборки. См. журналы по адресу {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Для запроса "{0}" требовались входные данные, но они не были предоставлены.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Не удалось проанализировать проект из-за ошибки сборки. См. журналы по адресу {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -167,6 +167,11 @@
         <target state="translated">'{0}' istemi için giriş gerekli ancak sağlanmadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Proje bir derleme hatası nedeniyle analiz edilemedi. {0} adresinde günlüklere bakın</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">'{0}' istemi için giriş gerekli ancak sağlanmadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">Proje bir derleme hatası nedeniyle analiz edilemedi. {0} adresinde günlüklere bakın</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -167,6 +167,11 @@
         <target state="translated">提示“{0}”需要输入，但未提供。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">由于生成错误，无法分析项目。请参阅 {0} 处的日志</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="translated">提示“{0}”需要输入，但未提供。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">由于生成错误，无法分析项目。请参阅 {0} 处的日志</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -167,6 +167,11 @@
         <target state="translated">提示 '{0}' 需要輸入，但未提供。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">因為組建錯誤，無法分析專案。請參閱 {0} 中的記錄</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="translated">提示 '{0}' 需要輸入，但未提供。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDoesNotExposeGuestAppHostApis">
+        <source>The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</source>
+        <target state="new">The package '{0}' does not expose any APIs for {1} AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.</target>
+        <note>{0} is the package ID, {1} is the guest AppHost language display name. Do not translate 'AppHost' or 'SDK'.</note>
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
         <source>The project could not be analyzed due to a build error. See logs at {0}</source>
         <target state="translated">因為組建錯誤，無法分析專案。請參閱 {0} 中的記錄</target>

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Commands.Sdk;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TypeSystem;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -530,6 +532,66 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
         Assert.Equal("Testing", envVars["ASPIRE_ENVIRONMENT"]);
     }
 
+    [Fact]
+    public async Task WarnAboutPackagesWithoutGeneratedSdkAsync_DisplaysWarningForEmptyPackageCapabilities()
+    {
+        var interactionService = new TestInteractionService();
+        var rpcClient = new TestAppHostRpcClient(new Dictionary<string, CapabilitiesInfo>
+        {
+            ["CommunityToolkit.Aspire.Hosting.Ollama"] = new()
+        });
+
+        await GuestAppHostProject.WarnAboutPackagesWithoutGeneratedSdkAsync(
+            languageDisplayName: "TypeScript (Node.js)",
+            codeGenerationPackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
+            interactionService: interactionService,
+            rpcClient: rpcClient,
+            integrations:
+            [
+                IntegrationReference.FromPackage("Aspire.Hosting", "13.3.0"),
+                IntegrationReference.FromPackage("CommunityToolkit.Aspire.Hosting.Ollama", "13.2.1-beta.528"),
+                IntegrationReference.FromPackage("Aspire.Hosting.CodeGeneration.TypeScript", "13.3.0")
+            ],
+            cancellationToken: default);
+
+        var displayedMessage = Assert.Single(interactionService.DisplayedMessages);
+        Assert.Equal("warning", displayedMessage.Emoji.Name);
+        Assert.Equal(
+            "The package 'CommunityToolkit.Aspire.Hosting.Ollama' does not expose any APIs for TypeScript (Node.js) AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.",
+            displayedMessage.Message);
+    }
+
+    [Fact]
+    public async Task WarnAboutPackagesWithoutGeneratedSdkAsync_SkipsPackagesThatExposeGeneratedSdkSurface()
+    {
+        var interactionService = new TestInteractionService();
+        var rpcClient = new TestAppHostRpcClient(new Dictionary<string, CapabilitiesInfo>
+        {
+            ["Aspire.Hosting.Redis"] = new()
+            {
+                Capabilities =
+                [
+                    new CapabilityInfo
+                    {
+                        CapabilityId = "capability-id",
+                        MethodName = "AddRedis",
+                        QualifiedMethodName = "Aspire.Hosting.Redis.RedisBuilderExtensions.AddRedis"
+                    }
+                ]
+            }
+        });
+
+        await GuestAppHostProject.WarnAboutPackagesWithoutGeneratedSdkAsync(
+            languageDisplayName: "TypeScript (Node.js)",
+            codeGenerationPackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
+            interactionService: interactionService,
+            rpcClient: rpcClient,
+            integrations: [IntegrationReference.FromPackage("Aspire.Hosting.Redis", "13.3.0")],
+            cancellationToken: default);
+
+        Assert.Empty(interactionService.DisplayedMessages);
+    }
+
     private static GuestAppHostProject CreateGuestAppHostProject()
     {
         var language = new LanguageInfo(
@@ -556,5 +618,37 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
             languageDiscovery: new TestLanguageDiscovery(),
             logger: NullLogger<GuestAppHostProject>.Instance,
             fileLoggerProvider: new FileLoggerProvider(logFilePath, new TestStartupErrorWriter()));
+    }
+
+    private sealed class TestAppHostRpcClient(Dictionary<string, CapabilitiesInfo> capabilitiesByAssembly) : IAppHostRpcClient
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public Task<RuntimeSpec> GetRuntimeSpecAsync(string languageId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<Dictionary<string, string>> ScaffoldAppHostAsync(string languageId, string targetPath, string? projectName, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<Dictionary<string, string>> GenerateCodeAsync(string languageId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<Dictionary<string, string>> GenerateCodeForAssemblyAsync(string languageId, string assemblyName, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<CapabilitiesInfo> GetCapabilitiesAsync(CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<CapabilitiesInfo> GetCapabilitiesForAssembliesAsync(IReadOnlyList<string> assemblyNames, CancellationToken cancellationToken)
+        {
+            var assemblyName = Assert.Single(assemblyNames);
+            return Task.FromResult(capabilitiesByAssembly.GetValueOrDefault(assemblyName) ?? new CapabilitiesInfo());
+        }
+
+        public Task<T> InvokeAsync<T>(string methodName, object?[] parameters, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task InvokeAsync(string methodName, object?[] parameters, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -556,6 +556,7 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
 
         var displayedMessage = Assert.Single(interactionService.DisplayedMessages);
         Assert.Equal("warning", displayedMessage.Emoji.Name);
+        Assert.Equal(typeof(string[]), rpcClient.LastAssemblyNamesRuntimeType);
         Assert.Equal(
             "The package 'CommunityToolkit.Aspire.Hosting.Ollama' does not expose any APIs for TypeScript (Node.js) AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.",
             displayedMessage.Message);
@@ -622,6 +623,8 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
 
     private sealed class TestAppHostRpcClient(Dictionary<string, CapabilitiesInfo> capabilitiesByAssembly) : IAppHostRpcClient
     {
+        public Type? LastAssemblyNamesRuntimeType { get; private set; }
+
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         public Task<RuntimeSpec> GetRuntimeSpecAsync(string languageId, CancellationToken cancellationToken)
@@ -641,6 +644,7 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
 
         public Task<CapabilitiesInfo> GetCapabilitiesForAssembliesAsync(IReadOnlyList<string> assemblyNames, CancellationToken cancellationToken)
         {
+            LastAssemblyNamesRuntimeType = assemblyNames.GetType();
             var assemblyName = Assert.Single(assemblyNames);
             return Task.FromResult(capabilitiesByAssembly.GetValueOrDefault(assemblyName) ?? new CapabilitiesInfo());
         }

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -567,6 +567,7 @@ public class GuestAppHostProjectTests : IDisposable
 
         var displayedMessage = Assert.Single(interactionService.DisplayedMessages);
         Assert.Equal("warning", displayedMessage.Emoji.Name);
+        Assert.Equal(typeof(string[]), rpcClient.LastAssemblyNamesRuntimeType);
         Assert.Equal(
             "The package 'CommunityToolkit.Aspire.Hosting.Ollama' does not expose any APIs for TypeScript (Node.js) AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.",
             displayedMessage.Message);
@@ -632,6 +633,8 @@ public class GuestAppHostProjectTests : IDisposable
 
     private sealed class TestAppHostRpcClient(Dictionary<string, CapabilitiesInfo> capabilitiesByAssembly) : IAppHostRpcClient
     {
+        public Type? LastAssemblyNamesRuntimeType { get; private set; }
+
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         public Task<RuntimeSpec> GetRuntimeSpecAsync(string languageId, CancellationToken cancellationToken)
@@ -651,6 +654,7 @@ public class GuestAppHostProjectTests : IDisposable
 
         public Task<CapabilitiesInfo> GetCapabilitiesForAssembliesAsync(IReadOnlyList<string> assemblyNames, CancellationToken cancellationToken)
         {
+            LastAssemblyNamesRuntimeType = assemblyNames.GetType();
             var assemblyName = Assert.Single(assemblyNames);
             return Task.FromResult(capabilitiesByAssembly.GetValueOrDefault(assemblyName) ?? new CapabilitiesInfo());
         }

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Commands.Sdk;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TypeSystem;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -541,6 +543,66 @@ public class GuestAppHostProjectTests : IDisposable
         Assert.Equal("Testing", envVars["ASPIRE_ENVIRONMENT"]);
     }
 
+    [Fact]
+    public async Task WarnAboutPackagesWithoutGeneratedSdkAsync_DisplaysWarningForEmptyPackageCapabilities()
+    {
+        var interactionService = new TestInteractionService();
+        var rpcClient = new TestAppHostRpcClient(new Dictionary<string, CapabilitiesInfo>
+        {
+            ["CommunityToolkit.Aspire.Hosting.Ollama"] = new()
+        });
+
+        await GuestAppHostProject.WarnAboutPackagesWithoutGeneratedSdkAsync(
+            languageDisplayName: "TypeScript (Node.js)",
+            codeGenerationPackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
+            interactionService: interactionService,
+            rpcClient: rpcClient,
+            integrations:
+            [
+                IntegrationReference.FromPackage("Aspire.Hosting", "13.3.0"),
+                IntegrationReference.FromPackage("CommunityToolkit.Aspire.Hosting.Ollama", "13.2.1-beta.528"),
+                IntegrationReference.FromPackage("Aspire.Hosting.CodeGeneration.TypeScript", "13.3.0")
+            ],
+            cancellationToken: default);
+
+        var displayedMessage = Assert.Single(interactionService.DisplayedMessages);
+        Assert.Equal("warning", displayedMessage.Emoji.Name);
+        Assert.Equal(
+            "The package 'CommunityToolkit.Aspire.Hosting.Ollama' does not expose any APIs for TypeScript (Node.js) AppHosts. Aspire can still run your app, but this package did not add anything to the generated SDK.",
+            displayedMessage.Message);
+    }
+
+    [Fact]
+    public async Task WarnAboutPackagesWithoutGeneratedSdkAsync_SkipsPackagesThatExposeGeneratedSdkSurface()
+    {
+        var interactionService = new TestInteractionService();
+        var rpcClient = new TestAppHostRpcClient(new Dictionary<string, CapabilitiesInfo>
+        {
+            ["Aspire.Hosting.Redis"] = new()
+            {
+                Capabilities =
+                [
+                    new CapabilityInfo
+                    {
+                        CapabilityId = "capability-id",
+                        MethodName = "AddRedis",
+                        QualifiedMethodName = "Aspire.Hosting.Redis.RedisBuilderExtensions.AddRedis"
+                    }
+                ]
+            }
+        });
+
+        await GuestAppHostProject.WarnAboutPackagesWithoutGeneratedSdkAsync(
+            languageDisplayName: "TypeScript (Node.js)",
+            codeGenerationPackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
+            interactionService: interactionService,
+            rpcClient: rpcClient,
+            integrations: [IntegrationReference.FromPackage("Aspire.Hosting.Redis", "13.3.0")],
+            cancellationToken: default);
+
+        Assert.Empty(interactionService.DisplayedMessages);
+    }
+
     private GuestAppHostProject CreateGuestAppHostProject()
     {
         var language = new LanguageInfo(
@@ -566,5 +628,37 @@ public class GuestAppHostProjectTests : IDisposable
             logger: NullLogger<GuestAppHostProject>.Instance,
             fileLoggerProvider: new FileLoggerProvider(logFilePath, new TestStartupErrorWriter()),
             profilingTelemetry: _profilingTelemetry);
+    }
+
+    private sealed class TestAppHostRpcClient(Dictionary<string, CapabilitiesInfo> capabilitiesByAssembly) : IAppHostRpcClient
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public Task<RuntimeSpec> GetRuntimeSpecAsync(string languageId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<Dictionary<string, string>> ScaffoldAppHostAsync(string languageId, string targetPath, string? projectName, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<Dictionary<string, string>> GenerateCodeAsync(string languageId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<Dictionary<string, string>> GenerateCodeForAssemblyAsync(string languageId, string assemblyName, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<CapabilitiesInfo> GetCapabilitiesAsync(CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<CapabilitiesInfo> GetCapabilitiesForAssembliesAsync(IReadOnlyList<string> assemblyNames, CancellationToken cancellationToken)
+        {
+            var assemblyName = Assert.Single(assemblyNames);
+            return Task.FromResult(capabilitiesByAssembly.GetValueOrDefault(assemblyName) ?? new CapabilitiesInfo());
+        }
+
+        public Task<T> InvokeAsync<T>(string methodName, object?[] parameters, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task InvokeAsync(string methodName, object?[] parameters, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary
- warn during guest SDK generation when a configured package exposes no generated SDK surface
- clarify that the app can still run and that the package simply adds nothing to the generated SDK
- add focused `GuestAppHostProject` coverage for empty and non-empty package capability results

## Details
Relates to #15119.

Current CLI behavior tolerates packages that do not expose polyglot APIs, but users get no explanation when a configured package contributes nothing to the generated guest SDK surface. This change checks package-scoped capabilities during guest SDK generation and emits a warning when a configured package returns no capabilities, handle types, DTO types, or enum types.

The warning is scoped to SDK generation, so it appears when generated files are refreshed rather than on every `aspire run`.

## Testing
- `.\artifacts\bin\Aspire.Cli.Tests\Debug\net10.0\Aspire.Cli.Tests.exe --filter-class Aspire.Cli.Tests.Projects.GuestAppHostProjectTests --minimum-expected-tests 10 --no-progress`