### PR TITLE
Add container runtime health check as orphan pipeline step

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -47,7 +47,7 @@ public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWith
                 Action = BuildProjectImage,
                 Tags = [WellKnownPipelineTags.BuildCompute],
                 RequiredBySteps = [WellKnownPipelineSteps.Build],
-                DependsOnSteps = [WellKnownPipelineSteps.BuildPrereq],
+                DependsOnSteps = [WellKnownPipelineSteps.BuildPrereq, WellKnownPipelineSteps.CheckContainerRuntime],
                 Resource = this
             };
             steps.Add(buildStep);

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -52,7 +52,7 @@ public static class ContainerResourceBuilderExtensions
                     },
                     Tags = [WellKnownPipelineTags.BuildCompute],
                     RequiredBySteps = [WellKnownPipelineSteps.Build],
-                    DependsOnSteps = [WellKnownPipelineSteps.BuildPrereq],
+                    DependsOnSteps = [WellKnownPipelineSteps.BuildPrereq, WellKnownPipelineSteps.CheckContainerRuntime],
                     Resource = builder.Resource
                 };
                 steps.Add(buildStep);

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIRECOMPUTE003
+#pragma warning disable ASPIRECONTAINERRUNTIME001
 #pragma warning disable ASPIREINTERACTION001
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREPIPELINES002
@@ -150,6 +151,66 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
             Name = WellKnownPipelineSteps.BuildPrereq,
             Description = "Prerequisite step that runs before any build operations.",
             Action = context => Task.CompletedTask
+        });
+
+        // Container runtime health check step. Checks if the Docker/Podman daemon is running.
+        // Build steps that need a container runtime depend on this step via DependsOnSteps.
+        // In interactive mode, prompts the user to start the runtime instead of failing immediately.
+        _steps.Add(new PipelineStep
+        {
+            Name = WellKnownPipelineSteps.CheckContainerRuntime,
+            Description = "Checks whether the container runtime (Docker/Podman) is running.",
+            Action = async context =>
+            {
+                var runtimeResolver = context.Services.GetRequiredService<IContainerRuntimeResolver>();
+                var containerRuntime = await runtimeResolver.ResolveAsync(context.CancellationToken).ConfigureAwait(false);
+
+                if (await containerRuntime.CheckIfRunningAsync(context.CancellationToken).ConfigureAwait(false))
+                {
+                    return;
+                }
+
+                // In interactive mode, prompt the user to start the runtime and retry
+                var interactionService = context.Services.GetService<IInteractionService>();
+                if (interactionService?.IsAvailable == true)
+                {
+                    var result = await interactionService.PromptNotificationAsync(
+                        $"{containerRuntime.Name} is not running",
+                        $"Start {containerRuntime.Name} and confirm to continue.",
+                        new NotificationInteractionOptions
+                        {
+                            Intent = MessageIntent.Warning
+                        },
+                        cancellationToken: context.CancellationToken).ConfigureAwait(false);
+
+                    if (!result.Canceled && result.Data)
+                    {
+                        // Poll for the runtime to become available — Docker can take
+                        // a while to start, especially on slower machines.
+                        // Give it up to 5 minutes before giving up.
+                        var timeProvider = context.Services.GetRequiredService<TimeProvider>();
+                        using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+                        waitCts.CancelAfter(TimeSpan.FromMinutes(5));
+
+                        try
+                        {
+                            while (!await containerRuntime.CheckIfRunningAsync(waitCts.Token).ConfigureAwait(false))
+                            {
+                                await Task.Delay(TimeSpan.FromSeconds(2), timeProvider, waitCts.Token).ConfigureAwait(false);
+                            }
+
+                            return;
+                        }
+                        catch (OperationCanceledException) when (!context.CancellationToken.IsCancellationRequested)
+                        {
+                            // Timed out waiting for the runtime to start — fall through to the error below
+                        }
+                    }
+                }
+
+                throw new DistributedApplicationException(
+                    $"{containerRuntime.Name} is not running. Start {containerRuntime.Name} and try again.");
+            }
         });
 
         // Add a default "Push" meta-step that all push steps should be required by

--- a/src/Aspire.Hosting/Pipelines/WellKnownPipelineSteps.cs
+++ b/src/Aspire.Hosting/Pipelines/WellKnownPipelineSteps.cs
@@ -65,6 +65,12 @@ public static class WellKnownPipelineSteps
     public const string Diagnostics = "diagnostics";
 
     /// <summary>
