### PR TITLE
Fix milestone workflow: restore permissions and update github-script to v9

### DIFF
--- a/.github/workflows/milestone-assignment.yml
+++ b/.github/workflows/milestone-assignment.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   assign-milestone:
@@ -15,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign milestone based on target branch
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branchToMilestone = {


### PR DESCRIPTION
## Description

Fixes the milestone auto-assignment workflow that was failing with a 403 error ([run #24421110155](https://github.com/microsoft/aspire/actions/runs/24421110155/job/71343265113)).

### Changes

1. **Restore \pull-requests: write\ permission** — The GitHub Issues API requires this permission when updating PR resources (PRs are issues under the hood). The 403 response header confirmed: \x-accepted-github-permissions: issues=write; pull_requests=write\

2. **Update \ctions/github-script\ from v7.0.1 to v9.0.0** — v7 uses Node.js 20 which is deprecated and will stop working June 2026. v9 uses Node.js 24 and a newer GitHub API version, resolving the deprecation warning.