### PR TITLE
Increase native build+sign timeout to 60 minutes

### DIFF
--- a/eng/pipelines/azure-pipelines-codeql.yml
+++ b/eng/pipelines/azure-pipelines-codeql.yml
@@ -33,7 +33,9 @@ schedules:
     branches:
       include:
       - main
-      - release/13.2
+      - release/*
+      exclude:
+      - "*preview*"
     always: true
 
 jobs:
@@ -50,41 +52,14 @@ jobs:
     inputs:
       useGlobalJson: true
 
-  # Install Node.js, yarn, and vsce so the VS Code extension can be built
-  - task: NodeTool@0
-    displayName: Install node.js
-    inputs:
-      versionSpec: '20.x'
-
-  - task: PowerShell@2
-    displayName: Install yarn
-    inputs:
-      targetType: 'inline'
-      script: |
-        npm install -g yarn@1.22.22
-        yarn --version
-      workingDirectory: '$(Build.SourcesDirectory)'
-
-  - task: PowerShell@2
-    displayName: Install vsce
-    inputs:
-      targetType: 'inline'
-      script: |
-        npm install -g @vscode/vsce@3.7.1
-        vsce --version
-      workingDirectory: '$(Build.SourcesDirectory)'
-
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
 
-  - script: build.cmd
-      -restore -build
+  - script: eng\common\cibuild.cmd
       -configuration $(_BuildConfig)
       -prepareMachine
-      -ci
-      /p:BuildExtension=true
-      /p:SkipNativeBuild=true
-    displayName: Build
+      /p:Test=false
+    displayName: Windows Build
 
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize

--- a/eng/pipelines/azure-pipelines-codeql.yml
+++ b/eng/pipelines/azure-pipelines-codeql.yml
@@ -33,9 +33,7 @@ schedules:
     branches:
       include:
       - main
-      - release/*
-      exclude:
-      - "*preview*"
+      - release/13.2
     always: true
 
 jobs:
@@ -52,14 +50,41 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  # Install Node.js, yarn, and vsce so the VS Code extension can be built
+  - task: NodeTool@0
+    displayName: Install node.js
+    inputs:
+      versionSpec: '20.x'
+
+  - task: PowerShell@2
+    displayName: Install yarn
+    inputs:
+      targetType: 'inline'
+      script: |
+        npm install -g yarn@1.22.22
+        yarn --version
+      workingDirectory: '$(Build.SourcesDirectory)'
+
+  - task: PowerShell@2
+    displayName: Install vsce
+    inputs:
+      targetType: 'inline'
+      script: |
+        npm install -g @vscode/vsce@3.7.1
+        vsce --version
+      workingDirectory: '$(Build.SourcesDirectory)'
+
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
 
-  - script: eng\common\cibuild.cmd
+  - script: build.cmd
+      -restore -build
       -configuration $(_BuildConfig)
       -prepareMachine
-      /p:Test=false
-    displayName: Windows Build
+      -ci
+      /p:BuildExtension=true
+      /p:SkipNativeBuild=true
+    displayName: Build
 
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -22,7 +22,7 @@ jobs:
       jobs:
       - job: BuildNative_${{ replace(targetRid, '-', '_') }}
         displayName: ${{ replace(targetRid, '-', '_') }}
-        timeoutInMinutes: 40
+        timeoutInMinutes: 60
 
         variables:
         - TeamName: ${{ parameters.teamName }}


### PR DESCRIPTION
The recent change to sign aspire-managed and aspire-cli separately added extra time to the macOS native build jobs. The previous 40-minute timeout was no longer sufficient, causing \osx_x64\ jobs to fail with worker timeout errors on the main branch.

This increases the timeout from 40 to 60 minutes to accommodate the additional signing steps.

cc @radical