+    /// The step that checks whether the container runtime (e.g., Docker or Podman) is running.
+    /// Build steps that need a container runtime should depend on this step.
+    /// </summary>
+    public const string CheckContainerRuntime = "check-container-runtime";
+
+    /// <summary>
     /// Aggregation step for all destroy operations.
     /// All destroy steps should be required by this step.
     /// </summary>

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -128,6 +128,13 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
 
     public override async Task BuildImageAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
     {
+        // Verify buildx is available before attempting a Dockerfile build
+        if (!await CheckDockerBuildxAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new DistributedApplicationException(
+                "Docker buildx is not available. Install the buildx plugin and try again.");
+        }
+
         // Normalize the context path to handle trailing slashes and relative paths
         var normalizedContextPath = Path.GetFullPath(contextPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
@@ -143,14 +150,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
 
     public override async Task<bool> CheckIfRunningAsync(CancellationToken cancellationToken)
     {
-        // First check if Docker daemon is running using the same check that DCP uses
-        if (!await CheckDockerDaemonAsync(cancellationToken).ConfigureAwait(false))
-        {
-            return false;
-        }
-
-        // Then check if Docker buildx is available
-        return await CheckDockerBuildxAsync(cancellationToken).ConfigureAwait(false);
+        return await CheckDockerDaemonAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<bool> CheckDockerDaemonAsync(CancellationToken cancellationToken)
@@ -179,10 +179,10 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
             var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
                 "buildx version",
                 "Docker buildx version failed with exit code {ExitCode}.",
-                "Docker buildx is available and running.",
+                "Docker buildx is available.",
                 cancellationToken,
                 Array.Empty<object>()).ConfigureAwait(false);
-            
+
             return exitCode == 0;
         }
         catch

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 31
+Total steps defined: 32
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -16,35 +16,36 @@ Steps with no dependencies run first, followed by steps that depend on them.
 
   1. process-parameters
   2. build-prereq
-  3. deploy-prereq
-  4. build-api
-  5. build
-  6. validate-azure-login
-  7. create-provisioning-context
-  8. provision-api-identity
-  9. provision-kv
- 10. provision-api-roles-kv
- 11. provision-env-acr
- 12. provision-env
- 13. login-to-acr-env-acr
- 14. push-prereq
- 15. push-api
- 16. provision-api-website
- 17. print-api-summary
- 18. provision-azure-bicep-resources
- 19. print-dashboard-url-env
- 20. deploy
- 21. deploy-api
- 22. destroy-prereq
- 23. destroy-azure-azure634f9
- 24. destroy
- 25. diagnostics
- 26. publish-prereq
- 27. publish-azure634f9
- 28. validate-appservice-config-env
- 29. publish
- 30. publish-manifest
- 31. push
+  3. check-container-runtime
+  4. deploy-prereq
+  5. build-api
+  6. build
+  7. validate-azure-login
+  8. create-provisioning-context
+  9. provision-api-identity
+ 10. provision-kv
+ 11. provision-api-roles-kv
+ 12. provision-env-acr
+ 13. provision-env
+ 14. login-to-acr-env-acr
+ 15. push-prereq
+ 16. push-api
+ 17. provision-api-website
+ 18. print-api-summary
+ 19. provision-azure-bicep-resources
+ 20. print-dashboard-url-env
+ 21. deploy
+ 22. deploy-api
+ 23. destroy-prereq
+ 24. destroy-azure-azure634f9
+ 25. destroy
+ 26. diagnostics
+ 27. publish-prereq
+ 28. publish-azure634f9
+ 29. validate-appservice-config-env
+ 30. publish
+ 31. publish-manifest
+ 32. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -57,13 +58,17 @@ Step: build
 
 Step: build-api
     Description: Builds the container image for the api project.
-    Dependencies: ✓ build-prereq, ✓ deploy-prereq
+    Dependencies: ✓ build-prereq, ✓ check-container-runtime, ✓ deploy-prereq
     Resource: api (ProjectResource)
     Tags: build-compute
 
 Step: build-prereq
     Description: Prerequisite step that runs before any build operations.
     Dependencies: ✓ process-parameters
+
+Step: check-container-runtime
+    Description: Checks whether the container runtime (Docker/Podman) is running.
+    Dependencies: none
 
 Step: create-provisioning-context
     Description: Creates the Azure provisioning context for infrastructure deployment.
@@ -217,18 +222,18 @@ Steps at the same level can run concurrently.
 ─────────────────────────────────────────────────────────────────────────────
 If targeting 'build':
   Direct dependencies: build-api
-  Total steps: 5
+  Total steps: 6
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api
     [3] build
 
 If targeting 'build-api':
-  Direct dependencies: build-prereq, deploy-prereq
-  Total steps: 4
+  Direct dependencies: build-prereq, check-container-runtime, deploy-prereq
+  Total steps: 5
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api
 
@@ -238,6 +243,12 @@ If targeting 'build-prereq':
   Execution order:
     [0] process-parameters
     [1] build-prereq
+
+If targeting 'check-container-runtime':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] check-container-runtime
 
 If targeting 'create-provisioning-context':
   Direct dependencies: deploy-prereq, validate-azure-login
