### PR TITLE
Improve CreateStartAndStopAspireProject test

### DIFF
--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -21,6 +21,7 @@ using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using StreamJsonRpc;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.DotNet;
@@ -247,7 +248,7 @@ internal sealed class DotNetCliRunner(
                 logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
                 return;
             }
-            catch (SocketException ex) when (execution is not null && execution.HasExited && execution.ExitCode != 0)
+            catch (Exception ex) when (ex is SocketException or RemoteRpcException && execution is {} && execution.HasExited && execution.ExitCode != 0)
             {
                 // Log at Debug level - this is expected when AppHost crashes, the real error is in AppHost output
                 logger.LogDebug(ex, "AppHost process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);
@@ -255,7 +256,7 @@ internal sealed class DotNetCliRunner(
                 backchannelCompletionSource.SetException(backchannelException);
                 return;
             }
-            catch (SocketException ex)
+            catch (Exception ex) when (ex is SocketException or RemoteRpcException)
             {
                 // If the process is taking a long time to open a back channel but
                 // it has not exited then it probably means that its a larger build

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -248,7 +248,7 @@ internal sealed class DotNetCliRunner(
                 logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
                 return;
             }
-            catch (Exception ex) when (ex is SocketException or RemoteRpcException && execution is {} && execution.HasExited && execution.ExitCode != 0)
+            catch (Exception ex) when (ex is SocketException or RemoteRpcException && execution is { HasExited: true, ExitCode: not 0 })
             {
                 // Log at Debug level - this is expected when AppHost crashes, the real error is in AppHost output
                 logger.LogDebug(ex, "AppHost process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -22,7 +22,8 @@ internal static class CliE2EAutomatorHelpers
     internal static async Task PrepareDockerEnvironmentAsync(
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter,
-        TemporaryWorkspace? workspace = null)
+        TemporaryWorkspace? workspace = null,
+        bool enableDcpDiagnostics = false)
     {
         // Wait for container to be ready (root prompt)
         await auto.WaitUntilTextAsync("# ", timeout: TimeSpan.FromSeconds(60));
@@ -45,14 +46,26 @@ internal static class CliE2EAutomatorHelpers
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
+        if (enableDcpDiagnostics)
+        {
+            await auto.TypeAsync("export DCP_DIAGNOSTICS_LOG_LEVEL=debug DCP_DIAGNOSTICS_LOG_FOLDER=~/.aspire/dcp-logs DCP_PRESERVE_EXECUTABLE_LOGS=1");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+        }
+
         if (workspace is not null)
         {
-            await auto.TypeAsync($"cd /workspace/{workspace.WorkspaceRoot.Name}");
+            var containerWorkspace = $"/workspace/{workspace.WorkspaceRoot.Name}";
+            var dcpCopyCommand = enableDcpDiagnostics
+                ? $"; cp -r ~/.aspire/dcp-logs {containerWorkspace}/.aspire-dcp-logs 2>/dev/null"
+                : string.Empty;
+
+            await auto.TypeAsync($"cd {containerWorkspace}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 
-            // Set up EXIT trap to copy .aspire diagnostics to workspace for CI capture
-            await auto.TypeAsync($"trap 'cp -r ~/.aspire/logs /workspace/{workspace.WorkspaceRoot.Name}/.aspire-logs 2>/dev/null; cp -r ~/.aspire/packages /workspace/{workspace.WorkspaceRoot.Name}/.aspire-packages 2>/dev/null' EXIT");
+            // Set up EXIT trap to copy .aspire diagnostics to workspace for CI capture.
+            await auto.TypeAsync($"trap 'cp -r ~/.aspire/logs {containerWorkspace}/.aspire-logs 2>/dev/null; cp -r ~/.aspire/packages {containerWorkspace}/.aspire-packages 2>/dev/null{dcpCopyCommand}' EXIT");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
         }
@@ -513,7 +526,7 @@ internal static class CliE2EAutomatorHelpers
     /// <summary>
     /// Copies interesting diagnostic directories from <c>~/.aspire</c> to the mounted workspace
     /// so they are captured by <see cref="CaptureWorkspaceOnFailureAttribute"/>. Call this before
-    /// exiting the container. Copies logs and NuGet restore output (libs directories).
+    /// exiting the container. Copies CLI logs, NuGet restore output, and any opt-in DCP logs.
     /// </summary>
     internal static async Task CaptureAspireDiagnosticsAsync(
         this Hex1bTerminalAutomator auto,
@@ -522,9 +535,9 @@ internal static class CliE2EAutomatorHelpers
     {
         var containerWorkspace = $"/workspace/{workspace.WorkspaceRoot.Name}";
 
-        // Copy CLI logs
         await auto.TypeAsync($"cp -r ~/.aspire/logs {containerWorkspace}/.aspire-logs 2>/dev/null; " +
                              $"cp -r ~/.aspire/packages {containerWorkspace}/.aspire-packages 2>/dev/null; " +
+                             $"cp -r ~/.aspire/dcp-logs {containerWorkspace}/.aspire-dcp-logs 2>/dev/null; " +
                              "echo done");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -67,7 +67,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
             // Docker network cleanup can lag behind aspire stop on contended CI runners.
             await auto.ExecuteCommandUntilOutputAsync(counter, $"docker network ls --format json | grep -i -- '{projectName}' | wc -l", "0", timeout: TimeSpan.FromMinutes(5));
         }
-        catch
+        catch (Exception)
         {
             testBodyFailed = true;
             throw;

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -67,7 +67,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
             // Docker network cleanup can lag behind aspire stop on contended CI runners.
             await auto.ExecuteCommandUntilOutputAsync(counter, $"docker network ls --format json | grep -i -- '{projectName}' | wc -l", "0", timeout: TimeSpan.FromMinutes(5));
         }
-        catch (Exception)
+        catch
         {
             testBodyFailed = true;
             throw;
@@ -78,10 +78,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
             {
                 await auto.CaptureAspireDiagnosticsAsync(counter, workspace);
             }
-            catch (Exception ex)
-            {
-                output.WriteLine($"Failed to capture Aspire diagnostics: {ex}");
-            }
+            catch { } // Best effort
 
             try
             {
@@ -89,14 +86,12 @@ public sealed class StartStopTests(ITestOutputHelper output)
                 await auto.EnterAsync();
                 await pendingRun;
             }
-            catch (Exception ex)
+            catch
             {
                 if (!testBodyFailed)
                 {
                     throw;
                 }
-
-                output.WriteLine($"Failed to exit Docker test terminal cleanly after test failure: {ex}");
             }
         }
     }

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -17,6 +17,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 public sealed class StartStopTests(ITestOutputHelper output)
 {
     [Fact]
+    [CaptureWorkspaceOnFailure]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/16191")]
     public async Task CreateStartAndStopAspireProject()
     {
@@ -34,40 +35,59 @@ public sealed class StartStopTests(ITestOutputHelper output)
         var counter = new SequenceCounter();
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
 
-        // Prepare Docker environment (prompt counting, umask, env vars)
-        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        try
+        {
+            // Prepare Docker environment (prompt counting, umask, env vars)
+            await auto.PrepareDockerEnvironmentAsync(counter, workspace, enableDcpDiagnostics: true);
 
-        // Install the Aspire CLI
-        await auto.InstallAspireCliAsync(strategy, counter);
+            // Install the Aspire CLI
+            await auto.InstallAspireCliAsync(strategy, counter);
 
-        // Create a new project using aspire new
-        await auto.AspireNewAsync(projectName, counter);
+            // Create a new project using aspire new
+            await auto.AspireNewAsync(projectName, counter);
 
-        // Navigate to the AppHost directory
-        await auto.TypeAsync($"cd {projectName}/{projectName}.AppHost");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+            // Navigate to the AppHost directory
+            await auto.TypeAsync($"cd {projectName}/{projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
 
-        // Start the AppHost in the background using aspire start
-        await auto.TypeAsync("aspire start");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+            // Start the AppHost in the background using aspire start
+            await auto.TypeAsync("aspire start");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
 
-        // Stop the AppHost using aspire stop
-        await auto.TypeAsync("aspire stop");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+            // Stop the AppHost using aspire stop
+            await auto.TypeAsync("aspire stop");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
 
-        await auto.ClearScreenAsync(counter);
+            await auto.ClearScreenAsync(counter);
 
-        // Docker network cleanup can lag behind aspire stop on contended CI runners.
-        await auto.ExecuteCommandUntilOutputAsync(counter, $"docker network ls --format json | grep -i -- '{projectName}' | wc -l", "0", timeout: TimeSpan.FromMinutes(5));
+            // Docker network cleanup can lag behind aspire stop on contended CI runners.
+            await auto.ExecuteCommandUntilOutputAsync(counter, $"docker network ls --format json | grep -i -- '{projectName}' | wc -l", "0", timeout: TimeSpan.FromMinutes(5));
+        }
+        finally
+        {
+            try
+            {
+                await auto.CaptureAspireDiagnosticsAsync(counter, workspace);
+            }
+            catch (Exception ex)
+            {
+                output.WriteLine($"Failed to capture Aspire diagnostics: {ex}");
+            }
 
-        // Exit the shell
-        await auto.TypeAsync("exit");
-        await auto.EnterAsync();
-
-        await pendingRun;
+            try
+            {
+                await auto.TypeAsync("exit");
+                await auto.EnterAsync();
+                await pendingRun;
+            }
+            catch (Exception ex)
+            {
+                output.WriteLine($"Failed to exit Docker test terminal cleanly: {ex}");
+            }
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -34,6 +34,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         var counter = new SequenceCounter();
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        var testBodyFailed = false;
 
         try
         {
@@ -66,6 +67,11 @@ public sealed class StartStopTests(ITestOutputHelper output)
             // Docker network cleanup can lag behind aspire stop on contended CI runners.
             await auto.ExecuteCommandUntilOutputAsync(counter, $"docker network ls --format json | grep -i -- '{projectName}' | wc -l", "0", timeout: TimeSpan.FromMinutes(5));
         }
+        catch
+        {
+            testBodyFailed = true;
+            throw;
+        }
         finally
         {
             try
@@ -85,7 +91,12 @@ public sealed class StartStopTests(ITestOutputHelper output)
             }
             catch (Exception ex)
             {
-                output.WriteLine($"Failed to exit Docker test terminal cleanly: {ex}");
+                if (!testBodyFailed)
+                {
+                    throw;
+                }
+
+                output.WriteLine($"Failed to exit Docker test terminal cleanly after test failure: {ex}");
             }
         }
     }


### PR DESCRIPTION
1. Upon failure, the test now captures diagnostic files, including DCP detailed logs.
2. I am also including a fix for app host crash that I experienced on regular basis when running the test locally. The crash is caused by the fact that we do not handle exceptions from `JsonRpc` stream when trying to establish a backchannel connection.