### PR TITLE
Quarantine flaky tests: CreateStartAndStopAspireProject, AllPublishMethodsBuildDockerImages, ExecutableExitsImmediately

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
@@ -6,6 +6,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
 using Xunit;
+using Aspire.TestUtilities;
 
 namespace Aspire.Cli.EndToEnd.Tests;
 
@@ -22,6 +23,7 @@ public sealed class JavaScriptPublishTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/16188")]
     public async Task AllPublishMethodsBuildDockerImages()
     {
         using var workspace = TemporaryWorkspace.Create(output);

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs
@@ -1,12 +1,12 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
 using Hex1b.Automation;
 using Xunit;
-using Aspire.TestUtilities;
 
 namespace Aspire.Cli.EndToEnd.Tests;
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
@@ -6,6 +6,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
 using Xunit;
+using Aspire.TestUtilities;
 
 namespace Aspire.Cli.EndToEnd.Tests;
 
@@ -16,6 +17,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 public sealed class StartStopTests(ITestOutputHelper output)
 {
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/16191")]
     public async Task CreateStartAndStopAspireProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -1,12 +1,12 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
 using Hex1b.Automation;
 using Xunit;
-using Aspire.TestUtilities;
 
 namespace Aspire.Cli.EndToEnd.Tests;
 

--- a/tests/Aspire.Hosting.Tests/ResourceFailureLoggingTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceFailureLoggingTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using TestConstants = Microsoft.AspNetCore.InternalTesting.TestConstants;
+using Aspire.TestUtilities;
 
 namespace Aspire.Hosting.Tests;
 
@@ -14,6 +15,7 @@ namespace Aspire.Hosting.Tests;
 public class ExecutableResourceFailureLoggingTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/16189")]
     public async Task ExecutableExitsImmediately()
     {
         using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.DefaultOrchestratorTestLongTimeout);

--- a/tests/Aspire.Hosting.Tests/ResourceFailureLoggingTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceFailureLoggingTests.cs
@@ -1,13 +1,13 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
+using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using TestConstants = Microsoft.AspNetCore.InternalTesting.TestConstants;
-using Aspire.TestUtilities;
 
 namespace Aspire.Hosting.Tests;
 


### PR DESCRIPTION
## Summary

This PR quarantines the following tests by adding the `[QuarantinedTest]` attribute:

| Test Method | File | Issue |
|-------------|------|-------|
| `CreateStartAndStopAspireProject` | `tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs` | #16191 |
| `AllPublishMethodsBuildDockerImages` | `tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs` | #16188 |
| `ExecutableExitsImmediately` | `tests/Aspire.Hosting.Tests/ResourceFailureLoggingTests.cs` | #16189 |

## Changes

- Added `[QuarantinedTest]` attribute to quarantine flaky tests

## Verification

✅ Built test project(s) successfully

## Related Issues

Addresses #16191
Addresses #16188
Addresses #16189

---

**Note:** This PR does NOT close the related issues. The tests should be re-enabled once the underlying problems are fixed.