### PR TITLE
Show Azure Portal links in deployment summaries

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
@@ -112,7 +112,12 @@ public class AzureContainerAppResource : AzureProvisioningResource
 
     private static async Task<string?> GetPortalUrlAsync(PipelineStepContext context, string resourceName, CancellationToken cancellationToken)
     {
-        var deploymentStateManager = context.Services.GetRequiredService<IDeploymentStateManager>();
+        var deploymentStateManager = context.Services.GetService<IDeploymentStateManager>();
+        if (deploymentStateManager is null)
+        {
+            return null;
+        }
+
         var azureStateSection = await deploymentStateManager.AcquireSectionAsync("Azure", cancellationToken).ConfigureAwait(false);
 
         var subscriptionId = azureStateSection.Data["SubscriptionId"]?.ToString();
@@ -124,7 +129,7 @@ public class AzureContainerAppResource : AzureProvisioningResource
             return null;
         }
 
-        var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{resourceName.ToLowerInvariant()}";
+        var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{resourceName}";
         Guid? tenantGuid = Guid.TryParse(tenantId, out var parsed) ? parsed : null;
 
         return AzurePortalUrls.GetResourceUrl(resourceId, tenantGuid);

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
@@ -3,10 +3,12 @@
 
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREAZURE001
+#pragma warning disable ASPIREPIPELINES002
 #pragma warning disable ASPIREPIPELINES003
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure.AppContainers;
@@ -61,6 +63,13 @@ public class AzureContainerAppResource : AzureProvisioningResource
                         ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to Azure Container Apps environment **{containerAppEnv.Name}**. No public endpoints were configured."));
                         ctx.Summary.Add(targetResource.Name, "No public endpoints");
                     }
+
+                    // Add Azure Portal link for the deployed resource
+                    var portalUrl = await GetPortalUrlAsync(ctx, targetResource.Name, cancellationToken: ctx.CancellationToken).ConfigureAwait(false);
+                    if (portalUrl is not null)
+                    {
+                        ctx.Summary.Add($"🔗 {targetResource.Name}", new MarkdownString($"[Azure Portal]({portalUrl})"));
+                    }
                 },
                 Tags = ["print-summary"],
                 RequiredBySteps = [WellKnownPipelineSteps.Deploy]
@@ -100,4 +109,24 @@ public class AzureContainerAppResource : AzureProvisioningResource
     /// Gets the target resource that this Azure Container App is being created for.
     /// </summary>
     public IResource TargetResource { get; }
+
+    private static async Task<string?> GetPortalUrlAsync(PipelineStepContext context, string resourceName, CancellationToken cancellationToken)
+    {
+        var deploymentStateManager = context.Services.GetRequiredService<IDeploymentStateManager>();
+        var azureStateSection = await deploymentStateManager.AcquireSectionAsync("Azure", cancellationToken).ConfigureAwait(false);
+
+        var subscriptionId = azureStateSection.Data["SubscriptionId"]?.ToString();
+        var resourceGroupName = azureStateSection.Data["ResourceGroup"]?.ToString();
+        var tenantId = azureStateSection.Data["TenantId"]?.ToString();
+
+        if (subscriptionId is null || resourceGroupName is null)
+        {
+            return null;
+        }
+
+        var resourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{resourceName.ToLowerInvariant()}";
+        Guid? tenantGuid = Guid.TryParse(tenantId, out var parsed) ? parsed : null;
+
+        return AzurePortalUrls.GetResourceUrl(resourceId, tenantGuid);
+    }
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -62,8 +62,11 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                     ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})"));
                     ctx.Summary.Add(targetResource.Name, new MarkdownString($"[{endpoint}]({endpoint})"));
 
+                    // Use the base App Service site resource name for Azure Portal links / ARM resource IDs.
+                    var websiteName = await GetAppServiceWebsiteNameAsync(ctx, null).ConfigureAwait(false);
+
                     // Add Azure Portal link for the deployed resource
