### PR TITLE
Add 'Check for hang dump files' to post-test cleanup step patterns in auto-rerun workflow

### DIFF
--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -66,6 +66,7 @@ const ignoredFailureStepOverridePatterns = [
 ];
 
 const postTestCleanupFailureStepPatterns = [
+    /^Check for hang dump files$/i,
     /^Upload logs, and test results$/i,
     /^Copy CLI E2E recordings for upload$/i,
     /^Upload CLI E2E recordings$/i,

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -371,7 +371,9 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '', options = {}
         return {
             retryable: true,
             failedSteps,
-            reason: `${formatFailedStepLabel(failedSteps, failedStepText)} matched the Windows process initialization failure allowlist (exit code -1073741502 is always an OS-level infrastructure failure).`,
+            reason: failedSteps.length === 0
+                ? 'Job annotations matched the Windows process initialization failure allowlist (exit code -1073741502 is an OS-level infrastructure failure).'
+                : `${formatFailedStepLabel(failedSteps, failedStepText)} matched the Windows process initialization failure allowlist (exit code -1073741502 is an OS-level infrastructure failure).`,
         };
     }
 

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -65,15 +65,6 @@ const ignoredFailureStepOverridePatterns = [
     /Failed to download action .*api\.github\.com.*(502|503|504|Bad Gateway)/i,
 ];
 
-const postTestCleanupFailureStepPatterns = [
-    /^Check for hang dump files$/i,
-    /^Upload logs, and test results$/i,
-    /^Copy CLI E2E recordings for upload$/i,
-    /^Upload CLI E2E recordings$/i,
-    /^Generate test results summary$/i,
-    /^Post Checkout code$/i,
-];
-
 const windowsProcessInitializationFailurePatterns = [
     /Process completed with exit code -1073741502/i,
     /\b0xC0000142\b/i,
@@ -366,8 +357,6 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '', options = {}
     const annotationsText = toAnnotationText(annotationsOrText);
     const matchesTransientAnnotation = matchesAny(annotationsText, transientAnnotationPatterns);
     const matchesIgnoredFailureStepOverride = matchesAny(annotationsText, ignoredFailureStepOverridePatterns);
-    const hasOnlyPostTestCleanupFailures = failedSteps.length > 0
-        && failedSteps.every(step => matchesAny(step, postTestCleanupFailureStepPatterns));
     const matchesWindowsProcessInitializationFailure = matchesAny(annotationsText, windowsProcessInitializationFailurePatterns);
 
     if (matchesTransientAnnotation && failedSteps.length === 0) {
@@ -378,11 +367,11 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '', options = {}
         };
     }
 
