### PR TITLE
Fix ANSI leaks in plain logs and telemetry output

### DIFF
--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -75,6 +75,7 @@ internal sealed class LogsCommand : BaseCommand
     internal override HelpGroup HelpGroup => HelpGroup.Monitoring;
 
     private readonly IInteractionService _interactionService;
+    private readonly ICliHostEnvironment _hostEnvironment;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<LogsCommand> _logger;
 
@@ -114,12 +115,14 @@ internal sealed class LogsCommand : BaseCommand
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
         AspireCliTelemetry telemetry,
+        ICliHostEnvironment hostEnvironment,
         ResourceColorMap resourceColorMap,
         ILogger<LogsCommand> logger)
         : base("logs", LogsCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _resourceColorMap = resourceColorMap;
         _interactionService = interactionService;
+        _hostEnvironment = hostEnvironment;
         _logger = logger;
         _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
 
@@ -349,6 +352,7 @@ internal sealed class LogsCommand : BaseCommand
     {
         var displayName = entry.ResourcePrefix ?? string.Empty;
         var content = entry.Content ?? entry.RawContent ?? string.Empty;
+        var displayContent = _hostEnvironment.SupportsAnsi ? content : AnsiParser.StripControlSequences(content);
         var timestampPrefix = timestamps && entry.Timestamp.HasValue ? FormatTimestamp(entry.Timestamp.Value) + " " : string.Empty;
 
         if (format == OutputFormat.Json)
@@ -369,7 +373,7 @@ internal sealed class LogsCommand : BaseCommand
         {
             // Colorized output: assign a consistent color to each resource
             var color = _resourceColorMap.GetColor(displayName);
-            var escapedContent = content.EscapeMarkup();
+            var escapedContent = displayContent.EscapeMarkup();
             _interactionService.DisplayMarkupLine($"{timestampPrefix.EscapeMarkup()}[{color}][[{displayName.EscapeMarkup()}]][/] {escapedContent}");
         }
     }

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Shared.ConsoleLogs;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Utils;
 using Aspire.Otlp.Serialization;
@@ -23,6 +24,7 @@ namespace Aspire.Cli.Commands;
 internal sealed class TelemetryLogsCommand : BaseCommand
 {
     private readonly IInteractionService _interactionService;
+    private readonly ICliHostEnvironment _hostEnvironment;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<TelemetryLogsCommand> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -51,6 +53,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
         AspireCliTelemetry telemetry,
+        ICliHostEnvironment hostEnvironment,
         IHttpClientFactory httpClientFactory,
         ResourceColorMap resourceColorMap,
         TimeProvider timeProvider,
@@ -58,6 +61,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         : base("logs", TelemetryCommandStrings.LogsDescription, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
+        _hostEnvironment = hostEnvironment;
         _httpClientFactory = httpClientFactory;
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
@@ -249,12 +253,13 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             : "";
         var severity = TelemetryCommandHelpers.GetSeverityText(log.SeverityNumber);
         var body = log.Body?.StringValue ?? "";
+        var displayBody = _hostEnvironment.SupportsAnsi ? body : AnsiParser.StripControlSequences(body);
 
         // Use severity number for color mapping (more reliable than text)
         var severityColor = TelemetryCommandHelpers.GetSeverityColor(log.SeverityNumber);
         var resourceColor = _resourceColorMap.GetColor(resourceName);
 
-        var escapedBody = body.EscapeMarkup();
+        var escapedBody = displayBody.EscapeMarkup();
         _interactionService.DisplayMarkupLine($"[grey]{timestamp}[/] [{severityColor}]{severity,-4}[/] [{resourceColor}]{resourceName.EscapeMarkup()}[/] {escapedBody}");
     }
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -642,7 +642,9 @@ public class Program
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
         var isPlayground = CliHostEnvironment.IsPlaygroundMode(configuration);
-        var usePlaygroundFormatting = isPlayground && hostEnvironment.SupportsAnsi && hostEnvironment.SupportsInteractiveOutput;
+        var supportsAnsi = hostEnvironment.SupportsAnsi;
+        var supportsInteractiveOutput = hostEnvironment.SupportsInteractiveOutput;
+        var usePlaygroundFormatting = isPlayground && supportsAnsi && supportsInteractiveOutput;
 
         // Create custom output that handles width detection better in CI environments
         // and encapsulates ASPIRE_CONSOLE_WIDTH environment variable handling
@@ -650,23 +652,17 @@ public class Program
 
         var settings = new AnsiConsoleSettings()
         {
-            Ansi = usePlaygroundFormatting ? AnsiSupport.Yes : AnsiSupport.No,
-            Interactive = usePlaygroundFormatting ? InteractionSupport.Yes : hostEnvironment.SupportsInteractiveOutput ? InteractionSupport.Detect : InteractionSupport.No,
-            ColorSystem = usePlaygroundFormatting ? ColorSystemSupport.Standard : ColorSystemSupport.NoColors,
+            Ansi = supportsAnsi ? AnsiSupport.Yes : AnsiSupport.No,
+            Interactive = supportsInteractiveOutput ? InteractionSupport.Detect : InteractionSupport.No,
+            ColorSystem = supportsAnsi ? ColorSystemSupport.EightBit : ColorSystemSupport.NoColors,
             Out = output,
         };
 
-        // Use SupportsAnsi from hostEnvironment so callers can explicitly suppress ANSI output,
-        // including the --non-interactive path used by automation and agents.
-        if (hostEnvironment.SupportsAnsi)
-        {
-            settings.Ansi = AnsiSupport.Yes;
-            // Using EightBit color system for better color support of Aspire brand colors in terminals that support ANSI
-            settings.ColorSystem = ColorSystemSupport.EightBit;
-        }
-
         if (usePlaygroundFormatting)
         {
+            settings.Interactive = InteractionSupport.Yes;
+            settings.ColorSystem = ColorSystemSupport.Standard;
+
             // Enrichers interfere with interactive playground experience so
             // this suppresses the default enrichers so that the CLI experience
             // is more like what we would get in an interactive experience.
@@ -677,13 +673,7 @@ public class Program
             };
         }
 
-        var ansiConsole = AnsiConsole.Create(settings);
-        if (!hostEnvironment.SupportsAnsi)
-        {
-            // Disable OSC 8 hyperlinks alongside colors to keep plain-text output free of terminal control sequences.
-            ansiConsole.Profile.Capabilities.Links = false;
-        }
-        return ansiConsole;
+        return AnsiConsole.Create(settings);
     }
 
     public static async Task<int> Main(string[] args)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -642,6 +642,7 @@ public class Program
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
         var isPlayground = CliHostEnvironment.IsPlaygroundMode(configuration);
