### PR TITLE
Add Anthropic provider data to Foundry deployments

### DIFF
--- a/src/Aspire.Hosting.Foundry/FoundryAnthropicDeploymentModel.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryAnthropicDeploymentModel.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Provisioning;
+using Azure.Provisioning.CognitiveServices;
+
+namespace Aspire.Hosting.Foundry;
+
+internal sealed class FoundryAnthropicDeploymentModel : CognitiveServicesAccountDeploymentModel
+{
+    private BicepValue<string>? _countryCode;
+    private BicepValue<string>? _industry;
+    private BicepValue<string>? _organizationName;
+
+    public BicepValue<string> CountryCode
+    {
+        get
+        {
+            Initialize();
+            return _countryCode!;
+        }
+        set
+        {
+            Initialize();
+            _countryCode!.Assign(value);
+        }
+    }
+
+    public BicepValue<string> Industry
+    {
+        get
+        {
+            Initialize();
+            return _industry!;
+        }
+        set
+        {
+            Initialize();
+            _industry!.Assign(value);
+        }
+    }
+
+    public BicepValue<string> OrganizationName
+    {
+        get
+        {
+            Initialize();
+            return _organizationName!;
+        }
+        set
+        {
+            Initialize();
+            _organizationName!.Assign(value);
+        }
+    }
+
+    protected override void DefineProvisionableProperties()
+    {
+        base.DefineProvisionableProperties();
+
+        _industry = DefineProperty<string>(nameof(Industry), ["modelProviderData", "industry"]);
+        _organizationName = DefineProperty<string>(nameof(OrganizationName), ["modelProviderData", "organizationName"]);
+        _countryCode = DefineProperty<string>(nameof(CountryCode), ["modelProviderData", "countryCode"]);
+    }
+}

--- a/src/Aspire.Hosting.Foundry/FoundryDeploymentResource.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryDeploymentResource.cs
@@ -64,9 +64,18 @@ public class FoundryDeploymentResource : Resource, IResourceWithParent<FoundryRe
     /// Gets or sets the format of deployment model.
     /// </summary>
     /// <remarks>
-    /// Typical values are "OpenAI", "Microsoft", "xAi", "Deepseek".
+    /// Typical values are "OpenAI", "Microsoft", "Anthropic", "xAi", "Deepseek".
     /// </remarks> 
     public string Format { get; set; }
+
+    /// <summary>
+    /// Gets or sets the provider-specific model metadata for this deployment.
+    /// </summary>
+    /// <remarks>
+    /// Some model providers, such as Anthropic, require extra metadata when deploying a model.
+    /// Configure these values by using <see cref="FoundryExtensions.WithProperties(IResourceBuilder{FoundryDeploymentResource}, Action{FoundryDeploymentResource})"/>.
+    /// </remarks>
+    public FoundryModelProviderData ModelProviderData { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the name of the SKU.
@@ -95,6 +104,31 @@ public class FoundryDeploymentResource : Resource, IResourceWithParent<FoundryRe
     /// </summary>
     public FoundryResource Parent { get; set; }
 
+    internal bool RequiresModelProviderData =>
+        string.Equals(Format, "Anthropic", StringComparison.OrdinalIgnoreCase);
+
+    internal string[] GetMissingModelProviderDataFields()
+    {
+        List<string> missingFields = [];
+
+        if (string.IsNullOrWhiteSpace(ModelProviderData.Industry))
+        {
+            missingFields.Add("industry");
+        }
+
+        if (string.IsNullOrWhiteSpace(ModelProviderData.OrganizationName))
+        {
+            missingFields.Add("organizationName");
+        }
+
+        if (string.IsNullOrWhiteSpace(ModelProviderData.CountryCode))
+        {
+            missingFields.Add("countryCode");
+        }
+
+        return [.. missingFields];
+    }
+
     /// <summary>
     /// Gets the connection string expression for the Microsoft Foundry resource with model/deployment information.
     /// </summary>
@@ -111,4 +145,28 @@ public class FoundryDeploymentResource : Resource, IResourceWithParent<FoundryRe
             new("Version", ReferenceExpression.Create($"{ModelVersion}")),
         ]);
     }
