### PR TITLE
Add cross-environment reference support for App Service and Container Apps

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
@@ -27,6 +27,53 @@ public class AzureContainerAppResource : AzureProvisioningResource
     {
         TargetResource = targetResource;
 
+        // Add pipeline step to allocate endpoint values after provisioning
+        // This is needed for cross-environment references: when another resource (e.g., on App Service)
+        // references an endpoint on this container app, its SetParametersAsync needs to resolve the
+        // endpoint URL. Without allocated endpoints, GetValueAsync() blocks forever.
+        Annotations.Add(new PipelineStepAnnotation((factoryContext) =>
+        {
+            var dta = targetResource.GetDeploymentTargetAnnotation();
+            if (dta is null)
+            {
+                return [];
+            }
+
+            var allocateEndpointsStep = new PipelineStep
+            {
+                Name = $"allocate-endpoints-{targetResource.Name}",
+                Description = $"Allocates endpoint values for {targetResource.Name} after provisioning.",
+                Action = async ctx =>
+                {
+                    var containerAppEnv = (AzureContainerAppEnvironmentResource)dta.ComputeEnvironment!;
+                    var domainValue = await containerAppEnv.ContainerAppDomain.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false);
+
+                    if (targetResource.TryGetEndpoints(out var endpoints))
+                    {
+                        foreach (var endpoint in endpoints)
+                        {
+                            var fqdn = endpoint.IsExternal
+                                ? $"{targetResource.Name.ToLowerInvariant()}.{domainValue}"
+                                : $"{targetResource.Name.ToLowerInvariant()}.internal.{domainValue}";
+
+                            var port = string.Equals(endpoint.UriScheme, "https", StringComparison.OrdinalIgnoreCase) ? 443 : 80;
+
+                            var allocatedEndpoint = new AllocatedEndpoint(
+                                endpoint, fqdn, port);
+
+                            endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(
+                                KnownNetworkIdentifiers.LocalhostNetwork, allocatedEndpoint);
+                        }
+                    }
+                },
+                Tags = [WellKnownPipelineTags.ProvisionInfrastructure]
+            };
+            allocateEndpointsStep.DependsOn($"provision-{name}");
+            allocateEndpointsStep.RequiredBy(AzureEnvironmentResource.ProvisionInfrastructureStepName);
+
+            return [allocateEndpointsStep];
+        }));
+
         // Add pipeline step annotation for deploy
         Annotations.Add(new PipelineStepAnnotation((factoryContext) =>
         {

--- a/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
@@ -222,15 +222,24 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
 
         if (value is EndpointReference ep)
         {
-            var context = ep.Resource == resource
-                ? this
-                : _containerAppEnvironmentContext.GetContainerAppContext(ep.Resource);
+            if (ep.Resource == resource)
+            {
+                var mapping = _endpointMapping[ep.EndpointName];
+                return (GetEndpointValue(mapping, EndpointProperty.Url), secretType);
+            }
 
-            var mapping = context._endpointMapping[ep.EndpointName];
+            if (_containerAppEnvironmentContext.TryGetContainerAppContext(ep.Resource, out var epContext))
+            {
+                var mapping = epContext._endpointMapping[ep.EndpointName];
+                return (GetEndpointValue(mapping, EndpointProperty.Url), secretType);
+            }
 
-            var url = GetEndpointValue(mapping, EndpointProperty.Url);
+            if (ep.Resource.GetComputeEnvironment() == _containerAppEnvironmentContext.Environment)
+            {
+                throw new InvalidOperationException($"Container app context not found for resource {ep.Resource.Name}.");
+            }
 
-            return (url, secretType);
+            // Cross-environment reference — fall through to IManifestExpressionProvider handler
         }
 
         if (value is ParameterResource param)
@@ -274,15 +283,26 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
 
         if (value is EndpointReferenceExpression epExpr)
         {
-            var context = epExpr.Endpoint.Resource == resource
-                ? this
-                : _containerAppEnvironmentContext.GetContainerAppContext(epExpr.Endpoint.Resource);
+            if (epExpr.Endpoint.Resource == resource)
+            {
+                var mapping = _endpointMapping[epExpr.Endpoint.EndpointName];
+                var val = GetEndpointValue(mapping, epExpr.Property);
+                return (val, secretType);
+            }
 
-            var mapping = context._endpointMapping[epExpr.Endpoint.EndpointName];
+            if (_containerAppEnvironmentContext.TryGetContainerAppContext(epExpr.Endpoint.Resource, out var epExprContext))
+            {
+                var mapping = epExprContext._endpointMapping[epExpr.Endpoint.EndpointName];
+                var val = GetEndpointValue(mapping, epExpr.Property);
+                return (val, secretType);
+            }
 
-            var val = GetEndpointValue(mapping, epExpr.Property);
+            if (epExpr.Endpoint.Resource.GetComputeEnvironment() == _containerAppEnvironmentContext.Environment)
+            {
+                throw new InvalidOperationException($"Container app context not found for resource {epExpr.Endpoint.Resource.Name}.");
+            }
 
-            return (val, secretType);
+            // Cross-environment reference — fall through to IManifestExpressionProvider handler
         }
 
         if (value is ReferenceExpression expr)

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREAZURE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppContainers;
 using Microsoft.Extensions.Logging;
@@ -69,6 +70,11 @@ internal sealed class ContainerAppEnvironmentContext(
         }
 
         return context;
+    }
+
+    public bool TryGetContainerAppContext(IResource resource, [NotNullWhen(true)] out BaseContainerAppContext? context)
+    {
+        return _containerApps.TryGetValue(resource, out context);
     }
 
     public async Task<AzureBicepResource> CreateContainerAppAsync(IResource resource, AzureProvisioningOptions provisioningOptions, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContext.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppService;
 using Microsoft.Extensions.Logging;
@@ -67,6 +68,11 @@ internal sealed class AzureAppServiceEnvironmentContext(
         }
 
         return context;
+    }
+
+    public bool TryGetAppServiceContext(IResource resource, [NotNullWhen(true)] out AzureAppServiceWebsiteContext? context)
+    {
+        return _appServices.TryGetValue(resource, out context);
     }
 
     public async Task<AzureBicepResource> CreateAppServiceAsync(IResource resource, AzureProvisioningOptions provisioningOptions, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -143,6 +143,15 @@ public class AzureAppServiceEnvironmentResource :
 
     private async Task PrintDashboardUrlAsync(PipelineStepContext context)
     {
+        if (!EnableDashboard)
+        {
+            await context.ReportingStep.CompleteAsync(
+                "Dashboard is disabled for this environment.",
+                CompletionState.Completed,
+                context.CancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         var dashboardUri = await DashboardUriReference.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(dashboardUri))

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -27,6 +27,49 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     {
         TargetResource = targetResource;
 
+        // Add pipeline step to allocate endpoint values after provisioning
+        // This is needed for cross-environment references: when another resource (e.g., on ACA)
+        // references an endpoint on this App Service resource, its SetParametersAsync needs to resolve
+        // the endpoint URL. Without allocated endpoints, GetValueAsync() blocks forever.
+        Annotations.Add(new PipelineStepAnnotation((factoryContext) =>
+        {
+            var dta = targetResource.GetDeploymentTargetAnnotation();
+            if (dta is null)
+            {
+                return [];
+            }
+
+            var allocateEndpointsStep = new PipelineStep
+            {
+                Name = $"allocate-endpoints-{targetResource.Name}",
+                Description = $"Allocates endpoint values for {targetResource.Name} after provisioning.",
+                Action = async ctx =>
+                {
+                    var hostName = await GetAppServiceWebsiteNameAsync(ctx).ConfigureAwait(false);
+                    var fqdn = $"{hostName}.azurewebsites.net";
+
+                    if (targetResource.TryGetEndpoints(out var endpoints))
+                    {
+                        foreach (var endpoint in endpoints)
+                        {
+                            var port = string.Equals(endpoint.UriScheme, "https", StringComparison.OrdinalIgnoreCase) ? 443 : 80;
+
+                            var allocatedEndpoint = new AllocatedEndpoint(
+                                endpoint, fqdn, port);
+
+                            endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(
+                                KnownNetworkIdentifiers.LocalhostNetwork, allocatedEndpoint);
+                        }
+                    }
+                },
+                Tags = [WellKnownPipelineTags.ProvisionInfrastructure]
+            };
+            allocateEndpointsStep.DependsOn($"provision-{name}");
+            allocateEndpointsStep.RequiredBy(AzureEnvironmentResource.ProvisionInfrastructureStepName);
+
+            return [allocateEndpointsStep];
+        }));
+
         // Add pipeline step annotation for deploy
         Annotations.Add(new PipelineStepAnnotation((factoryContext) =>
         {

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -167,10 +167,19 @@ internal sealed class AzureAppServiceWebsiteContext(
 
         if (value is EndpointReference ep)
         {
-            var context = environmentContext.GetAppServiceContext(ep.Resource);
-            return isSlot ?
-                (GetEndpointValue(context._slotEndpointMapping[ep.EndpointName], EndpointProperty.Url), secretType) :
-                (GetEndpointValue(context._endpointMapping[ep.EndpointName], EndpointProperty.Url), secretType);
+            if (environmentContext.TryGetAppServiceContext(ep.Resource, out var epContext))
+            {
+                return isSlot ?
+                    (GetEndpointValue(epContext._slotEndpointMapping[ep.EndpointName], EndpointProperty.Url), secretType) :
+                    (GetEndpointValue(epContext._endpointMapping[ep.EndpointName], EndpointProperty.Url), secretType);
+            }
+
+            if (ep.Resource.GetComputeEnvironment() == environmentContext.Environment)
+            {
+                throw new InvalidOperationException($"App Service context not found for resource {ep.Resource.Name}.");
+            }
+
+            // Cross-environment reference — fall through to IManifestExpressionProvider handler
         }
 
         if (value is ParameterResource param)
@@ -206,10 +215,19 @@ internal sealed class AzureAppServiceWebsiteContext(
 
         if (value is EndpointReferenceExpression epExpr)
         {
-            var context = environmentContext.GetAppServiceContext(epExpr.Endpoint.Resource);
-            var mapping = isSlot ? context._slotEndpointMapping[epExpr.Endpoint.EndpointName] : context._endpointMapping[epExpr.Endpoint.EndpointName];
-            var val = GetEndpointValue(mapping, epExpr.Property);
-            return (val, secretType);
+            if (environmentContext.TryGetAppServiceContext(epExpr.Endpoint.Resource, out var epExprContext))
+            {
+                var mapping = isSlot ? epExprContext._slotEndpointMapping[epExpr.Endpoint.EndpointName] : epExprContext._endpointMapping[epExpr.Endpoint.EndpointName];
+                var val = GetEndpointValue(mapping, epExpr.Property);
+                return (val, secretType);
+            }
+
+            if (epExpr.Endpoint.Resource.GetComputeEnvironment() == environmentContext.Environment)
+            {
+                throw new InvalidOperationException($"App Service context not found for resource {epExpr.Endpoint.Resource.Name}.");
+            }
+
+            // Cross-environment reference — fall through to IManifestExpressionProvider handler
         }
 
         if (value is ReferenceExpression expr)

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -83,6 +83,14 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
             // Make this resource's provision steps depend on the provision steps of referenced Azure resources
             foreach (var azureReference in azureReferences)
             {
+                // Skip self-references to avoid circular dependencies. This can happen when a resource's
+                // parameters reference its own target resource (e.g., ProjectResource) which has a
+                // DeploymentTargetAnnotation pointing back to this Azure resource.
+                if (ReferenceEquals(azureReference, this))
+                {
+                    continue;
+                }
+
                 var dependencySteps = context.GetSteps(azureReference, WellKnownPipelineTags.ProvisionInfrastructure);
                 provisionSteps.DependsOn(dependencySteps);
             }
@@ -530,6 +538,24 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
         if (value is IAzureResource azureResource)
         {
             azureReferences.Add(azureResource);
+        }
+
+        // For non-Azure resources (e.g., ProjectResource), check if they have a deployment target
+        // that is an Azure resource. This handles cross-environment references where an endpoint
+        // reference points to a ProjectResource whose actual Azure deployment target (e.g.,
+        // AzureContainerAppResource) needs to be provisioned first.
+        if (value is IResource resource && resource is not IAzureResource)
+        {
+            if (resource.TryGetAnnotationsOfType<DeploymentTargetAnnotation>(out var deploymentTargets))
+            {
+                foreach (var dt in deploymentTargets)
+                {
+                    if (dt.DeploymentTarget is IAzureResource azureTarget)
+                    {
+                        azureReferences.Add(azureTarget);
+                    }
+                }
+            }
         }
 
         // Recursively process references if the value implements IValueWithReferences

--- a/tests/Aspire.Deployment.EndToEnd.Tests/CrossEnvironmentDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/CrossEnvironmentDeploymentTests.cs
@@ -228,11 +228,11 @@ public sealed class CrossEnvironmentDeploymentTests(ITestOutputHelper output)
                 "success=0 && " +
                 "for i in $(seq 1 12); do " +
                 "BODY=$(curl -s \"https://$webapp_url/weather\" --max-time 30 2>/dev/null); " +
-                "if echo \"$BODY\" | grep -q 'class=\"table\"'; then " +
+                // Check for table with actual data rows (td elements) to confirm weather API data loaded.
+                // Note: Blazor SSR streaming responses contain both the initial "Loading..." marker and the
+                // final table in the same response body, so checking for "Loading..." is unreliable.
+                "if echo \"$BODY\" | grep -q 'class=\"table\"' && echo \"$BODY\" | grep -q '<td>'; then " +
                 "echo \"  ✅ Weather page contains table data (attempt $i)\"; " +
-                // Also verify it's not stuck on Loading
-                "if echo \"$BODY\" | grep -q 'Loading...'; then " +
-                "echo \"  ⚠️ Page still loading, retrying...\"; sleep 10; continue; fi; " +
                 "success=1; break; fi; " +
                 "echo \"  Attempt $i: Weather table not found, retrying in 10s...\"; sleep 10; " +
                 "done && " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/CrossEnvironmentDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/CrossEnvironmentDeploymentTests.cs
@@ -1,0 +1,313 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying Aspire applications across multiple Azure compute environments.
+/// Validates cross-environment references between Azure App Service and Azure Container Apps.
+/// </summary>
+public sealed class CrossEnvironmentDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 45 minutes to allow for both ACA and App Service provisioning.
+    // Cross-environment deployments provision infrastructure in two environments, so they take longer.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployStarterWithWebFrontendOnAppServiceAndApiServiceOnAca()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterWithWebFrontendOnAppServiceAndApiServiceOnAcaCore(cancellationToken);
+    }
+
+    private async Task DeployStarterWithWebFrontendOnAppServiceAndApiServiceOnAcaCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("crossenv");
+        var projectName = "CrossEnvDeploy";
+
+        output.WriteLine($"Test: {nameof(DeployStarterWithWebFrontendOnAppServiceAndApiServiceOnAca)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            // Step 2: Set up CLI environment (in CI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                output.WriteLine("Step 2: Using pre-installed Aspire CLI from local build...");
+                await auto.SourceAspireCliEnvironmentAsync(counter);
+            }
+
+            // Step 3: Create starter project (Blazor) without Redis
+            output.WriteLine("Step 3: Creating starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            // Step 4: Navigate to project directory
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 5: Add both Azure hosting packages for cross-environment deployment
+            output.WriteLine("Step 5a: Adding Azure Container Apps hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
+            await auto.EnterAsync();
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
+                await auto.EnterAsync();
+            }
+
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+
+            output.WriteLine("Step 5b: Adding Azure App Service hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppService");
+            await auto.EnterAsync();
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
+                await auto.EnterAsync();
+            }
+
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+
+            // Step 6: Modify AppHost.cs for cross-environment deployment
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+            output.WriteLine($"Original AppHost.cs:\n{content}");
+
+            // 6a: Add compute environment declarations before apiService
+            var original = content;
+            content = content.Replace(
+                "var apiService =",
+                """
+                // Add both compute environments for cross-environment deployment
+                var aca = builder.AddAzureContainerAppEnvironment("aca")
+                    .WithDashboard(false);
+                var appService = builder.AddAzureAppServiceEnvironment("appService")
+                    .WithDashboard(false);
+
+                var apiService =
+                """);
+            Assert.True(content != original, "Failed to insert compute environment declarations into AppHost.cs");
+
+            // 6b: Add .WithComputeEnvironment(aca) and .WithExternalHttpEndpoints() to apiservice
+            original = content;
+            content = content.Replace(
+                "(\"apiservice\")\n    .WithHttpHealthCheck",
+                "(\"apiservice\")\n    .WithComputeEnvironment(aca)\n    .WithExternalHttpEndpoints()\n    .WithHttpHealthCheck");
+            Assert.True(content != original, "Failed to add WithComputeEnvironment(aca) to apiservice in AppHost.cs");
+
+            // 6c: Add .WithComputeEnvironment(appService) to webfrontend
+            original = content;
+            content = content.Replace(
+                "(\"webfrontend\")\n    .WithExternalHttpEndpoints",
+                "(\"webfrontend\")\n    .WithComputeEnvironment(appService)\n    .WithExternalHttpEndpoints");
+            Assert.True(content != original, "Failed to add WithComputeEnvironment(appService) to webfrontend in AppHost.cs");
+
+            File.WriteAllText(appHostFilePath, content);
+            output.WriteLine($"Modified AppHost.cs:\n{content}");
+
+            // Step 7: Navigate to AppHost project directory
+            output.WriteLine("Step 7: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 8: Set environment variables for deployment
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 9: Deploy to Azure using aspire deploy
+            output.WriteLine("Step 9: Starting cross-environment deployment...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            // Cross-environment deployment provisions both ACA and App Service infrastructure
+            await auto.WaitUntilTextAsync(ConsoleActivityLoggerStrings.PipelineSucceeded, timeout: TimeSpan.FromMinutes(35));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Step 10: Verify deployed endpoints
+            // Get the App Service URL for webfrontend and verify the weather page works
+            output.WriteLine("Step 10: Verifying deployed endpoints...");
+            await auto.TypeAsync(
+                $"RG_NAME=\"{resourceGroupName}\" && " +
+                "echo \"Resource group: $RG_NAME\" && " +
+                "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
+                // Verify App Service (webfrontend) endpoints
+                "webapp_urls=$(az webapp list -g \"$RG_NAME\" --query \"[].defaultHostName\" -o tsv 2>/dev/null) && " +
+                "if [ -z \"$webapp_urls\" ]; then echo \"❌ No App Service endpoints found\"; exit 1; fi && " +
+                // Verify Container App (apiservice) endpoints - exclude internal endpoints
+                "ca_urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
+                "if [ -z \"$ca_urls\" ]; then echo \"❌ No external Container App endpoints found\"; exit 1; fi && " +
+                // Check each App Service endpoint is accessible
+                "failed=0 && " +
+                "for url in $webapp_urls; do " +
+                "echo \"Checking App Service: https://$url...\"; " +
+                "success=0; " +
+                "for i in $(seq 1 18); do " +
+                "STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$url\" --max-time 30 2>/dev/null); " +
+                "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"  ✅ $STATUS (attempt $i)\"; success=1; break; fi; " +
+                "echo \"  Attempt $i: $STATUS, retrying in 10s...\"; sleep 10; " +
+                "done; " +
+                "if [ \"$success\" -eq 0 ]; then echo \"  ❌ App Service endpoint failed after 18 attempts\"; failed=1; fi; " +
+                "done && " +
+                // Check each Container App endpoint is accessible
+                "for url in $ca_urls; do " +
+                "echo \"Checking Container App: https://$url...\"; " +
+                "success=0; " +
+                "for i in $(seq 1 18); do " +
+                "STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$url\" --max-time 10 2>/dev/null); " +
+                "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"  ✅ $STATUS (attempt $i)\"; success=1; break; fi; " +
+                "echo \"  Attempt $i: $STATUS, retrying in 10s...\"; sleep 10; " +
+                "done; " +
+                "if [ \"$success\" -eq 0 ]; then echo \"  ❌ Container App endpoint failed after 18 attempts\"; failed=1; fi; " +
+                "done && " +
+                "if [ \"$failed\" -ne 0 ]; then echo \"❌ One or more endpoint checks failed\"; exit 1; fi");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            // Step 11: Verify the weather page on webfrontend returns actual data from apiservice (cross-env reference)
+            // This proves the App Service webfrontend can successfully call the ACA apiservice
+            output.WriteLine("Step 11: Verifying weather page returns data from apiservice (cross-environment reference)...");
+            await auto.TypeAsync(
+                $"RG_NAME=\"{resourceGroupName}\" && " +
+                "webapp_url=$(az webapp list -g \"$RG_NAME\" --query \"[0].defaultHostName\" -o tsv 2>/dev/null) && " +
+                "echo \"Fetching weather page from https://$webapp_url/weather...\" && " +
+                "success=0 && " +
+                "for i in $(seq 1 12); do " +
+                "BODY=$(curl -s \"https://$webapp_url/weather\" --max-time 30 2>/dev/null); " +
+                "if echo \"$BODY\" | grep -q 'class=\"table\"'; then " +
+                "echo \"  ✅ Weather page contains table data (attempt $i)\"; " +
+                // Also verify it's not stuck on Loading
+                "if echo \"$BODY\" | grep -q 'Loading...'; then " +
+                "echo \"  ⚠️ Page still loading, retrying...\"; sleep 10; continue; fi; " +
+                "success=1; break; fi; " +
+                "echo \"  Attempt $i: Weather table not found, retrying in 10s...\"; sleep 10; " +
+                "done && " +
+                "if [ \"$success\" -eq 0 ]; then echo \"❌ Weather page did not return expected data\"; exit 1; fi && " +
+                "echo \"✅ Cross-environment reference verified: webfrontend (App Service) successfully called apiservice (ACA)\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            // Step 12: Exit terminal
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            // Report success
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterWithWebFrontendOnAppServiceAndApiServiceOnAca),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterWithWebFrontendOnAppServiceAndApiServiceOnAca),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            // Clean up the resource group we created
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName, output);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+    }
+
+    /// <summary>
+    /// Triggers cleanup of a specific resource group.
+    /// This is fire-and-forget - the hourly cleanup workflow handles any missed resources.
+    /// </summary>
+    private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)
+    {
+        var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2EAutomatorHelpers.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -1036,4 +1036,80 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
     {
         public string ValueExpression => "{customValue}";
     }
+
+    [Fact]
+    public async Task CrossEnvironmentReference_AppServiceReferencingContainerApp_GeneratesBicep()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var aca = builder.AddAzureContainerAppEnvironment("aca");
+        var appService = builder.AddAzureAppServiceEnvironment("appService");
+
+        var apiService = builder.AddProject<Project>("apiservice", launchProfileName: null)
+            .WithComputeEnvironment(aca)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+
+        var webfrontend = builder.AddProject<Project>("webfrontend", launchProfileName: null)
+            .WithComputeEnvironment(appService)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithReference(apiService);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        webfrontend.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task CrossEnvironmentReference_ContainerAppReferencingAppService_GeneratesBicep()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var aca = builder.AddAzureContainerAppEnvironment("aca");
+        var appService = builder.AddAzureAppServiceEnvironment("appService");
+
+        var webfrontend = builder.AddProject<Project>("webfrontend", launchProfileName: null)
+            .WithComputeEnvironment(appService)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+
+        var apiService = builder.AddProject<Project>("apiservice", launchProfileName: null)
+            .WithComputeEnvironment(aca)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithReference(webfrontend);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var apiResource = Assert.Single(model.GetProjectResources(), r => r.Name == "apiservice");
+
+        apiResource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CrossEnvironmentReference_AppServiceReferencingContainerApp_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CrossEnvironmentReference_AppServiceReferencingContainerApp_GeneratesBicep.verified.bicep
@@ -1,0 +1,130 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param appservice_outputs_azure_container_registry_endpoint string
+
+param appservice_outputs_planid string
+
+param appservice_outputs_azure_container_registry_managed_identity_id string
+
+param appservice_outputs_azure_container_registry_managed_identity_client_id string
+
+param webfrontend_containerimage string
+
+param webfrontend_containerport string
+
+param apiservice_bindings_http_url string
+
+param appservice_outputs_azure_app_service_dashboard_uri string
+
+param appservice_outputs_azure_website_contributor_managed_identity_id string
+
+param appservice_outputs_azure_website_contributor_managed_identity_principal_id string
+
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: webfrontend_containerimage
+    isMain: true
+    targetPort: webfrontend_containerport
+    userManagedIdentityClientId: appservice_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+resource webapp 'Microsoft.Web/sites@2025-03-01' = {
+  name: take('${toLower('webfrontend')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: appservice_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: appservice_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: webfrontend_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: webfrontend_containerport
+        }
+        {
+          name: 'APISERVICE_HTTP'
+          value: apiservice_bindings_http_url
+        }
+        {
+          name: 'services__apiservice__http__0'
+          value: apiservice_bindings_http_url
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'appService'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'webfrontend'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: appservice_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: appservice_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${appservice_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource webfrontend_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, appservice_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: appservice_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'APISERVICE_HTTP'
+      'services__apiservice__http__0'
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CrossEnvironmentReference_AppServiceReferencingContainerApp_GeneratesBicep.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CrossEnvironmentReference_AppServiceReferencingContainerApp_GeneratesBicep.verified.json
@@ -1,0 +1,16 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "webfrontend-website.module.bicep",
+  "params": {
+    "appservice_outputs_azure_container_registry_endpoint": "{appService.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "appservice_outputs_planid": "{appService.outputs.planId}",
+    "appservice_outputs_azure_container_registry_managed_identity_id": "{appService.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "appservice_outputs_azure_container_registry_managed_identity_client_id": "{appService.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "webfrontend_containerimage": "{webfrontend.containerImage}",
+    "webfrontend_containerport": "{webfrontend.containerPort}",
+    "apiservice_bindings_http_url": "{apiservice.bindings.http.url}",
+    "appservice_outputs_azure_app_service_dashboard_uri": "{appService.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "appservice_outputs_azure_website_contributor_managed_identity_id": "{appService.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "appservice_outputs_azure_website_contributor_managed_identity_principal_id": "{appService.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CrossEnvironmentReference_ContainerAppReferencingAppService_GeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CrossEnvironmentReference_ContainerAppReferencingAppService_GeneratesBicep.verified.bicep
@@ -1,0 +1,82 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param aca_outputs_azure_container_apps_environment_default_domain string
+
+param aca_outputs_azure_container_apps_environment_id string
+
+param aca_outputs_azure_container_registry_endpoint string
+
+param aca_outputs_azure_container_registry_managed_identity_id string
+
+param apiservice_containerimage string
+
+param apiservice_containerport string
+
+param webfrontend_bindings_http_url string
+
+resource apiservice 'Microsoft.App/containerApps@2025-10-02-preview' = {
+  name: 'apiservice'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: int(apiservice_containerport)
+        transport: 'http'
+      }
+      registries: [
+        {
+          server: aca_outputs_azure_container_registry_endpoint
+          identity: aca_outputs_azure_container_registry_managed_identity_id
+        }
+      ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
+    }
+    environmentId: aca_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: apiservice_containerimage
+          name: 'apiservice'
+          env: [
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+              value: 'true'
+            }
+            {
+              name: 'HTTP_PORTS'
+              value: apiservice_containerport
+            }
+            {
+              name: 'WEBFRONTEND_HTTP'
+              value: webfrontend_bindings_http_url
+            }
+            {
+              name: 'services__webfrontend__http__0'
+              value: webfrontend_bindings_http_url
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${aca_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CrossEnvironmentReference_ContainerAppReferencingAppService_GeneratesBicep.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CrossEnvironmentReference_ContainerAppReferencingAppService_GeneratesBicep.verified.json
@@ -1,0 +1,13 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "apiservice-containerapp.module.bicep",
+  "params": {
+    "aca_outputs_azure_container_apps_environment_default_domain": "{aca.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+    "aca_outputs_azure_container_apps_environment_id": "{aca.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+    "aca_outputs_azure_container_registry_endpoint": "{aca.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "aca_outputs_azure_container_registry_managed_identity_id": "{aca.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "apiservice_containerimage": "{apiservice.containerImage}",
+    "apiservice_containerport": "{apiservice.containerPort}",
+    "webfrontend_bindings_http_url": "{webfrontend.bindings.http.url}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 31
+Total steps defined: 32
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -15,41 +15,48 @@ This shows the order in which steps would execute, respecting all dependencies.
 Steps with no dependencies run first, followed by steps that depend on them.
 
   1. process-parameters
-  2. build-prereq
-  3. deploy-prereq
-  4. build-api
-  5. build
-  6. validate-azure-login
-  7. create-provisioning-context
-  8. provision-api-identity
-  9. provision-kv
- 10. provision-api-roles-kv
- 11. provision-env-acr
- 12. provision-env
- 13. login-to-acr-env-acr
- 14. push-prereq
- 15. push-api
- 16. provision-api-website
- 17. print-api-summary
- 18. provision-azure-bicep-resources
- 19. print-dashboard-url-env
- 20. deploy
- 21. deploy-api
- 22. destroy-prereq
- 23. destroy-azure-azure634f9
- 24. destroy
- 25. diagnostics
- 26. publish-prereq
- 27. publish-azure634f9
- 28. validate-appservice-config-env
- 29. publish
- 30. publish-manifest
- 31. push
+  2. deploy-prereq
+  3. validate-azure-login
+  4. create-provisioning-context
+  5. provision-api-identity
+  6. provision-kv
+  7. provision-api-roles-kv
+  8. provision-env-acr
+  9. provision-env
+ 10. build-prereq
+ 11. build-api
+ 12. login-to-acr-env-acr
+ 13. push-prereq
+ 14. push-api
+ 15. provision-api-website
+ 16. allocate-endpoints-api
+ 17. build
+ 18. print-api-summary
+ 19. provision-azure-bicep-resources
+ 20. print-dashboard-url-env
+ 21. deploy
+ 22. deploy-api
+ 23. destroy-prereq
+ 24. destroy-azure-azure634f9
+ 25. destroy
+ 26. diagnostics
+ 27. publish-prereq
+ 28. publish-azure634f9
+ 29. validate-appservice-config-env
+ 30. publish
+ 31. publish-manifest
+ 32. push
 
 DETAILED STEP ANALYSIS
 ======================
 Shows each step's dependencies, associated resources, tags, and descriptions.
 ✓ = dependency exists, ? = dependency missing
+
+Step: allocate-endpoints-api
+    Description: Allocates endpoint values for api after provisioning.
+    Dependencies: ✓ provision-api-identity, ✓ provision-api-roles-kv, ✓ provision-api-website, ✓ provision-env, ✓ provision-kv, ✓ push-api
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: provision-infra
 
 Step: build
     Description: Aggregation step for all build operations. All build steps should be required by this step.
@@ -108,7 +115,7 @@ Step: login-to-acr-env-acr
 
 Step: print-api-summary
     Description: Prints the deployment summary and URL for api.
-    Dependencies: ✓ provision-api-website
+    Dependencies: ✓ allocate-endpoints-api, ✓ provision-api-website
     Resource: api-website (AzureAppServiceWebSiteResource)
     Tags: print-summary
 
@@ -142,7 +149,7 @@ Step: provision-api-website
 
 Step: provision-azure-bicep-resources
     Description: Aggregation step for all Azure infrastructure provisioning operations.
-    Dependencies: ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-identity, ✓ provision-api-roles-kv, ✓ provision-api-website, ✓ provision-env, ✓ provision-env-acr, ✓ provision-kv
+    Dependencies: ✓ allocate-endpoints-api, ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-identity, ✓ provision-api-roles-kv, ✓ provision-api-website, ✓ provision-env, ✓ provision-env-acr, ✓ provision-kv
     Resource: azure634f9 (AzureEnvironmentResource)
     Tags: provision-infra
 
@@ -215,6 +222,21 @@ EXECUTION SIMULATION ("What If" Analysis):
 Shows what steps would run for each possible target step and in what order.
 Steps at the same level can run concurrently.
 ─────────────────────────────────────────────────────────────────────────────
+If targeting 'allocate-endpoints-api':
+  Direct dependencies: provision-api-identity, provision-api-roles-kv, provision-api-website, provision-env, provision-kv, push-api
+  Total steps: 16
+  Execution order:
+    [0] process-parameters
+    [1] build-prereq | deploy-prereq (parallel)
+    [2] build-api | validate-azure-login (parallel)
+    [3] create-provisioning-context
+    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env (parallel)
+    [6] push-prereq
+    [7] push-api
+    [8] provision-api-website
+    [9] allocate-endpoints-api
+
 If targeting 'build':
   Direct dependencies: build-api
   Total steps: 5
@@ -250,7 +272,7 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 19
+  Total steps: 20
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -261,13 +283,14 @@ If targeting 'deploy':
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
-    [9] print-api-summary | provision-azure-bicep-resources (parallel)
-    [10] print-dashboard-url-env
-    [11] deploy
+    [9] allocate-endpoints-api
+    [10] print-api-summary | provision-azure-bicep-resources (parallel)
+    [11] print-dashboard-url-env
+    [12] deploy
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 17
+  Total steps: 18
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -278,8 +301,9 @@ If targeting 'deploy-api':
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
-    [9] print-api-summary
-    [10] deploy-api
+    [9] allocate-endpoints-api
+    [10] print-api-summary
+    [11] deploy-api
 
 If targeting 'deploy-prereq':
   Direct dependencies: process-parameters
@@ -327,22 +351,7 @@ If targeting 'login-to-acr-env-acr':
     [5] login-to-acr-env-acr
 
 If targeting 'print-api-summary':
-  Direct dependencies: provision-api-website
-  Total steps: 16
-  Execution order:
-    [0] process-parameters
-    [1] build-prereq | deploy-prereq (parallel)
-    [2] build-api | validate-azure-login (parallel)
-    [3] create-provisioning-context
-    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
-    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env (parallel)
-    [6] push-prereq
-    [7] push-api
-    [8] provision-api-website
-    [9] print-api-summary
-
-If targeting 'print-dashboard-url-env':
-  Direct dependencies: provision-azure-bicep-resources, provision-env
+  Direct dependencies: allocate-endpoints-api, provision-api-website
   Total steps: 17
   Execution order:
     [0] process-parameters
@@ -354,8 +363,25 @@ If targeting 'print-dashboard-url-env':
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
-    [9] provision-azure-bicep-resources
-    [10] print-dashboard-url-env
+    [9] allocate-endpoints-api
+    [10] print-api-summary
+
+If targeting 'print-dashboard-url-env':
+  Direct dependencies: provision-azure-bicep-resources, provision-env
+  Total steps: 18
+  Execution order:
+    [0] process-parameters
+    [1] build-prereq | deploy-prereq (parallel)
+    [2] build-api | validate-azure-login (parallel)
+    [3] create-provisioning-context
+    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env (parallel)
+    [6] push-prereq
+    [7] push-api
+    [8] provision-api-website
+    [9] allocate-endpoints-api
+    [10] provision-azure-bicep-resources
+    [11] print-dashboard-url-env
 
 If targeting 'process-parameters':
   Direct dependencies: none
@@ -399,8 +425,8 @@ If targeting 'provision-api-website':
     [8] provision-api-website
 
 If targeting 'provision-azure-bicep-resources':
-  Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-kv, provision-api-website, provision-env, provision-env-acr, provision-kv
-  Total steps: 16
+  Direct dependencies: allocate-endpoints-api, create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-kv, provision-api-website, provision-env, provision-env-acr, provision-kv
+  Total steps: 17
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -411,7 +437,8 @@ If targeting 'provision-azure-bicep-resources':
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
-    [9] provision-azure-bicep-resources
+    [9] allocate-endpoints-api
+    [10] provision-azure-bicep-resources
 
 If targeting 'provision-env':
   Direct dependencies: create-provisioning-context, provision-env-acr

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 41
+Total steps defined: 44
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -15,51 +15,72 @@ This shows the order in which steps would execute, respecting all dependencies.
 Steps with no dependencies run first, followed by steps that depend on them.
 
   1. process-parameters
-  2. build-prereq
-  3. deploy-prereq
-  4. build-api-service
-  5. build-python-app
-  6. build
-  7. validate-azure-login
-  8. create-provisioning-context
-  9. provision-aas-env-acr
- 10. provision-aas-env
- 11. login-to-acr-aas-env-acr
- 12. provision-aca-env-acr
- 13. login-to-acr-aca-env-acr
- 14. push-prereq
- 15. push-api-service
- 16. provision-api-service-website
- 17. print-api-service-summary
- 18. provision-aca-env
- 19. provision-cache-containerapp
- 20. print-cache-summary
- 21. push-python-app
- 22. provision-python-app-containerapp
- 23. provision-storage
- 24. provision-azure-bicep-resources
- 25. print-dashboard-url-aas-env
- 26. print-dashboard-url-aca-env
- 27. print-python-app-summary
- 28. deploy
- 29. deploy-api-service
- 30. deploy-cache
- 31. deploy-python-app
- 32. destroy-prereq
- 33. destroy-azure-azure634f9
- 34. destroy
- 35. diagnostics
- 36. publish-prereq
- 37. publish-azure634f9
- 38. validate-appservice-config-aas-env
- 39. publish
- 40. publish-manifest
- 41. push
+  2. deploy-prereq
+  3. validate-azure-login
+  4. create-provisioning-context
+  5. provision-aas-env-acr
+  6. provision-aas-env
+  7. build-prereq
+  8. build-api-service
+  9. login-to-acr-aas-env-acr
+ 10. provision-aca-env-acr
+ 11. login-to-acr-aca-env-acr
+ 12. push-prereq
+ 13. push-api-service
+ 14. provision-api-service-website
+ 15. allocate-endpoints-api-service
+ 16. provision-aca-env
+ 17. provision-cache-containerapp
+ 18. allocate-endpoints-cache
+ 19. build-python-app
+ 20. push-python-app
+ 21. provision-python-app-containerapp
+ 22. allocate-endpoints-python-app
+ 23. build
+ 24. print-api-service-summary
+ 25. print-cache-summary
+ 26. provision-storage
+ 27. provision-azure-bicep-resources
+ 28. print-dashboard-url-aas-env
+ 29. print-dashboard-url-aca-env
+ 30. print-python-app-summary
+ 31. deploy
+ 32. deploy-api-service
+ 33. deploy-cache
+ 34. deploy-python-app
+ 35. destroy-prereq
+ 36. destroy-azure-azure634f9
+ 37. destroy
+ 38. diagnostics
+ 39. publish-prereq
+ 40. publish-azure634f9
+ 41. validate-appservice-config-aas-env
+ 42. publish
+ 43. publish-manifest
+ 44. push
 
 DETAILED STEP ANALYSIS
 ======================
 Shows each step's dependencies, associated resources, tags, and descriptions.
 ✓ = dependency exists, ? = dependency missing
+
+Step: allocate-endpoints-api-service
+    Description: Allocates endpoint values for api-service after provisioning.
+    Dependencies: ✓ provision-aas-env, ✓ provision-api-service-website, ✓ push-api-service
+    Resource: api-service-website (AzureAppServiceWebSiteResource)
+    Tags: provision-infra
+
+Step: allocate-endpoints-cache
+    Description: Allocates endpoint values for cache after provisioning.
+    Dependencies: ✓ provision-aca-env, ✓ provision-cache-containerapp
+    Resource: cache-containerapp (AzureContainerAppResource)
+    Tags: provision-infra
+
+Step: allocate-endpoints-python-app
+    Description: Allocates endpoint values for python-app after provisioning.
+    Dependencies: ✓ provision-aca-env, ✓ provision-python-app-containerapp, ✓ push-python-app
+    Resource: python-app-containerapp (AzureContainerAppResource)
+    Tags: provision-infra
 
 Step: build
     Description: Aggregation step for all build operations. All build steps should be required by this step.
@@ -140,13 +161,13 @@ Step: login-to-acr-aca-env-acr
 
 Step: print-api-service-summary
     Description: Prints the deployment summary and URL for api-service.
-    Dependencies: ✓ provision-api-service-website
+    Dependencies: ✓ allocate-endpoints-api-service, ✓ provision-api-service-website
     Resource: api-service-website (AzureAppServiceWebSiteResource)
     Tags: print-summary
 
 Step: print-cache-summary
     Description: Prints the deployment summary and URL for cache.
-    Dependencies: ✓ provision-cache-containerapp
+    Dependencies: ✓ allocate-endpoints-cache, ✓ provision-cache-containerapp
     Resource: cache-containerapp (AzureContainerAppResource)
     Tags: print-summary
 
@@ -164,7 +185,7 @@ Step: print-dashboard-url-aca-env
 
 Step: print-python-app-summary
     Description: Prints the deployment summary and URL for python-app.
-    Dependencies: ✓ provision-python-app-containerapp
+    Dependencies: ✓ allocate-endpoints-python-app, ✓ provision-python-app-containerapp
     Resource: python-app-containerapp (AzureContainerAppResource)
     Tags: print-summary
 
@@ -204,7 +225,7 @@ Step: provision-api-service-website
 
 Step: provision-azure-bicep-resources
     Description: Aggregation step for all Azure infrastructure provisioning operations.
-    Dependencies: ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-aas-env, ✓ provision-aas-env-acr, ✓ provision-aca-env, ✓ provision-aca-env-acr, ✓ provision-api-service-website, ✓ provision-cache-containerapp, ✓ provision-python-app-containerapp, ✓ provision-storage
+    Dependencies: ✓ allocate-endpoints-api-service, ✓ allocate-endpoints-cache, ✓ allocate-endpoints-python-app, ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-aas-env, ✓ provision-aas-env-acr, ✓ provision-aca-env, ✓ provision-aca-env-acr, ✓ provision-api-service-website, ✓ provision-cache-containerapp, ✓ provision-python-app-containerapp, ✓ provision-storage
     Resource: azure634f9 (AzureEnvironmentResource)
     Tags: provision-infra
 
@@ -282,6 +303,49 @@ EXECUTION SIMULATION ("What If" Analysis):
 Shows what steps would run for each possible target step and in what order.
 Steps at the same level can run concurrently.
 ─────────────────────────────────────────────────────────────────────────────
+If targeting 'allocate-endpoints-api-service':
+  Direct dependencies: provision-aas-env, provision-api-service-website, push-api-service
+  Total steps: 15
+  Execution order:
+    [0] process-parameters
+    [1] build-prereq | deploy-prereq (parallel)
+    [2] build-api-service | validate-azure-login (parallel)
+    [3] create-provisioning-context
+    [4] provision-aas-env-acr | provision-aca-env-acr (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env (parallel)
+    [6] push-prereq
+    [7] push-api-service
+    [8] provision-api-service-website
+    [9] allocate-endpoints-api-service
+
+If targeting 'allocate-endpoints-cache':
+  Direct dependencies: provision-aca-env, provision-cache-containerapp
+  Total steps: 8
+  Execution order:
+    [0] process-parameters
+    [1] deploy-prereq
+    [2] validate-azure-login
+    [3] create-provisioning-context
+    [4] provision-aca-env-acr
+    [5] provision-aca-env
+    [6] provision-cache-containerapp
+    [7] allocate-endpoints-cache
+
+If targeting 'allocate-endpoints-python-app':
+  Direct dependencies: provision-aca-env, provision-python-app-containerapp, push-python-app
+  Total steps: 15
+  Execution order:
+    [0] process-parameters
+    [1] build-prereq | deploy-prereq (parallel)
+    [2] build-python-app | validate-azure-login (parallel)
+    [3] create-provisioning-context
+    [4] provision-aas-env-acr | provision-aca-env-acr (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aca-env (parallel)
+    [6] push-prereq
+    [7] push-python-app
+    [8] provision-python-app-containerapp
+    [9] allocate-endpoints-python-app
+
 If targeting 'build':
   Direct dependencies: build-api-service, build-python-app
   Total steps: 6
@@ -325,7 +389,7 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api-service, build-python-app, create-provisioning-context, print-api-service-summary, print-cache-summary, print-dashboard-url-aas-env, print-dashboard-url-aca-env, print-python-app-summary, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 27
+  Total steps: 30
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -334,15 +398,16 @@ If targeting 'deploy':
     [4] provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
     [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env (parallel)
     [6] provision-cache-containerapp | push-prereq (parallel)
-    [7] print-cache-summary | push-api-service | push-python-app (parallel)
-    [8] provision-api-service-website | provision-python-app-containerapp (parallel)
-    [9] print-api-service-summary | print-python-app-summary | provision-azure-bicep-resources (parallel)
-    [10] print-dashboard-url-aas-env | print-dashboard-url-aca-env (parallel)
-    [11] deploy
+    [7] allocate-endpoints-cache | push-api-service | push-python-app (parallel)
+    [8] print-cache-summary | provision-api-service-website | provision-python-app-containerapp (parallel)
+    [9] allocate-endpoints-api-service | allocate-endpoints-python-app (parallel)
+    [10] print-api-service-summary | print-python-app-summary | provision-azure-bicep-resources (parallel)
+    [11] print-dashboard-url-aas-env | print-dashboard-url-aca-env (parallel)
+    [12] deploy
 
 If targeting 'deploy-api-service':
   Direct dependencies: print-api-service-summary
-  Total steps: 16
+  Total steps: 17
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -353,12 +418,13 @@ If targeting 'deploy-api-service':
     [6] push-prereq
     [7] push-api-service
     [8] provision-api-service-website
-    [9] print-api-service-summary
-    [10] deploy-api-service
+    [9] allocate-endpoints-api-service
+    [10] print-api-service-summary
+    [11] deploy-api-service
 
 If targeting 'deploy-cache':
   Direct dependencies: print-cache-summary
-  Total steps: 9
+  Total steps: 10
   Execution order:
     [0] process-parameters
     [1] deploy-prereq
@@ -367,8 +433,9 @@ If targeting 'deploy-cache':
     [4] provision-aca-env-acr
     [5] provision-aca-env
     [6] provision-cache-containerapp
-    [7] print-cache-summary
-    [8] deploy-cache
+    [7] allocate-endpoints-cache
+    [8] print-cache-summary
+    [9] deploy-cache
 
 If targeting 'deploy-prereq':
   Direct dependencies: process-parameters
@@ -379,7 +446,7 @@ If targeting 'deploy-prereq':
 
 If targeting 'deploy-python-app':
   Direct dependencies: print-python-app-summary
-  Total steps: 16
+  Total steps: 17
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -390,8 +457,9 @@ If targeting 'deploy-python-app':
     [6] push-prereq
     [7] push-python-app
     [8] provision-python-app-containerapp
-    [9] print-python-app-summary
-    [10] deploy-python-app
+    [9] allocate-endpoints-python-app
+    [10] print-python-app-summary
+    [11] deploy-python-app
 
 If targeting 'destroy':
   Direct dependencies: destroy-azure-azure634f9
@@ -443,8 +511,8 @@ If targeting 'login-to-acr-aca-env-acr':
     [5] login-to-acr-aca-env-acr
 
 If targeting 'print-api-service-summary':
-  Direct dependencies: provision-api-service-website
-  Total steps: 15
+  Direct dependencies: allocate-endpoints-api-service, provision-api-service-website
+  Total steps: 16
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -455,11 +523,12 @@ If targeting 'print-api-service-summary':
     [6] push-prereq
     [7] push-api-service
     [8] provision-api-service-website
-    [9] print-api-service-summary
+    [9] allocate-endpoints-api-service
+    [10] print-api-service-summary
 
 If targeting 'print-cache-summary':
-  Direct dependencies: provision-cache-containerapp
-  Total steps: 8
+  Direct dependencies: allocate-endpoints-cache, provision-cache-containerapp
+  Total steps: 9
   Execution order:
     [0] process-parameters
     [1] deploy-prereq
@@ -468,11 +537,12 @@ If targeting 'print-cache-summary':
     [4] provision-aca-env-acr
     [5] provision-aca-env
     [6] provision-cache-containerapp
-    [7] print-cache-summary
+    [7] allocate-endpoints-cache
+    [8] print-cache-summary
 
 If targeting 'print-dashboard-url-aas-env':
   Direct dependencies: provision-aas-env, provision-azure-bicep-resources
-  Total steps: 22
+  Total steps: 25
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -481,14 +551,15 @@ If targeting 'print-dashboard-url-aas-env':
     [4] provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
     [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env (parallel)
     [6] provision-cache-containerapp | push-prereq (parallel)
-    [7] push-api-service | push-python-app (parallel)
+    [7] allocate-endpoints-cache | push-api-service | push-python-app (parallel)
     [8] provision-api-service-website | provision-python-app-containerapp (parallel)
-    [9] provision-azure-bicep-resources
-    [10] print-dashboard-url-aas-env
+    [9] allocate-endpoints-api-service | allocate-endpoints-python-app (parallel)
+    [10] provision-azure-bicep-resources
+    [11] print-dashboard-url-aas-env
 
 If targeting 'print-dashboard-url-aca-env':
   Direct dependencies: provision-aca-env, provision-azure-bicep-resources
-  Total steps: 22
+  Total steps: 25
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -497,14 +568,15 @@ If targeting 'print-dashboard-url-aca-env':
     [4] provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
     [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env (parallel)
     [6] provision-cache-containerapp | push-prereq (parallel)
-    [7] push-api-service | push-python-app (parallel)
+    [7] allocate-endpoints-cache | push-api-service | push-python-app (parallel)
     [8] provision-api-service-website | provision-python-app-containerapp (parallel)
-    [9] provision-azure-bicep-resources
-    [10] print-dashboard-url-aca-env
+    [9] allocate-endpoints-api-service | allocate-endpoints-python-app (parallel)
+    [10] provision-azure-bicep-resources
+    [11] print-dashboard-url-aca-env
 
 If targeting 'print-python-app-summary':
-  Direct dependencies: provision-python-app-containerapp
-  Total steps: 15
+  Direct dependencies: allocate-endpoints-python-app, provision-python-app-containerapp
+  Total steps: 16
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -515,7 +587,8 @@ If targeting 'print-python-app-summary':
     [6] push-prereq
     [7] push-python-app
     [8] provision-python-app-containerapp
-    [9] print-python-app-summary
+    [9] allocate-endpoints-python-app
+    [10] print-python-app-summary
 
 If targeting 'process-parameters':
   Direct dependencies: none
@@ -580,8 +653,8 @@ If targeting 'provision-api-service-website':
     [8] provision-api-service-website
 
 If targeting 'provision-azure-bicep-resources':
-  Direct dependencies: create-provisioning-context, deploy-prereq, provision-aas-env, provision-aas-env-acr, provision-aca-env, provision-aca-env-acr, provision-api-service-website, provision-cache-containerapp, provision-python-app-containerapp, provision-storage
-  Total steps: 21
+  Direct dependencies: allocate-endpoints-api-service, allocate-endpoints-cache, allocate-endpoints-python-app, create-provisioning-context, deploy-prereq, provision-aas-env, provision-aas-env-acr, provision-aca-env, provision-aca-env-acr, provision-api-service-website, provision-cache-containerapp, provision-python-app-containerapp, provision-storage
+  Total steps: 24
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -590,9 +663,10 @@ If targeting 'provision-azure-bicep-resources':
     [4] provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
     [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env (parallel)
     [6] provision-cache-containerapp | push-prereq (parallel)
-    [7] push-api-service | push-python-app (parallel)
+    [7] allocate-endpoints-cache | push-api-service | push-python-app (parallel)
     [8] provision-api-service-website | provision-python-app-containerapp (parallel)
-    [9] provision-azure-bicep-resources
+    [9] allocate-endpoints-api-service | allocate-endpoints-python-app (parallel)
+    [10] provision-azure-bicep-resources
 
 If targeting 'provision-cache-containerapp':
   Direct dependencies: create-provisioning-context, provision-aca-env

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 43
+Total steps defined: 44
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -15,53 +15,60 @@ This shows the order in which steps would execute, respecting all dependencies.
 Steps with no dependencies run first, followed by steps that depend on them.
 
   1. process-parameters
-  2. build-prereq
-  3. deploy-prereq
-  4. build-api
-  5. build
-  6. validate-azure-login
-  7. create-provisioning-context
-  8. provision-api-identity
-  9. provision-cosmos
- 10. provision-api-roles-cosmos
- 11. provision-sql-nsg
- 12. provision-vnet
- 13. provision-privatelink-file-core-windows-net
- 14. provision-sql-store
- 15. provision-pe-subnet-files-pe
- 16. provision-privatelink-database-windows-net
- 17. provision-sql
- 18. provision-pe-subnet-sql-pe
- 19. provision-api-roles-sql
- 20. provision-env-acr
- 21. provision-env
- 22. provision-privatelink-documents-azure-com
- 23. provision-pe-subnet-cosmos-pe
- 24. login-to-acr-env-acr
- 25. push-prereq
- 26. push-api
- 27. provision-api-containerapp
- 28. print-api-summary
- 29. provision-sql-admin-identity
- 30. provision-sql-admin-identity-roles-sql-store
- 31. provision-azure-bicep-resources
- 32. print-dashboard-url-env
- 33. deploy
- 34. deploy-api
- 35. destroy-prereq
- 36. destroy-azure-azure634f9
- 37. destroy
- 38. diagnostics
- 39. publish-prereq
- 40. publish-azure634f9
- 41. publish
- 42. publish-manifest
- 43. push
+  2. deploy-prereq
+  3. validate-azure-login
+  4. create-provisioning-context
+  5. provision-api-identity
+  6. provision-cosmos
+  7. provision-api-roles-cosmos
+  8. provision-sql-nsg
+  9. provision-vnet
+ 10. provision-privatelink-file-core-windows-net
+ 11. provision-sql-store
+ 12. provision-pe-subnet-files-pe
+ 13. provision-privatelink-database-windows-net
+ 14. provision-sql
+ 15. provision-pe-subnet-sql-pe
+ 16. provision-api-roles-sql
+ 17. provision-env-acr
+ 18. provision-env
+ 19. provision-privatelink-documents-azure-com
+ 20. provision-pe-subnet-cosmos-pe
+ 21. build-prereq
+ 22. build-api
+ 23. login-to-acr-env-acr
+ 24. push-prereq
+ 25. push-api
+ 26. provision-api-containerapp
+ 27. allocate-endpoints-api
+ 28. build
+ 29. print-api-summary
+ 30. provision-sql-admin-identity
+ 31. provision-sql-admin-identity-roles-sql-store
+ 32. provision-azure-bicep-resources
+ 33. print-dashboard-url-env
+ 34. deploy
+ 35. deploy-api
+ 36. destroy-prereq
+ 37. destroy-azure-azure634f9
+ 38. destroy
+ 39. diagnostics
+ 40. publish-prereq
+ 41. publish-azure634f9
+ 42. publish
+ 43. publish-manifest
+ 44. push
 
 DETAILED STEP ANALYSIS
 ======================
 Shows each step's dependencies, associated resources, tags, and descriptions.
 ✓ = dependency exists, ? = dependency missing
+
+Step: allocate-endpoints-api
+    Description: Allocates endpoint values for api after provisioning.
+    Dependencies: ✓ provision-api-containerapp, ✓ provision-api-identity, ✓ provision-api-roles-cosmos, ✓ provision-api-roles-sql, ✓ provision-cosmos, ✓ provision-env, ✓ provision-pe-subnet-cosmos-pe, ✓ provision-pe-subnet-sql-pe, ✓ provision-sql, ✓ push-api
+    Resource: api-containerapp (AzureContainerAppResource)
+    Tags: provision-infra
 
 Step: build
     Description: Aggregation step for all build operations. All build steps should be required by this step.
@@ -120,7 +127,7 @@ Step: login-to-acr-env-acr
 
 Step: print-api-summary
     Description: Prints the deployment summary and URL for api.
-    Dependencies: ✓ provision-api-containerapp
+    Dependencies: ✓ allocate-endpoints-api, ✓ provision-api-containerapp
     Resource: api-containerapp (AzureContainerAppResource)
     Tags: print-summary
 
@@ -160,7 +167,7 @@ Step: provision-api-roles-sql
 
 Step: provision-azure-bicep-resources
     Description: Aggregation step for all Azure infrastructure provisioning operations.
-    Dependencies: ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-containerapp, ✓ provision-api-identity, ✓ provision-api-roles-cosmos, ✓ provision-api-roles-sql, ✓ provision-cosmos, ✓ provision-env, ✓ provision-env-acr, ✓ provision-pe-subnet-cosmos-pe, ✓ provision-pe-subnet-files-pe, ✓ provision-pe-subnet-sql-pe, ✓ provision-privatelink-database-windows-net, ✓ provision-privatelink-documents-azure-com, ✓ provision-privatelink-file-core-windows-net, ✓ provision-sql, ✓ provision-sql-admin-identity, ✓ provision-sql-admin-identity-roles-sql-store, ✓ provision-sql-nsg, ✓ provision-sql-store, ✓ provision-vnet
+    Dependencies: ✓ allocate-endpoints-api, ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-containerapp, ✓ provision-api-identity, ✓ provision-api-roles-cosmos, ✓ provision-api-roles-sql, ✓ provision-cosmos, ✓ provision-env, ✓ provision-env-acr, ✓ provision-pe-subnet-cosmos-pe, ✓ provision-pe-subnet-files-pe, ✓ provision-pe-subnet-sql-pe, ✓ provision-privatelink-database-windows-net, ✓ provision-privatelink-documents-azure-com, ✓ provision-privatelink-file-core-windows-net, ✓ provision-sql, ✓ provision-sql-admin-identity, ✓ provision-sql-admin-identity-roles-sql-store, ✓ provision-sql-nsg, ✓ provision-sql-store, ✓ provision-vnet
     Resource: azure634f9 (AzureEnvironmentResource)
     Tags: provision-infra
 
@@ -300,6 +307,22 @@ EXECUTION SIMULATION ("What If" Analysis):
 Shows what steps would run for each possible target step and in what order.
 Steps at the same level can run concurrently.
 ─────────────────────────────────────────────────────────────────────────────
+If targeting 'allocate-endpoints-api':
+  Direct dependencies: provision-api-containerapp, provision-api-identity, provision-api-roles-cosmos, provision-api-roles-sql, provision-cosmos, provision-env, provision-pe-subnet-cosmos-pe, provision-pe-subnet-sql-pe, provision-sql, push-api
+  Total steps: 27
+  Execution order:
+    [0] process-parameters
+    [1] build-prereq | deploy-prereq (parallel)
+    [2] build-api | validate-azure-login (parallel)
+    [3] create-provisioning-context
+    [4] provision-api-identity | provision-cosmos | provision-env-acr | provision-sql | provision-sql-nsg | provision-sql-store (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-cosmos | provision-env | provision-vnet (parallel)
+    [6] provision-privatelink-database-windows-net | provision-privatelink-documents-azure-com | provision-privatelink-file-core-windows-net | push-prereq (parallel)
+    [7] provision-pe-subnet-cosmos-pe | provision-pe-subnet-files-pe | provision-pe-subnet-sql-pe | push-api (parallel)
+    [8] provision-api-roles-sql
+    [9] provision-api-containerapp
+    [10] allocate-endpoints-api
+
 If targeting 'build':
   Direct dependencies: build-api
   Total steps: 5
@@ -335,7 +358,7 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 32
+  Total steps: 33
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -347,13 +370,14 @@ If targeting 'deploy':
     [7] provision-pe-subnet-cosmos-pe | provision-pe-subnet-files-pe | provision-pe-subnet-sql-pe | push-api (parallel)
     [8] provision-api-roles-sql
     [9] provision-api-containerapp
-    [10] print-api-summary | provision-azure-bicep-resources (parallel)
-    [11] print-dashboard-url-env
-    [12] deploy
+    [10] allocate-endpoints-api
+    [11] print-api-summary | provision-azure-bicep-resources (parallel)
+    [12] print-dashboard-url-env
+    [13] deploy
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 28
+  Total steps: 29
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -365,8 +389,9 @@ If targeting 'deploy-api':
     [7] provision-pe-subnet-cosmos-pe | provision-pe-subnet-files-pe | provision-pe-subnet-sql-pe | push-api (parallel)
     [8] provision-api-roles-sql
     [9] provision-api-containerapp
-    [10] print-api-summary
-    [11] deploy-api
+    [10] allocate-endpoints-api
+    [11] print-api-summary
+    [12] deploy-api
 
 If targeting 'deploy-prereq':
   Direct dependencies: process-parameters
@@ -414,8 +439,8 @@ If targeting 'login-to-acr-env-acr':
     [5] login-to-acr-env-acr
 
 If targeting 'print-api-summary':
-  Direct dependencies: provision-api-containerapp
-  Total steps: 27
+  Direct dependencies: allocate-endpoints-api, provision-api-containerapp
+  Total steps: 28
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -427,11 +452,12 @@ If targeting 'print-api-summary':
     [7] provision-pe-subnet-cosmos-pe | provision-pe-subnet-files-pe | provision-pe-subnet-sql-pe | push-api (parallel)
     [8] provision-api-roles-sql
     [9] provision-api-containerapp
-    [10] print-api-summary
+    [10] allocate-endpoints-api
+    [11] print-api-summary
 
 If targeting 'print-dashboard-url-env':
   Direct dependencies: provision-azure-bicep-resources, provision-env
-  Total steps: 30
+  Total steps: 31
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -443,8 +469,9 @@ If targeting 'print-dashboard-url-env':
     [7] provision-pe-subnet-cosmos-pe | provision-pe-subnet-files-pe | provision-pe-subnet-sql-pe | push-api (parallel)
     [8] provision-api-roles-sql
     [9] provision-api-containerapp
-    [10] provision-azure-bicep-resources
-    [11] print-dashboard-url-env
+    [10] allocate-endpoints-api
+    [11] provision-azure-bicep-resources
+    [12] print-dashboard-url-env
 
 If targeting 'process-parameters':
   Direct dependencies: none
@@ -503,8 +530,8 @@ If targeting 'provision-api-roles-sql':
     [8] provision-api-roles-sql
 
 If targeting 'provision-azure-bicep-resources':
-  Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-containerapp, provision-api-identity, provision-api-roles-cosmos, provision-api-roles-sql, provision-cosmos, provision-env, provision-env-acr, provision-pe-subnet-cosmos-pe, provision-pe-subnet-files-pe, provision-pe-subnet-sql-pe, provision-privatelink-database-windows-net, provision-privatelink-documents-azure-com, provision-privatelink-file-core-windows-net, provision-sql, provision-sql-admin-identity, provision-sql-admin-identity-roles-sql-store, provision-sql-nsg, provision-sql-store, provision-vnet
-  Total steps: 29
+  Direct dependencies: allocate-endpoints-api, create-provisioning-context, deploy-prereq, provision-api-containerapp, provision-api-identity, provision-api-roles-cosmos, provision-api-roles-sql, provision-cosmos, provision-env, provision-env-acr, provision-pe-subnet-cosmos-pe, provision-pe-subnet-files-pe, provision-pe-subnet-sql-pe, provision-privatelink-database-windows-net, provision-privatelink-documents-azure-com, provision-privatelink-file-core-windows-net, provision-sql, provision-sql-admin-identity, provision-sql-admin-identity-roles-sql-store, provision-sql-nsg, provision-sql-store, provision-vnet
+  Total steps: 30
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -516,7 +543,8 @@ If targeting 'provision-azure-bicep-resources':
     [7] provision-pe-subnet-cosmos-pe | provision-pe-subnet-files-pe | provision-pe-subnet-sql-pe | push-api (parallel)
     [8] provision-api-roles-sql
     [9] provision-api-containerapp
-    [10] provision-azure-bicep-resources
+    [10] allocate-endpoints-api
+    [11] provision-azure-bicep-resources
 
 If targeting 'provision-cosmos':
   Direct dependencies: create-provisioning-context

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 38
+Total steps defined: 39
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -15,48 +15,55 @@ This shows the order in which steps would execute, respecting all dependencies.
 Steps with no dependencies run first, followed by steps that depend on them.
 
   1. process-parameters
-  2. build-prereq
-  3. deploy-prereq
-  4. build-api
-  5. build
-  6. validate-azure-login
-  7. create-provisioning-context
-  8. provision-api-identity
-  9. provision-cache-kv
- 10. provision-api-roles-cache-kv
- 11. provision-cosmos-kv
- 12. provision-api-roles-cosmos-kv
- 13. provision-pg-kv
- 14. provision-api-roles-pg-kv
- 15. provision-cache
- 16. provision-cosmos
- 17. provision-env-acr
- 18. provision-env
- 19. provision-pg
- 20. login-to-acr-env-acr
- 21. push-prereq
- 22. push-api
- 23. provision-api-website
- 24. print-api-summary
- 25. provision-azure-bicep-resources
- 26. print-dashboard-url-env
- 27. deploy
- 28. deploy-api
- 29. destroy-prereq
- 30. destroy-azure-azure634f9
- 31. destroy
- 32. diagnostics
- 33. publish-prereq
- 34. publish-azure634f9
- 35. validate-appservice-config-env
- 36. publish
- 37. publish-manifest
- 38. push
+  2. deploy-prereq
+  3. validate-azure-login
+  4. create-provisioning-context
+  5. provision-api-identity
+  6. provision-cache-kv
+  7. provision-api-roles-cache-kv
+  8. provision-cosmos-kv
+  9. provision-api-roles-cosmos-kv
+ 10. provision-pg-kv
+ 11. provision-api-roles-pg-kv
+ 12. provision-cache
+ 13. provision-cosmos
+ 14. provision-env-acr
+ 15. provision-env
+ 16. provision-pg
+ 17. build-prereq
+ 18. build-api
+ 19. login-to-acr-env-acr
+ 20. push-prereq
+ 21. push-api
+ 22. provision-api-website
+ 23. allocate-endpoints-api
+ 24. build
+ 25. print-api-summary
+ 26. provision-azure-bicep-resources
+ 27. print-dashboard-url-env
+ 28. deploy
+ 29. deploy-api
+ 30. destroy-prereq
+ 31. destroy-azure-azure634f9
+ 32. destroy
+ 33. diagnostics
+ 34. publish-prereq
+ 35. publish-azure634f9
+ 36. validate-appservice-config-env
+ 37. publish
+ 38. publish-manifest
+ 39. push
 
 DETAILED STEP ANALYSIS
 ======================
 Shows each step's dependencies, associated resources, tags, and descriptions.
 ✓ = dependency exists, ? = dependency missing
+
+Step: allocate-endpoints-api
+    Description: Allocates endpoint values for api after provisioning.
+    Dependencies: ✓ provision-api-identity, ✓ provision-api-roles-cache-kv, ✓ provision-api-roles-cosmos-kv, ✓ provision-api-roles-pg-kv, ✓ provision-api-website, ✓ provision-cache, ✓ provision-cache-kv, ✓ provision-cosmos, ✓ provision-cosmos-kv, ✓ provision-env, ✓ provision-pg, ✓ provision-pg-kv, ✓ push-api
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: provision-infra
 
 Step: build
     Description: Aggregation step for all build operations. All build steps should be required by this step.
@@ -115,7 +122,7 @@ Step: login-to-acr-env-acr
 
 Step: print-api-summary
     Description: Prints the deployment summary and URL for api.
-    Dependencies: ✓ provision-api-website
+    Dependencies: ✓ allocate-endpoints-api, ✓ provision-api-website
     Resource: api-website (AzureAppServiceWebSiteResource)
     Tags: print-summary
 
@@ -161,7 +168,7 @@ Step: provision-api-website
 
 Step: provision-azure-bicep-resources
     Description: Aggregation step for all Azure infrastructure provisioning operations.
-    Dependencies: ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-identity, ✓ provision-api-roles-cache-kv, ✓ provision-api-roles-cosmos-kv, ✓ provision-api-roles-pg-kv, ✓ provision-api-website, ✓ provision-cache, ✓ provision-cache-kv, ✓ provision-cosmos, ✓ provision-cosmos-kv, ✓ provision-env, ✓ provision-env-acr, ✓ provision-pg, ✓ provision-pg-kv
+    Dependencies: ✓ allocate-endpoints-api, ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-identity, ✓ provision-api-roles-cache-kv, ✓ provision-api-roles-cosmos-kv, ✓ provision-api-roles-pg-kv, ✓ provision-api-website, ✓ provision-cache, ✓ provision-cache-kv, ✓ provision-cosmos, ✓ provision-cosmos-kv, ✓ provision-env, ✓ provision-env-acr, ✓ provision-pg, ✓ provision-pg-kv
     Resource: azure634f9 (AzureEnvironmentResource)
     Tags: provision-infra
 
@@ -264,6 +271,21 @@ EXECUTION SIMULATION ("What If" Analysis):
 Shows what steps would run for each possible target step and in what order.
 Steps at the same level can run concurrently.
 ─────────────────────────────────────────────────────────────────────────────
+If targeting 'allocate-endpoints-api':
+  Direct dependencies: provision-api-identity, provision-api-roles-cache-kv, provision-api-roles-cosmos-kv, provision-api-roles-pg-kv, provision-api-website, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-pg, provision-pg-kv, push-api
+  Total steps: 23
+  Execution order:
+    [0] process-parameters
+    [1] build-prereq | deploy-prereq (parallel)
+    [2] build-api | validate-azure-login (parallel)
+    [3] create-provisioning-context
+    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
+    [6] push-prereq
+    [7] push-api
+    [8] provision-api-website
+    [9] allocate-endpoints-api
+
 If targeting 'build':
   Direct dependencies: build-api
   Total steps: 5
@@ -299,7 +321,7 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 26
+  Total steps: 27
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -310,13 +332,14 @@ If targeting 'deploy':
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
-    [9] print-api-summary | provision-azure-bicep-resources (parallel)
-    [10] print-dashboard-url-env
-    [11] deploy
+    [9] allocate-endpoints-api
+    [10] print-api-summary | provision-azure-bicep-resources (parallel)
+    [11] print-dashboard-url-env
+    [12] deploy
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 24
+  Total steps: 25
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -327,8 +350,9 @@ If targeting 'deploy-api':
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
-    [9] print-api-summary
-    [10] deploy-api
+    [9] allocate-endpoints-api
+    [10] print-api-summary
+    [11] deploy-api
 
 If targeting 'deploy-prereq':
   Direct dependencies: process-parameters
@@ -376,22 +400,7 @@ If targeting 'login-to-acr-env-acr':
     [5] login-to-acr-env-acr
 
 If targeting 'print-api-summary':
-  Direct dependencies: provision-api-website
-  Total steps: 23
-  Execution order:
-    [0] process-parameters
-    [1] build-prereq | deploy-prereq (parallel)
-    [2] build-api | validate-azure-login (parallel)
-    [3] create-provisioning-context
-    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
-    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
-    [6] push-prereq
-    [7] push-api
-    [8] provision-api-website
-    [9] print-api-summary
-
-If targeting 'print-dashboard-url-env':
-  Direct dependencies: provision-azure-bicep-resources, provision-env
+  Direct dependencies: allocate-endpoints-api, provision-api-website
   Total steps: 24
   Execution order:
     [0] process-parameters
@@ -403,8 +412,25 @@ If targeting 'print-dashboard-url-env':
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
-    [9] provision-azure-bicep-resources
-    [10] print-dashboard-url-env
+    [9] allocate-endpoints-api
+    [10] print-api-summary
+
+If targeting 'print-dashboard-url-env':
+  Direct dependencies: provision-azure-bicep-resources, provision-env
+  Total steps: 25
+  Execution order:
+    [0] process-parameters
+    [1] build-prereq | deploy-prereq (parallel)
+    [2] build-api | validate-azure-login (parallel)
+    [3] create-provisioning-context
+    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
+    [6] push-prereq
+    [7] push-api
+    [8] provision-api-website
+    [9] allocate-endpoints-api
+    [10] provision-azure-bicep-resources
+    [11] print-dashboard-url-env
 
 If targeting 'process-parameters':
   Direct dependencies: none
@@ -470,8 +496,8 @@ If targeting 'provision-api-website':
     [8] provision-api-website
 
 If targeting 'provision-azure-bicep-resources':
-  Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-cache-kv, provision-api-roles-cosmos-kv, provision-api-roles-pg-kv, provision-api-website, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-env-acr, provision-pg, provision-pg-kv
-  Total steps: 23
+  Direct dependencies: allocate-endpoints-api, create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-cache-kv, provision-api-roles-cosmos-kv, provision-api-roles-pg-kv, provision-api-website, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-env-acr, provision-pg, provision-pg-kv
+  Total steps: 24
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -482,7 +508,8 @@ If targeting 'provision-azure-bicep-resources':
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
-    [9] provision-azure-bicep-resources
+    [9] allocate-endpoints-api
+    [10] provision-azure-bicep-resources
 
 If targeting 'provision-cache':
   Direct dependencies: create-provisioning-context, provision-cache-kv


### PR DESCRIPTION
## Description

Add cross-environment reference support for Azure App Service and Azure Container Apps compute environments.

This enables scenarios where resources deployed to different compute environments can reference each other — for example, an App Service website referencing a Container App endpoint, or a Container App referencing an App Service website.

### Changes

- **`BaseContainerAppContext.cs`** / **`ContainerAppEnvironmentContext.cs`** — Added support for Container Apps to resolve references to resources in other compute environments (e.g., App Service).
- **`AzureAppServiceEnvironmentContext.cs`** / **`AzureAppServiceWebsiteContext.cs`** — Added support for App Service to resolve references to resources in other compute environments (e.g., Container Apps).
- **`AzureAppServiceTests.cs`** — Added two new tests verifying cross-environment reference bicep generation in both directions.

### Validation

- Unit tests added and passing
- Verified bicep output via snapshot tests for both directions (App Service → Container App and Container App → App Service)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