-                    var portalUrl = await GetPortalUrlAsync(ctx, hostName, deploymentSlot, ctx.CancellationToken).ConfigureAwait(false);
+                    var portalUrl = await GetPortalUrlAsync(ctx, websiteName, deploymentSlot, ctx.CancellationToken).ConfigureAwait(false);
                     if (portalUrl is not null)
                     {
                         ctx.Summary.Add($"🔗 {targetResource.Name}", new MarkdownString($"[Azure Portal]({portalUrl})"));
@@ -147,7 +150,12 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
 
     private static async Task<string?> GetPortalUrlAsync(PipelineStepContext context, string websiteName, string? deploymentSlot, CancellationToken cancellationToken)
     {
-        var deploymentStateManager = context.Services.GetRequiredService<IDeploymentStateManager>();
+        var deploymentStateManager = context.Services.GetService<IDeploymentStateManager>();
+        if (deploymentStateManager is null)
+        {
+            return null;
+        }
+
         var azureStateSection = await deploymentStateManager.AcquireSectionAsync("Azure", cancellationToken).ConfigureAwait(false);
 
         var subscriptionId = azureStateSection.Data["SubscriptionId"]?.ToString();

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -3,10 +3,12 @@
 
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREAZURE001
+#pragma warning disable ASPIREPIPELINES002
 #pragma warning disable ASPIREPIPELINES003
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure;
@@ -59,6 +61,13 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                     var endpoint = $"https://{hostName}.azurewebsites.net";
                     ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})"));
                     ctx.Summary.Add(targetResource.Name, new MarkdownString($"[{endpoint}]({endpoint})"));
+
+                    // Add Azure Portal link for the deployed resource
+                    var portalUrl = await GetPortalUrlAsync(ctx, hostName, deploymentSlot, ctx.CancellationToken).ConfigureAwait(false);
+                    if (portalUrl is not null)
+                    {
+                        ctx.Summary.Add($"🔗 {targetResource.Name}", new MarkdownString($"[Azure Portal]({portalUrl})"));
+                    }
                 },
                 Tags = ["print-summary"],
                 RequiredBySteps = [WellKnownPipelineSteps.Deploy]
@@ -135,4 +144,27 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     // Source of truth: https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites?path=%2Fsrc%2FHosting%2FAdministrationService%2FMicrosoft.Web.Hosting.Administration.Api%2FCommonConstants.cs&_a=contents&version=GBdev
     internal const int MaxHostPrefixLengthWithSlot = 59;
     internal const int MaxWebSiteNamePrefixLengthWithSlot = 40;
