### PR TITLE
Fix flaky SdkDumpCi test timeout

### DIFF
--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -213,7 +213,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
                 Environment.SetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE", "false");
 
                 // ExtraLongTimeout because this spawns a real dotnet build of Aspire.Hosting.csproj
-                // in a child process, which can exceed 60s under concurrent test load.
+                // in a child process, which can exceed the default timeout under concurrent test load.
                 var exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
                 Assert.Equal(ExitCodeConstants.Success, exitCode);
 

--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -212,7 +212,9 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
                 Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true");
                 Environment.SetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE", "false");
 
-                var exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+                // ExtraLongTimeout because this spawns a real dotnet build of Aspire.Hosting.csproj
+                // in a child process, which can exceed 60s under concurrent test load.
+                var exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
                 Assert.Equal(ExitCodeConstants.Success, exitCode);
 
                 var output = await File.ReadAllTextAsync(outputPath);


### PR DESCRIPTION
## Description

`SdkDumpCi_ForHostingProject_DoesNotEmitWarnings` uses `RemoteExecutor` to spawn a child process that runs `sdk dump`, which performs a real `dotnet build` of `Aspire.Hosting.csproj`. The timeout was `LongTimeoutTimeSpan` (60s local / 180s CI), which is insufficient when the machine is under load from concurrent tests.

Changed to `ExtraLongTimeoutTimeSpan` (180s local / 360s CI) and added a comment explaining why.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
