### PR TITLE
Fix aspire new non-interactive defaults

### DIFF
--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -28,20 +28,13 @@ internal sealed partial class CliTemplateFactory
             return new TemplateResult(ExitCodeConstants.InvalidCommand);
         }
 
-        var projectName = inputs.Name;
-        if (string.IsNullOrWhiteSpace(projectName))
+        var (projectNameResolved, projectName) = await ResolveProjectNameAsync(inputs, cancellationToken);
+        if (!projectNameResolved || projectName is null)
         {
-            var defaultName = _executionContext.WorkingDirectory.Name;
-            projectName = await _prompter.PromptForProjectNameAsync(defaultName, cancellationToken);
+            return new TemplateResult(ExitCodeConstants.InvalidCommand);
         }
 
-        var outputPath = inputs.Output;
-        if (string.IsNullOrWhiteSpace(outputPath))
-        {
-            var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken);
-        }
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
+        var outputPath = await ResolveOutputPathAsync(inputs.Output, projectName, cancellationToken);
 
         _logger.LogDebug("Applying empty AppHost template. LanguageId: {LanguageId}, Language: {LanguageDisplayName}, ProjectName: {ProjectName}, OutputPath: {OutputPath}.", languageId, language.DisplayName, projectName, outputPath);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -14,11 +14,10 @@ internal sealed partial class CliTemplateFactory
 {
     private async Task<TemplateResult> ApplyPythonStarterTemplateAsync(CallbackTemplate _, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var projectName = inputs.Name;
-        if (string.IsNullOrWhiteSpace(projectName))
+        var (projectNameResolved, projectName) = await ResolveProjectNameAsync(inputs, cancellationToken);
+        if (!projectNameResolved || projectName is null)
         {
-            var defaultName = _executionContext.WorkingDirectory.Name;
-            projectName = await _prompter.PromptForProjectNameAsync(defaultName, cancellationToken);
+            return new TemplateResult(ExitCodeConstants.InvalidCommand);
         }
 
         if (string.IsNullOrWhiteSpace(inputs.Version))
@@ -28,13 +27,7 @@ internal sealed partial class CliTemplateFactory
         }
 
         var aspireVersion = inputs.Version;
-        var outputPath = inputs.Output;
-        if (string.IsNullOrWhiteSpace(outputPath))
-        {
-            var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken);
-        }
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
+        var outputPath = await ResolveOutputPathAsync(inputs.Output, projectName, cancellationToken);
 
         _logger.LogDebug("Applying Python starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -14,11 +14,10 @@ internal sealed partial class CliTemplateFactory
 {
     private async Task<TemplateResult> ApplyTypeScriptStarterTemplateAsync(CallbackTemplate _, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var projectName = inputs.Name;
-        if (string.IsNullOrWhiteSpace(projectName))
+        var (projectNameResolved, projectName) = await ResolveProjectNameAsync(inputs, cancellationToken);
+        if (!projectNameResolved || projectName is null)
         {
-            var defaultName = _executionContext.WorkingDirectory.Name;
-            projectName = await _prompter.PromptForProjectNameAsync(defaultName, cancellationToken);
+            return new TemplateResult(ExitCodeConstants.InvalidCommand);
         }
 
         if (string.IsNullOrWhiteSpace(inputs.Version))
@@ -28,13 +27,7 @@ internal sealed partial class CliTemplateFactory
         }
 
         var aspireVersion = inputs.Version;
-        var outputPath = inputs.Output;
-        if (string.IsNullOrWhiteSpace(outputPath))
-        {
-            var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken);
-        }
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
+        var outputPath = await ResolveOutputPathAsync(inputs.Output, projectName, cancellationToken);
 
         _logger.LogDebug("Applying TypeScript starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -273,4 +273,47 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             _interactionService.DisplayMessage(KnownEmojis.Information, TemplatingStrings.RunAspireRun);
         }
     }