@@ -250,9 +261,9 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 19
+  Total steps: 20
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -267,9 +278,9 @@ If targeting 'deploy':
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 17
+  Total steps: 18
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -328,9 +339,9 @@ If targeting 'login-to-acr-env-acr':
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-website
-  Total steps: 16
+  Total steps: 17
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -343,9 +354,9 @@ If targeting 'print-api-summary':
 
 If targeting 'print-dashboard-url-env':
   Direct dependencies: provision-azure-bicep-resources, provision-env
-  Total steps: 17
+  Total steps: 18
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -386,9 +397,9 @@ If targeting 'provision-api-roles-kv':
 
 If targeting 'provision-api-website':
   Direct dependencies: create-provisioning-context, provision-api-identity, provision-api-roles-kv, provision-env, provision-kv, push-api
-  Total steps: 15
+  Total steps: 16
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -400,9 +411,9 @@ If targeting 'provision-api-website':
 
 If targeting 'provision-azure-bicep-resources':
   Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-kv, provision-api-website, provision-env, provision-env-acr, provision-kv
-  Total steps: 16
+  Total steps: 17
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -476,9 +487,9 @@ If targeting 'publish-prereq':
 
 If targeting 'push':
   Direct dependencies: push-api, push-prereq
-  Total steps: 11
+  Total steps: 12
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -490,9 +501,9 @@ If targeting 'push':
 
 If targeting 'push-api':
   Direct dependencies: build-api, push-prereq
-  Total steps: 10
+  Total steps: 11
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 41
+Total steps defined: 42
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -16,45 +16,46 @@ Steps with no dependencies run first, followed by steps that depend on them.
 
   1. process-parameters
   2. build-prereq
-  3. deploy-prereq
-  4. build-api-service
-  5. build-python-app
-  6. build
-  7. validate-azure-login
-  8. create-provisioning-context
-  9. provision-aas-env-acr
- 10. provision-aas-env
- 11. login-to-acr-aas-env-acr
- 12. provision-aca-env-acr
- 13. login-to-acr-aca-env-acr
- 14. push-prereq
- 15. push-api-service
- 16. provision-api-service-website
- 17. print-api-service-summary
- 18. provision-aca-env
- 19. provision-cache-containerapp
- 20. print-cache-summary
- 21. push-python-app
- 22. provision-python-app-containerapp
- 23. provision-storage
- 24. provision-azure-bicep-resources
- 25. print-dashboard-url-aas-env
- 26. print-dashboard-url-aca-env
- 27. print-python-app-summary
- 28. deploy
- 29. deploy-api-service
- 30. deploy-cache
- 31. deploy-python-app
- 32. destroy-prereq
- 33. destroy-azure-azure634f9
- 34. destroy
- 35. diagnostics
- 36. publish-prereq
- 37. publish-azure634f9
- 38. validate-appservice-config-aas-env
- 39. publish
- 40. publish-manifest
- 41. push
+  3. check-container-runtime
+  4. deploy-prereq
+  5. build-api-service
+  6. build-python-app
+  7. build
+  8. validate-azure-login
+  9. create-provisioning-context
+ 10. provision-aas-env-acr
+ 11. provision-aas-env
+ 12. login-to-acr-aas-env-acr
+ 13. provision-aca-env-acr
+ 14. login-to-acr-aca-env-acr
+ 15. push-prereq
+ 16. push-api-service
+ 17. provision-api-service-website
+ 18. print-api-service-summary
+ 19. provision-aca-env
+ 20. provision-cache-containerapp
+ 21. print-cache-summary
+ 22. push-python-app
+ 23. provision-python-app-containerapp
+ 24. provision-storage
+ 25. provision-azure-bicep-resources
+ 26. print-dashboard-url-aas-env
+ 27. print-dashboard-url-aca-env
+ 28. print-python-app-summary
+ 29. deploy
+ 30. deploy-api-service
+ 31. deploy-cache
+ 32. deploy-python-app
+ 33. destroy-prereq
+ 34. destroy-azure-azure634f9
+ 35. destroy
+ 36. diagnostics
+ 37. publish-prereq
+ 38. publish-azure634f9
+ 39. validate-appservice-config-aas-env
+ 40. publish
+ 41. publish-manifest
+ 42. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -67,7 +68,7 @@ Step: build
 
 Step: build-api-service
     Description: Builds the container image for the api-service project.