+        var usePlaygroundFormatting = isPlayground && hostEnvironment.SupportsAnsi && hostEnvironment.SupportsInteractiveOutput;
 
         // Create custom output that handles width detection better in CI environments
         // and encapsulates ASPIRE_CONSOLE_WIDTH environment variable handling
@@ -649,9 +650,9 @@ public class Program
 
         var settings = new AnsiConsoleSettings()
         {
-            Ansi = isPlayground ? AnsiSupport.Yes : AnsiSupport.No,
-            Interactive = isPlayground ? InteractionSupport.Yes : hostEnvironment.SupportsInteractiveOutput ? InteractionSupport.Detect : InteractionSupport.No,
-            ColorSystem = isPlayground ? ColorSystemSupport.Standard : ColorSystemSupport.NoColors,
+            Ansi = usePlaygroundFormatting ? AnsiSupport.Yes : AnsiSupport.No,
+            Interactive = usePlaygroundFormatting ? InteractionSupport.Yes : hostEnvironment.SupportsInteractiveOutput ? InteractionSupport.Detect : InteractionSupport.No,
+            ColorSystem = usePlaygroundFormatting ? ColorSystemSupport.Standard : ColorSystemSupport.NoColors,
             Out = output,
         };
 
@@ -664,7 +665,7 @@ public class Program
             settings.ColorSystem = ColorSystemSupport.EightBit;
         }
 