+
+    private async Task<(bool Success, string? ProjectName)> ResolveProjectNameAsync(TemplateInputs inputs, CancellationToken cancellationToken)
+    {
+        if (inputs.Name is { } projectName && ProjectNameValidator.IsProjectNameValid(projectName))
+        {
+            return (true, projectName);
+        }
+
+        if (!_hostEnvironment.SupportsInteractiveInput)
+        {
+            if (inputs.Name is not null)
+            {
+                _interactionService.DisplayError(NewCommandStrings.InvalidProjectName);
+                return (false, null);
+            }
+
+            var defaultName = _executionContext.WorkingDirectory.Name;
+            if (!ProjectNameValidator.IsProjectNameValid(defaultName))
+            {
+                _interactionService.DisplayError(NewCommandStrings.InvalidProjectName);
+                return (false, null);
+            }
+
+            return (true, defaultName);
+        }
+
+        var promptedName = await _prompter.PromptForProjectNameAsync(_executionContext.WorkingDirectory.Name, cancellationToken);
+        return (true, promptedName);
+    }
+
+    private async Task<string> ResolveOutputPathAsync(string? outputPath, string projectName, CancellationToken cancellationToken)
+    {
+        var resolvedOutputPath = outputPath;
+        if (string.IsNullOrWhiteSpace(resolvedOutputPath))
+        {
+            var defaultOutputPath = $"./{projectName}";
+            resolvedOutputPath = _hostEnvironment.SupportsInteractiveInput
+                ? await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken)
+                : defaultOutputPath;
+        }
+
+        return Path.GetFullPath(resolvedOutputPath, _executionContext.WorkingDirectory.FullName);
+    }
 }

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -634,7 +634,8 @@ internal class DotNetTemplateFactory(
 
     private async Task<string> GetOutputPathAsync(TemplateInputs inputs, Func<string, string> pathDeriver, string projectName, CancellationToken cancellationToken)
     {
-        if (inputs.Output is not { } outputPath)
+        var outputPath = inputs.Output;
+        if (string.IsNullOrWhiteSpace(outputPath))
         {
             var defaultOutputPath = pathDeriver(projectName);
             outputPath = hostEnvironment.SupportsInteractiveInput

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -473,7 +473,12 @@ internal class DotNetTemplateFactory(
             return new TemplateResult(ExitCodeConstants.SdkNotInstalled);
         }
 
-        var name = await GetProjectNameAsync(inputs, cancellationToken);
+        var (nameResolved, name) = await GetProjectNameAsync(inputs, cancellationToken);
+        if (!nameResolved || name is null)
+        {
+            return new TemplateResult(ExitCodeConstants.InvalidCommand);
+        }
+
         var outputPath = await GetOutputPathAsync(inputs, template.PathDeriver, name, cancellationToken);
 
         return await ApplyTemplateAsync(template, inputs, name, outputPath, parseResult, extraArgsCallback, cancellationToken);
@@ -598,25 +603,46 @@ internal class DotNetTemplateFactory(
         }
     }
 
-    private async Task<string> GetProjectNameAsync(TemplateInputs inputs, CancellationToken cancellationToken)
+    private async Task<(bool Success, string? ProjectName)> GetProjectNameAsync(TemplateInputs inputs, CancellationToken cancellationToken)
     {
-        if (inputs.Name is not { } name || !ProjectNameValidator.IsProjectNameValid(name))
+        if (inputs.Name is { } name && ProjectNameValidator.IsProjectNameValid(name))
         {
-            var defaultName = executionContext.WorkingDirectory.Name;
-            name = await prompter.PromptForProjectNameAsync(defaultName, cancellationToken);
+            return (true, name);
         }
 
-        return name;
+        if (!hostEnvironment.SupportsInteractiveInput)
+        {
+            if (inputs.Name is not null)
+            {
+                interactionService.DisplayError(NewCommandStrings.InvalidProjectName);
+                return (false, null);
+            }
+
+            var defaultName = executionContext.WorkingDirectory.Name;
+            if (!ProjectNameValidator.IsProjectNameValid(defaultName))
+            {
+                interactionService.DisplayError(NewCommandStrings.InvalidProjectName);
+                return (false, null);
+            }
+
+            return (true, defaultName);
+        }
+
+        var promptedName = await prompter.PromptForProjectNameAsync(executionContext.WorkingDirectory.Name, cancellationToken);
+        return (true, promptedName);
     }
 
     private async Task<string> GetOutputPathAsync(TemplateInputs inputs, Func<string, string> pathDeriver, string projectName, CancellationToken cancellationToken)
     {
         if (inputs.Output is not { } outputPath)
         {
-            outputPath = await prompter.PromptForOutputPath(pathDeriver(projectName), cancellationToken);
+            var defaultOutputPath = pathDeriver(projectName);
+            outputPath = hostEnvironment.SupportsInteractiveInput
+                ? await prompter.PromptForOutputPath(defaultOutputPath, cancellationToken)
+                : defaultOutputPath;
         }
 
-        outputPath = Path.GetFullPath(outputPath);
+        outputPath = Path.GetFullPath(outputPath, executionContext.WorkingDirectory.FullName);
 
         // When running in extension mode (VS Code), the folder picker returns the parent
         // directory the user selected. Append the project name as a subdirectory so the

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -302,6 +302,75 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandNonInteractiveWithoutOutputUsesDefaultOutputPathForDotNetTemplate()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedOutputPath = null;
+        var promptedForOutputPath = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+                prompter.PromptForOutputPathCallback = (_) =>
+                {
+                    promptedForOutputPath = true;
+                    throw new InvalidOperationException("Should not prompt for output in non-interactive mode.");
+                };
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (_) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, runnerOptions, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                };
+
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                {
+                    return (0, version);
+                };
+
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    capturedOutputPath = outputPath;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-starter --name SmokeApp");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.False(promptedForOutputPath);
+        Assert.Equal(Path.Combine(workspace.WorkspaceRoot.FullName, "SmokeApp"), capturedOutputPath);
+    }
+
+    [Fact]
     public async Task NewCommandWithChannelOptionUsesSpecifiedChannel()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1276,6 +1345,73 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandNonInteractiveWithoutOutputUsesDefaultOutputPathForCliTemplate()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedTargetDirectory = null;
+        var promptedForOutputPath = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+                prompter.PromptForOutputPathCallback = (_) =>
+                {
+                    promptedForOutputPath = true;
+                    throw new InvalidOperationException("Should not prompt for output in non-interactive mode.");
+                };
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (_) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, runnerOptions, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                };
+
+                return runner;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                capturedTargetDirectory = context.TargetDirectory.FullName;
+                return Task.FromResult(true);
+            }
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-ts-empty --name TestApp --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.False(promptedForOutputPath);
+        Assert.Equal(Path.Combine(workspace.WorkspaceRoot.FullName, "TestApp"), capturedTargetDirectory);
+    }
+
+    [Fact]
     public async Task NewCommandWithEmptyTemplateAndTypeScriptPromptsForLocalhostTldAndUsesSelection()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1676,6 +1812,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
             {
@@ -1744,6 +1881,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
             {
@@ -1812,7 +1950,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            // Default InteractionServiceFactory creates ConsoleInteractionService (not extension mode)
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                ConfirmCallback = (_, _) => false
+            };
 
             options.NewCommandPrompterFactory = (sp) =>
             {
@@ -1880,6 +2022,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
             {
+                options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
                 options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
                 options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
                 {

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -861,6 +861,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                ConfirmCallback = (_, _) => false
+            };
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -952,6 +957,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                ConfirmCallback = (_, _) => false
+            };
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -96,13 +96,33 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandInteractiveFlowSmokeTest()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var promptedForProjectName = false;
+        var promptedForOutputPath = false;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                ConfirmCallback = (_, _) => false
+            };
+
             // Set of options that we'll give when prompted.
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
-                return new TestNewCommandPrompter(interactionService);
+                var prompter = new TestNewCommandPrompter(interactionService);
+                prompter.PromptForProjectNameCallback = (defaultName) =>
+                {
+                    promptedForProjectName = true;
+                    return defaultName;
+                };
+                prompter.PromptForOutputPathCallback = (path) =>
+                {
+                    promptedForOutputPath = true;
+                    return path;
+                };
+
+                return prompter;
             };
 
             options.DotNetCliRunnerFactory = (sp) =>