-    Dependencies: ✓ build-prereq, ✓ deploy-prereq, ✓ deploy-prereq
+    Dependencies: ✓ build-prereq, ✓ check-container-runtime, ✓ deploy-prereq, ✓ deploy-prereq
     Resource: api-service (ProjectResource)
     Tags: build-compute
 
@@ -76,9 +77,13 @@ Step: build-prereq
     Dependencies: ✓ process-parameters
 
 Step: build-python-app
-    Dependencies: ✓ build-prereq, ✓ deploy-prereq, ✓ deploy-prereq
+    Dependencies: ✓ build-prereq, ✓ check-container-runtime, ✓ deploy-prereq, ✓ deploy-prereq
     Resource: python-app (ContainerResource)
     Tags: build-compute
+
+Step: check-container-runtime
+    Description: Checks whether the container runtime (Docker/Podman) is running.
+    Dependencies: none
 
 Step: create-provisioning-context
     Description: Creates the Azure provisioning context for infrastructure deployment.
@@ -284,18 +289,18 @@ Steps at the same level can run concurrently.
 ─────────────────────────────────────────────────────────────────────────────
 If targeting 'build':
   Direct dependencies: build-api-service, build-python-app
-  Total steps: 6
+  Total steps: 7
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app (parallel)
     [3] build
 
 If targeting 'build-api-service':
-  Direct dependencies: build-prereq, deploy-prereq, deploy-prereq
-  Total steps: 4
+  Direct dependencies: build-prereq, check-container-runtime, deploy-prereq, deploy-prereq
+  Total steps: 5
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service
 
@@ -307,12 +312,18 @@ If targeting 'build-prereq':
     [1] build-prereq
 
 If targeting 'build-python-app':
-  Direct dependencies: build-prereq, deploy-prereq, deploy-prereq
-  Total steps: 4
+  Direct dependencies: build-prereq, check-container-runtime, deploy-prereq, deploy-prereq
+  Total steps: 5
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-python-app
+
+If targeting 'check-container-runtime':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] check-container-runtime
 
 If targeting 'create-provisioning-context':
   Direct dependencies: deploy-prereq, validate-azure-login
@@ -325,9 +336,9 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api-service, build-python-app, create-provisioning-context, print-api-service-summary, print-cache-summary, print-dashboard-url-aas-env, print-dashboard-url-aca-env, print-python-app-summary, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 27
+  Total steps: 28
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -342,9 +353,9 @@ If targeting 'deploy':
 
 If targeting 'deploy-api-service':
   Direct dependencies: print-api-service-summary
-  Total steps: 16
+  Total steps: 17
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -379,9 +390,9 @@ If targeting 'deploy-prereq':
 
 If targeting 'deploy-python-app':
   Direct dependencies: print-python-app-summary
-  Total steps: 16
+  Total steps: 17
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -444,9 +455,9 @@ If targeting 'login-to-acr-aca-env-acr':
 
 If targeting 'print-api-service-summary':
   Direct dependencies: provision-api-service-website
-  Total steps: 15
+  Total steps: 16
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -472,9 +483,9 @@ If targeting 'print-cache-summary':
 
 If targeting 'print-dashboard-url-aas-env':
   Direct dependencies: provision-aas-env, provision-azure-bicep-resources
-  Total steps: 22
+  Total steps: 23
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -488,9 +499,9 @@ If targeting 'print-dashboard-url-aas-env':
 
 If targeting 'print-dashboard-url-aca-env':
   Direct dependencies: provision-aca-env, provision-azure-bicep-resources
-  Total steps: 22
+  Total steps: 23
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -504,9 +515,9 @@ If targeting 'print-dashboard-url-aca-env':
 
 If targeting 'print-python-app-summary':
   Direct dependencies: provision-python-app-containerapp
