### PR TITLE
Fix flaky OtlpGrpcServiceTests file-changed test

### DIFF
--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
@@ -225,7 +225,7 @@ public class OtlpGrpcServiceTests
         await File.WriteAllTextAsync(configPath, configJson.ToString()).DefaultTimeout();
 
         logger.LogInformation("Waiting for options change.");
-        var options = await tcs.Task;
+        var options = await tcs.Task.DefaultTimeout();
 
         logger.LogInformation("Assert new API key.");
         Assert.Equal("Different", options.Otlp.PrimaryApiKey);

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
@@ -199,8 +199,14 @@ public class OtlpGrpcServiceTests
         var tcs = new TaskCompletionSource<DashboardOptions>(TaskCreationOptions.RunContinuationsAsynchronously);
         using var monitorRegistration = app.DashboardOptionsMonitor.OnChange((o, n) =>
         {
-            logger.LogInformation("Options changed.");
-            tcs.TrySetResult(o);
+            // FileSystemWatcher can fire multiple events during a single file write (truncate, write, close).
+            // The first event may trigger a config reload that reads stale content. Only complete when
+            // the value has actually changed to avoid capturing old options with TrySetResult.
+            if (o.Otlp.PrimaryApiKey != apiKey)
+            {
+                logger.LogInformation("Options changed.");
+                tcs.TrySetResult(o);
+            }
         });
 
         configJson = new JsonObject


### PR DESCRIPTION
## Description

Fix flaky `CallService_OtlpGrpcEndPoint_ExternalFile_FileChanged_UseConfiguredKey` test in `OtlpGrpcServiceTests`.

`FileSystemWatcher` can fire multiple change events during a single `File.WriteAllTextAsync` (truncate → write → close). The first event triggers a config reload that may read stale file content. Since `TrySetResult` only succeeds once, the `TaskCompletionSource` captured the old API key `"TestKey123!"` instead of the expected `"Different"` value.

The fix guards the `OnChange` callback so it only completes the TCS when `PrimaryApiKey` has actually changed from the original value, filtering out spurious notifications with stale options.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