-        if (isPlayground)
+        if (usePlaygroundFormatting)
         {
             // Enrichers interfere with interactive playground experience so
             // this suppresses the default enrichers so that the CLI experience

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -661,7 +661,6 @@ public class Program
         if (usePlaygroundFormatting)
         {
             settings.Interactive = InteractionSupport.Yes;
-            settings.ColorSystem = ColorSystemSupport.Standard;
 
             // Enrichers interfere with interactive playground experience so
             // this suppresses the default enrichers so that the CLI experience

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -649,13 +649,14 @@ public class Program
 
         var settings = new AnsiConsoleSettings()
         {
-            Ansi = isPlayground ? AnsiSupport.Yes : AnsiSupport.Detect,
-            Interactive = isPlayground ? InteractionSupport.Yes : InteractionSupport.Detect,
-            ColorSystem = isPlayground ? ColorSystemSupport.Standard : ColorSystemSupport.Detect,
+            Ansi = isPlayground ? AnsiSupport.Yes : AnsiSupport.No,
+            Interactive = isPlayground ? InteractionSupport.Yes : hostEnvironment.SupportsInteractiveOutput ? InteractionSupport.Detect : InteractionSupport.No,
+            ColorSystem = isPlayground ? ColorSystemSupport.Standard : ColorSystemSupport.NoColors,
             Out = output,
         };
 
-        // Use SupportsAnsi from hostEnvironment which already checks ASPIRE_ANSI_PASS_THRU
+        // Use SupportsAnsi from hostEnvironment so callers can explicitly suppress ANSI output,
+        // including the --non-interactive path used by automation and agents.
         if (hostEnvironment.SupportsAnsi)
         {
             settings.Ansi = AnsiSupport.Yes;
@@ -676,6 +677,11 @@ public class Program
         }
 
         var ansiConsole = AnsiConsole.Create(settings);
+        if (!hostEnvironment.SupportsAnsi)
+        {
+            // Disable OSC 8 hyperlinks alongside colors to keep plain-text output free of terminal control sequences.
+            ansiConsole.Profile.Capabilities.Links = false;
+        }
         return ansiConsole;
     }
 

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -68,15 +68,14 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
 
     public CliHostEnvironment(IConfiguration configuration, bool nonInteractive)
     {
-        // If --non-interactive is explicitly set, disable interactive input, interactive output,
-        // and ANSI styling so redirected/automation scenarios stay plain-text friendly.
-        // This takes precedence over all other settings including ASPIRE_PLAYGROUND and
-        // ASPIRE_ANSI_PASS_THRU.
+        // If --non-interactive is explicitly set, disable interactive input and output.
+        // ANSI support is still determined from the host configuration so explicit
+        // output settings such as NO_COLOR or ASPIRE_ANSI_PASS_THRU continue to apply.
         if (nonInteractive)
         {
             SupportsInteractiveInput = false;
             SupportsInteractiveOutput = false;
-            SupportsAnsi = false;
+            SupportsAnsi = DetectAnsiSupport(configuration);
         }
         // Check if ASPIRE_PLAYGROUND is set to force interactive mode
         else if (IsPlaygroundMode(configuration))

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -68,13 +68,15 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
 
     public CliHostEnvironment(IConfiguration configuration, bool nonInteractive)
     {
-        // If --non-interactive is explicitly set, disable interactive input and output.
-        // This takes precedence over all other settings including ASPIRE_PLAYGROUND.
+        // If --non-interactive is explicitly set, disable interactive input, interactive output,
+        // and ANSI styling so redirected/automation scenarios stay plain-text friendly.
+        // This takes precedence over all other settings including ASPIRE_PLAYGROUND and
+        // ASPIRE_ANSI_PASS_THRU.
         if (nonInteractive)
         {
             SupportsInteractiveInput = false;
             SupportsInteractiveOutput = false;
-            SupportsAnsi = DetectAnsiSupport(configuration);
+            SupportsAnsi = false;
         }
         // Check if ASPIRE_PLAYGROUND is set to force interactive mode
         else if (IsPlaygroundMode(configuration))

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -6,7 +6,6 @@ using Aspire.Cli.Certificates;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.Utils;
-using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -92,7 +91,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var certificateToolRunner = serviceProvider.GetRequiredService<ICertificateToolRunner>();
                 var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
                 var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
-                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new TestCliHostEnvironment(supportsInteractiveInput: true));
+                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new global::Aspire.Cli.Tests.TestCliHostEnvironment(supportsInteractiveInput: true));
             };
         });
 
@@ -190,7 +189,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var certificateToolRunner = serviceProvider.GetRequiredService<ICertificateToolRunner>();
                 var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
                 var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
-                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new TestCliHostEnvironment(supportsInteractiveInput: true));
+                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new global::Aspire.Cli.Tests.TestCliHostEnvironment(supportsInteractiveInput: true));
             };
         });
 