-  Total steps: 15
+  Total steps: 16
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -567,9 +578,9 @@ If targeting 'provision-aca-env-acr':
 
 If targeting 'provision-api-service-website':
   Direct dependencies: create-provisioning-context, provision-aas-env, push-api-service
-  Total steps: 14
+  Total steps: 15
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -581,9 +592,9 @@ If targeting 'provision-api-service-website':
 
 If targeting 'provision-azure-bicep-resources':
   Direct dependencies: create-provisioning-context, deploy-prereq, provision-aas-env, provision-aas-env-acr, provision-aca-env, provision-aca-env-acr, provision-api-service-website, provision-cache-containerapp, provision-python-app-containerapp, provision-storage
-  Total steps: 21
+  Total steps: 22
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -608,9 +619,9 @@ If targeting 'provision-cache-containerapp':
 
 If targeting 'provision-python-app-containerapp':
   Direct dependencies: create-provisioning-context, provision-aca-env, push-python-app
-  Total steps: 14
+  Total steps: 15
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -662,9 +673,9 @@ If targeting 'publish-prereq':
 
 If targeting 'push':
   Direct dependencies: push-api-service, push-prereq, push-python-app
-  Total steps: 15
+  Total steps: 16
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -676,9 +687,9 @@ If targeting 'push':
 
 If targeting 'push-api-service':
   Direct dependencies: build-api-service, push-prereq
-  Total steps: 12
+  Total steps: 13
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -701,9 +712,9 @@ If targeting 'push-prereq':
 
 If targeting 'push-python-app':
   Direct dependencies: build-python-app, push-prereq
-  Total steps: 12
+  Total steps: 13
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 43
+Total steps defined: 44
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -16,47 +16,48 @@ Steps with no dependencies run first, followed by steps that depend on them.
 
   1. process-parameters
   2. build-prereq
-  3. deploy-prereq
-  4. build-api
-  5. build
-  6. validate-azure-login
-  7. create-provisioning-context
-  8. provision-api-identity
-  9. provision-cosmos
- 10. provision-api-roles-cosmos
- 11. provision-sql-nsg
- 12. provision-vnet
- 13. provision-privatelink-file-core-windows-net
- 14. provision-sql-store
- 15. provision-pe-subnet-files-pe
- 16. provision-privatelink-database-windows-net
- 17. provision-sql
- 18. provision-pe-subnet-sql-pe
- 19. provision-api-roles-sql
- 20. provision-env-acr
- 21. provision-env
- 22. provision-privatelink-documents-azure-com
- 23. provision-pe-subnet-cosmos-pe
- 24. login-to-acr-env-acr
- 25. push-prereq
- 26. push-api
- 27. provision-api-containerapp
- 28. print-api-summary
- 29. provision-sql-admin-identity
- 30. provision-sql-admin-identity-roles-sql-store
- 31. provision-azure-bicep-resources
- 32. print-dashboard-url-env
- 33. deploy
- 34. deploy-api
- 35. destroy-prereq
- 36. destroy-azure-azure634f9
- 37. destroy
- 38. diagnostics
- 39. publish-prereq
- 40. publish-azure634f9
- 41. publish
- 42. publish-manifest
- 43. push
+  3. check-container-runtime
+  4. deploy-prereq
+  5. build-api
+  6. build
+  7. validate-azure-login
+  8. create-provisioning-context
+  9. provision-api-identity
+ 10. provision-cosmos
+ 11. provision-api-roles-cosmos
+ 12. provision-sql-nsg
+ 13. provision-vnet
+ 14. provision-privatelink-file-core-windows-net
+ 15. provision-sql-store
+ 16. provision-pe-subnet-files-pe
+ 17. provision-privatelink-database-windows-net
+ 18. provision-sql
+ 19. provision-pe-subnet-sql-pe
+ 20. provision-api-roles-sql
+ 21. provision-env-acr
+ 22. provision-env
+ 23. provision-privatelink-documents-azure-com
+ 24. provision-pe-subnet-cosmos-pe
+ 25. login-to-acr-env-acr
+ 26. push-prereq
+ 27. push-api
+ 28. provision-api-containerapp
+ 29. print-api-summary
+ 30. provision-sql-admin-identity
+ 31. provision-sql-admin-identity-roles-sql-store
+ 32. provision-azure-bicep-resources
+ 33. print-dashboard-url-env
+ 34. deploy
+ 35. deploy-api
+ 36. destroy-prereq
+ 37. destroy-azure-azure634f9
+ 38. destroy
+ 39. diagnostics
+ 40. publish-prereq
+ 41. publish-azure634f9
+ 42. publish
+ 43. publish-manifest
+ 44. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -69,13 +70,17 @@ Step: build
 
 Step: build-api
     Description: Builds the container image for the api project.