@@ -133,6 +153,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
+        Assert.True(promptedForProjectName);
+        Assert.True(promptedForOutputPath);
     }
 
     [Fact]
@@ -140,7 +162,14 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandDerivesOutputPathFromProjectNameForStarterTemplate()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var promptedForProjectName = false;
+        var promptedForOutputPath = false;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                ConfirmCallback = (_, _) => false
+            };
 
             // Set of options that we'll give when prompted.
             options.NewCommandPrompterFactory = (sp) =>
@@ -150,11 +179,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 prompter.PromptForProjectNameCallback = (defaultName) =>
                 {
+                    promptedForProjectName = true;
                     return "CustomName";
                 };
 
                 prompter.PromptForOutputPathCallback = (path) =>
                 {
+                    promptedForOutputPath = true;
                     Assert.Equal("./CustomName", path);
                     return path;
                 };
@@ -190,6 +221,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
+        Assert.True(promptedForProjectName);
+        Assert.True(promptedForOutputPath);
     }
 
     [Fact]
@@ -743,11 +776,24 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommand_WhenCertificateServiceThrows_ReturnsNonZeroExitCode()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var promptedForProjectName = false;
+        var promptedForOutputPath = false;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.NewCommandPrompterFactory = (sp) => {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
                 var prompter = new TestNewCommandPrompter(interactionService);
+                prompter.PromptForProjectNameCallback = (defaultName) =>
+                {
+                    promptedForProjectName = true;
+                    return defaultName;
+                };
+                prompter.PromptForOutputPathCallback = (path) =>
+                {
+                    promptedForOutputPath = true;
+                    return path;
+                };
                 return prompter;
             };
             options.CertificateServiceFactory = _ => new ThrowingCertificateService();
