### PR TITLE
Disambiguate duplicate paths in aspire ps output

### DIFF
--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -204,6 +204,8 @@ internal sealed class PsCommand : BaseCommand
             return;
         }
 
+        var shortPaths = FileSystemHelper.ShortenPaths(appHosts.Select(a => a.AppHostPath).ToList());
+
         var table = new Table();
         table.AddBoldColumn(PsCommandStrings.HeaderPath);
         table.AddBoldColumn(PsCommandStrings.HeaderPid);
@@ -212,7 +214,7 @@ internal sealed class PsCommand : BaseCommand
 
         foreach (var appHost in appHosts)
         {
-            var shortPath = ShortenPath(appHost.AppHostPath);
+            var shortPath = shortPaths[appHost.AppHostPath];
             var cliPid = appHost.CliPid?.ToString(CultureInfo.InvariantCulture) ?? "-";
             var dashboard = "-";
             if (!string.IsNullOrEmpty(appHost.DashboardUrl))
@@ -238,29 +240,4 @@ internal sealed class PsCommand : BaseCommand
         _interactionService.DisplayRenderable(table);
     }
 
-    private static string ShortenPath(string path)
-    {
-        var fileName = Path.GetFileName(path);
-
-        if (string.IsNullOrEmpty(fileName))
-        {
-            return path;
-        }
-
-        // For .csproj files, just show the filename (folder often has same name)
-        if (fileName.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
-        {
-            return fileName;
-        }
-
-        // For single-file AppHosts (.cs), show parent/filename
-        var directory = Path.GetDirectoryName(path);
-        var parentFolder = !string.IsNullOrEmpty(directory)
-            ? Path.GetFileName(directory)
-            : null;
-
-        return !string.IsNullOrEmpty(parentFolder)
-            ? $"{parentFolder}/{fileName}"
-            : fileName;
-    }
 }