-    Dependencies: ✓ build-prereq, ✓ deploy-prereq
+    Dependencies: ✓ build-prereq, ✓ check-container-runtime, ✓ deploy-prereq
     Resource: api (ProjectResource)
     Tags: build-compute
 
 Step: build-prereq
     Description: Prerequisite step that runs before any build operations.
     Dependencies: ✓ process-parameters
+
+Step: check-container-runtime
+    Description: Checks whether the container runtime (Docker/Podman) is running.
+    Dependencies: none
 
 Step: create-provisioning-context
     Description: Creates the Azure provisioning context for infrastructure deployment.
@@ -302,18 +307,18 @@ Steps at the same level can run concurrently.
 ─────────────────────────────────────────────────────────────────────────────
 If targeting 'build':
   Direct dependencies: build-api
-  Total steps: 5
+  Total steps: 6
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api
     [3] build
 
 If targeting 'build-api':
-  Direct dependencies: build-prereq, deploy-prereq
-  Total steps: 4
+  Direct dependencies: build-prereq, check-container-runtime, deploy-prereq
+  Total steps: 5
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api
 
@@ -323,6 +328,12 @@ If targeting 'build-prereq':
   Execution order:
     [0] process-parameters
     [1] build-prereq
+
+If targeting 'check-container-runtime':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] check-container-runtime
 
 If targeting 'create-provisioning-context':
   Direct dependencies: deploy-prereq, validate-azure-login
@@ -335,9 +346,9 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 32
+  Total steps: 33
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -353,9 +364,9 @@ If targeting 'deploy':
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 28
+  Total steps: 29
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -415,9 +426,9 @@ If targeting 'login-to-acr-env-acr':
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-containerapp
-  Total steps: 27
+  Total steps: 28
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -431,9 +442,9 @@ If targeting 'print-api-summary':
 
 If targeting 'print-dashboard-url-env':
   Direct dependencies: provision-azure-bicep-resources, provision-env
-  Total steps: 30
+  Total steps: 31
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -454,9 +465,9 @@ If targeting 'process-parameters':
 
 If targeting 'provision-api-containerapp':
   Direct dependencies: create-provisioning-context, provision-api-identity, provision-api-roles-cosmos, provision-api-roles-sql, provision-cosmos, provision-env, provision-pe-subnet-cosmos-pe, provision-pe-subnet-sql-pe, provision-sql, push-api
-  Total steps: 26
+  Total steps: 27
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -504,9 +515,9 @@ If targeting 'provision-api-roles-sql':
 
 If targeting 'provision-azure-bicep-resources':
   Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-containerapp, provision-api-identity, provision-api-roles-cosmos, provision-api-roles-sql, provision-cosmos, provision-env, provision-env-acr, provision-pe-subnet-cosmos-pe, provision-pe-subnet-files-pe, provision-pe-subnet-sql-pe, provision-privatelink-database-windows-net, provision-privatelink-documents-azure-com, provision-privatelink-file-core-windows-net, provision-sql, provision-sql-admin-identity, provision-sql-admin-identity-roles-sql-store, provision-sql-nsg, provision-sql-store, provision-vnet
-  Total steps: 29
+  Total steps: 30
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -720,9 +731,9 @@ If targeting 'publish-prereq':
 
 If targeting 'push':
   Direct dependencies: push-api, push-prereq
-  Total steps: 11
+  Total steps: 12
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -734,9 +745,9 @@ If targeting 'push':
 
 If targeting 'push-api':
   Direct dependencies: build-api, push-prereq
-  Total steps: 10
+  Total steps: 11
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 38
+Total steps defined: 39
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -16,42 +16,43 @@ Steps with no dependencies run first, followed by steps that depend on them.
 
   1. process-parameters
   2. build-prereq