@@ -278,7 +277,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
                 var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
                 // Simulate a platform where non-interactive trust is NOT supported (e.g. macOS/Windows)
-                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new TestCliHostEnvironment(), isNonInteractiveTrustSupported: () => false);
+                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new global::Aspire.Cli.Tests.TestCliHostEnvironment(), isNonInteractiveTrustSupported: () => false);
             };
         });
 
@@ -333,7 +332,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
                 var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
                 // Simulate a platform where non-interactive trust is NOT supported (e.g. macOS/Windows)
-                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new TestCliHostEnvironment(), isNonInteractiveTrustSupported: () => false);
+                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new global::Aspire.Cli.Tests.TestCliHostEnvironment(), isNonInteractiveTrustSupported: () => false);
             };
         });
 
@@ -388,7 +387,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
                 var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
                 // Simulate a platform where non-interactive trust IS supported (e.g. Linux)
-                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new TestCliHostEnvironment(), isNonInteractiveTrustSupported: () => true);
+                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new global::Aspire.Cli.Tests.TestCliHostEnvironment(), isNonInteractiveTrustSupported: () => true);
             };
         });
 
@@ -443,12 +442,4 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             => new CertificateCleanResult { Success = true };
     }
 
-    private sealed class TestCliHostEnvironment(bool supportsInteractiveInput = false, bool supportsInteractiveOutput = false, bool supportsAnsi = true) : ICliHostEnvironment
-    {
-        public bool SupportsInteractiveInput => supportsInteractiveInput;
-
-        public bool SupportsInteractiveOutput => supportsInteractiveOutput;
-
-        public bool SupportsAnsi => supportsAnsi;
-    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -570,6 +570,72 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task LogsCommand_TextOutput_StripsAnsiControlSequences_WhenAnsiDisabled()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(
+            workspace,
+            outputWriter,
+            disableAnsi: true,
+            logLines:
+            [
+                new ResourceLogLine
+                {
+                    ResourceName = "redis",
+                    LineNumber = 1,
+                    Content = "2025-01-15T10:30:00Z \u001b[38;5;252mReady\u001b[0m to accept connections",
+                    IsError = false
+                }
+            ]);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var logLine = Assert.Single(outputWriter.Logs, l => l.StartsWith("[", StringComparison.Ordinal));
+        Assert.Equal("[redis] Ready to accept connections", logLine);
+        Assert.DoesNotContain("\u001b", logLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task LogsCommand_JsonOutput_PreservesAnsiControlSequences()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(
+            workspace,
+            outputWriter,
+            logLines:
+            [
+                new ResourceLogLine
+                {
+                    ResourceName = "redis",
+                    LineNumber = 1,
+                    Content = "2025-01-15T10:30:00Z \u001b[38;5;252mReady\u001b[0m to accept connections",
+                    IsError = false
+                }
+            ]);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = outputWriter.Logs.First(l => l.Contains("\"logs\"", StringComparison.Ordinal));
+        var logsOutput = JsonSerializer.Deserialize(jsonOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
+
+        Assert.NotNull(logsOutput);
+        var log = Assert.Single(logsOutput.Logs);
+        Assert.Equal("\u001b[38;5;252mReady\u001b[0m to accept connections", log.Content);
+    }
+
+    [Fact]
     public async Task LogsCommand_HiddenResources_AreExcludedByDefault()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -895,7 +961,8 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         TemporaryWorkspace workspace,
         TestOutputTextWriter outputWriter,
         Action<Dictionary<string, string?>>? configureOptions = null,
-        bool disableAnsi = false)
+        bool disableAnsi = false,
+        IEnumerable<ResourceLogLine>? logLines = null)
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -932,7 +999,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
                     State = "Running"
                 }
             ],
-            LogLines =
+            LogLines = logLines is not null ? [.. logLines] :
             [
                 // Log lines are intentionally out of timestamp order to verify sorting
                 new ResourceLogLine

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -609,6 +609,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         var provider = CreateLogsTestServices(
             workspace,
             outputWriter,
+            disableAnsi: true,
             logLines:
             [
                 new ResourceLogLine

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -119,6 +119,34 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddSeconds(1))} WARN apiservice-aaaaaaaa Slow response from replica 2", logLines[1]);
     }
 