--- a/src/Aspire.Cli/Utils/FileSystemHelper.cs
+++ b/src/Aspire.Cli/Utils/FileSystemHelper.cs
@@ -154,7 +154,7 @@ internal static class FileSystemHelper
         while (true)
         {
             var duplicateGroups = result
-                .GroupBy(kvp => kvp.Value, StringComparer.OrdinalIgnoreCase)
+                .GroupBy(kvp => kvp.Value, comparer)
                 .Where(g => g.Count() > 1)
                 .ToList();
 

--- a/src/Aspire.Cli/Utils/FileSystemHelper.cs
+++ b/src/Aspire.Cli/Utils/FileSystemHelper.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Projects;
+
 namespace Aspire.Cli.Utils;
 
 /// <summary>
@@ -101,5 +103,101 @@ internal static class FileSystemHelper
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Shortens a list of paths so each is uniquely identifiable using the minimum
+    /// number of trailing path segments. Duplicate filenames get parent directories
+    /// added with a "~" prefix until unique. Non-project files (e.g. single-file
+    /// AppHosts like AppHost.cs) always include at least the parent folder to
+    /// provide context.
+    /// </summary>
+    internal static Dictionary<string, string> ShortenPaths(IReadOnlyList<string> paths)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (paths.Count == 0)
+        {
+            return result;
+        }
+
+        // Split each path into normalized segments
+        var segmentsMap = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        var depthMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in paths)
+        {
+            if (result.ContainsKey(path))
+            {
+                continue; // Skip duplicate paths
+            }
+
+            var normalized = path.Replace('\\', '/').TrimEnd('/');
+            var segments = normalized.Split('/');
+            segmentsMap[path] = segments;
+
+            // Non-project files (single-file AppHosts) always show parent/filename
+            var fileName = segments.Length > 0 ? segments[^1] : path;
+            var extension = Path.GetExtension(fileName);
+            var isProjectFile = DotNetAppHostProject.ProjectExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase);
+            var minDepth = !isProjectFile && segments.Length >= 2 ? 2 : 1;
+
+            depthMap[path] = minDepth;
+            result[path] = minDepth >= 2
+                ? Path.Combine(segments[^2], segments[^1])
+                : fileName;
+        }
+
+        // Iteratively resolve duplicates by adding more parent directory segments
+        while (true)
+        {
+            var duplicateGroups = result
+                .GroupBy(kvp => kvp.Value, StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1)
+                .ToList();
+
+            if (duplicateGroups.Count == 0)
+            {
+                break;
+            }
+
+            foreach (var group in duplicateGroups)
+            {
+                foreach (var kvp in group)
+                {
+                    var originalPath = kvp.Key;
+                    var segments = segmentsMap[originalPath];
+                    var newDepth = depthMap[originalPath] + 1;
+                    depthMap[originalPath] = newDepth;
+
+                    if (newDepth >= segments.Length)
+                    {
+                        // Use full path when all segments exhausted
+                        result[originalPath] = originalPath;
+                    }
+                    else
+                    {
+                        var candidate = Path.Combine(segments[^newDepth..]);
+
+                        // If adding one more parent segment would reach the path root,
+                        // switch to the full original path to avoid displaying
+                        // something like "~\C:\folder\Project.csproj".
+                        var nextIndex = segments.Length - newDepth - 1;
+                        if (nextIndex >= 0)
+                        {
+                            var nextSegment = segments[nextIndex];
+                            if (nextSegment.Length == 0 || Path.IsPathRooted(nextSegment))
+                            {
+                                candidate = originalPath;
+                            }
+                        }
+
+                        result[originalPath] = candidate;
+                    }
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/src/Aspire.Cli/Utils/FileSystemHelper.cs
+++ b/src/Aspire.Cli/Utils/FileSystemHelper.cs
@@ -108,13 +108,15 @@ internal static class FileSystemHelper
     /// <summary>
     /// Shortens a list of paths so each is uniquely identifiable using the minimum
     /// number of trailing path segments. Duplicate filenames get parent directories
-    /// added with a "~" prefix until unique. Non-project files (e.g. single-file
-    /// AppHosts like AppHost.cs) always include at least the parent folder to
-    /// provide context.
+    /// added until unique. Non-project files (e.g. single-file AppHosts like
+    /// AppHost.cs) always include at least the parent folder to provide context.
     /// </summary>
     internal static Dictionary<string, string> ShortenPaths(IReadOnlyList<string> paths)
     {
-        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var comparer = OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var result = new Dictionary<string, string>(comparer);
 
         if (paths.Count == 0)
         {
@@ -122,8 +124,8 @@ internal static class FileSystemHelper
         }
 
         // Split each path into normalized segments
-        var segmentsMap = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
-        var depthMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var segmentsMap = new Dictionary<string, string[]>(comparer);
+        var depthMap = new Dictionary<string, int>(comparer);
 
         foreach (var path in paths)
         {
@@ -179,17 +181,14 @@ internal static class FileSystemHelper
                     {
                         var candidate = Path.Combine(segments[^newDepth..]);
 
-                        // If adding one more parent segment would reach the path root,
-                        // switch to the full original path to avoid displaying
-                        // something like "~\C:\folder\Project.csproj".
-                        var nextIndex = segments.Length - newDepth - 1;
-                        if (nextIndex >= 0)
+                        // Switch to the full original path when the candidate itself
+                        // would include a root/drive segment, to avoid displaying
+                        // something like "C:\folder\Project.csproj" with a tilde prefix.
+                        var firstCandidateIndex = segments.Length - newDepth;
+                        var firstCandidateSegment = segments[firstCandidateIndex];
+                        if (firstCandidateSegment.Length == 0 || Path.IsPathRooted(firstCandidateSegment))
                         {
-                            var nextSegment = segments[nextIndex];
-                            if (nextSegment.Length == 0 || Path.IsPathRooted(nextSegment))
-                            {
-                                candidate = originalPath;
-                            }
+                            candidate = originalPath;
                         }
 
                         result[originalPath] = candidate;

--- a/tests/Aspire.Cli.Tests/Utils/FileSystemHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/FileSystemHelperTests.cs
@@ -254,4 +254,182 @@ public class FileSystemHelperTests(ITestOutputHelper outputHelper)
         Assert.Throws<IOException>(() => 
             FileSystemHelper.CopyDirectory(sourceDir.FullName, destDir, overwrite: false));
     }
+
+    [Fact]
+    public void ShortenPaths_UniqueFilenames_ReturnsJustFilename()
+    {
+        var paths = new List<string>
+        {
+            "/home/user/folder1/App1.AppHost.csproj",
+            "/home/user/folder2/App2.AppHost.csproj"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal("App1.AppHost.csproj", result[paths[0]]);
+        Assert.Equal("App2.AppHost.csproj", result[paths[1]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_DuplicateFilenames_AddsParentDirectoryToDisambiguate()
+    {
+        var paths = new List<string>
+        {
+            "/home/user/folder1/Project.csproj",
+            "/home/user/folder2/Project.csproj"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(Path.Combine("folder1", "Project.csproj"), result[paths[0]]);
+        Assert.Equal(Path.Combine("folder2", "Project.csproj"), result[paths[1]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_DuplicateFilenamesWithBackslashes_AddsParentDirectoryToDisambiguate()
+    {
+        var paths = new List<string>
+        {
+            @"C:\folder1\Project.csproj",
+            @"C:\folder2\Project.csproj"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(@"C:\folder1\Project.csproj", result[paths[0]]);
+        Assert.Equal(@"C:\folder2\Project.csproj", result[paths[1]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_DuplicateFilenamesWithSameParent_AddsMoreSegments()
+    {
+        var paths = new List<string>
+        {
+            "/home/a/shared/Project.csproj",
+            "/home/b/shared/Project.csproj"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(Path.Combine("a", "shared", "Project.csproj"), result[paths[0]]);
+        Assert.Equal(Path.Combine("b", "shared", "Project.csproj"), result[paths[1]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_SinglePath_CsFile_ReturnsParentAndFilename()
+    {
+        var paths = new List<string> { "/home/user/repos/MyApp/AppHost.cs" };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(Path.Combine("MyApp", "AppHost.cs"), result[paths[0]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_SinglePath_Csproj_ReturnsJustFilename()
+    {
+        var paths = new List<string> { "/home/user/repos/MyApp/MyApp.AppHost.csproj" };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal("MyApp.AppHost.csproj", result[paths[0]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_SingleCsFile_ReturnsParentAndFilename()
+    {
+        var paths = new List<string>
+        {
+            "/home/user/App1/AppHost.cs"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(Path.Combine("App1", "AppHost.cs"), result[paths[0]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_UniqueCsFiles_ReturnsParentAndFilename()
+    {
+        var paths = new List<string>
+        {
+            "/home/user/App1/AppHost.cs",
+            "/home/user/App2/AppHost.cs"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(Path.Combine("App1", "AppHost.cs"), result[paths[0]]);
+        Assert.Equal(Path.Combine("App2", "AppHost.cs"), result[paths[1]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_DuplicateCsFiles_AddMoreSegments()
+    {
+        var paths = new List<string>
+        {
+            "/home/user/a/src/AppHost.cs",
+            "/home/user/b/src/AppHost.cs"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(Path.Combine("a", "src", "AppHost.cs"), result[paths[0]]);
+        Assert.Equal(Path.Combine("b", "src", "AppHost.cs"), result[paths[1]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_MixedCsprojAndCsFiles()
+    {
+        var paths = new List<string>
+        {
+            "/home/user/App1/App1.AppHost.csproj",
+            "/home/user/App2/AppHost.cs"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal("App1.AppHost.csproj", result[paths[0]]);
+        Assert.Equal(Path.Combine("App2", "AppHost.cs"), result[paths[1]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_EmptyList_ReturnsEmptyDictionary()
+    {
+        var result = FileSystemHelper.ShortenPaths(Array.Empty<string>());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ShortenPaths_MixOfUniqueAndDuplicateFilenames()
+    {
+        var paths = new List<string>
+        {
+            "/a/folder1/Project.csproj",
+            "/a/folder2/Project.csproj",
+            "/a/folder3/Unique.csproj"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(Path.Combine("folder1", "Project.csproj"), result[paths[0]]);
+        Assert.Equal(Path.Combine("folder2", "Project.csproj"), result[paths[1]]);
+        Assert.Equal("Unique.csproj", result[paths[2]]);
+    }
+
+    [Fact]
+    public void ShortenPaths_DuplicateFilenamesExhaustSegments_ReturnsFullPath()
+    {
+        var paths = new List<string>
+        {
+            @"C:\folder\Project.csproj",
+            @"D:\folder\Project.csproj"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(@"C:\folder\Project.csproj", result[paths[0]]);
+        Assert.Equal(@"D:\folder\Project.csproj", result[paths[1]]);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/FileSystemHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/FileSystemHelperTests.cs
@@ -432,4 +432,21 @@ public class FileSystemHelperTests(ITestOutputHelper outputHelper)
         Assert.Equal(@"C:\folder\Project.csproj", result[paths[0]]);
         Assert.Equal(@"D:\folder\Project.csproj", result[paths[1]]);
     }
+
+    [Fact]
+    public void ShortenPaths_PathsDifferingOnlyByCase_TreatedAsDistinctOnCaseSensitiveOS()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "Case-sensitive filesystem test only runs on Linux.");
+
+        var paths = new List<string>
+        {
+            "/repo/Folder/Project.csproj",
+            "/repo/folder/Project.csproj"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Equal(Path.Combine("Folder", "Project.csproj"), result[paths[0]]);
+        Assert.Equal(Path.Combine("folder", "Project.csproj"), result[paths[1]]);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/FileSystemHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/FileSystemHelperTests.cs
@@ -296,8 +296,8 @@ public class FileSystemHelperTests(ITestOutputHelper outputHelper)
 
         var result = FileSystemHelper.ShortenPaths(paths);
 
-        Assert.Equal(@"C:\folder1\Project.csproj", result[paths[0]]);
-        Assert.Equal(@"C:\folder2\Project.csproj", result[paths[1]]);
+        Assert.Equal(Path.Combine("folder1", "Project.csproj"), result[paths[0]]);
+        Assert.Equal(Path.Combine("folder2", "Project.csproj"), result[paths[1]]);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/FileSystemHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/FileSystemHelperTests.cs
@@ -449,4 +449,19 @@ public class FileSystemHelperTests(ITestOutputHelper outputHelper)
         Assert.Equal(Path.Combine("Folder", "Project.csproj"), result[paths[0]]);
         Assert.Equal(Path.Combine("folder", "Project.csproj"), result[paths[1]]);
     }
+
+    [Fact]
+    public void ShortenPaths_DuplicatePaths_ReturnsSingleEntry()
+    {
+        var paths = new List<string>
+        {
+            "/home/user/folder1/Project.csproj",
+            "/home/user/folder1/Project.csproj"
+        };
+
+        var result = FileSystemHelper.ShortenPaths(paths);
+
+        Assert.Single(result);
+        Assert.Equal("Project.csproj", result[paths[0]]);
+    }
 }


### PR DESCRIPTION
## Description

Disambiguate duplicate paths in `aspire ps` table output.

Previously, `ShortenPath` processed each path independently, so two AppHosts at `c:\folder1\Project.csproj` and `c:\folder2\Project.csproj` would both display as `Project.csproj`. The new `ShortenPaths` method compares all paths together and adds the minimum number of parent directory segments needed to make each display value unique.

Key behaviors:
- **Unique filenames**: shown as just the filename (e.g. `MyApp.AppHost.csproj`)
- **Duplicate filenames**: parent directories are added with a `~\` prefix until unique (e.g. `~\folder1\Project.csproj`)
- **Single-file AppHosts** (`.cs` files): always include at least the parent folder for context (e.g. `MyApp\AppHost.cs`)
- **Root segments**: when disambiguation would reach a drive letter or leading `/`, the full original path is used instead

The method was moved from `PsCommand` to `FileSystemHelper` for reusability and testability.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