-  3. deploy-prereq
-  4. build-api
-  5. build
-  6. validate-azure-login
-  7. create-provisioning-context
-  8. provision-api-identity
-  9. provision-cache-kv
- 10. provision-api-roles-cache-kv
- 11. provision-cosmos-kv
- 12. provision-api-roles-cosmos-kv
- 13. provision-pg-kv
- 14. provision-api-roles-pg-kv
- 15. provision-cache
- 16. provision-cosmos
- 17. provision-env-acr
- 18. provision-env
- 19. provision-pg
- 20. login-to-acr-env-acr
- 21. push-prereq
- 22. push-api
- 23. provision-api-website
- 24. print-api-summary
- 25. provision-azure-bicep-resources
- 26. print-dashboard-url-env
- 27. deploy
- 28. deploy-api
- 29. destroy-prereq
- 30. destroy-azure-azure634f9
- 31. destroy
- 32. diagnostics
- 33. publish-prereq
- 34. publish-azure634f9
- 35. validate-appservice-config-env
- 36. publish
- 37. publish-manifest
- 38. push
+  3. check-container-runtime
+  4. deploy-prereq
+  5. build-api
+  6. build
+  7. validate-azure-login
+  8. create-provisioning-context
+  9. provision-api-identity
+ 10. provision-cache-kv
+ 11. provision-api-roles-cache-kv
+ 12. provision-cosmos-kv
+ 13. provision-api-roles-cosmos-kv
+ 14. provision-pg-kv
+ 15. provision-api-roles-pg-kv
+ 16. provision-cache
+ 17. provision-cosmos
+ 18. provision-env-acr
+ 19. provision-env
+ 20. provision-pg
+ 21. login-to-acr-env-acr
+ 22. push-prereq
+ 23. push-api
+ 24. provision-api-website
+ 25. print-api-summary
+ 26. provision-azure-bicep-resources
+ 27. print-dashboard-url-env
+ 28. deploy
+ 29. deploy-api
+ 30. destroy-prereq
+ 31. destroy-azure-azure634f9
+ 32. destroy
+ 33. diagnostics
+ 34. publish-prereq
+ 35. publish-azure634f9
+ 36. validate-appservice-config-env
+ 37. publish
+ 38. publish-manifest
+ 39. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -64,13 +65,17 @@ Step: build
 
 Step: build-api
     Description: Builds the container image for the api project.
-    Dependencies: ✓ build-prereq, ✓ deploy-prereq
+    Dependencies: ✓ build-prereq, ✓ check-container-runtime, ✓ deploy-prereq
     Resource: api (ProjectResource)
     Tags: build-compute
 
 Step: build-prereq
     Description: Prerequisite step that runs before any build operations.
     Dependencies: ✓ process-parameters
+
+Step: check-container-runtime
+    Description: Checks whether the container runtime (Docker/Podman) is running.
+    Dependencies: none
 
 Step: create-provisioning-context
     Description: Creates the Azure provisioning context for infrastructure deployment.
@@ -266,18 +271,18 @@ Steps at the same level can run concurrently.
 ─────────────────────────────────────────────────────────────────────────────
 If targeting 'build':
   Direct dependencies: build-api
-  Total steps: 5
+  Total steps: 6
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api
     [3] build
 
 If targeting 'build-api':
-  Direct dependencies: build-prereq, deploy-prereq
-  Total steps: 4
+  Direct dependencies: build-prereq, check-container-runtime, deploy-prereq
+  Total steps: 5
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api
 
@@ -287,6 +292,12 @@ If targeting 'build-prereq':
   Execution order:
     [0] process-parameters
     [1] build-prereq
+
+If targeting 'check-container-runtime':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] check-container-runtime
 
 If targeting 'create-provisioning-context':
   Direct dependencies: deploy-prereq, validate-azure-login
@@ -299,9 +310,9 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 26
+  Total steps: 27
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -316,9 +327,9 @@ If targeting 'deploy':
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 24
+  Total steps: 25
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -377,9 +388,9 @@ If targeting 'login-to-acr-env-acr':
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-website
-  Total steps: 23
+  Total steps: 24
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -392,9 +403,9 @@ If targeting 'print-api-summary':
 
 If targeting 'print-dashboard-url-env':
   Direct dependencies: provision-azure-bicep-resources, provision-env
-  Total steps: 24
+  Total steps: 25
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -457,9 +468,9 @@ If targeting 'provision-api-roles-pg-kv':
 
 If targeting 'provision-api-website':
   Direct dependencies: create-provisioning-context, provision-api-identity, provision-api-roles-cache-kv, provision-api-roles-cosmos-kv, provision-api-roles-pg-kv, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-pg, provision-pg-kv, push-api