+}
+
+/// <summary>
+/// Represents provider-specific metadata for a Microsoft Foundry model deployment.
+/// </summary>
+/// <remarks>
+/// Anthropic deployments currently require these values when they are provisioned in Azure.
+/// </remarks>
+public class FoundryModelProviderData
+{
+    /// <summary>
+    /// Gets or sets the industry associated with the deployment.
+    /// </summary>
+    public string? Industry { get; set; }
+
+    /// <summary>
+    /// Gets or sets the organization name associated with the deployment.
+    /// </summary>
+    public string? OrganizationName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ISO country or region code associated with the deployment.
+    /// </summary>
+    public string? CountryCode { get; set; }
 }

--- a/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
@@ -408,6 +408,41 @@ public static class FoundryExtensions
         return builder;
     }
 
+    private static CognitiveServicesAccountDeploymentModel CreateDeploymentModel(FoundryDeploymentResource deployment)
+    {
+        if (!deployment.RequiresModelProviderData)
+        {
+            return new CognitiveServicesAccountDeploymentModel()
+            {
+                Name = deployment.ModelName,
+                Version = deployment.ModelVersion,
+                Format = deployment.Format
+            };
+        }
+
+        var missingFields = deployment.GetMissingModelProviderDataFields();
+        if (missingFields.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Foundry deployment '{deployment.Name}' targets an Anthropic model and requires ModelProviderData to be configured before provisioning. " +
+                $"Set ModelProviderData.{nameof(FoundryModelProviderData.Industry)}, " +
+                $"ModelProviderData.{nameof(FoundryModelProviderData.OrganizationName)}, and " +
+                $"ModelProviderData.{nameof(FoundryModelProviderData.CountryCode)} by using WithProperties(...). " +
+                $"Missing fields: {string.Join(", ", missingFields)}.");
+        }
+
+        return new FoundryAnthropicDeploymentModel()
+        {
+            Name = deployment.ModelName,
+            Version = deployment.ModelVersion,
+            Format = deployment.Format,
+            Publisher = deployment.Format,
+            Industry = deployment.ModelProviderData.Industry!,
+            OrganizationName = deployment.ModelProviderData.OrganizationName!,
+            CountryCode = deployment.ModelProviderData.CountryCode!
+        };
+    }
+
     private static void ConfigureInfrastructure(AzureResourceInfrastructure infrastructure)
     {
         var azureResource = (FoundryResource)infrastructure.AspireResource;
@@ -498,12 +533,7 @@ public static class FoundryExtensions
                 Parent = cogServicesAccount,
                 Properties = new CognitiveServicesAccountDeploymentProperties()
                 {
-                    Model = new CognitiveServicesAccountDeploymentModel()
-                    {
-                        Name = deployment.ModelName,
-                        Version = deployment.ModelVersion,
-                        Format = deployment.Format
-                    }
+                    Model = CreateDeploymentModel(deployment)
                 },
                 Sku = new CognitiveServicesSku()
                 {

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -59,6 +59,24 @@ var chat = builder.AddFoundry("foundry")
 
 See the [Azure AI quota management](https://learn.microsoft.com/azure/ai-foundry/openai/how-to/quota) documentation for available quota limits per model and region.
 
+### Configuring Anthropic deployments
+
+Anthropic deployments require provider metadata to be sent during provisioning. Use `WithProperties` to configure the `ModelProviderData` values before you deploy the model:
+
+```csharp
+var chat = builder.AddFoundry("foundry")
+                  .AddDeployment("chat", FoundryModel.Anthropic.ClaudeSonnet46)
+                  .WithProperties(d =>
+                  {
+                      d.ModelProviderData = new FoundryModelProviderData
+                      {
+                          Industry = "Technology",
+                          OrganizationName = "Contoso",
+                          CountryCode = "US"
+                      };
+                  });
+```
+
 In the _Program.cs_ file of `MyService`, the connection can be consumed using a client library like [Aspire.Azure.AI.Inference](https://www.nuget.org/packages/Aspire.Azure.AI.Inference) or [Aspire.OpenAI](https://www.nuget.org/packages/Aspire.OpenAI) if the model is compatible with the OpenAI API:
 
 Note: The `format` parameter of the `AddDeployment()` method can be found in the Microsoft Foundry portal in the details

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -56,6 +56,29 @@ public class FoundryExtensionsTests
     }
 
     [Fact]
+    public void WithProperties_ShouldApplyModelProviderDataConfiguration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var deploymentBuilder = builder.AddFoundry("myAIFoundry")
+            .AddDeployment("deployment1", FoundryModel.Anthropic.ClaudeSonnet46);
+
+        deploymentBuilder.WithProperties(d =>
+        {
+            d.ModelProviderData = new FoundryModelProviderData
+            {
+                Industry = "Technology",
+                OrganizationName = "Contoso",
+                CountryCode = "US"
+            };
+        });
+
+        var deployment = Assert.Single(builder.Resources.OfType<FoundryResource>().Single().Deployments);
+        Assert.Equal("Technology", deployment.ModelProviderData.Industry);
+        Assert.Equal("Contoso", deployment.ModelProviderData.OrganizationName);
+        Assert.Equal("US", deployment.ModelProviderData.CountryCode);
+    }
+
+    [Fact]
     public void AddFoundry_ConnectionString_IsCorrect()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -180,6 +203,55 @@ public class FoundryExtensionsTests
 
         await Verify(manifest.BicepText, extension: "bicep")
             .AppendContentAsFile(rolesManifest.BicepText, "bicep");
+    }
+
+    [Fact]
+    public async Task AddFoundry_AnthropicDeploymentWithoutModelProviderData_ThrowsHelpfulError()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var foundry = builder.AddFoundry("foundry");
+        foundry.AddDeployment("chat", FoundryModel.Anthropic.ClaudeSonnet46);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureManifestUtils.GetManifestWithBicep(model, foundry.Resource));
+
+        Assert.Contains("Anthropic model", exception.Message);
+        Assert.Contains("ModelProviderData.Industry", exception.Message);
+        Assert.Contains("ModelProviderData.OrganizationName", exception.Message);
+        Assert.Contains("ModelProviderData.CountryCode", exception.Message);
+    }
+
+    [Fact]
+    public async Task AddFoundry_AnthropicDeploymentWithModelProviderData_GeneratesModelProviderDataInBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var foundry = builder.AddFoundry("foundry");
+        foundry.AddDeployment("chat", FoundryModel.Anthropic.ClaudeSonnet46)
+            .WithProperties(d =>
+            {
+                d.ModelProviderData = new FoundryModelProviderData
+                {
+                    Industry = "Technology",
+                    OrganizationName = "Contoso",
+                    CountryCode = "US"
+                };
+            });
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(model, foundry.Resource);
+
+        Assert.Contains("modelProviderData:", manifest.BicepText);
+        Assert.Contains("industry: 'Technology'", manifest.BicepText);
+        Assert.Contains("organizationName: 'Contoso'", manifest.BicepText);
+        Assert.Contains("countryCode: 'US'", manifest.BicepText);
+        Assert.Contains("publisher: 'Anthropic'", manifest.BicepText);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fixes Anthropic model provisioning for Microsoft Foundry deployments. Azure now rejects Anthropic deployments unless provider metadata is supplied, but the current `Azure.Provisioning.CognitiveServices` SDK does not expose `modelProviderData` directly.

This change surfaces `ModelProviderData` on `FoundryDeploymentResource`, emits Anthropic provider metadata through a derived provisioning model, and fails fast with a clear Aspire-side error when the required values are missing. It also documents the required configuration in the Foundry README and adds targeted tests for both validation and generated Bicep output.

This is only to show the gap until the Provisioning SDK exposes it natively.
I haven't checked if the RP expects specific values (like in the portal) which would then require a custom enumeration for allowed values).

Fixes #16127

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No