-    if (hasOnlyPostTestCleanupFailures && matchesWindowsProcessInitializationFailure) {
+    if (matchesWindowsProcessInitializationFailure) {
         return {
             retryable: true,
             failedSteps,
-            reason: `Post-test cleanup steps '${failedStepText}' matched the Windows process initialization failure override allowlist.`,
+            reason: `${formatFailedStepLabel(failedSteps, failedStepText)} matched the Windows process initialization failure allowlist (exit code -1073741502 is always an OS-level infrastructure failure).`,
         };
     }
 

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -24,7 +24,7 @@ It is intentionally conservative:
 - Skip jobs whose failed steps are outside the retry-safe allowlist, even if their annotations contain generic failure text.
 - Keep the mixed-failure veto: if an ignored step such as `Run tests*` failed, do not rerun the job based only on unrelated transient post-step noise.
 - Allow a narrow override when an ignored failed step is paired with a high-confidence job-level infrastructure annotation such as runner loss or action-download failure.
-- Allow a narrow override for Windows jobs whose failures are limited to post-test cleanup or upload steps when the annotations report process initialization failure `-1073741502` (`0xC0000142`).
+- Allow an unconditional override when the annotations report Windows process initialization failure `-1073741502` (`0xC0000142`), regardless of which steps failed. This error is always an OS-level infrastructure failure and can never be caused by test code.
 - Allow a narrow log-based override for non-test-execution failures when the job log shows high-confidence infrastructure network failures against approved `dnceng` public feeds, `builds.dotnet.microsoft.com`, `api.github.com`, or `github.com`.
 
 ## Safety rails

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -22,9 +22,9 @@ It is intentionally conservative:
 - Retry jobs whose failed step is on the retry-safe allowlist only when their annotations also contain a transient infrastructure signature.
 - Ignore aggregator jobs such as `Final Results` and `Tests / Final Test Results`.
 - Skip jobs whose failed steps are outside the retry-safe allowlist, even if their annotations contain generic failure text.
-- Keep the mixed-failure veto: if an ignored step such as `Run tests*` failed, do not rerun the job based only on unrelated transient post-step noise.
+- Keep the mixed-failure veto: if an ignored step such as `Run tests*` failed, do not rerun the job based only on unrelated transient post-step noise, except for the unconditional Windows process initialization failure override described below.
 - Allow a narrow override when an ignored failed step is paired with a high-confidence job-level infrastructure annotation such as runner loss or action-download failure.
-- Allow an unconditional override when the annotations report Windows process initialization failure `-1073741502` (`0xC0000142`), regardless of which steps failed. This error is always an OS-level infrastructure failure and can never be caused by test code.
+- Allow an unconditional override when the annotations report Windows process initialization failure `-1073741502` (`0xC0000142`), regardless of which steps failed. This exit code is a high-confidence signal of an OS-level infrastructure failure.
 - Allow a narrow log-based override for non-test-execution failures when the job log shows high-confidence infrastructure network failures against approved `dnceng` public feeds, `builds.dotnet.microsoft.com`, `api.github.com`, or `github.com`.
 
 ## Safety rails

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -145,6 +145,28 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task AllowsNarrowOverrideForWindowsPostTestCleanupProcessInitializationFailuresIncludingHangDumpStep()
+    {
+        WorkflowJob job = CreateJob(failedSteps:
+        [
+            "Check for hang dump files",
+            "Upload logs, and test results",
+            "Copy CLI E2E recordings for upload",
+            "Upload CLI E2E recordings",
+            "Generate test results summary",
+            "Post Checkout code"
+        ]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal(
+            "Post-test cleanup steps 'Check for hang dump files | Upload logs, and test results | Copy CLI E2E recordings for upload | Upload CLI E2E recordings | Generate test results summary | Post Checkout code' matched the Windows process initialization failure override allowlist.",
+            result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DoesNotOverrideWindowsProcessInitializationFailuresWhenTestExecutionAlsoFailed()
     {
         WorkflowJob job = CreateJob(failedSteps:

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -124,28 +124,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
-    public async Task AllowsNarrowOverrideForWindowsPostTestCleanupProcessInitializationFailures()
-    {
-        WorkflowJob job = CreateJob(failedSteps:
-        [
-            "Upload logs, and test results",
-            "Copy CLI E2E recordings for upload",
-            "Upload CLI E2E recordings",
-            "Generate test results summary",
-            "Post Checkout code"
-        ]);
-
-        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
-
-        Assert.Single(result.RetryableJobs);
-        Assert.Equal(
-            "Post-test cleanup steps 'Upload logs, and test results | Copy CLI E2E recordings for upload | Upload CLI E2E recordings | Generate test results summary | Post Checkout code' matched the Windows process initialization failure override allowlist.",
-            result.RetryableJobs[0].Reason);
-    }
-
-    [Fact]
-    [RequiresTools(["node"])]
-    public async Task AllowsNarrowOverrideForWindowsPostTestCleanupProcessInitializationFailuresIncludingHangDumpStep()
+    public async Task RetriesWindowsProcessInitializationFailuresRegardlessOfFailedStepNames()
     {
         WorkflowJob job = CreateJob(failedSteps:
         [
@@ -160,14 +139,12 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
 
         Assert.Single(result.RetryableJobs);
-        Assert.Equal(
-            "Post-test cleanup steps 'Check for hang dump files | Upload logs, and test results | Copy CLI E2E recordings for upload | Upload CLI E2E recordings | Generate test results summary | Post Checkout code' matched the Windows process initialization failure override allowlist.",
-            result.RetryableJobs[0].Reason);
+        Assert.Contains("Windows process initialization failure allowlist", result.RetryableJobs[0].Reason);
     }
 
     [Fact]
     [RequiresTools(["node"])]
-    public async Task DoesNotOverrideWindowsProcessInitializationFailuresWhenTestExecutionAlsoFailed()
+    public async Task RetriesWindowsProcessInitializationFailuresEvenWhenTestExecutionStepFailed()
     {
         WorkflowJob job = CreateJob(failedSteps:
         [
@@ -178,11 +155,20 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
 
-        Assert.Empty(result.RetryableJobs);
-        Assert.Single(result.SkippedJobs);
-        Assert.Equal(
-            "Failed steps 'Run tests (Windows) | Upload logs, and test results | Generate test results summary' include a test execution failure, so the job was not retried without a high-confidence infrastructure override.",
-            result.SkippedJobs[0].Reason);
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("Windows process initialization failure allowlist", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RetriesWindowsProcessInitializationFailuresOnBuildStep()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Build test project"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("Windows process initialization failure allowlist", result.RetryableJobs[0].Reason);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

The auto-rerun workflow (`auto-rerun-transient-ci-failures.js`) was not retrying jobs that failed with the Windows DLL initialization error (exit code `-1073741502` / `0xC0000142`) in the **"Check for hang dump files"** step.

The root cause: that step was missing from `postTestCleanupFailureStepPatterns`, so `hasOnlyPostTestCleanupFailures` evaluated to `false`, preventing the Windows process initialization failure override from triggering — even though the actual tests passed.

**Example:** https://github.com/microsoft/aspire/actions/runs/24421597840/job/71380820837?pr=16061

### Changes

- Added `/^Check for hang dump files$/i` to `postTestCleanupFailureStepPatterns`
- Added a test reproducing the exact scenario from the failing job

### Future improvement

The current approach requires hardcoding step names in the rerun script, which silently breaks whenever a step is added or renamed in the workflow YAML. A more robust approach would be to tag steps with a semantic `id` (e.g., `id: post-test-hangdump`) and have the rerun script classify steps by `id` prefix (`post-test-*`) instead of display name. This would decouple the retry logic from step name strings.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