-  Total steps: 22
+  Total steps: 23
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -471,9 +482,9 @@ If targeting 'provision-api-website':
 
 If targeting 'provision-azure-bicep-resources':
   Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-cache-kv, provision-api-roles-cosmos-kv, provision-api-roles-pg-kv, provision-api-website, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-env-acr, provision-pg, provision-pg-kv
-  Total steps: 23
+  Total steps: 24
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -600,9 +611,9 @@ If targeting 'publish-prereq':
 
 If targeting 'push':
   Direct dependencies: push-api, push-prereq
-  Total steps: 11
+  Total steps: 12
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -614,9 +625,9 @@ If targeting 'push':
 
 If targeting 'push-api':
   Direct dependencies: build-api, push-prereq
-  Total steps: 10
+  Total steps: 11
   Execution order:
-    [0] process-parameters
+    [0] check-container-runtime | process-parameters (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -730,7 +730,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
     [Fact]
     public async Task ExecuteAsync_WithDependencyFailure_ReportsFailedDependency()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: null).WithTestAndResourceLogging(testOutputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: "deploy").WithTestAndResourceLogging(testOutputHelper);
 
         builder.Services.AddSingleton(testOutputHelper);
         builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
@@ -750,7 +750,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         {
             dependentStepExecuted = true;
             await Task.CompletedTask;
-        }, dependsOn: "failing-dependency");
+        }, dependsOn: "failing-dependency", requiredBy: "deploy");
 
         var context = CreateDeployingContext(builder.Build());
 
@@ -812,7 +812,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
     public async Task ExecuteAsync_WithFailure_PreventsOtherStepsFromStarting()
     {
         // Test that when one step fails, other steps that haven't started yet don't start
-        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: null).WithTestAndResourceLogging(testOutputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: "deploy").WithTestAndResourceLogging(testOutputHelper);
 
         builder.Services.AddSingleton(testOutputHelper);
         builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
@@ -832,7 +832,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         {
             step2Started = true;
             await Task.CompletedTask;
-        }, dependsOn: "step1");
+        }, dependsOn: "step1", requiredBy: "deploy");
 
         var context = CreateDeployingContext(builder.Build());
 
@@ -878,7 +878,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
     [Fact]
     public async Task ExecuteAsync_WhenStepThrowsProcessFailedException_RethrowsWithoutWrapping()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: null).WithTestAndResourceLogging(testOutputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: "failing-step").WithTestAndResourceLogging(testOutputHelper);
 
         builder.Services.AddSingleton(testOutputHelper);
         builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
@@ -1448,7 +1448,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         await pipeline.ExecuteAsync(context).DefaultTimeout();
 
         Assert.True(callbackExecuted);
-        Assert.Equal(14, capturedSteps.Count); // Default steps: deploy, deploy-prereq, process-parameters, build, build-prereq, push, push-prereq, publish, publish-prereq, diagnostics, destroy, destroy-prereq + step1, step2
+        Assert.Equal(15, capturedSteps.Count); // Default steps: deploy, deploy-prereq, process-parameters, build, build-prereq, check-container-runtime, push, push-prereq, publish, publish-prereq, diagnostics, destroy, destroy-prereq + step1, step2
         Assert.Contains(capturedSteps, s => s.Name == "deploy");
         Assert.Contains(capturedSteps, s => s.Name == "process-parameters");
         Assert.Contains(capturedSteps, s => s.Name == "deploy-prereq");


### PR DESCRIPTION
## Description

Add a container runtime health check as an orphan pipeline step that prevents cascading failures when Docker/Podman isn't running during deployment.

**Problem:** When Docker isn't running and a user runs `aspire deploy`, the container build step fails and cancels sibling pipeline steps (like Azure provisioning) via the shared CancellationTokenSource. The cancelled provisioning step surfaces misleading `DefaultAzureCredential` errors, burying the actual root cause.

**Solution:** Add a `check-container-runtime` step to the pipeline that:
- Is an **orphan by default** — no dependencies, nothing depends on it. It only participates when a resource's build step explicitly depends on it (ProjectResource, ContainerResource).
- Uses `IContainerRuntimeResolver` to detect and verify the runtime.
- In **interactive mode**, prompts the user to start the runtime and retry instead of failing immediately.
- In **non-interactive mode** (CI), fails fast with a clear error message.
- Adds `WellKnownPipelineSteps.CheckContainerRuntime` so third-party resources can depend on it too.

Fixes #12348

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