+    [Fact]
+    public async Task TelemetryLogsCommand_TableOutput_StripsAnsiControlSequencesFromBody()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
+            resources:
+            [
+                new ResourceInfoJson { Name = "apiservice", InstanceId = null },
+            ],
+            telemetryEndpoints: new Dictionary<string, string>
+            {
+                ["/api/telemetry/logs"] = BuildLogsJson(
+                    ("apiservice", null, 9, "Information", "\u001b[38;5;252mRequest received\u001b[0m", s_testTime))
+            });
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel logs");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var logLine = Assert.Single(outputWriter.Logs, l => l.Contains("apiservice", StringComparison.Ordinal));
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} INFO apiservice Request received", logLine);
+        Assert.DoesNotContain("\u001b", logLine, StringComparison.Ordinal);
+    }
+
     private static string BuildLogsJson(params (string serviceName, string? instanceId, int severityNumber, string severityText, string body, DateTime time)[] entries)
     {
         var resourceLogs = entries

--- a/tests/Aspire.Cli.Tests/ProgramTests.cs
+++ b/tests/Aspire.Cli.Tests/ProgramTests.cs
@@ -60,13 +60,4 @@ public class ProgramTests
         Assert.Contains("hello", output, StringComparison.Ordinal);
         Assert.DoesNotContain("\u001b", output, StringComparison.Ordinal);
     }
-
-    private sealed class TestCliHostEnvironment(bool supportsAnsi, bool supportsInteractiveOutput) : ICliHostEnvironment
-    {
-        public bool SupportsInteractiveInput => supportsInteractiveOutput;
-
-        public bool SupportsInteractiveOutput => supportsInteractiveOutput;
-
-        public bool SupportsAnsi => supportsAnsi;
-    }
 }

--- a/tests/Aspire.Cli.Tests/ProgramTests.cs
+++ b/tests/Aspire.Cli.Tests/ProgramTests.cs
@@ -1,6 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
+using System.Text;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console;
+
 namespace Aspire.Cli.Tests;
 
 public class ProgramTests
@@ -27,5 +34,39 @@ public class ProgramTests
         var result = Program.ParseLogFileOption(["run", "--", "--log-file", "app.log"]);
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void BuildAnsiConsole_DoesNotReenablePlaygroundFormatting_WhenHostDisablesAnsi()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ASPIRE_PLAYGROUND"] = "true"
+        }).Build());
+        services.AddSingleton<ICliHostEnvironment>(new TestCliHostEnvironment(supportsAnsi: false, supportsInteractiveOutput: false));
+
+        var serviceProvider = services.BuildServiceProvider();
+        var writer = new StringWriter(new StringBuilder());
+        var buildAnsiConsole = typeof(Program).GetMethod("BuildAnsiConsole", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(buildAnsiConsole);
+
+        var ansiConsole = Assert.IsAssignableFrom<Spectre.Console.IAnsiConsole>(buildAnsiConsole.Invoke(null, [serviceProvider, writer]));
+
+        ansiConsole.MarkupLine("[red]hello[/]");
+
+        var output = writer.ToString();
+        Assert.Contains("hello", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("\u001b", output, StringComparison.Ordinal);
+    }
+
+    private sealed class TestCliHostEnvironment(bool supportsAnsi, bool supportsInteractiveOutput) : ICliHostEnvironment
+    {
+        public bool SupportsInteractiveInput => supportsInteractiveOutput;
+
+        public bool SupportsInteractiveOutput => supportsInteractiveOutput;
+
+        public bool SupportsAnsi => supportsAnsi;
     }
 }

--- a/tests/Aspire.Cli.Tests/TestHelpers.cs
+++ b/tests/Aspire.Cli.Tests/TestHelpers.cs
@@ -16,11 +16,13 @@ internal static class TestHelpers
     {
         return new TestCliHostEnvironment(supportsInteractiveInput: false, supportsInteractiveOutput: false, supportsAnsi: false);
     }
+}
 