@@ -790,19 +836,36 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.FailedToTrustCertificates, exitCode);
+        Assert.True(promptedForProjectName);
+        Assert.True(promptedForOutputPath);
     }
 
     [Fact]
     public async Task NewCommandWithExitCode73ShowsUserFriendlyError()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var promptedForProjectName = false;
+        var promptedForOutputPath = false;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
 
             // Set of options that we'll give when prompted.
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
-                return new TestNewCommandPrompter(interactionService);
+                var prompter = new TestNewCommandPrompter(interactionService);
+                prompter.PromptForProjectNameCallback = (defaultName) =>
+                {
+                    promptedForProjectName = true;
+                    return defaultName;
+                };
+                prompter.PromptForOutputPathCallback = (path) =>
+                {
+                    promptedForOutputPath = true;
+                    return path;
+                };
+
+                return prompter;
             };
 
             options.DotNetCliRunnerFactory = (sp) =>
@@ -843,6 +906,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+        Assert.True(promptedForProjectName);
+        Assert.True(promptedForOutputPath);
     }
 
     private sealed class ThrowingCertificateService : ICertificateService
@@ -1360,16 +1425,26 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         string? capturedTargetDirectory = null;
+        var promptedForOutputPath = false;
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                ConfirmCallback = (_, _) => false
+            };
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
                 var prompter = new TestNewCommandPrompter(interactionService);
 
                 // Accept the default "./TestApp" path from the prompt
-                prompter.PromptForOutputPathCallback = (path) => path;
+                prompter.PromptForOutputPathCallback = (path) =>
+                {
+                    promptedForOutputPath = true;
+                    return path;
+                };
 
                 return prompter;
             };
@@ -1410,6 +1485,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
         Assert.NotNull(capturedTargetDirectory);
+        Assert.True(promptedForOutputPath);
 
         // The output path should be properly normalized without "./" segments
         Assert.DoesNotContain("./", capturedTargetDirectory);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -371,6 +371,75 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandNonInteractiveWithWhitespaceOutputUsesDefaultOutputPathForDotNetTemplate()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedOutputPath = null;
+        var promptedForOutputPath = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+                prompter.PromptForOutputPathCallback = (_) =>
+                {
+                    promptedForOutputPath = true;
+                    throw new InvalidOperationException("Should not prompt for output in non-interactive mode.");
+                };
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (_) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, runnerOptions, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                };
+
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                {
+                    return (0, version);
+                };
+
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    capturedOutputPath = outputPath;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-starter --name SmokeApp --output \"   \"");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.False(promptedForOutputPath);
+        Assert.Equal(Path.Combine(workspace.WorkspaceRoot.FullName, "SmokeApp"), capturedOutputPath);
+    }
+
+    [Fact]
     public async Task NewCommandWithChannelOptionUsesSpecifiedChannel()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -862,10 +862,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
-            options.InteractionServiceFactory = _ => new TestInteractionService
-            {
-                ConfirmCallback = (_, _) => false
-            };
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();


### PR DESCRIPTION
## Description

`aspire new` was still falling back to interactive name/output prompts in non-interactive mode when `--output` was omitted, which produced the misleading "Interactive input is not supported" failure from issue #15841.

This change resolves name/output defaults before template execution for both dotnet-backed and CLI-backed templates so non-interactive runs can proceed without prompting. It also normalizes dotnet template output paths against the CLI working directory, which keeps output-path handling consistent with the CLI-backed templates and with the updated regression coverage.

Fixes #15841

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No