+
+    private static async Task<string?> GetPortalUrlAsync(PipelineStepContext context, string websiteName, string? deploymentSlot, CancellationToken cancellationToken)
+    {
+        var deploymentStateManager = context.Services.GetRequiredService<IDeploymentStateManager>();
+        var azureStateSection = await deploymentStateManager.AcquireSectionAsync("Azure", cancellationToken).ConfigureAwait(false);
+
+        var subscriptionId = azureStateSection.Data["SubscriptionId"]?.ToString();
+        var resourceGroupName = azureStateSection.Data["ResourceGroup"]?.ToString();
+        var tenantId = azureStateSection.Data["TenantId"]?.ToString();
+
+        if (subscriptionId is null || resourceGroupName is null)
+        {
+            return null;
+        }
+
+        var resourceId = string.IsNullOrWhiteSpace(deploymentSlot)
+            ? $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{websiteName}"
+            : $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{websiteName}/slots/{deploymentSlot}";
+
+        Guid? tenantGuid = Guid.TryParse(tenantId, out var parsed) ? parsed : null;
+
+        return AzurePortalUrls.GetResourceUrl(resourceId, tenantGuid);
+    }
 }

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -41,6 +41,7 @@
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.ContainerRegistry" />
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.AppService" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.AppContainers" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.Azure/AzurePortalUrls.cs
+++ b/src/Aspire.Hosting.Azure/AzurePortalUrls.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.Azure;
 internal static class AzurePortalUrls
 {
     private const string PortalBaseUrl = "https://portal.azure.com/";
-    private const string PortalDeploymentOverviewUrl = "https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id";
+    private const string PortalDeploymentOverviewUrl = PortalBaseUrl + "#view/HubsExtension/DeploymentDetailsBlade/~/overview/id";
 
     /// <summary>
     /// Gets the Azure portal URL for a resource group overview page.

--- a/src/Aspire.Hosting.Azure/AzurePortalUrls.cs
+++ b/src/Aspire.Hosting.Azure/AzurePortalUrls.cs
@@ -8,6 +8,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 internal static class AzurePortalUrls
 {
+    private const string PortalBaseUrl = "https://portal.azure.com/";
     private const string PortalDeploymentOverviewUrl = "https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id";
 
     /// <summary>
@@ -16,7 +17,21 @@ internal static class AzurePortalUrls
     internal static string GetResourceGroupUrl(string subscriptionId, string resourceGroupName, Guid? tenantId = null)
     {
         var tenantSegment = tenantId.HasValue ? $"#@{tenantId.Value}" : "#";
-        return $"https://portal.azure.com/{tenantSegment}/resource/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/overview";
+        return $"{PortalBaseUrl}{tenantSegment}/resource/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/overview";
+    }
+
+    /// <summary>
+    /// Gets the Azure portal URL for a specific Azure resource using its fully qualified resource ID.
+    /// </summary>
+    /// <remarks>
+    /// The resource ID should be in the standard ARM format, e.g.:
+    /// <c>/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.App/containerApps/{name}</c>
+    /// This also handles child resources like App Service deployment slots.
+    /// </remarks>
+    internal static string GetResourceUrl(string resourceId, Guid? tenantId = null)
+    {
+        var tenantSegment = tenantId.HasValue ? $"#@{tenantId.Value}" : "#";
+        return $"{PortalBaseUrl}{tenantSegment}/resource{resourceId}";
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePortalUrlsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePortalUrlsTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzurePortalUrlsTests
+{
+    [Fact]
+    public void GetResourceGroupUrl_WithoutTenantId_ReturnsCorrectUrl()
+    {
+        var url = AzurePortalUrls.GetResourceGroupUrl("sub-123", "rg-myapp");
+
+        Assert.Equal("https://portal.azure.com/#/resource/subscriptions/sub-123/resourceGroups/rg-myapp/overview", url);
+    }
+
+    [Fact]
+    public void GetResourceGroupUrl_WithTenantId_IncludesTenantInUrl()
+    {
+        var tenantId = Guid.Parse("aaaabbbb-cccc-dddd-eeee-ffff00001111");
+        var url = AzurePortalUrls.GetResourceGroupUrl("sub-123", "rg-myapp", tenantId);
+
+        Assert.Equal("https://portal.azure.com/#@aaaabbbb-cccc-dddd-eeee-ffff00001111/resource/subscriptions/sub-123/resourceGroups/rg-myapp/overview", url);
+    }
+
+    [Fact]
+    public void GetResourceUrl_WithoutTenantId_ReturnsCorrectUrl()
+    {
+        var resourceId = "/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.App/containerApps/myapi";
+        var url = AzurePortalUrls.GetResourceUrl(resourceId);
+
+        Assert.Equal("https://portal.azure.com/#/resource/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.App/containerApps/myapi", url);
+    }
+
+    [Fact]
+    public void GetResourceUrl_WithTenantId_IncludesTenantInUrl()
+    {
+        var tenantId = Guid.Parse("aaaabbbb-cccc-dddd-eeee-ffff00001111");
+        var resourceId = "/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.App/containerApps/myapi";
+        var url = AzurePortalUrls.GetResourceUrl(resourceId, tenantId);
+
+        Assert.Equal("https://portal.azure.com/#@aaaabbbb-cccc-dddd-eeee-ffff00001111/resource/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.App/containerApps/myapi", url);
+    }
+
+    [Fact]
+    public void GetResourceUrl_WithAppServiceSite_ReturnsCorrectUrl()
+    {
+        var resourceId = "/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.Web/sites/mywebapp";
+        var url = AzurePortalUrls.GetResourceUrl(resourceId);
+
+        Assert.Contains("Microsoft.Web/sites/mywebapp", url);
+    }
+
+    [Fact]
+    public void GetResourceUrl_WithAppServiceSlot_ReturnsCorrectUrl()
+    {
+        var resourceId = "/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.Web/sites/mywebapp/slots/staging";
+        var url = AzurePortalUrls.GetResourceUrl(resourceId);
+
+        Assert.Contains("Microsoft.Web/sites/mywebapp/slots/staging", url);
+    }
+
+    [Fact]
+    public void GetDeploymentUrl_WithComponents_ReturnsUrlEncodedPath()
+    {
+        var url = AzurePortalUrls.GetDeploymentUrl("/subscriptions/sub-123", "rg-myapp", "deploy-001");
+
+        Assert.StartsWith("https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id/", url);
+        Assert.Contains(Uri.EscapeDataString("/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.Resources/deployments/deploy-001"), url);
+    }
+
+    [Fact]
+    public void GetDeploymentUrl_WithResourceIdentifier_ReturnsUrlEncodedPath()
+    {
+        var deploymentId = new global::Azure.Core.ResourceIdentifier(
+            "/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.Resources/deployments/deploy-001");
+        var url = AzurePortalUrls.GetDeploymentUrl(deploymentId);
+
+        Assert.StartsWith("https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id/", url);
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePortalUrlsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePortalUrlsTests.cs
@@ -47,7 +47,7 @@ public class AzurePortalUrlsTests
         var resourceId = "/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.Web/sites/mywebapp";
         var url = AzurePortalUrls.GetResourceUrl(resourceId);
 
-        Assert.Contains("Microsoft.Web/sites/mywebapp", url);
+        Assert.Equal("https://portal.azure.com/#/resource/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.Web/sites/mywebapp", url);
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class AzurePortalUrlsTests
         var resourceId = "/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.Web/sites/mywebapp/slots/staging";
         var url = AzurePortalUrls.GetResourceUrl(resourceId);
 
-        Assert.Contains("Microsoft.Web/sites/mywebapp/slots/staging", url);
+        Assert.Equal("https://portal.azure.com/#/resource/subscriptions/sub-123/resourceGroups/rg-myapp/providers/Microsoft.Web/sites/mywebapp/slots/staging", url);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adds Azure Portal links for individual deployed resources to the pipeline summary output after `aspire deploy` completes.

### Before
```
✅ Pipeline succeeded

  ☁️ Target: Azure
  📦 Resource Group: rg-myapp (portal link)
  🔑 Subscription: 12345...
  🌐 Location: eastus
  webfrontend: https://webfrontend.azurecontainerapps.io
  api: No public endpoints
```

### After
```
✅ Pipeline succeeded

  ☁️ Target: Azure
  📦 Resource Group: rg-myapp (portal link)
  🔑 Subscription: 12345...
  🌐 Location: eastus
  webfrontend: https://webfrontend.azurecontainerapps.io
  🔗 webfrontend: Azure Portal   ← NEW
  api: No public endpoints
  🔗 api: Azure Portal            ← NEW
```

## Changes

- **`AzurePortalUrls.cs`** — Added `GetResourceUrl(resourceId, tenantId?)` method that generates portal URLs from full ARM resource IDs (supports child resources like deployment slots)
- **`AzureContainerAppResource.cs`** — Updated print-summary step to include portal link for both external-endpoint and no-endpoint cases
- **`AzureAppServiceWebSiteResource.cs`** — Updated print-summary step to include portal link with deployment slot URL support
- **`Aspire.Hosting.Azure.csproj`** — Added `InternalsVisibleTo` for `Aspire.Hosting.Azure.AppContainers` to access `AzurePortalUrls` helper
- **`AzurePortalUrlsTests.cs`** — 8 unit tests covering all URL generation methods

## Implementation Notes

- Portal links read subscription/resource-group/tenant from `IDeploymentStateManager` (the "Azure" section populated during provisioning) — no internal member access needed from AppContainers/AppService assemblies
- Resource IDs use full ARM format (`/subscriptions/.../providers/Microsoft.App/containerApps/...`) which handles nested resources like App Service slots naturally
- Portal links appear in the summary regardless of whether the resource has public endpoints

## Testing

- [x] 8 unit tests for `AzurePortalUrls` (all methods, with/without tenant, slots)
- [x] Build passes for all affected projects
- [x] Screenshots from live deployment (posted in comments)

Fixes #16119