-    private sealed class TestCliHostEnvironment(bool supportsInteractiveInput, bool supportsInteractiveOutput, bool supportsAnsi) : ICliHostEnvironment
-    {
-        public bool SupportsInteractiveInput => supportsInteractiveInput;
-        public bool SupportsInteractiveOutput => supportsInteractiveOutput;
-        public bool SupportsAnsi => supportsAnsi;
-    }
+internal sealed class TestCliHostEnvironment(bool supportsInteractiveInput = false, bool supportsInteractiveOutput = false, bool supportsAnsi = true) : ICliHostEnvironment
+{
+    public bool SupportsInteractiveInput => supportsInteractiveInput;
+
+    public bool SupportsInteractiveOutput => supportsInteractiveOutput;
+
+    public bool SupportsAnsi => supportsAnsi;
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
@@ -166,16 +166,21 @@ public class CliHostEnvironmentTests
     }
 
     [Fact]
-    public void SupportsAnsi_ReturnsFalse_WhenNonInteractiveTrue()
+    public void SupportsAnsi_RespectsAnsiConfiguration_WhenNonInteractiveTrue()
     {
-        // Arrange
-        var configuration = new ConfigurationBuilder().Build();
+        // Arrange - --non-interactive should not suppress ANSI when it is explicitly enabled.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPIRE_ANSI_PASS_THRU"] = "true"
+            })
+            .Build();
 
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
 
         // Assert
-        Assert.False(env.SupportsAnsi);
+        Assert.True(env.SupportsAnsi);
     }
 
     [Fact]
@@ -344,24 +349,6 @@ public class CliHostEnvironmentTests
 
         // Assert
         Assert.True(env.SupportsAnsi);
-    }
-
-    [Fact]
-    public void SupportsAnsi_ReturnsFalse_WhenAnsiPassThruSet_WithNonInteractive()
-    {
-        // Arrange - --non-interactive should take precedence over ANSI pass-through for plain-text automation output
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["ASPIRE_ANSI_PASS_THRU"] = "true"
-            })
-            .Build();
-
-        // Act
-        var env = new CliHostEnvironment(configuration, nonInteractive: true);
-
-        // Assert
-        Assert.False(env.SupportsAnsi);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
@@ -166,6 +166,19 @@ public class CliHostEnvironmentTests
     }
 
     [Fact]
+    public void SupportsAnsi_ReturnsFalse_WhenNonInteractiveTrue()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder().Build();
+
+        // Act
+        var env = new CliHostEnvironment(configuration, nonInteractive: true);
+
+        // Assert
+        Assert.False(env.SupportsAnsi);
+    }
+
+    [Fact]
     public void SupportsInteractiveInput_ReturnsTrue_WhenPlaygroundModeSet()
     {
         // Arrange
@@ -334,9 +347,9 @@ public class CliHostEnvironmentTests
     }
 
     [Fact]
-    public void SupportsAnsi_ReturnsTrue_WhenAnsiPassThruSet_WithNonInteractive()
+    public void SupportsAnsi_ReturnsFalse_WhenAnsiPassThruSet_WithNonInteractive()
     {
-        // Arrange - ASPIRE_ANSI_PASS_THRU explicitly enables ANSI even with --non-interactive
+        // Arrange - --non-interactive should take precedence over ANSI pass-through for plain-text automation output
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -348,7 +361,7 @@ public class CliHostEnvironmentTests
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
 
         // Assert
-        Assert.True(env.SupportsAnsi);
+        Assert.False(env.SupportsAnsi);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -70,6 +70,11 @@ internal static class CliTestHelper
 
         options.ConfigurationCallback(configurationValues);
 
+        if (options.DisableAnsi)
+        {
+            configurationValues.TryAdd("NO_COLOR", "1");
+        }
+
         configBuilder.AddInMemoryCollection(configurationValues);
 
         var globalSettingsFilePath = Path.Combine(options.WorkingDirectory.FullName, ".aspire", "settings.global.json");


### PR DESCRIPTION
## Description

Fixes the plain-text output leak reported in #15845. In non-ANSI and automation-oriented scenarios, the CLI could still emit Spectre styling or pass through embedded ANSI sequences, which showed up as raw fragments in `aspire logs` and telemetry output.

This change makes `--non-interactive` force plain console rendering, updates the CLI console setup to honor the resolved ANSI capability instead of falling back to auto-detection, disables hyperlinks when ANSI is off, and strips embedded control sequences from human-readable `aspire logs` and `aspire otel logs` output while preserving JSON output.

Validation:

- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.LogsCommandTests" --filter-class "*.TelemetryLogsCommandTests" --filter-class "*.TelemetryTracesCommandTests" --filter-class "*.CliHostEnvironmentTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes #15845

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No