### PR TITLE
Export remaining ATS Aspire.Hosting APIs

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Rust/AtsRustCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/AtsRustCodeGenerator.cs
@@ -185,6 +185,8 @@ internal sealed class AtsRustCodeGenerator : ICodeGenerator
             return;
         }
 
+        var dtoTypesById = dtoTypes.ToDictionary(dto => dto.TypeId, StringComparer.Ordinal);
+
         WriteLine("// ============================================================================");
         WriteLine("// DTOs");
         WriteLine("// ============================================================================");
@@ -200,7 +202,10 @@ internal sealed class AtsRustCodeGenerator : ICodeGenerator
 
             var dtoName = _dtoNames[dto.TypeId];
             WriteLine($"/// {dto.Name}");
-            WriteLine("#[derive(Debug, Clone, Default, Serialize, Deserialize)]");
+            var derivesDefault = CanDeriveDefault(dto, dtoTypesById, []);
+            WriteLine(derivesDefault
+                ? "#[derive(Debug, Clone, Default, Serialize, Deserialize)]"
+                : "#[derive(Debug, Clone, Serialize, Deserialize)]");
             WriteLine($"pub struct {dtoName} {{");
             foreach (var property in dto.Properties)
             {
@@ -242,6 +247,60 @@ internal sealed class AtsRustCodeGenerator : ICodeGenerator
             WriteLine("}");
             WriteLine();
         }
+    }
+
+    private static bool CanDeriveDefault(
+        AtsDtoTypeInfo dto,
+        IReadOnlyDictionary<string, AtsDtoTypeInfo> dtoTypesById,
+        HashSet<string> visitedTypeIds)
+    {
+        if (!visitedTypeIds.Add(dto.TypeId))
+        {
+            return true;
+        }
+
+        try
+        {
+            return dto.Properties.All(property => CanDeriveDefault(property.Type, property.IsOptional, dtoTypesById, visitedTypeIds));
+        }
+        finally
+        {
+            visitedTypeIds.Remove(dto.TypeId);
+        }
+    }
+
+    private static bool CanDeriveDefault(
+        AtsTypeRef? typeRef,
+        bool isOptional,
+        IReadOnlyDictionary<string, AtsDtoTypeInfo> dtoTypesById,
+        HashSet<string> visitedTypeIds)
+    {
+        if (isOptional || typeRef is null)
+        {
+            return true;
+        }
+
+        if (typeRef.TypeId == AtsConstants.ReferenceExpressionTypeId
+            || IsCancellationTokenTypeId(typeRef.TypeId))
+        {
+            return false;
+        }
+
+        return typeRef.Category switch
+        {
+            AtsTypeCategory.Primitive => true,
+            AtsTypeCategory.Enum => true,
+            AtsTypeCategory.Handle => true,
+            AtsTypeCategory.Dto => !dtoTypesById.TryGetValue(typeRef.TypeId, out var dto)
+                || CanDeriveDefault(dto, dtoTypesById, visitedTypeIds),
+            AtsTypeCategory.Callback => true,
+            AtsTypeCategory.Array => true,
+            AtsTypeCategory.List => true,
+            AtsTypeCategory.Dict => true,
+            AtsTypeCategory.Union => true,
+            AtsTypeCategory.Unknown => true,
+            _ => true
+        };
     }
 
     private void GenerateHandleTypes(

--- a/src/Aspire.Hosting/ApplicationModel/AspireStoreExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AspireStoreExtensions.cs
@@ -17,6 +17,7 @@ public static class AspireStoreExtensions
     /// <param name="sourceFilename">An existing file.</param>
     /// <returns>A deterministic file path with the same content as <paramref name="sourceFilename"/>.</returns>
     /// <exception cref="FileNotFoundException">Thrown when the source file does not exist.</exception>
+    [AspireExport(Description = "Gets a deterministic file path for the specified file contents")]
     public static string GetFileNameWithContent(this IAspireStore aspireStore, string filenameTemplate, string sourceFilename)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filenameTemplate);

--- a/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
@@ -152,6 +152,7 @@ public class CertificateTrustExecutionConfigurationData : IExecutionConfiguratio
 /// Context for configuring certificate trust configuration properties.
 /// </summary>
 [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireDto]
 public class CertificateTrustExecutionConfigurationContext
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ExecutionConfigurationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutionConfigurationBuilderExtensions.cs
@@ -16,6 +16,7 @@ public static class ExecutionConfigurationBuilderExtensions
     /// </summary>
     /// <param name="builder">The builder to add the configuration gatherer to.</param>
     /// <returns>The builder with the configuration gatherer added.</returns>
+    [AspireExport(Description = "Adds an arguments configuration gatherer")]
     public static IExecutionConfigurationBuilder WithArgumentsConfig(this IExecutionConfigurationBuilder builder)
     {
         return builder.AddExecutionConfigurationGatherer(new ArgumentsExecutionConfigurationGatherer());
@@ -26,6 +27,7 @@ public static class ExecutionConfigurationBuilderExtensions
     /// </summary>
     /// <param name="builder">The builder to add the configuration gatherer to.</param>
     /// <returns>The builder with the configuration gatherer added.</returns>
+    [AspireExport(Description = "Adds an environment variables configuration gatherer")]
     public static IExecutionConfigurationBuilder WithEnvironmentVariablesConfig(this IExecutionConfigurationBuilder builder)
     {
         return builder.AddExecutionConfigurationGatherer(new EnvironmentVariablesExecutionConfigurationGatherer());
@@ -38,6 +40,7 @@ public static class ExecutionConfigurationBuilderExtensions
     /// <param name="configContextFactory">A factory function to create the configuration context.</param>
     /// <returns>The builder with the configuration gatherer added.</returns>
     [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExport(Description = "Adds a certificate trust configuration gatherer")]
     public static IExecutionConfigurationBuilder WithCertificateTrustConfig(this IExecutionConfigurationBuilder builder, Func<CertificateTrustScope, CertificateTrustExecutionConfigurationContext> configContextFactory)
     {
         return builder.AddExecutionConfigurationGatherer(new CertificateTrustExecutionConfigurationGatherer(configContextFactory));
@@ -50,6 +53,7 @@ public static class ExecutionConfigurationBuilderExtensions
     /// <param name="configContextFactory">A factory function to create the configuration context.</param>
     /// <returns>The builder with the configuration gatherer added.</returns>
     [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExportIgnore(Reason = "X509Certificate2 callback input is not ATS-compatible. Use the ATS-specific withHttpsCertificateConfig export instead.")]
     public static IExecutionConfigurationBuilder WithHttpsCertificateConfig(this IExecutionConfigurationBuilder builder, Func<X509Certificate2, HttpsCertificateExecutionConfigurationContext> configContextFactory)
     {
         return builder.AddExecutionConfigurationGatherer(new HttpsCertificateExecutionConfigurationGatherer(configContextFactory));

--- a/src/Aspire.Hosting/ApplicationModel/ExecutionConfigurationResultExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutionConfigurationResultExtensions.cs
@@ -18,6 +18,7 @@ public static class ExecutionConfigurationResultExtensions
     /// <param name="configuration">The resource execution configuration.</param>
     /// <param name="additionalData">The additional data if found.</param>
     /// <returns>True if the additional data was found; otherwise, false.</returns>
+    [AspireExportIgnore(Reason = "Generic out-parameter helper — use getCertificateTrustData or getHttpsCertificateData instead.")]
     public static bool TryGetAdditionalData<T>(this IExecutionConfigurationResult configuration, [NotNullWhen(true)] out T? additionalData) where T : IExecutionConfigurationData
     {
         foreach (var item in configuration.AdditionalConfigurationData)

--- a/src/Aspire.Hosting/ApplicationModel/HttpsCertificateExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpsCertificateExecutionConfigurationGatherer.cs
@@ -173,6 +173,7 @@ public class HttpsCertificateExecutionConfigurationData : IExecutionConfiguratio
 /// Configuration context for server authentication certificate configuration.
 /// </summary>
 [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireDto]
 public class HttpsCertificateExecutionConfigurationContext
 {
     /// <summary>

--- a/src/Aspire.Hosting/Ats/AtsTypeMappings.cs
+++ b/src/Aspire.Hosting/Ats/AtsTypeMappings.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -27,6 +28,9 @@ using Microsoft.Extensions.Logging;
 // Reference types (from Aspire.Hosting.ApplicationModel namespace)
 [assembly: AspireExport(typeof(EndpointReference))]
 [assembly: AspireExport(typeof(ReferenceExpression))]
+[assembly: AspireExport(typeof(IAspireStore), ExposeProperties = true)]
+[assembly: AspireExport(typeof(IExecutionConfigurationBuilder))]
+[assembly: AspireExport(typeof(IExecutionConfigurationResult))]
 
 // Note: EnvironmentCallbackContext has [AspireExport(ExposeProperties = true)] on the type itself
 
@@ -50,6 +54,7 @@ using Microsoft.Extensions.Logging;
 
 // Service types
 [assembly: AspireExport(typeof(IServiceProvider))]
+[assembly: AspireExport(typeof(IServiceCollection))]
 [assembly: AspireExport(typeof(ResourceNotificationService))]
 [assembly: AspireExport(typeof(ResourceLoggerService))]
 

--- a/src/Aspire.Hosting/Ats/AtsTypeMappings.cs
+++ b/src/Aspire.Hosting/Ats/AtsTypeMappings.cs
@@ -8,7 +8,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -54,7 +53,6 @@ using Microsoft.Extensions.Logging;
 
 // Service types
 [assembly: AspireExport(typeof(IServiceProvider))]
-[assembly: AspireExport(typeof(IServiceCollection))]
 [assembly: AspireExport(typeof(ResourceNotificationService))]
 [assembly: AspireExport(typeof(ResourceLoggerService))]
 

--- a/src/Aspire.Hosting/Ats/ExecutionConfigurationExports.cs
+++ b/src/Aspire.Hosting/Ats/ExecutionConfigurationExports.cs
@@ -1,0 +1,218 @@
+#pragma warning disable CS0618
+#pragma warning disable ASPIRECERTIFICATES001
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography.X509Certificates;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.Ats;
+
+/// <summary>
+/// ATS exports for execution-configuration helpers that need DTO or callback shims.
+/// </summary>
+internal static class ExecutionConfigurationExports
+{
+    /// <summary>
+    /// Creates an execution configuration builder for the specified resource.
+    /// </summary>
+    /// <param name="resource">The resource to build the execution configuration for.</param>
+    /// <returns>The execution configuration builder.</returns>
+    [AspireExport(Description = "Creates an execution configuration builder")]
+    public static IExecutionConfigurationBuilder CreateExecutionConfiguration(this IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return ExecutionConfigurationBuilder.Create(resource);
+    }
+
+    /// <summary>
+    /// Builds the execution configuration for the specified builder.
+    /// </summary>
+    /// <param name="builder">The execution configuration builder.</param>
+    /// <param name="executionContext">The execution context used while building the configuration.</param>
+    /// <param name="resourceLogger">The logger used while resolving values.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The resolved execution configuration.</returns>
+    [AspireExport("buildExecutionConfiguration", MethodName = "build", Description = "Builds the execution configuration")]
+    public static Task<IExecutionConfigurationResult> Build(
+        this IExecutionConfigurationBuilder builder,
+        DistributedApplicationExecutionContext executionContext,
+        ILogger? resourceLogger = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(executionContext);
+
+        return builder.BuildAsync(executionContext, resourceLogger ?? NullLogger.Instance, cancellationToken);
+    }
+
+    /// <summary>
+    /// Adds an HTTPS certificate configuration gatherer using certificate metadata instead of a raw X509 certificate.
+    /// </summary>
+    /// <param name="builder">The execution configuration builder.</param>
+    /// <param name="configContextFactory">The factory that creates the HTTPS certificate configuration context.</param>
+    /// <returns>The execution configuration builder.</returns>
+    [AspireExport("withHttpsCertificateConfigExport", MethodName = "withHttpsCertificateConfig", Description = "Adds an HTTPS certificate configuration gatherer")]
+    public static IExecutionConfigurationBuilder WithHttpsCertificateConfig(
+        this IExecutionConfigurationBuilder builder,
+        Func<HttpsCertificateInfo, HttpsCertificateExecutionConfigurationContext> configContextFactory)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configContextFactory);
+
+        return ExecutionConfigurationBuilderExtensions.WithHttpsCertificateConfig(
+            builder,
+            certificate => configContextFactory(HttpsCertificateInfo.FromCertificate(certificate)));
+    }
+
+    /// <summary>
+    /// Gets certificate trust execution-configuration data when present.
+    /// </summary>
+    /// <param name="configuration">The execution configuration result.</param>
+    /// <returns>The certificate trust data, or <see langword="null"/> when not present.</returns>
+    [AspireExport(Description = "Gets certificate trust execution-configuration data")]
+    public static CertificateTrustExecutionConfigurationExportData? GetCertificateTrustData(this IExecutionConfigurationResult configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        if (!configuration.TryGetAdditionalData<CertificateTrustExecutionConfigurationData>(out var additionalData))
+        {
+            return null;
+        }
+
+        return new CertificateTrustExecutionConfigurationExportData
+        {
+            Scope = additionalData.Scope,
+            CertificateSubjects = [.. additionalData.Certificates.Cast<X509Certificate2>().Select(static certificate => certificate.Subject)],
+            CustomBundlePaths = [.. additionalData.CustomBundlesFactories.Keys]
+        };
+    }
+
+    /// <summary>
+    /// Gets HTTPS certificate execution-configuration data when present.
+    /// </summary>
+    /// <param name="configuration">The execution configuration result.</param>
+    /// <returns>The HTTPS certificate data, or <see langword="null"/> when not present.</returns>
+    [AspireExport(Description = "Gets HTTPS certificate execution-configuration data")]
+    public static HttpsCertificateExecutionConfigurationExportData? GetHttpsCertificateData(this IExecutionConfigurationResult configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        if (!configuration.TryGetAdditionalData<HttpsCertificateExecutionConfigurationData>(out var additionalData))
+        {
+            return null;
+        }
+
+        return new HttpsCertificateExecutionConfigurationExportData
+        {
+            Subject = additionalData.Certificate.Subject,
+            Thumbprint = additionalData.Certificate.Thumbprint,
+            KeyPathExpression = additionalData.KeyPathReference.ValueExpression,
+            PfxPathExpression = additionalData.PfxPathReference.ValueExpression,
+            IsKeyPathReferenced = additionalData.IsKeyPathReferenced,
+            IsPfxPathReferenced = additionalData.IsPfxPathReferenced,
+            Password = additionalData.Password
+        };
+    }
+
+}
+
+/// <summary>
+/// ATS-friendly certificate metadata supplied to HTTPS certificate configuration callbacks.
+/// </summary>
+[AspireDto]
+internal sealed class HttpsCertificateInfo
+{
+    /// <summary>
+    /// The certificate subject.
+    /// </summary>
+    public required string Subject { get; init; }
+
+    /// <summary>
+    /// The certificate issuer.
+    /// </summary>
+    public required string Issuer { get; init; }
+
+    /// <summary>
+    /// The certificate thumbprint.
+    /// </summary>
+    public string? Thumbprint { get; init; }
+
+    internal static HttpsCertificateInfo FromCertificate(X509Certificate2 certificate)
+    {
+        return new HttpsCertificateInfo
+        {
+            Subject = certificate.Subject,
+            Issuer = certificate.Issuer,
+            Thumbprint = certificate.Thumbprint
+        };
+    }
+}
+
+/// <summary>
+/// ATS-friendly certificate trust data returned from an execution-configuration result.
+/// </summary>
+[AspireDto]
+internal sealed class CertificateTrustExecutionConfigurationExportData
+{
+    /// <summary>
+    /// The certificate trust scope.
+    /// </summary>
+    public required CertificateTrustScope Scope { get; init; }
+
+    /// <summary>
+    /// The certificate subjects included in the trust configuration.
+    /// </summary>
+    public required string[] CertificateSubjects { get; init; }
+
+    /// <summary>
+    /// The relative custom bundle paths.
+    /// </summary>
+    public required string[] CustomBundlePaths { get; init; }
+}
+
+/// <summary>
+/// ATS-friendly HTTPS certificate data returned from an execution-configuration result.
+/// </summary>
+[AspireDto]
+internal sealed class HttpsCertificateExecutionConfigurationExportData
+{
+    /// <summary>
+    /// The certificate subject.
+    /// </summary>
+    public required string Subject { get; init; }
+
+    /// <summary>
+    /// The certificate thumbprint.
+    /// </summary>
+    public string? Thumbprint { get; init; }
+
+    /// <summary>
+    /// The expression for the key path reference.
+    /// </summary>
+    public required string KeyPathExpression { get; init; }
+
+    /// <summary>
+    /// The expression for the PFX path reference.
+    /// </summary>
+    public required string PfxPathExpression { get; init; }
+
+    /// <summary>
+    /// Indicates whether the key path was referenced.
+    /// </summary>
+    public required bool IsKeyPathReferenced { get; init; }
+
+    /// <summary>
+    /// Indicates whether the PFX path was referenced.
+    /// </summary>
+    public required bool IsPfxPathReferenced { get; init; }
+
+    /// <summary>
+    /// The certificate password, if any.
+    /// </summary>
+    public string? Password { get; init; }
+}

--- a/src/Aspire.Hosting/Ats/ExecutionConfigurationExports.cs
+++ b/src/Aspire.Hosting/Ats/ExecutionConfigurationExports.cs
@@ -73,15 +73,20 @@ internal static class ExecutionConfigurationExports
     /// Gets certificate trust execution-configuration data when present.
     /// </summary>
     /// <param name="configuration">The execution configuration result.</param>
-    /// <returns>The certificate trust data, or <see langword="null"/> when not present.</returns>
+    /// <returns>The certificate trust data. When no additional data is present, an empty DTO is returned.</returns>
     [AspireExport(Description = "Gets certificate trust execution-configuration data")]
-    public static CertificateTrustExecutionConfigurationExportData? GetCertificateTrustData(this IExecutionConfigurationResult configuration)
+    public static CertificateTrustExecutionConfigurationExportData GetCertificateTrustData(this IExecutionConfigurationResult configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
         if (!configuration.TryGetAdditionalData<CertificateTrustExecutionConfigurationData>(out var additionalData))
         {
-            return null;
+            return new CertificateTrustExecutionConfigurationExportData
+            {
+                Scope = CertificateTrustScope.None,
+                CertificateSubjects = [],
+                CustomBundlePaths = []
+            };
         }
 
         return new CertificateTrustExecutionConfigurationExportData
@@ -96,15 +101,22 @@ internal static class ExecutionConfigurationExports
     /// Gets HTTPS certificate execution-configuration data when present.
     /// </summary>
     /// <param name="configuration">The execution configuration result.</param>
-    /// <returns>The HTTPS certificate data, or <see langword="null"/> when not present.</returns>
+    /// <returns>The HTTPS certificate data. When no additional data is present, an empty DTO is returned.</returns>
     [AspireExport(Description = "Gets HTTPS certificate execution-configuration data")]
-    public static HttpsCertificateExecutionConfigurationExportData? GetHttpsCertificateData(this IExecutionConfigurationResult configuration)
+    public static HttpsCertificateExecutionConfigurationExportData GetHttpsCertificateData(this IExecutionConfigurationResult configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
         if (!configuration.TryGetAdditionalData<HttpsCertificateExecutionConfigurationData>(out var additionalData))
         {
-            return null;
+            return new HttpsCertificateExecutionConfigurationExportData
+            {
+                Subject = string.Empty,
+                KeyPathExpression = string.Empty,
+                PfxPathExpression = string.Empty,
+                IsKeyPathReferenced = false,
+                IsPfxPathReferenced = false
+            };
         }
 
         return new HttpsCertificateExecutionConfigurationExportData

--- a/src/Aspire.Hosting/Ats/ExecutionConfigurationExports.cs
+++ b/src/Aspire.Hosting/Ats/ExecutionConfigurationExports.cs
@@ -1,4 +1,3 @@
-#pragma warning disable CS0618
 #pragma warning disable ASPIRECERTIFICATES001
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/src/Aspire.Hosting/Ats/ServiceCollectionExports.cs
+++ b/src/Aspire.Hosting/Ats/ServiceCollectionExports.cs
@@ -9,10 +9,45 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Aspire.Hosting.Ats;
 
 /// <summary>
-/// ATS exports for service collection and service-provider helpers.
+/// ATS exports for distributed-application builder and service-provider helpers.
 /// </summary>
 internal static class ServiceCollectionExports
 {
+    /// <summary>
+    /// Adds an ATS-friendly eventing subscriber callback to the distributed-application builder.
+    /// </summary>
+    /// <param name="builder">The distributed-application builder.</param>
+    /// <param name="subscribe">The callback that registers the event subscriptions.</param>
+    [AspireExport(Description = "Adds an eventing subscriber")]
+    public static void AddEventingSubscriber(this IDistributedApplicationBuilder builder, Func<EventingSubscriberRegistrationContext, Task> subscribe)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(subscribe);
+
+        builder.Services.AddSingleton<IDistributedApplicationEventingSubscriber>(new CallbackEventingSubscriber(subscribe));
+    }
+
+    /// <summary>
+    /// Attempts to add an ATS-friendly eventing subscriber callback to the distributed-application builder.
+    /// </summary>
+    /// <param name="builder">The distributed-application builder.</param>
+    /// <param name="subscribe">The callback that registers the event subscriptions.</param>
+    [AspireExport(Description = "Attempts to add an eventing subscriber")]
+    public static void TryAddEventingSubscriber(this IDistributedApplicationBuilder builder, Func<EventingSubscriberRegistrationContext, Task> subscribe)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(subscribe);
+
+        if (builder.Services.Any(descriptor => descriptor.ServiceType == typeof(IDistributedApplicationEventingSubscriber) &&
+                                               descriptor.ImplementationInstance is CallbackEventingSubscriber existing &&
+                                               existing.Matches(subscribe)))
+        {
+            return;
+        }
+
+        builder.Services.AddSingleton<IDistributedApplicationEventingSubscriber>(new CallbackEventingSubscriber(subscribe));
+    }
+
     /// <summary>
     /// Gets the Aspire store from the service provider.
     /// </summary>
@@ -24,41 +59,6 @@ internal static class ServiceCollectionExports
         ArgumentNullException.ThrowIfNull(serviceProvider);
 
         return serviceProvider.GetRequiredService<IAspireStore>();
-    }
-
-    /// <summary>
-    /// Adds an ATS-friendly eventing subscriber callback to the service collection.
-    /// </summary>
-    /// <param name="services">The service collection.</param>
-    /// <param name="subscribe">The callback that registers the event subscriptions.</param>
-    [AspireExport(Description = "Adds an eventing subscriber")]
-    public static void AddEventingSubscriber(this IServiceCollection services, Func<EventingSubscriberRegistrationContext, Task> subscribe)
-    {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(subscribe);
-
-        services.AddSingleton<IDistributedApplicationEventingSubscriber>(new CallbackEventingSubscriber(subscribe));
-    }
-
-    /// <summary>
-    /// Attempts to add an ATS-friendly eventing subscriber callback to the service collection.
-    /// </summary>
-    /// <param name="services">The service collection.</param>
-    /// <param name="subscribe">The callback that registers the event subscriptions.</param>
-    [AspireExport(Description = "Attempts to add an eventing subscriber")]
-    public static void TryAddEventingSubscriber(this IServiceCollection services, Func<EventingSubscriberRegistrationContext, Task> subscribe)
-    {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(subscribe);
-
-        if (services.Any(descriptor => descriptor.ServiceType == typeof(IDistributedApplicationEventingSubscriber) &&
-                                       descriptor.ImplementationInstance is CallbackEventingSubscriber existing &&
-                                       existing.Matches(subscribe)))
-        {
-            return;
-        }
-
-        services.AddSingleton<IDistributedApplicationEventingSubscriber>(new CallbackEventingSubscriber(subscribe));
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Ats/ServiceCollectionExports.cs
+++ b/src/Aspire.Hosting/Ats/ServiceCollectionExports.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Lifecycle;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Ats;
+
+/// <summary>
+/// ATS exports for service collection and service-provider helpers.
+/// </summary>
+internal static class ServiceCollectionExports
+{
+    /// <summary>
+    /// Gets the Aspire store from the service provider.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <returns>The Aspire store.</returns>
+    [AspireExport(Description = "Gets the Aspire store from the service provider")]
+    public static IAspireStore GetAspireStore(this IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        return serviceProvider.GetRequiredService<IAspireStore>();
+    }
+
+    /// <summary>
+    /// Adds an ATS-friendly eventing subscriber callback to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="subscribe">The callback that registers the event subscriptions.</param>
+    [AspireExport(Description = "Adds an eventing subscriber")]
+    public static void AddEventingSubscriber(this IServiceCollection services, Func<EventingSubscriberRegistrationContext, Task> subscribe)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(subscribe);
+
+        services.AddSingleton<IDistributedApplicationEventingSubscriber>(new CallbackEventingSubscriber(subscribe));
+    }
+
+    /// <summary>
+    /// Attempts to add an ATS-friendly eventing subscriber callback to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="subscribe">The callback that registers the event subscriptions.</param>
+    [AspireExport(Description = "Attempts to add an eventing subscriber")]
+    public static void TryAddEventingSubscriber(this IServiceCollection services, Func<EventingSubscriberRegistrationContext, Task> subscribe)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(subscribe);
+
+        if (services.Any(descriptor => descriptor.ServiceType == typeof(IDistributedApplicationEventingSubscriber) &&
+                                       descriptor.ImplementationInstance is CallbackEventingSubscriber existing &&
+                                       existing.Matches(subscribe)))
+        {
+            return;
+        }
+
+        services.AddSingleton<IDistributedApplicationEventingSubscriber>(new CallbackEventingSubscriber(subscribe));
+    }
+
+    /// <summary>
+    /// Subscribes to the BeforeStart event from an eventing subscriber registration context.
+    /// </summary>
+    /// <param name="context">The eventing subscriber registration context.</param>
+    /// <param name="callback">The callback to invoke when the event fires.</param>
+    /// <returns>The event subscription.</returns>
+    [AspireExport("eventingSubscriberOnBeforeStart", MethodName = "onBeforeStart", Description = "Subscribes an eventing subscriber to the BeforeStart event")]
+    public static DistributedApplicationEventSubscription OnBeforeStart(this EventingSubscriberRegistrationContext context, Func<BeforeStartEvent, Task> callback)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        return context.Eventing.Subscribe<BeforeStartEvent>((@event, _) => callback(@event));
+    }
+
+    /// <summary>
+    /// Subscribes to the AfterResourcesCreated event from an eventing subscriber registration context.
+    /// </summary>
+    /// <param name="context">The eventing subscriber registration context.</param>
+    /// <param name="callback">The callback to invoke when the event fires.</param>
+    /// <returns>The event subscription.</returns>
+    [AspireExport("eventingSubscriberOnAfterResourcesCreated", MethodName = "onAfterResourcesCreated", Description = "Subscribes an eventing subscriber to the AfterResourcesCreated event")]
+    public static DistributedApplicationEventSubscription OnAfterResourcesCreated(this EventingSubscriberRegistrationContext context, Func<AfterResourcesCreatedEvent, Task> callback)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        return context.Eventing.Subscribe<AfterResourcesCreatedEvent>((@event, _) => callback(@event));
+    }
+
+    private sealed class CallbackEventingSubscriber(Func<EventingSubscriberRegistrationContext, Task> subscribe) : IDistributedApplicationEventingSubscriber
+    {
+        public bool Matches(Func<EventingSubscriberRegistrationContext, Task> otherSubscribe)
+        {
+            return subscribe == otherSubscribe;
+        }
+
+        public Task SubscribeAsync(IDistributedApplicationEventing eventing, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
+        {
+            return subscribe(new EventingSubscriberRegistrationContext(eventing, executionContext, cancellationToken));
+        }
+    }
+}
+
+/// <summary>
+/// Context passed to ATS-friendly eventing subscriber registrations.
+/// </summary>
+[AspireExport(ExposeProperties = true)]
+internal sealed class EventingSubscriberRegistrationContext(
+    IDistributedApplicationEventing eventing,
+    DistributedApplicationExecutionContext executionContext,
+    CancellationToken cancellationToken)
+{
+    internal IDistributedApplicationEventing Eventing { get; } = eventing;
+
+    /// <summary>
+    /// The execution context for the AppHost invocation.
+    /// </summary>
+    public DistributedApplicationExecutionContext ExecutionContext { get; } = executionContext;
+
+    /// <summary>
+    /// The cancellation token associated with the subscriber registration.
+    /// </summary>
+    public CancellationToken CancellationToken { get; } = cancellationToken;
+}

--- a/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
@@ -76,6 +76,7 @@ public interface IDistributedApplicationBuilder
     public IHostEnvironment Environment { get; }
 
     /// <inheritdoc cref="HostApplicationBuilder.Services" />
+    [AspireExportIgnore(Reason = "IServiceCollection is not exported to ATS. Use IDistributedApplicationBuilder.addEventingSubscriber or tryAddEventingSubscriber for ATS event subscriber registration.")]
     public IServiceCollection Services { get; }
 
     /// <summary>

--- a/src/Aspire.Hosting/Lifecycle/EventingSubscriberServiceCollectionExtensions.cs
+++ b/src/Aspire.Hosting/Lifecycle/EventingSubscriberServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ public static class EventingSubscriberServiceCollectionExtensions
     /// </summary>
     /// <typeparam name="T">A service that implements <see cref="IDistributedApplicationEventingSubscriber"/></typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the event subscriber to.</param>
-    [AspireExportIgnore(Reason = "Generic service registration is not ATS-compatible. Use the ATS-specific addEventingSubscriber export instead.")]
+    [AspireExportIgnore(Reason = "IServiceCollection is not exported to ATS, and generic service registration is not ATS-compatible. Use IDistributedApplicationBuilder.addEventingSubscriber instead.")]
     public static void AddEventingSubscriber<T>(this IServiceCollection services) where T : class, IDistributedApplicationEventingSubscriber
     {
         services.AddSingleton<IDistributedApplicationEventingSubscriber, T>();
@@ -27,7 +27,7 @@ public static class EventingSubscriberServiceCollectionExtensions
     /// </summary>
     /// <typeparam name="T">A service that implements <see cref="IDistributedApplicationEventingSubscriber"/></typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the event subscriber to.</param>
-    [AspireExportIgnore(Reason = "Generic service registration is not ATS-compatible. Use the ATS-specific tryAddEventingSubscriber export instead.")]
+    [AspireExportIgnore(Reason = "IServiceCollection is not exported to ATS, and generic service registration is not ATS-compatible. Use IDistributedApplicationBuilder.tryAddEventingSubscriber instead.")]
     public static void TryAddEventingSubscriber<T>(this IServiceCollection services) where T : class, IDistributedApplicationEventingSubscriber
     {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationEventingSubscriber, T>());

--- a/src/Aspire.Hosting/Lifecycle/EventingSubscriberServiceCollectionExtensions.cs
+++ b/src/Aspire.Hosting/Lifecycle/EventingSubscriberServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class EventingSubscriberServiceCollectionExtensions
     /// </summary>
     /// <typeparam name="T">A service that implements <see cref="IDistributedApplicationEventingSubscriber"/></typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the event subscriber to.</param>
+    [AspireExportIgnore(Reason = "Generic service registration is not ATS-compatible. Use the ATS-specific addEventingSubscriber export instead.")]
     public static void AddEventingSubscriber<T>(this IServiceCollection services) where T : class, IDistributedApplicationEventingSubscriber
     {
         services.AddSingleton<IDistributedApplicationEventingSubscriber, T>();
@@ -26,6 +27,7 @@ public static class EventingSubscriberServiceCollectionExtensions
     /// </summary>
     /// <typeparam name="T">A service that implements <see cref="IDistributedApplicationEventingSubscriber"/></typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the event subscriber to.</param>
+    [AspireExportIgnore(Reason = "Generic service registration is not ATS-compatible. Use the ATS-specific tryAddEventingSubscriber export instead.")]
     public static void TryAddEventingSubscriber<T>(this IServiceCollection services) where T : class, IDistributedApplicationEventingSubscriber
     {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationEventingSubscriber, T>());

--- a/src/Aspire.Hosting/Lifecycle/LifecycleHookServiceCollectionExtensions.cs
+++ b/src/Aspire.Hosting/Lifecycle/LifecycleHookServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class LifecycleHookServiceCollectionExtensions
     /// <typeparam name="T">The type of the distributed application lifecycle hook to add.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the distributed application lifecycle hook to.</param>
     [Obsolete("Use EventingSubscriberServiceCollectionExtensions.AddEventingSubscriber instead.")]
+    [AspireExportIgnore(Reason = "IServiceCollection is not exported to ATS, and generic lifecycle hook registration is not ATS-compatible. Use IDistributedApplicationBuilder.addEventingSubscriber instead.")]
     public static void AddLifecycleHook<T>(this IServiceCollection services) where T : class, IDistributedApplicationLifecycleHook
     {
         services.AddSingleton<IDistributedApplicationLifecycleHook, T>();
@@ -28,6 +29,7 @@ public static class LifecycleHookServiceCollectionExtensions
     /// <typeparam name="T">The type of the distributed application lifecycle hook to add.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the distributed application lifecycle hook to.</param>
     [Obsolete("Use EventingSubscriberServiceCollectionExtensions.TryAddEventingSubscriber instead.")]
+    [AspireExportIgnore(Reason = "IServiceCollection is not exported to ATS, and generic lifecycle hook registration is not ATS-compatible. Use IDistributedApplicationBuilder.tryAddEventingSubscriber instead.")]
     public static void TryAddLifecycleHook<T>(this IServiceCollection services) where T : class, IDistributedApplicationLifecycleHook
     {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationLifecycleHook, T>());
@@ -40,6 +42,7 @@ public static class LifecycleHookServiceCollectionExtensions
     /// <param name="services">The service collection to add the hook to.</param>
     /// <param name="implementationFactory">A factory function that creates the hook implementation.</param>
     [Obsolete("Use EventingSubscriberServiceCollectionExtensions.AddEventingSubscriber instead.")]
+    [AspireExportIgnore(Reason = "IServiceCollection is not exported to ATS, and IServiceProvider factory registration is not ATS-compatible. Use IDistributedApplicationBuilder.addEventingSubscriber instead.")]
     public static void AddLifecycleHook<T>(this IServiceCollection services, Func<IServiceProvider, T> implementationFactory) where T : class, IDistributedApplicationLifecycleHook
     {
         services.AddSingleton<IDistributedApplicationLifecycleHook, T>(implementationFactory);
@@ -52,6 +55,7 @@ public static class LifecycleHookServiceCollectionExtensions
     /// <param name="services">The service collection to add the hook to.</param>
     /// <param name="implementationFactory">A factory function that creates the hook implementation.</param>
     [Obsolete("Use EventingSubscriberServiceCollectionExtensions.TryAddEventingSubscriber instead.")]
+    [AspireExportIgnore(Reason = "IServiceCollection is not exported to ATS, and IServiceProvider factory registration is not ATS-compatible. Use IDistributedApplicationBuilder.tryAddEventingSubscriber instead.")]
     public static void TryAddLifecycleHook<T>(this IServiceCollection services, Func<IServiceProvider, T> implementationFactory) where T : class, IDistributedApplicationLifecycleHook
     {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationLifecycleHook, T>(implementationFactory));

--- a/src/Aspire.Hosting/Pipelines/PipelineStepExtensions.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineStepExtensions.cs
@@ -17,6 +17,7 @@ public static class PipelineStepExtensions
     /// <param name="steps">The collection of steps.</param>
     /// <param name="step">The step to depend on.</param>
     /// <returns>The original collection of steps.</returns>
+    [AspireExportIgnore(Reason = "Use PipelineStep.dependsOn on each step in the collection, or mutate PipelineStep.dependsOnSteps directly.")]
     public static IEnumerable<PipelineStep> DependsOn(this IEnumerable<PipelineStep> steps, PipelineStep? step)
     {
         if (step is null)
@@ -38,6 +39,7 @@ public static class PipelineStepExtensions
     /// <param name="steps">The collection of steps.</param>
     /// <param name="stepName">The name of the step to depend on.</param>
     /// <returns>The original collection of steps.</returns>
+    [AspireExportIgnore(Reason = "Use PipelineStep.dependsOn on each step in the collection, or mutate PipelineStep.dependsOnSteps directly.")]
     public static IEnumerable<PipelineStep> DependsOn(this IEnumerable<PipelineStep> steps, string stepName)
     {
         if (string.IsNullOrEmpty(stepName))
@@ -59,6 +61,7 @@ public static class PipelineStepExtensions
     /// <param name="steps">The collection of steps.</param>
     /// <param name="targetSteps">The target steps to depend on.</param>
     /// <returns>The original collection of steps.</returns>
+    [AspireExportIgnore(Reason = "Use PipelineStep.dependsOn on each step in the collection, or mutate PipelineStep.dependsOnSteps directly.")]
     public static IEnumerable<PipelineStep> DependsOn(this IEnumerable<PipelineStep> steps, IEnumerable<PipelineStep> targetSteps)
     {
         foreach (var step in targetSteps)
@@ -78,6 +81,7 @@ public static class PipelineStepExtensions
     /// <param name="steps">The collection of steps.</param>
     /// <param name="step">The step that requires these steps.</param>
     /// <returns>The original collection of steps.</returns>
+    [AspireExportIgnore(Reason = "Use PipelineStep.requiredBy on each step in the collection, or mutate PipelineStep.requiredBySteps directly.")]
     public static IEnumerable<PipelineStep> RequiredBy(this IEnumerable<PipelineStep> steps, PipelineStep? step)
     {
         if (step is null)
@@ -99,6 +103,7 @@ public static class PipelineStepExtensions
     /// <param name="steps">The collection of steps.</param>
     /// <param name="stepName">The name of the step that requires these steps.</param>
     /// <returns>The original collection of steps.</returns>
+    [AspireExportIgnore(Reason = "Use PipelineStep.requiredBy on each step in the collection, or mutate PipelineStep.requiredBySteps directly.")]
     public static IEnumerable<PipelineStep> RequiredBy(this IEnumerable<PipelineStep> steps, string stepName)
     {
         if (string.IsNullOrEmpty(stepName))
@@ -120,6 +125,7 @@ public static class PipelineStepExtensions
     /// <param name="steps">The collection of steps.</param>
     /// <param name="targetSteps">The target steps that require these steps.</param>
     /// <returns>The original collection of steps.</returns>
+    [AspireExportIgnore(Reason = "Use PipelineStep.requiredBy on each step in the collection, or mutate PipelineStep.requiredBySteps directly.")]
     public static IEnumerable<PipelineStep> RequiredBy(this IEnumerable<PipelineStep> steps, IEnumerable<PipelineStep> targetSteps)
     {
         foreach (var step in targetSteps)

--- a/src/Aspire.Hosting/Utils/LoggingUtils.cs
+++ b/src/Aspire.Hosting/Utils/LoggingUtils.cs
@@ -8,6 +8,7 @@ namespace Aspire.Hosting.Utils;
 
 internal static class LoggingUtils
 {
+    [AspireExportIgnore(Reason = "Health check logging suppression is an internal helper and is not part of the ATS surface.")]
     public static void SuppressHealthCheckHttpClientLogging(this IServiceCollection services, string healthCheckName)
     {
         services.AddLogging(configure =>

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -1,4 +1,4 @@
-﻿// aspire.go - Capability-based Aspire SDK
+// aspire.go - Capability-based Aspire SDK
 // GENERATED CODE - DO NOT EDIT
 
 package aspire

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -1,4 +1,4 @@
-// aspire.go - Capability-based Aspire SDK
+﻿// aspire.go - Capability-based Aspire SDK
 // GENERATED CODE - DO NOT EDIT
 
 package aspire
@@ -217,6 +217,62 @@ func (d *CreateBuilderOptions) ToMap() map[string]any {
 	}
 }
 
+// HttpsCertificateInfo represents HttpsCertificateInfo.
+type HttpsCertificateInfo struct {
+	Subject string `json:"Subject,omitempty"`
+	Issuer string `json:"Issuer,omitempty"`
+	Thumbprint string `json:"Thumbprint,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *HttpsCertificateInfo) ToMap() map[string]any {
+	return map[string]any{
+		"Subject": SerializeValue(d.Subject),
+		"Issuer": SerializeValue(d.Issuer),
+		"Thumbprint": SerializeValue(d.Thumbprint),
+	}
+}
+
+// CertificateTrustExecutionConfigurationExportData represents CertificateTrustExecutionConfigurationExportData.
+type CertificateTrustExecutionConfigurationExportData struct {
+	Scope CertificateTrustScope `json:"Scope,omitempty"`
+	CertificateSubjects []string `json:"CertificateSubjects,omitempty"`
+	CustomBundlePaths []string `json:"CustomBundlePaths,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *CertificateTrustExecutionConfigurationExportData) ToMap() map[string]any {
+	return map[string]any{
+		"Scope": SerializeValue(d.Scope),
+		"CertificateSubjects": SerializeValue(d.CertificateSubjects),
+		"CustomBundlePaths": SerializeValue(d.CustomBundlePaths),
+	}
+}
+
+// HttpsCertificateExecutionConfigurationExportData represents HttpsCertificateExecutionConfigurationExportData.
+type HttpsCertificateExecutionConfigurationExportData struct {
+	Subject string `json:"Subject,omitempty"`
+	Thumbprint string `json:"Thumbprint,omitempty"`
+	KeyPathExpression string `json:"KeyPathExpression,omitempty"`
+	PfxPathExpression string `json:"PfxPathExpression,omitempty"`
+	IsKeyPathReferenced bool `json:"IsKeyPathReferenced,omitempty"`
+	IsPfxPathReferenced bool `json:"IsPfxPathReferenced,omitempty"`
+	Password string `json:"Password,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *HttpsCertificateExecutionConfigurationExportData) ToMap() map[string]any {
+	return map[string]any{
+		"Subject": SerializeValue(d.Subject),
+		"Thumbprint": SerializeValue(d.Thumbprint),
+		"KeyPathExpression": SerializeValue(d.KeyPathExpression),
+		"PfxPathExpression": SerializeValue(d.PfxPathExpression),
+		"IsKeyPathReferenced": SerializeValue(d.IsKeyPathReferenced),
+		"IsPfxPathReferenced": SerializeValue(d.IsPfxPathReferenced),
+		"Password": SerializeValue(d.Password),
+	}
+}
+
 // ResourceEventDto represents ResourceEventDto.
 type ResourceEventDto struct {
 	ResourceName string `json:"ResourceName,omitempty"`
@@ -254,6 +310,24 @@ func (d *ReferenceEnvironmentInjectionOptions) ToMap() map[string]any {
 		"ConnectionProperties": SerializeValue(d.ConnectionProperties),
 		"ServiceDiscovery": SerializeValue(d.ServiceDiscovery),
 		"Endpoints": SerializeValue(d.Endpoints),
+	}
+}
+
+// CertificateTrustExecutionConfigurationContext represents CertificateTrustExecutionConfigurationContext.
+type CertificateTrustExecutionConfigurationContext struct {
+	CertificateBundlePath *ReferenceExpression `json:"CertificateBundlePath,omitempty"`
+	CertificateDirectoriesPath *ReferenceExpression `json:"CertificateDirectoriesPath,omitempty"`
+	RootCertificatesPath string `json:"RootCertificatesPath,omitempty"`
+	IsContainer bool `json:"IsContainer,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *CertificateTrustExecutionConfigurationContext) ToMap() map[string]any {
+	return map[string]any{
+		"CertificateBundlePath": SerializeValue(d.CertificateBundlePath),
+		"CertificateDirectoriesPath": SerializeValue(d.CertificateDirectoriesPath),
+		"RootCertificatesPath": SerializeValue(d.RootCertificatesPath),
+		"IsContainer": SerializeValue(d.IsContainer),
 	}
 }
 
@@ -306,6 +380,22 @@ func (d *HttpCommandExportOptions) ToMap() map[string]any {
 		"EndpointName": SerializeValue(d.EndpointName),
 		"MethodName": SerializeValue(d.MethodName),
 		"ResultMode": SerializeValue(d.ResultMode),
+	}
+}
+
+// HttpsCertificateExecutionConfigurationContext represents HttpsCertificateExecutionConfigurationContext.
+type HttpsCertificateExecutionConfigurationContext struct {
+	CertificatePath *ReferenceExpression `json:"CertificatePath,omitempty"`
+	KeyPath *ReferenceExpression `json:"KeyPath,omitempty"`
+	PfxPath *ReferenceExpression `json:"PfxPath,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *HttpsCertificateExecutionConfigurationContext) ToMap() map[string]any {
+	return map[string]any{
+		"CertificatePath": SerializeValue(d.CertificatePath),
+		"KeyPath": SerializeValue(d.KeyPath),
+		"PfxPath": SerializeValue(d.PfxPath),
 	}
 }
 
@@ -1655,6 +1745,18 @@ func (s *CSharpAppResource) OnResourceReady(callback func(...any) any) (*IResour
 	return result.(*IResource), nil
 }
 
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *CSharpAppResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
 // WithOptionalString adds an optional string parameter
 func (s *CSharpAppResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -2623,6 +2725,18 @@ func (s *ConnectionStringResource) OnResourceReady(callback func(...any) any) (*
 	return result.(*IResource), nil
 }
 
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *ConnectionStringResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
 // WithOptionalString adds an optional string parameter
 func (s *ConnectionStringResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -3517,6 +3631,18 @@ func (s *ContainerRegistryResource) OnResourceReady(callback func(...any) any) (
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *ContainerRegistryResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
 }
 
 // WithOptionalString adds an optional string parameter
@@ -5179,6 +5305,18 @@ func (s *ContainerResource) OnResourceReady(callback func(...any) any) (*IResour
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *ContainerResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
 }
 
 // WithOptionalString adds an optional string parameter
@@ -7219,6 +7357,18 @@ func (s *DotnetToolResource) OnResourceReady(callback func(...any) any) (*IResou
 	return result.(*IResource), nil
 }
 
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *DotnetToolResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
 // WithOptionalString adds an optional string parameter
 func (s *DotnetToolResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -8192,6 +8342,72 @@ func (s *EnvironmentCallbackContext) ExecutionContext() (*DistributedApplication
 		return nil, err
 	}
 	return result.(*DistributedApplicationExecutionContext), nil
+}
+
+// EventingSubscriberRegistrationContext wraps a handle for Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext.
+type EventingSubscriberRegistrationContext struct {
+	HandleWrapperBase
+}
+
+// NewEventingSubscriberRegistrationContext creates a new EventingSubscriberRegistrationContext.
+func NewEventingSubscriberRegistrationContext(handle *Handle, client *AspireClient) *EventingSubscriberRegistrationContext {
+	return &EventingSubscriberRegistrationContext{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// OnBeforeStart subscribes an eventing subscriber to the BeforeStart event
+func (s *EventingSubscriberRegistrationContext) OnBeforeStart(callback func(...any) any) (*DistributedApplicationEventSubscription, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/eventingSubscriberOnBeforeStart", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*DistributedApplicationEventSubscription), nil
+}
+
+// OnAfterResourcesCreated subscribes an eventing subscriber to the AfterResourcesCreated event
+func (s *EventingSubscriberRegistrationContext) OnAfterResourcesCreated(callback func(...any) any) (*DistributedApplicationEventSubscription, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	if callback != nil {
+		reqArgs["callback"] = RegisterCallback(callback)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/eventingSubscriberOnAfterResourcesCreated", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*DistributedApplicationEventSubscription), nil
+}
+
+// ExecutionContext gets the ExecutionContext property
+func (s *EventingSubscriberRegistrationContext) ExecutionContext() (*DistributedApplicationExecutionContext, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.executionContext", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*DistributedApplicationExecutionContext), nil
+}
+
+// CancellationToken gets the CancellationToken property
+func (s *EventingSubscriberRegistrationContext) CancellationToken() (*CancellationToken, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.cancellationToken", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*CancellationToken), nil
 }
 
 // ExecutableResource wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource.
@@ -9295,6 +9511,18 @@ func (s *ExecutableResource) OnResourceReady(callback func(...any) any) (*IResou
 	return result.(*IResource), nil
 }
 
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *ExecutableResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
 // WithOptionalString adds an optional string parameter
 func (s *ExecutableResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -10138,6 +10366,18 @@ func (s *ExternalServiceResource) OnResourceReady(callback func(...any) any) (*I
 	return result.(*IResource), nil
 }
 
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *ExternalServiceResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
 // WithOptionalString adds an optional string parameter
 func (s *ExternalServiceResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -10457,6 +10697,32 @@ func (s *ExternalServiceResource) WithMergeRouteMiddleware(path string, method s
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// IAspireStore wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore.
+type IAspireStore struct {
+	HandleWrapperBase
+}
+
+// NewIAspireStore creates a new IAspireStore.
+func NewIAspireStore(handle *Handle, client *AspireClient) *IAspireStore {
+	return &IAspireStore{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// GetFileNameWithContent gets a deterministic file path for the specified file contents
+func (s *IAspireStore) GetFileNameWithContent(filenameTemplate string, sourceFilename string) (*string, error) {
+	reqArgs := map[string]any{
+		"aspireStore": SerializeValue(s.Handle()),
+	}
+	reqArgs["filenameTemplate"] = SerializeValue(filenameTemplate)
+	reqArgs["sourceFilename"] = SerializeValue(sourceFilename)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/getFileNameWithContent", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*string), nil
 }
 
 // IComputeResource wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IComputeResource.
@@ -10795,6 +11061,18 @@ func (s *IDistributedApplicationBuilder) Environment() (*IHostEnvironment, error
 		return nil, err
 	}
 	return result.(*IHostEnvironment), nil
+}
+
+// Services gets the Services property
+func (s *IDistributedApplicationBuilder) Services() (*IServiceCollection, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/IDistributedApplicationBuilder.services", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IServiceCollection), nil
 }
 
 // Eventing gets the Eventing property
@@ -11181,6 +11459,127 @@ func NewIDistributedApplicationResourceEvent(handle *Handle, client *AspireClien
 	return &IDistributedApplicationResourceEvent{
 		HandleWrapperBase: NewHandleWrapperBase(handle, client),
 	}
+}
+
+// IExecutionConfigurationBuilder wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder.
+type IExecutionConfigurationBuilder struct {
+	HandleWrapperBase
+}
+
+// NewIExecutionConfigurationBuilder creates a new IExecutionConfigurationBuilder.
+func NewIExecutionConfigurationBuilder(handle *Handle, client *AspireClient) *IExecutionConfigurationBuilder {
+	return &IExecutionConfigurationBuilder{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// Build builds the execution configuration
+func (s *IExecutionConfigurationBuilder) Build(executionContext *DistributedApplicationExecutionContext, resourceLogger *ILogger, cancellationToken *CancellationToken) (*IExecutionConfigurationResult, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["executionContext"] = SerializeValue(executionContext)
+	if resourceLogger != nil {
+		reqArgs["resourceLogger"] = SerializeValue(resourceLogger)
+	}
+	if cancellationToken != nil {
+		reqArgs["cancellationToken"] = RegisterCancellation(cancellationToken, s.Client())
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/buildExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationResult), nil
+}
+
+// WithHttpsCertificateConfig adds an HTTPS certificate configuration gatherer
+func (s *IExecutionConfigurationBuilder) WithHttpsCertificateConfig(configContextFactory func(...any) any) (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if configContextFactory != nil {
+		reqArgs["configContextFactory"] = RegisterCallback(configContextFactory)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsCertificateConfigExport", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
+// WithArgumentsConfig adds an arguments configuration gatherer
+func (s *IExecutionConfigurationBuilder) WithArgumentsConfig() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withArgumentsConfig", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
+// WithEnvironmentVariablesConfig adds an environment variables configuration gatherer
+func (s *IExecutionConfigurationBuilder) WithEnvironmentVariablesConfig() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentVariablesConfig", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
+// WithCertificateTrustConfig adds a certificate trust configuration gatherer
+func (s *IExecutionConfigurationBuilder) WithCertificateTrustConfig(configContextFactory func(...any) any) (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if configContextFactory != nil {
+		reqArgs["configContextFactory"] = RegisterCallback(configContextFactory)
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withCertificateTrustConfig", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
+// IExecutionConfigurationResult wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult.
+type IExecutionConfigurationResult struct {
+	HandleWrapperBase
+}
+
+// NewIExecutionConfigurationResult creates a new IExecutionConfigurationResult.
+func NewIExecutionConfigurationResult(handle *Handle, client *AspireClient) *IExecutionConfigurationResult {
+	return &IExecutionConfigurationResult{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// GetCertificateTrustData gets certificate trust execution-configuration data
+func (s *IExecutionConfigurationResult) GetCertificateTrustData() (*CertificateTrustExecutionConfigurationExportData, error) {
+	reqArgs := map[string]any{
+		"configuration": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/getCertificateTrustData", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*CertificateTrustExecutionConfigurationExportData), nil
+}
+
+// GetHttpsCertificateData gets HTTPS certificate execution-configuration data
+func (s *IExecutionConfigurationResult) GetHttpsCertificateData() (*HttpsCertificateExecutionConfigurationExportData, error) {
+	reqArgs := map[string]any{
+		"configuration": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/getHttpsCertificateData", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*HttpsCertificateExecutionConfigurationExportData), nil
 }
 
 // IExpressionValue wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExpressionValue.
@@ -11635,6 +12034,42 @@ func NewIResourceWithWaitSupport(handle *Handle, client *AspireClient) *IResourc
 	}
 }
 
+// IServiceCollection wraps a handle for Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection.
+type IServiceCollection struct {
+	HandleWrapperBase
+}
+
+// NewIServiceCollection creates a new IServiceCollection.
+func NewIServiceCollection(handle *Handle, client *AspireClient) *IServiceCollection {
+	return &IServiceCollection{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
+// AddEventingSubscriber adds an eventing subscriber
+func (s *IServiceCollection) AddEventingSubscriber(subscribe func(...any) any) error {
+	reqArgs := map[string]any{
+		"services": SerializeValue(s.Handle()),
+	}
+	if subscribe != nil {
+		reqArgs["subscribe"] = RegisterCallback(subscribe)
+	}
+	_, err := s.Client().InvokeCapability("Aspire.Hosting/addEventingSubscriber", reqArgs)
+	return err
+}
+
+// TryAddEventingSubscriber attempts to add an eventing subscriber
+func (s *IServiceCollection) TryAddEventingSubscriber(subscribe func(...any) any) error {
+	reqArgs := map[string]any{
+		"services": SerializeValue(s.Handle()),
+	}
+	if subscribe != nil {
+		reqArgs["subscribe"] = RegisterCallback(subscribe)
+	}
+	_, err := s.Client().InvokeCapability("Aspire.Hosting/tryAddEventingSubscriber", reqArgs)
+	return err
+}
+
 // IServiceProvider wraps a handle for System.ComponentModel/System.IServiceProvider.
 type IServiceProvider struct {
 	HandleWrapperBase
@@ -11705,6 +12140,18 @@ func (s *IServiceProvider) GetResourceNotificationService() (*ResourceNotificati
 		return nil, err
 	}
 	return result.(*ResourceNotificationService), nil
+}
+
+// GetAspireStore gets the Aspire store from the service provider
+func (s *IServiceProvider) GetAspireStore() (*IAspireStore, error) {
+	reqArgs := map[string]any{
+		"serviceProvider": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/getAspireStore", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IAspireStore), nil
 }
 
 // GetUserSecretsManager gets the user secrets manager from the service provider
@@ -12254,6 +12701,18 @@ func (s *ParameterResource) OnResourceReady(callback func(...any) any) (*IResour
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *ParameterResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
 }
 
 // WithOptionalString adds an optional string parameter
@@ -14279,6 +14738,18 @@ func (s *ProjectResource) OnResourceReady(callback func(...any) any) (*IResource
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *ProjectResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
 }
 
 // WithOptionalString adds an optional string parameter
@@ -16562,6 +17033,18 @@ func (s *TestDatabaseResource) OnResourceReady(callback func(...any) any) (*IRes
 	return result.(*IResource), nil
 }
 
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *TestDatabaseResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
 // WithOptionalString adds an optional string parameter
 func (s *TestDatabaseResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -18395,6 +18878,18 @@ func (s *TestRedisResource) OnResourceReady(callback func(...any) any) (*IResour
 		return nil, err
 	}
 	return result.(*IResource), nil
+}
+
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *TestRedisResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
 }
 
 // AddTestChildDatabase adds a child database to a test Redis resource
@@ -20345,6 +20840,18 @@ func (s *TestVaultResource) OnResourceReady(callback func(...any) any) (*IResour
 	return result.(*IResource), nil
 }
 
+// CreateExecutionConfiguration creates an execution configuration builder
+func (s *TestVaultResource) CreateExecutionConfiguration() (*IExecutionConfigurationBuilder, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IExecutionConfigurationBuilder), nil
+}
+
 // WithOptionalString adds an optional string parameter
 func (s *TestVaultResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -20761,6 +21268,15 @@ func init() {
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReference", func(h *Handle, c *AspireClient) any {
 		return NewEndpointReference(h, c)
 	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore", func(h *Handle, c *AspireClient) any {
+		return NewIAspireStore(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder", func(h *Handle, c *AspireClient) any {
+		return NewIExecutionConfigurationBuilder(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult", func(h *Handle, c *AspireClient) any {
+		return NewIExecutionConfigurationResult(h, c)
+	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource", func(h *Handle, c *AspireClient) any {
 		return NewIResource(h, c)
 	})
@@ -20805,6 +21321,9 @@ func init() {
 	})
 	RegisterHandleWrapper("System.ComponentModel/System.IServiceProvider", func(h *Handle, c *AspireClient) any {
 		return NewIServiceProvider(h, c)
+	})
+	RegisterHandleWrapper("Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection", func(h *Handle, c *AspireClient) any {
+		return NewIServiceCollection(h, c)
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceNotificationService", func(h *Handle, c *AspireClient) any {
 		return NewResourceNotificationService(h, c)
@@ -20877,6 +21396,9 @@ func init() {
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationEventing", func(h *Handle, c *AspireClient) any {
 		return NewIDistributedApplicationEventing(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext", func(h *Handle, c *AspireClient) any {
+		return NewEventingSubscriberRegistrationContext(h, c)
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.AfterResourcesCreatedEvent", func(h *Handle, c *AspireClient) any {
 		return NewAfterResourcesCreatedEvent(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -11063,18 +11063,6 @@ func (s *IDistributedApplicationBuilder) Environment() (*IHostEnvironment, error
 	return result.(*IHostEnvironment), nil
 }
 
-// Services gets the Services property
-func (s *IDistributedApplicationBuilder) Services() (*IServiceCollection, error) {
-	reqArgs := map[string]any{
-		"context": SerializeValue(s.Handle()),
-	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/IDistributedApplicationBuilder.services", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IServiceCollection), nil
-}
-
 // Eventing gets the Eventing property
 func (s *IDistributedApplicationBuilder) Eventing() (*IDistributedApplicationEventing, error) {
 	reqArgs := map[string]any{
@@ -11341,6 +11329,30 @@ func (s *IDistributedApplicationBuilder) SubscribeAfterResourcesCreated(callback
 		return nil, err
 	}
 	return result.(*DistributedApplicationEventSubscription), nil
+}
+
+// AddEventingSubscriber adds an eventing subscriber
+func (s *IDistributedApplicationBuilder) AddEventingSubscriber(subscribe func(...any) any) error {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if subscribe != nil {
+		reqArgs["subscribe"] = RegisterCallback(subscribe)
+	}
+	_, err := s.Client().InvokeCapability("Aspire.Hosting/addEventingSubscriber", reqArgs)
+	return err
+}
+
+// TryAddEventingSubscriber attempts to add an eventing subscriber
+func (s *IDistributedApplicationBuilder) TryAddEventingSubscriber(subscribe func(...any) any) error {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	if subscribe != nil {
+		reqArgs["subscribe"] = RegisterCallback(subscribe)
+	}
+	_, err := s.Client().InvokeCapability("Aspire.Hosting/tryAddEventingSubscriber", reqArgs)
+	return err
 }
 
 // AddTestRedis adds a test Redis resource
@@ -12032,42 +12044,6 @@ func NewIResourceWithWaitSupport(handle *Handle, client *AspireClient) *IResourc
 	return &IResourceWithWaitSupport{
 		ResourceBuilderBase: NewResourceBuilderBase(handle, client),
 	}
-}
-
-// IServiceCollection wraps a handle for Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection.
-type IServiceCollection struct {
-	HandleWrapperBase
-}
-
-// NewIServiceCollection creates a new IServiceCollection.
-func NewIServiceCollection(handle *Handle, client *AspireClient) *IServiceCollection {
-	return &IServiceCollection{
-		HandleWrapperBase: NewHandleWrapperBase(handle, client),
-	}
-}
-
-// AddEventingSubscriber adds an eventing subscriber
-func (s *IServiceCollection) AddEventingSubscriber(subscribe func(...any) any) error {
-	reqArgs := map[string]any{
-		"services": SerializeValue(s.Handle()),
-	}
-	if subscribe != nil {
-		reqArgs["subscribe"] = RegisterCallback(subscribe)
-	}
-	_, err := s.Client().InvokeCapability("Aspire.Hosting/addEventingSubscriber", reqArgs)
-	return err
-}
-
-// TryAddEventingSubscriber attempts to add an eventing subscriber
-func (s *IServiceCollection) TryAddEventingSubscriber(subscribe func(...any) any) error {
-	reqArgs := map[string]any{
-		"services": SerializeValue(s.Handle()),
-	}
-	if subscribe != nil {
-		reqArgs["subscribe"] = RegisterCallback(subscribe)
-	}
-	_, err := s.Client().InvokeCapability("Aspire.Hosting/tryAddEventingSubscriber", reqArgs)
-	return err
 }
 
 // IServiceProvider wraps a handle for System.ComponentModel/System.IServiceProvider.
@@ -21321,9 +21297,6 @@ func init() {
 	})
 	RegisterHandleWrapper("System.ComponentModel/System.IServiceProvider", func(h *Handle, c *AspireClient) any {
 		return NewIServiceProvider(h, c)
-	})
-	RegisterHandleWrapper("Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection", func(h *Handle, c *AspireClient) any {
-		return NewIServiceCollection(h, c)
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceNotificationService", func(h *Handle, c *AspireClient) any {
 		return NewResourceNotificationService(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1177,7 +1177,6 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference", (h, c) -> new ContainerImageReference(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference", (h, c) -> new ContainerPortReference(h, c));
         AspireClient.registerHandleWrapper("System.ComponentModel/System.IServiceProvider", (h, c) -> new IServiceProvider(h, c));
-        AspireClient.registerHandleWrapper("Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection", (h, c) -> new IServiceCollection(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceNotificationService", (h, c) -> new ResourceNotificationService(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceLoggerService", (h, c) -> new ResourceLoggerService(h, c));
         AspireClient.registerHandleWrapper("Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfiguration", (h, c) -> new IConfiguration(h, c));
@@ -12512,13 +12511,6 @@ public class IDistributedApplicationBuilder extends HandleWrapperBase {
         return (IHostEnvironment) getClient().invokeCapability("Aspire.Hosting/IDistributedApplicationBuilder.environment", reqArgs);
     }
 
-    /** Gets the Services property */
-    public IServiceCollection services() {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
-        return (IServiceCollection) getClient().invokeCapability("Aspire.Hosting/IDistributedApplicationBuilder.services", reqArgs);
-    }
-
     /** Gets the Eventing property */
     public IDistributedApplicationEventing eventing() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -12749,6 +12741,36 @@ public class IDistributedApplicationBuilder extends HandleWrapperBase {
             reqArgs.put("callback", callbackId);
         }
         return (DistributedApplicationEventSubscription) getClient().invokeCapability("Aspire.Hosting/subscribeAfterResourcesCreated", reqArgs);
+    }
+
+    /** Adds an eventing subscriber */
+    public void addEventingSubscriber(AspireAction1<EventingSubscriberRegistrationContext> subscribe) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var subscribeId = getClient().registerCallback(args -> {
+            var arg = (EventingSubscriberRegistrationContext) args[0];
+            subscribe.invoke(arg);
+            return null;
+        });
+        if (subscribeId != null) {
+            reqArgs.put("subscribe", subscribeId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/addEventingSubscriber", reqArgs);
+    }
+
+    /** Attempts to add an eventing subscriber */
+    public void tryAddEventingSubscriber(AspireAction1<EventingSubscriberRegistrationContext> subscribe) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var subscribeId = getClient().registerCallback(args -> {
+            var arg = (EventingSubscriberRegistrationContext) args[0];
+            subscribe.invoke(arg);
+            return null;
+        });
+        if (subscribeId != null) {
+            reqArgs.put("subscribe", subscribeId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/tryAddEventingSubscriber", reqArgs);
     }
 
     public TestRedisResource addTestRedis(String name) {
@@ -13505,52 +13527,6 @@ import java.util.function.*;
 public class IResourceWithWaitSupport extends ResourceBuilderBase {
     IResourceWithWaitSupport(Handle handle, AspireClient client) {
         super(handle, client);
-    }
-
-}
-
-// ===== IServiceCollection.java =====
-// IServiceCollection.java - GENERATED CODE - DO NOT EDIT
-
-package aspire;
-
-import java.util.*;
-import java.util.function.*;
-
-/** Wrapper for Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection. */
-public class IServiceCollection extends HandleWrapperBase {
-    IServiceCollection(Handle handle, AspireClient client) {
-        super(handle, client);
-    }
-
-    /** Adds an eventing subscriber */
-    public void addEventingSubscriber(AspireAction1<EventingSubscriberRegistrationContext> subscribe) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("services", AspireClient.serializeValue(getHandle()));
-        var subscribeId = getClient().registerCallback(args -> {
-            var arg = (EventingSubscriberRegistrationContext) args[0];
-            subscribe.invoke(arg);
-            return null;
-        });
-        if (subscribeId != null) {
-            reqArgs.put("subscribe", subscribeId);
-        }
-        getClient().invokeCapability("Aspire.Hosting/addEventingSubscriber", reqArgs);
-    }
-
-    /** Attempts to add an eventing subscriber */
-    public void tryAddEventingSubscriber(AspireAction1<EventingSubscriberRegistrationContext> subscribe) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("services", AspireClient.serializeValue(getHandle()));
-        var subscribeId = getClient().registerCallback(args -> {
-            var arg = (EventingSubscriberRegistrationContext) args[0];
-            subscribe.invoke(arg);
-            return null;
-        });
-        if (subscribeId != null) {
-            reqArgs.put("subscribe", subscribeId);
-        }
-        getClient().invokeCapability("Aspire.Hosting/tryAddEventingSubscriber", reqArgs);
     }
 
 }
@@ -24009,7 +23985,6 @@ public final class WithVolumeOptions {
 .modules/IResourceWithEnvironment.java
 .modules/IResourceWithParent.java
 .modules/IResourceWithWaitSupport.java
-.modules/IServiceCollection.java
 .modules/IServiceProvider.java
 .modules/ITestVaultResource.java
 .modules/IUserSecretsManager.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1159,6 +1159,9 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline", (h, c) -> new IDistributedApplicationPipeline(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.DistributedApplication", (h, c) -> new DistributedApplication(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReference", (h, c) -> new EndpointReference(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore", (h, c) -> new IAspireStore(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder", (h, c) -> new IExecutionConfigurationBuilder(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult", (h, c) -> new IExecutionConfigurationResult(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource", (h, c) -> new IResource(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment", (h, c) -> new IResourceWithEnvironment(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints", (h, c) -> new IResourceWithEndpoints(h, c));
@@ -1174,6 +1177,7 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference", (h, c) -> new ContainerImageReference(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference", (h, c) -> new ContainerPortReference(h, c));
         AspireClient.registerHandleWrapper("System.ComponentModel/System.IServiceProvider", (h, c) -> new IServiceProvider(h, c));
+        AspireClient.registerHandleWrapper("Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection", (h, c) -> new IServiceCollection(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceNotificationService", (h, c) -> new ResourceNotificationService(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceLoggerService", (h, c) -> new ResourceLoggerService(h, c));
         AspireClient.registerHandleWrapper("Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfiguration", (h, c) -> new IConfiguration(h, c));
@@ -1198,6 +1202,7 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationEvent", (h, c) -> new IDistributedApplicationEvent(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent", (h, c) -> new IDistributedApplicationResourceEvent(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationEventing", (h, c) -> new IDistributedApplicationEventing(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext", (h, c) -> new EventingSubscriberRegistrationContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.AfterResourcesCreatedEvent", (h, c) -> new AfterResourcesCreatedEvent(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeResourceStartedEvent", (h, c) -> new BeforeResourceStartedEvent(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeStartEvent", (h, c) -> new BeforeStartEvent(h, c));
@@ -1377,6 +1382,33 @@ public class BeforeStartEvent extends HandleWrapperBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("context", AspireClient.serializeValue(getHandle()));
         return (DistributedApplicationModel) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/BeforeStartEvent.model", reqArgs);
+    }
+
+}
+
+// ===== BuildOptions.java =====
+// BuildOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for Build. */
+public final class BuildOptions {
+    private ILogger resourceLogger;
+    private CancellationToken cancellationToken;
+
+    public ILogger getResourceLogger() { return resourceLogger; }
+    public BuildOptions resourceLogger(ILogger value) {
+        this.resourceLogger = value;
+        return this;
+    }
+
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+    public BuildOptions cancellationToken(CancellationToken value) {
+        this.cancellationToken = value;
+        return this;
     }
 
 }
@@ -2565,6 +2597,13 @@ public class CSharpAppResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
+    }
+
     /** Adds an optional string parameter */
     public CSharpAppResource withOptionalString(WithOptionalStringOptions options) {
         var value = options == null ? null : options.getValue();
@@ -2961,6 +3000,70 @@ public class CapabilityError extends RuntimeException {
 
     String getCode() { return code; }
     Object getData() { return data; }
+}
+
+// ===== CertificateTrustExecutionConfigurationContext.java =====
+// CertificateTrustExecutionConfigurationContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** CertificateTrustExecutionConfigurationContext DTO. */
+public class CertificateTrustExecutionConfigurationContext {
+    private ReferenceExpression certificateBundlePath;
+    private ReferenceExpression certificateDirectoriesPath;
+    private String rootCertificatesPath;
+    private boolean isContainer;
+
+    public ReferenceExpression getCertificateBundlePath() { return certificateBundlePath; }
+    public void setCertificateBundlePath(ReferenceExpression value) { this.certificateBundlePath = value; }
+    public ReferenceExpression getCertificateDirectoriesPath() { return certificateDirectoriesPath; }
+    public void setCertificateDirectoriesPath(ReferenceExpression value) { this.certificateDirectoriesPath = value; }
+    public String getRootCertificatesPath() { return rootCertificatesPath; }
+    public void setRootCertificatesPath(String value) { this.rootCertificatesPath = value; }
+    public boolean getIsContainer() { return isContainer; }
+    public void setIsContainer(boolean value) { this.isContainer = value; }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("CertificateBundlePath", AspireClient.serializeValue(certificateBundlePath));
+        map.put("CertificateDirectoriesPath", AspireClient.serializeValue(certificateDirectoriesPath));
+        map.put("RootCertificatesPath", AspireClient.serializeValue(rootCertificatesPath));
+        map.put("IsContainer", AspireClient.serializeValue(isContainer));
+        return map;
+    }
+}
+
+// ===== CertificateTrustExecutionConfigurationExportData.java =====
+// CertificateTrustExecutionConfigurationExportData.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** CertificateTrustExecutionConfigurationExportData DTO. */
+public class CertificateTrustExecutionConfigurationExportData {
+    private CertificateTrustScope scope;
+    private String[] certificateSubjects;
+    private String[] customBundlePaths;
+
+    public CertificateTrustScope getScope() { return scope; }
+    public void setScope(CertificateTrustScope value) { this.scope = value; }
+    public String[] getCertificateSubjects() { return certificateSubjects; }
+    public void setCertificateSubjects(String[] value) { this.certificateSubjects = value; }
+    public String[] getCustomBundlePaths() { return customBundlePaths; }
+    public void setCustomBundlePaths(String[] value) { this.customBundlePaths = value; }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Scope", AspireClient.serializeValue(scope));
+        map.put("CertificateSubjects", AspireClient.serializeValue(certificateSubjects));
+        map.put("CustomBundlePaths", AspireClient.serializeValue(customBundlePaths));
+        return map;
+    }
 }
 
 // ===== CertificateTrustScope.java =====
@@ -3821,6 +3924,13 @@ public class ConnectionStringResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/onResourceReady", reqArgs);
         return this;
+    }
+
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
     }
 
     /** Adds an optional string parameter */
@@ -4710,6 +4820,13 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/onResourceReady", reqArgs);
         return this;
+    }
+
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
     }
 
     /** Adds an optional string parameter */
@@ -6421,6 +6538,13 @@ public class ContainerResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/onResourceReady", reqArgs);
         return this;
+    }
+
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
     }
 
     /** Adds an optional string parameter */
@@ -8544,6 +8668,13 @@ public class DotnetToolResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
+    }
+
     /** Adds an optional string parameter */
     public DotnetToolResource withOptionalString(WithOptionalStringOptions options) {
         var value = options == null ? null : options.getValue();
@@ -9326,6 +9457,66 @@ public class EnvironmentCallbackContext extends HandleWrapperBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("context", AspireClient.serializeValue(getHandle()));
         return (DistributedApplicationExecutionContext) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/EnvironmentCallbackContext.executionContext", reqArgs);
+    }
+
+}
+
+// ===== EventingSubscriberRegistrationContext.java =====
+// EventingSubscriberRegistrationContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext. */
+public class EventingSubscriberRegistrationContext extends HandleWrapperBase {
+    EventingSubscriberRegistrationContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Subscribes an eventing subscriber to the BeforeStart event */
+    public DistributedApplicationEventSubscription onBeforeStart(AspireAction1<BeforeStartEvent> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (BeforeStartEvent) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        return (DistributedApplicationEventSubscription) getClient().invokeCapability("Aspire.Hosting/eventingSubscriberOnBeforeStart", reqArgs);
+    }
+
+    /** Subscribes an eventing subscriber to the AfterResourcesCreated event */
+    public DistributedApplicationEventSubscription onAfterResourcesCreated(AspireAction1<AfterResourcesCreatedEvent> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (AfterResourcesCreatedEvent) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        return (DistributedApplicationEventSubscription) getClient().invokeCapability("Aspire.Hosting/eventingSubscriberOnAfterResourcesCreated", reqArgs);
+    }
+
+    /** Gets the ExecutionContext property */
+    public DistributedApplicationExecutionContext executionContext() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        return (DistributedApplicationExecutionContext) getClient().invokeCapability("Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.executionContext", reqArgs);
+    }
+
+    /** Gets the CancellationToken property */
+    public CancellationToken cancellationToken() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        return (CancellationToken) getClient().invokeCapability("Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.cancellationToken", reqArgs);
     }
 
 }
@@ -10505,6 +10696,13 @@ public class ExecutableResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
+    }
+
     /** Adds an optional string parameter */
     public ExecutableResource withOptionalString(WithOptionalStringOptions options) {
         var value = options == null ? null : options.getValue();
@@ -11360,6 +11558,13 @@ public class ExternalServiceResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
+    }
+
     /** Adds an optional string parameter */
     public ExternalServiceResource withOptionalString(WithOptionalStringOptions options) {
         var value = options == null ? null : options.getValue();
@@ -11874,6 +12079,137 @@ public enum HttpCommandResultMode implements WireValueEnum {
     }
 }
 
+// ===== HttpsCertificateExecutionConfigurationContext.java =====
+// HttpsCertificateExecutionConfigurationContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** HttpsCertificateExecutionConfigurationContext DTO. */
+public class HttpsCertificateExecutionConfigurationContext {
+    private ReferenceExpression certificatePath;
+    private ReferenceExpression keyPath;
+    private ReferenceExpression pfxPath;
+
+    public ReferenceExpression getCertificatePath() { return certificatePath; }
+    public void setCertificatePath(ReferenceExpression value) { this.certificatePath = value; }
+    public ReferenceExpression getKeyPath() { return keyPath; }
+    public void setKeyPath(ReferenceExpression value) { this.keyPath = value; }
+    public ReferenceExpression getPfxPath() { return pfxPath; }
+    public void setPfxPath(ReferenceExpression value) { this.pfxPath = value; }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("CertificatePath", AspireClient.serializeValue(certificatePath));
+        map.put("KeyPath", AspireClient.serializeValue(keyPath));
+        map.put("PfxPath", AspireClient.serializeValue(pfxPath));
+        return map;
+    }
+}
+
+// ===== HttpsCertificateExecutionConfigurationExportData.java =====
+// HttpsCertificateExecutionConfigurationExportData.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** HttpsCertificateExecutionConfigurationExportData DTO. */
+public class HttpsCertificateExecutionConfigurationExportData {
+    private String subject;
+    private String thumbprint;
+    private String keyPathExpression;
+    private String pfxPathExpression;
+    private boolean isKeyPathReferenced;
+    private boolean isPfxPathReferenced;
+    private String password;
+
+    public String getSubject() { return subject; }
+    public void setSubject(String value) { this.subject = value; }
+    public String getThumbprint() { return thumbprint; }
+    public void setThumbprint(String value) { this.thumbprint = value; }
+    public String getKeyPathExpression() { return keyPathExpression; }
+    public void setKeyPathExpression(String value) { this.keyPathExpression = value; }
+    public String getPfxPathExpression() { return pfxPathExpression; }
+    public void setPfxPathExpression(String value) { this.pfxPathExpression = value; }
+    public boolean getIsKeyPathReferenced() { return isKeyPathReferenced; }
+    public void setIsKeyPathReferenced(boolean value) { this.isKeyPathReferenced = value; }
+    public boolean getIsPfxPathReferenced() { return isPfxPathReferenced; }
+    public void setIsPfxPathReferenced(boolean value) { this.isPfxPathReferenced = value; }
+    public String getPassword() { return password; }
+    public void setPassword(String value) { this.password = value; }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Subject", AspireClient.serializeValue(subject));
+        map.put("Thumbprint", AspireClient.serializeValue(thumbprint));
+        map.put("KeyPathExpression", AspireClient.serializeValue(keyPathExpression));
+        map.put("PfxPathExpression", AspireClient.serializeValue(pfxPathExpression));
+        map.put("IsKeyPathReferenced", AspireClient.serializeValue(isKeyPathReferenced));
+        map.put("IsPfxPathReferenced", AspireClient.serializeValue(isPfxPathReferenced));
+        map.put("Password", AspireClient.serializeValue(password));
+        return map;
+    }
+}
+
+// ===== HttpsCertificateInfo.java =====
+// HttpsCertificateInfo.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** HttpsCertificateInfo DTO. */
+public class HttpsCertificateInfo {
+    private String subject;
+    private String issuer;
+    private String thumbprint;
+
+    public String getSubject() { return subject; }
+    public void setSubject(String value) { this.subject = value; }
+    public String getIssuer() { return issuer; }
+    public void setIssuer(String value) { this.issuer = value; }
+    public String getThumbprint() { return thumbprint; }
+    public void setThumbprint(String value) { this.thumbprint = value; }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Subject", AspireClient.serializeValue(subject));
+        map.put("Issuer", AspireClient.serializeValue(issuer));
+        map.put("Thumbprint", AspireClient.serializeValue(thumbprint));
+        return map;
+    }
+}
+
+// ===== IAspireStore.java =====
+// IAspireStore.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore. */
+public class IAspireStore extends HandleWrapperBase {
+    IAspireStore(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets a deterministic file path for the specified file contents */
+    public String getFileNameWithContent(String filenameTemplate, String sourceFilename) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("aspireStore", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("filenameTemplate", AspireClient.serializeValue(filenameTemplate));
+        reqArgs.put("sourceFilename", AspireClient.serializeValue(sourceFilename));
+        return (String) getClient().invokeCapability("Aspire.Hosting/getFileNameWithContent", reqArgs);
+    }
+
+}
+
 // ===== IComputeResource.java =====
 // IComputeResource.java - GENERATED CODE - DO NOT EDIT
 
@@ -12174,6 +12510,13 @@ public class IDistributedApplicationBuilder extends HandleWrapperBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("context", AspireClient.serializeValue(getHandle()));
         return (IHostEnvironment) getClient().invokeCapability("Aspire.Hosting/IDistributedApplicationBuilder.environment", reqArgs);
+    }
+
+    /** Gets the Services property */
+    public IServiceCollection services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        return (IServiceCollection) getClient().invokeCapability("Aspire.Hosting/IDistributedApplicationBuilder.services", reqArgs);
     }
 
     /** Gets the Eventing property */
@@ -12549,6 +12892,119 @@ import java.util.function.*;
 public class IDistributedApplicationResourceEvent extends HandleWrapperBase {
     IDistributedApplicationResourceEvent(Handle handle, AspireClient client) {
         super(handle, client);
+    }
+
+}
+
+// ===== IExecutionConfigurationBuilder.java =====
+// IExecutionConfigurationBuilder.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder. */
+public class IExecutionConfigurationBuilder extends HandleWrapperBase {
+    IExecutionConfigurationBuilder(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Builds the execution configuration */
+    public IExecutionConfigurationResult build(DistributedApplicationExecutionContext executionContext, BuildOptions options) {
+        var resourceLogger = options == null ? null : options.getResourceLogger();
+        var cancellationToken = options == null ? null : options.getCancellationToken();
+        return buildImpl(executionContext, resourceLogger, cancellationToken);
+    }
+
+    public IExecutionConfigurationResult build(DistributedApplicationExecutionContext executionContext) {
+        return build(executionContext, null);
+    }
+
+    /** Builds the execution configuration */
+    private IExecutionConfigurationResult buildImpl(DistributedApplicationExecutionContext executionContext, ILogger resourceLogger, CancellationToken cancellationToken) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("executionContext", AspireClient.serializeValue(executionContext));
+        if (resourceLogger != null) {
+            reqArgs.put("resourceLogger", AspireClient.serializeValue(resourceLogger));
+        }
+        if (cancellationToken != null) {
+            reqArgs.put("cancellationToken", getClient().registerCancellation(cancellationToken));
+        }
+        return (IExecutionConfigurationResult) getClient().invokeCapability("Aspire.Hosting/buildExecutionConfiguration", reqArgs);
+    }
+
+    /** Adds an HTTPS certificate configuration gatherer */
+    public IExecutionConfigurationBuilder withHttpsCertificateConfig(AspireFunc1<HttpsCertificateInfo, HttpsCertificateExecutionConfigurationContext> configContextFactory) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var configContextFactoryId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateInfo) args[0];
+            return AspireClient.awaitValue(configContextFactory.invoke(arg));
+        });
+        if (configContextFactoryId != null) {
+            reqArgs.put("configContextFactory", configContextFactoryId);
+        }
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfigExport", reqArgs);
+    }
+
+    /** Adds an arguments configuration gatherer */
+    public IExecutionConfigurationBuilder withArgumentsConfig() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/withArgumentsConfig", reqArgs);
+    }
+
+    /** Adds an environment variables configuration gatherer */
+    public IExecutionConfigurationBuilder withEnvironmentVariablesConfig() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/withEnvironmentVariablesConfig", reqArgs);
+    }
+
+    /** Adds a certificate trust configuration gatherer */
+    public IExecutionConfigurationBuilder withCertificateTrustConfig(AspireFunc1<CertificateTrustScope, CertificateTrustExecutionConfigurationContext> configContextFactory) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var configContextFactoryId = getClient().registerCallback(args -> {
+            var arg = (CertificateTrustScope) args[0];
+            return AspireClient.awaitValue(configContextFactory.invoke(arg));
+        });
+        if (configContextFactoryId != null) {
+            reqArgs.put("configContextFactory", configContextFactoryId);
+        }
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/withCertificateTrustConfig", reqArgs);
+    }
+
+}
+
+// ===== IExecutionConfigurationResult.java =====
+// IExecutionConfigurationResult.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult. */
+public class IExecutionConfigurationResult extends HandleWrapperBase {
+    IExecutionConfigurationResult(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets certificate trust execution-configuration data */
+    public CertificateTrustExecutionConfigurationExportData getCertificateTrustData() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("configuration", AspireClient.serializeValue(getHandle()));
+        return (CertificateTrustExecutionConfigurationExportData) getClient().invokeCapability("Aspire.Hosting/getCertificateTrustData", reqArgs);
+    }
+
+    /** Gets HTTPS certificate execution-configuration data */
+    public HttpsCertificateExecutionConfigurationExportData getHttpsCertificateData() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("configuration", AspireClient.serializeValue(getHandle()));
+        return (HttpsCertificateExecutionConfigurationExportData) getClient().invokeCapability("Aspire.Hosting/getHttpsCertificateData", reqArgs);
     }
 
 }
@@ -13053,6 +13509,52 @@ public class IResourceWithWaitSupport extends ResourceBuilderBase {
 
 }
 
+// ===== IServiceCollection.java =====
+// IServiceCollection.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection. */
+public class IServiceCollection extends HandleWrapperBase {
+    IServiceCollection(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Adds an eventing subscriber */
+    public void addEventingSubscriber(AspireAction1<EventingSubscriberRegistrationContext> subscribe) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("services", AspireClient.serializeValue(getHandle()));
+        var subscribeId = getClient().registerCallback(args -> {
+            var arg = (EventingSubscriberRegistrationContext) args[0];
+            subscribe.invoke(arg);
+            return null;
+        });
+        if (subscribeId != null) {
+            reqArgs.put("subscribe", subscribeId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/addEventingSubscriber", reqArgs);
+    }
+
+    /** Attempts to add an eventing subscriber */
+    public void tryAddEventingSubscriber(AspireAction1<EventingSubscriberRegistrationContext> subscribe) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("services", AspireClient.serializeValue(getHandle()));
+        var subscribeId = getClient().registerCallback(args -> {
+            var arg = (EventingSubscriberRegistrationContext) args[0];
+            subscribe.invoke(arg);
+            return null;
+        });
+        if (subscribeId != null) {
+            reqArgs.put("subscribe", subscribeId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/tryAddEventingSubscriber", reqArgs);
+    }
+
+}
+
 // ===== IServiceProvider.java =====
 // IServiceProvider.java - GENERATED CODE - DO NOT EDIT
 
@@ -13100,6 +13602,13 @@ public class IServiceProvider extends HandleWrapperBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("serviceProvider", AspireClient.serializeValue(getHandle()));
         return (ResourceNotificationService) getClient().invokeCapability("Aspire.Hosting/getResourceNotificationService", reqArgs);
+    }
+
+    /** Gets the Aspire store from the service provider */
+    public IAspireStore getAspireStore() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("serviceProvider", AspireClient.serializeValue(getHandle()));
+        return (IAspireStore) getClient().invokeCapability("Aspire.Hosting/getAspireStore", reqArgs);
     }
 
     /** Gets the user secrets manager from the service provider */
@@ -13725,6 +14234,13 @@ public class ParameterResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/onResourceReady", reqArgs);
         return this;
+    }
+
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
     }
 
     /** Adds an optional string parameter */
@@ -15694,6 +16210,13 @@ public class ProjectResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/onResourceReady", reqArgs);
         return this;
+    }
+
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
     }
 
     /** Adds an optional string parameter */
@@ -18317,6 +18840,13 @@ public class TestDatabaseResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
+    }
+
     /** Adds an optional string parameter */
     public TestDatabaseResource withOptionalString(WithOptionalStringOptions options) {
         var value = options == null ? null : options.getValue();
@@ -20254,6 +20784,13 @@ public class TestRedisResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/onResourceReady", reqArgs);
         return this;
+    }
+
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
     }
 
     public TestDatabaseResource addTestChildDatabase(String name) {
@@ -22244,6 +22781,13 @@ public class TestVaultResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Creates an execution configuration builder */
+    public IExecutionConfigurationBuilder createExecutionConfiguration() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        return (IExecutionConfigurationBuilder) getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
+    }
+
     /** Adds an optional string parameter */
     public TestVaultResource withOptionalString(WithOptionalStringOptions options) {
         var value = options == null ? null : options.getValue();
@@ -23384,9 +23928,12 @@ public final class WithVolumeOptions {
 .modules/BaseRegistrations.java
 .modules/BeforeResourceStartedEvent.java
 .modules/BeforeStartEvent.java
+.modules/BuildOptions.java
 .modules/CSharpAppResource.java
 .modules/CancellationToken.java
 .modules/CapabilityError.java
+.modules/CertificateTrustExecutionConfigurationContext.java
+.modules/CertificateTrustExecutionConfigurationExportData.java
 .modules/CertificateTrustScope.java
 .modules/CommandLineArgsCallbackContext.java
 .modules/CommandOptions.java
@@ -23423,6 +23970,7 @@ public final class WithVolumeOptions {
 .modules/EndpointReferenceExpression.java
 .modules/EndpointUpdateContext.java
 .modules/EnvironmentCallbackContext.java
+.modules/EventingSubscriberRegistrationContext.java
 .modules/ExecutableResource.java
 .modules/ExecuteCommandContext.java
 .modules/ExecuteCommandResult.java
@@ -23432,6 +23980,10 @@ public final class WithVolumeOptions {
 .modules/HandleWrapperBase.java
 .modules/HttpCommandExportOptions.java
 .modules/HttpCommandResultMode.java
+.modules/HttpsCertificateExecutionConfigurationContext.java
+.modules/HttpsCertificateExecutionConfigurationExportData.java
+.modules/HttpsCertificateInfo.java
+.modules/IAspireStore.java
 .modules/IComputeResource.java
 .modules/IConfiguration.java
 .modules/IConfigurationSection.java
@@ -23441,6 +23993,8 @@ public final class WithVolumeOptions {
 .modules/IDistributedApplicationEventing.java
 .modules/IDistributedApplicationPipeline.java
 .modules/IDistributedApplicationResourceEvent.java
+.modules/IExecutionConfigurationBuilder.java
+.modules/IExecutionConfigurationResult.java
 .modules/IExpressionValue.java
 .modules/IHostEnvironment.java
 .modules/ILogger.java
@@ -23455,6 +24009,7 @@ public final class WithVolumeOptions {
 .modules/IResourceWithEnvironment.java
 .modules/IResourceWithParent.java
 .modules/IResourceWithWaitSupport.java
+.modules/IServiceCollection.java
 .modules/IServiceProvider.java
 .modules/ITestVaultResource.java
 .modules/IUserSecretsManager.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1,4 +1,4 @@
-﻿// ===== AddContainerOptions.java =====
+// ===== AddContainerOptions.java =====
 // AddContainerOptions.java - GENERATED CODE - DO NOT EDIT
 
 package aspire;

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1,4 +1,4 @@
-#   -------------------------------------------------------------
+﻿#   -------------------------------------------------------------
 #   Copyright (c) Microsoft Corporation. All rights reserved.
 #   Licensed under the MIT License. See LICENSE in project root for information.
 #
@@ -1704,6 +1704,17 @@ class AddContainerOptions(typing.TypedDict, total=False):
     Image: str
     Tag: str
 
+class CertificateTrustExecutionConfigurationContext(typing.TypedDict, total=False):
+    CertificateBundlePath: ReferenceExpression
+    CertificateDirectoriesPath: ReferenceExpression
+    RootCertificatesPath: str
+    IsContainer: bool
+
+class CertificateTrustExecutionConfigurationExportData(typing.TypedDict, total=False):
+    Scope: CertificateTrustScope
+    CertificateSubjects: typing.Iterable[str]
+    CustomBundlePaths: typing.Iterable[str]
+
 class CommandOptions(typing.TypedDict, total=False):
     Description: str
     Parameter: typing.Any
@@ -1757,6 +1768,25 @@ class HttpCommandExportOptions(typing.TypedDict, total=False):
     MethodName: str
     ResultMode: HttpCommandResultMode
 
+class HttpsCertificateExecutionConfigurationContext(typing.TypedDict, total=False):
+    CertificatePath: ReferenceExpression
+    KeyPath: ReferenceExpression
+    PfxPath: ReferenceExpression
+
+class HttpsCertificateExecutionConfigurationExportData(typing.TypedDict, total=False):
+    Subject: str
+    Thumbprint: str
+    KeyPathExpression: str
+    PfxPathExpression: str
+    IsKeyPathReferenced: bool
+    IsPfxPathReferenced: bool
+    Password: str
+
+class HttpsCertificateInfo(typing.TypedDict, total=False):
+    Subject: str
+    Issuer: str
+    Thumbprint: str
+
 class ReferenceEnvironmentInjectionOptions(typing.TypedDict, total=False):
     ConnectionString: bool
     ConnectionProperties: bool
@@ -1797,6 +1827,33 @@ class TestNestedDto(typing.TypedDict, total=False):
 # ============================================================================
 # Type Classes
 # ============================================================================
+
+class AbstractAspireStore:
+    """Type class for AbstractAspireStore."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"AbstractAspireStore(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    def get_file_name_with_content(self, filename_template: str, source_filename: str) -> str:
+        """Gets a deterministic file path for the specified file contents"""
+        rpc_args: dict[str, typing.Any] = {'aspireStore': self._handle}
+        rpc_args['filenameTemplate'] = filename_template
+        rpc_args['sourceFilename'] = source_filename
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/getFileNameWithContent',
+            rpc_args,
+        )
+        return result
+
 
 class AbstractConfiguration:
     """Type class for AbstractConfiguration."""
@@ -1916,6 +1973,15 @@ class DistributedApplicationBuilder:
             {'context': self._handle}
         )
         return typing.cast(AbstractHostEnvironment, result)
+
+    @_cached_property
+    def services(self) -> AbstractServiceCollection:
+        """Gets the Services property"""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/IDistributedApplicationBuilder.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceCollection, result)
 
     @_cached_property
     def eventing(self) -> AbstractDistributedApplicationEventing:
@@ -2377,6 +2443,108 @@ class AbstractDistributedApplicationPipeline:
 class AbstractDistributedApplicationResourceEvent(abc.ABC):
     """Abstract base class for AbstractDistributedApplicationResourceEvent."""
 
+class AbstractExecutionConfigurationBuilder:
+    """Type class for AbstractExecutionConfigurationBuilder."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"AbstractExecutionConfigurationBuilder(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    def build(self, execution_context: DistributedApplicationExecutionContext, *, resource_logger: AbstractLogger | None = None, timeout: int | None = None) -> AbstractExecutionConfigurationResult:
+        """Builds the execution configuration"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['executionContext'] = execution_context
+        if resource_logger is not None:
+            rpc_args['resourceLogger'] = resource_logger
+        if timeout is not None:
+            rpc_args['cancellationToken'] = self._client.register_cancellation_token(timeout)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/buildExecutionConfiguration',
+            rpc_args,
+        )
+        return typing.cast(AbstractExecutionConfigurationResult, result)
+
+    def with_https_certificate_config(self, config_context_factory: typing.Callable[[HttpsCertificateInfo], HttpsCertificateExecutionConfigurationContext]) -> AbstractExecutionConfigurationBuilder:
+        """Adds an HTTPS certificate configuration gatherer"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['configContextFactory'] = self._client.register_callback(config_context_factory)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withHttpsCertificateConfigExport',
+            rpc_args,
+        )
+        return typing.cast(AbstractExecutionConfigurationBuilder, result)
+
+    def with_arguments_config(self) -> AbstractExecutionConfigurationBuilder:
+        """Adds an arguments configuration gatherer"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withArgumentsConfig',
+            rpc_args,
+        )
+        return typing.cast(AbstractExecutionConfigurationBuilder, result)
+
+    def with_env_vars_config(self) -> AbstractExecutionConfigurationBuilder:
+        """Adds an environment variables configuration gatherer"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withEnvironmentVariablesConfig',
+            rpc_args,
+        )
+        return typing.cast(AbstractExecutionConfigurationBuilder, result)
+
+    def with_certificate_trust_config(self, config_context_factory: typing.Callable[[CertificateTrustScope], CertificateTrustExecutionConfigurationContext]) -> AbstractExecutionConfigurationBuilder:
+        """Adds a certificate trust configuration gatherer"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['configContextFactory'] = self._client.register_callback(config_context_factory)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withCertificateTrustConfig',
+            rpc_args,
+        )
+        return typing.cast(AbstractExecutionConfigurationBuilder, result)
+
+
+class AbstractExecutionConfigurationResult:
+    """Type class for AbstractExecutionConfigurationResult."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"AbstractExecutionConfigurationResult(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    def get_certificate_trust_data(self) -> CertificateTrustExecutionConfigurationExportData:
+        """Gets certificate trust execution-configuration data"""
+        rpc_args: dict[str, typing.Any] = {'configuration': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/getCertificateTrustData',
+            rpc_args,
+        )
+        return typing.cast(CertificateTrustExecutionConfigurationExportData, result)
+
+    def get_https_certificate_data(self) -> HttpsCertificateExecutionConfigurationExportData:
+        """Gets HTTPS certificate execution-configuration data"""
+        rpc_args: dict[str, typing.Any] = {'configuration': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/getHttpsCertificateData',
+            rpc_args,
+        )
+        return typing.cast(HttpsCertificateExecutionConfigurationExportData, result)
+
+
 class AbstractValueProvider(abc.ABC):
     """Abstract base class for AbstractValueProvider."""
 
@@ -2681,6 +2849,40 @@ class AbstractReportingTask:
 class AbstractValueWithReferences(abc.ABC):
     """Abstract base class for AbstractValueWithReferences."""
 
+class AbstractServiceCollection:
+    """Type class for AbstractServiceCollection."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"AbstractServiceCollection(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    def add_eventing_subscriber(self, subscribe: typing.Callable[[EventingSubscriberRegistrationContext], None]) -> None:
+        """Adds an eventing subscriber"""
+        rpc_args: dict[str, typing.Any] = {'services': self._handle}
+        rpc_args['subscribe'] = self._client.register_callback(subscribe)
+        self._client.invoke_capability(
+            'Aspire.Hosting/addEventingSubscriber',
+            rpc_args
+        )
+
+    def try_add_eventing_subscriber(self, subscribe: typing.Callable[[EventingSubscriberRegistrationContext], None]) -> None:
+        """Attempts to add an eventing subscriber"""
+        rpc_args: dict[str, typing.Any] = {'services': self._handle}
+        rpc_args['subscribe'] = self._client.register_callback(subscribe)
+        self._client.invoke_capability(
+            'Aspire.Hosting/tryAddEventingSubscriber',
+            rpc_args
+        )
+
+
 class AbstractServiceProvider:
     """Type class for AbstractServiceProvider."""
 
@@ -2740,6 +2942,15 @@ class AbstractServiceProvider:
             rpc_args,
         )
         return typing.cast(ResourceNotificationService, result)
+
+    def get_aspire_store(self) -> AbstractAspireStore:
+        """Gets the Aspire store from the service provider"""
+        rpc_args: dict[str, typing.Any] = {'serviceProvider': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/getAspireStore',
+            rpc_args,
+        )
+        return typing.cast(AbstractAspireStore, result)
 
     def get_user_secrets_manager(self) -> AbstractUserSecretsManager:
         """Gets the user secrets manager from the service provider"""
@@ -4032,6 +4243,59 @@ class EnvironmentCallbackContext:
             {'context': self._handle}
         )
         return typing.cast(DistributedApplicationExecutionContext, result)
+
+
+class EventingSubscriberRegistrationContext:
+    """Type class for EventingSubscriberRegistrationContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"EventingSubscriberRegistrationContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def execution_context(self) -> DistributedApplicationExecutionContext:
+        """Gets the ExecutionContext property"""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.executionContext',
+            {'context': self._handle}
+        )
+        return typing.cast(DistributedApplicationExecutionContext, result)
+
+    def cancel(self) -> None:
+        """Cancel the operation."""
+        token: CancellationToken = self._client.invoke_capability(
+            'Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.cancellationToken',
+            {'context': self._handle}
+        )
+        token.cancel()
+
+    def on_before_start(self, callback: typing.Callable[[BeforeStartEvent], None]) -> DistributedApplicationEventSubscription:
+        """Subscribes an eventing subscriber to the BeforeStart event"""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/eventingSubscriberOnBeforeStart',
+            rpc_args,
+        )
+        return typing.cast(DistributedApplicationEventSubscription, result)
+
+    def on_after_resources_created(self, callback: typing.Callable[[AfterResourcesCreatedEvent], None]) -> DistributedApplicationEventSubscription:
+        """Subscribes an eventing subscriber to the AfterResourcesCreated event"""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/eventingSubscriberOnAfterResourcesCreated',
+            rpc_args,
+        )
+        return typing.cast(DistributedApplicationEventSubscription, result)
 
 
 class ExecuteCommandContext:
@@ -5426,6 +5690,10 @@ class AbstractResource(abc.ABC):
         """Subscribes to the ResourceReady event"""
 
     @abc.abstractmethod
+    def create_execution_config(self) -> AbstractExecutionConfigurationBuilder:
+        """Creates an execution configuration builder"""
+
+    @abc.abstractmethod
     def with_optional_string(self, *, value: str | None = None, enabled: bool = True) -> typing.Self:
         """Adds an optional string parameter"""
 
@@ -6080,6 +6348,15 @@ class _BaseResource(AbstractResource):
         )
         self._handle = self._wrap_builder(result)
         return self
+
+    def create_execution_config(self) -> AbstractExecutionConfigurationBuilder:
+        """Creates an execution configuration builder"""
+        rpc_args: dict[str, typing.Any] = {'resource': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpc_args,
+        )
+        return typing.cast(AbstractExecutionConfigurationBuilder, result)
 
     def with_optional_string(self, *, value: str | None = None, enabled: bool = True) -> typing.Self:
         """Adds an optional string parameter"""
@@ -11028,14 +11305,18 @@ _register_handle_wrapper("Aspire.Hosting/List<any>", AspireList)
 _register_handle_wrapper("Aspire.Hosting/Dict<string,string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression>", AspireDict)
 _register_handle_wrapper("Aspire.Hosting/List<Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceUrlAnnotation>", AspireList)
 _register_handle_wrapper("Aspire.Hosting/Dict<string,string>", AspireDict)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore", AbstractAspireStore)
 _register_handle_wrapper("Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfiguration", AbstractConfiguration)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationEventing", AbstractDistributedApplicationEventing)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline", AbstractDistributedApplicationPipeline)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder", AbstractExecutionConfigurationBuilder)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult", AbstractExecutionConfigurationResult)
 _register_handle_wrapper("Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.IHostEnvironment", AbstractHostEnvironment)
 _register_handle_wrapper("Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILogger", AbstractLogger)
 _register_handle_wrapper("Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory", AbstractLoggerFactory)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep", AbstractReportingStep)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingTask", AbstractReportingTask)
+_register_handle_wrapper("Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection", AbstractServiceCollection)
 _register_handle_wrapper("System.ComponentModel/System.IServiceProvider", AbstractServiceProvider)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.IUserSecretsManager", AbstractUserSecretsManager)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.AfterResourcesCreatedEvent", AfterResourcesCreatedEvent)
@@ -11056,6 +11337,7 @@ _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.Endpoin
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReferenceExpression", EndpointReferenceExpression)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext", EndpointUpdateContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext", EnvironmentCallbackContext)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext", EventingSubscriberRegistrationContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext", ExecuteCommandContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent", InitializeResourceEvent)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigurationContext", PipelineConfigurationContext)

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1,4 +1,4 @@
-﻿#   -------------------------------------------------------------
+#   -------------------------------------------------------------
 #   Copyright (c) Microsoft Corporation. All rights reserved.
 #   Licensed under the MIT License. See LICENSE in project root for information.
 #

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1975,15 +1975,6 @@ class DistributedApplicationBuilder:
         return typing.cast(AbstractHostEnvironment, result)
 
     @_cached_property
-    def services(self) -> AbstractServiceCollection:
-        """Gets the Services property"""
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/IDistributedApplicationBuilder.services',
-            {'context': self._handle}
-        )
-        return typing.cast(AbstractServiceCollection, result)
-
-    @_cached_property
     def eventing(self) -> AbstractDistributedApplicationEventing:
         """Gets the Eventing property"""
         result = self._client.invoke_capability(
@@ -2347,6 +2338,24 @@ class DistributedApplicationBuilder:
             rpc_args,
         )
         return typing.cast(DistributedApplicationEventSubscription, result)
+
+    def add_eventing_subscriber(self, subscribe: typing.Callable[[EventingSubscriberRegistrationContext], None]) -> None:
+        """Adds an eventing subscriber"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['subscribe'] = self._client.register_callback(subscribe)
+        self._client.invoke_capability(
+            'Aspire.Hosting/addEventingSubscriber',
+            rpc_args
+        )
+
+    def try_add_eventing_subscriber(self, subscribe: typing.Callable[[EventingSubscriberRegistrationContext], None]) -> None:
+        """Attempts to add an eventing subscriber"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['subscribe'] = self._client.register_callback(subscribe)
+        self._client.invoke_capability(
+            'Aspire.Hosting/tryAddEventingSubscriber',
+            rpc_args
+        )
 
     def add_test_redis(self, name: str, *, port: int | None = None, **kwargs: typing.Unpack["TestRedisResourceKwargs"]) -> TestRedisResource:  # type: ignore
         """Adds a test Redis resource"""
@@ -2848,40 +2857,6 @@ class AbstractReportingTask:
 
 class AbstractValueWithReferences(abc.ABC):
     """Abstract base class for AbstractValueWithReferences."""
-
-class AbstractServiceCollection:
-    """Type class for AbstractServiceCollection."""
-
-    def __init__(self, handle: Handle, client: AspireClient) -> None:
-        self._handle = handle
-        self._client = client
-
-    def __repr__(self) -> str:
-        return f"AbstractServiceCollection(handle={self._handle.handle_id})"
-
-    @_uncached_property
-    def handle(self) -> Handle:
-        """The underlying object reference handle."""
-        return self._handle
-
-    def add_eventing_subscriber(self, subscribe: typing.Callable[[EventingSubscriberRegistrationContext], None]) -> None:
-        """Adds an eventing subscriber"""
-        rpc_args: dict[str, typing.Any] = {'services': self._handle}
-        rpc_args['subscribe'] = self._client.register_callback(subscribe)
-        self._client.invoke_capability(
-            'Aspire.Hosting/addEventingSubscriber',
-            rpc_args
-        )
-
-    def try_add_eventing_subscriber(self, subscribe: typing.Callable[[EventingSubscriberRegistrationContext], None]) -> None:
-        """Attempts to add an eventing subscriber"""
-        rpc_args: dict[str, typing.Any] = {'services': self._handle}
-        rpc_args['subscribe'] = self._client.register_callback(subscribe)
-        self._client.invoke_capability(
-            'Aspire.Hosting/tryAddEventingSubscriber',
-            rpc_args
-        )
-
 
 class AbstractServiceProvider:
     """Type class for AbstractServiceProvider."""
@@ -11316,7 +11291,6 @@ _register_handle_wrapper("Microsoft.Extensions.Logging.Abstractions/Microsoft.Ex
 _register_handle_wrapper("Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory", AbstractLoggerFactory)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep", AbstractReportingStep)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingTask", AbstractReportingTask)
-_register_handle_wrapper("Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection", AbstractServiceCollection)
 _register_handle_wrapper("System.ComponentModel/System.IServiceProvider", AbstractServiceProvider)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.IUserSecretsManager", AbstractUserSecretsManager)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.AfterResourcesCreatedEvent", AfterResourcesCreatedEvent)

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -616,7 +616,7 @@ impl ReferenceEnvironmentInjectionOptions {
 }
 
 /// CertificateTrustExecutionConfigurationContext
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CertificateTrustExecutionConfigurationContext {
     #[serde(rename = "CertificateBundlePath")]
     pub certificate_bundle_path: ReferenceExpression,
@@ -712,7 +712,7 @@ impl HttpCommandExportOptions {
 }
 
 /// HttpsCertificateExecutionConfigurationContext
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HttpsCertificateExecutionConfigurationContext {
     #[serde(rename = "CertificatePath")]
     pub certificate_path: ReferenceExpression,

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -1,4 +1,4 @@
-﻿//! aspire.rs - Capability-based Aspire SDK
+//! aspire.rs - Capability-based Aspire SDK
 //! GENERATED CODE - DO NOT EDIT
 
 use std::collections::HashMap;

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -9753,15 +9753,6 @@ impl IDistributedApplicationBuilder {
         Ok(IHostEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Gets the Services property
-    pub fn services(&self) -> Result<IServiceCollection, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("context".to_string(), self.handle.to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/IDistributedApplicationBuilder.services", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IServiceCollection::new(handle, self.client.clone()))
-    }
-
     /// Gets the Eventing property
     pub fn eventing(&self) -> Result<IDistributedApplicationEventing, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -9970,6 +9961,26 @@ impl IDistributedApplicationBuilder {
         let result = self.client.invoke_capability("Aspire.Hosting/subscribeAfterResourcesCreated", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(DistributedApplicationEventSubscription::new(handle, self.client.clone()))
+    }
+
+    /// Adds an eventing subscriber
+    pub fn add_eventing_subscriber(&self, subscribe: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<(), Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(subscribe);
+        args.insert("subscribe".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/addEventingSubscriber", args)?;
+        Ok(())
+    }
+
+    /// Attempts to add an eventing subscriber
+    pub fn try_add_eventing_subscriber(&self, subscribe: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<(), Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(subscribe);
+        args.insert("subscribe".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/tryAddEventingSubscriber", args)?;
+        Ok(())
     }
 
     /// Adds a test Redis resource
@@ -10870,52 +10881,6 @@ impl IResourceWithWaitSupport {
 
     pub fn client(&self) -> &Arc<AspireClient> {
         &self.client
-    }
-}
-
-/// Wrapper for Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection
-pub struct IServiceCollection {
-    handle: Handle,
-    client: Arc<AspireClient>,
-}
-
-impl HasHandle for IServiceCollection {
-    fn handle(&self) -> &Handle {
-        &self.handle
-    }
-}
-
-impl IServiceCollection {
-    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
-        Self { handle, client }
-    }
-
-    pub fn handle(&self) -> &Handle {
-        &self.handle
-    }
-
-    pub fn client(&self) -> &Arc<AspireClient> {
-        &self.client
-    }
-
-    /// Adds an eventing subscriber
-    pub fn add_eventing_subscriber(&self, subscribe: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<(), Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("services".to_string(), self.handle.to_json());
-        let callback_id = register_callback(subscribe);
-        args.insert("subscribe".to_string(), Value::String(callback_id));
-        let result = self.client.invoke_capability("Aspire.Hosting/addEventingSubscriber", args)?;
-        Ok(())
-    }
-
-    /// Attempts to add an eventing subscriber
-    pub fn try_add_eventing_subscriber(&self, subscribe: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<(), Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("services".to_string(), self.handle.to_json());
-        let callback_id = register_callback(subscribe);
-        args.insert("subscribe".to_string(), Value::String(callback_id));
-        let result = self.client.invoke_capability("Aspire.Hosting/tryAddEventingSubscriber", args)?;
-        Ok(())
     }
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -1,4 +1,4 @@
-//! aspire.rs - Capability-based Aspire SDK
+﻿//! aspire.rs - Capability-based Aspire SDK
 //! GENERATED CODE - DO NOT EDIT
 
 use std::collections::HashMap;
@@ -486,6 +486,81 @@ impl CreateBuilderOptions {
     }
 }
 
+/// HttpsCertificateInfo
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HttpsCertificateInfo {
+    #[serde(rename = "Subject")]
+    pub subject: String,
+    #[serde(rename = "Issuer")]
+    pub issuer: String,
+    #[serde(rename = "Thumbprint")]
+    pub thumbprint: String,
+}
+
+impl HttpsCertificateInfo {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("Subject".to_string(), serde_json::to_value(&self.subject).unwrap_or(Value::Null));
+        map.insert("Issuer".to_string(), serde_json::to_value(&self.issuer).unwrap_or(Value::Null));
+        map.insert("Thumbprint".to_string(), serde_json::to_value(&self.thumbprint).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// CertificateTrustExecutionConfigurationExportData
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CertificateTrustExecutionConfigurationExportData {
+    #[serde(rename = "Scope")]
+    pub scope: CertificateTrustScope,
+    #[serde(rename = "CertificateSubjects")]
+    pub certificate_subjects: Vec<String>,
+    #[serde(rename = "CustomBundlePaths")]
+    pub custom_bundle_paths: Vec<String>,
+}
+
+impl CertificateTrustExecutionConfigurationExportData {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("Scope".to_string(), serde_json::to_value(&self.scope).unwrap_or(Value::Null));
+        map.insert("CertificateSubjects".to_string(), serde_json::to_value(&self.certificate_subjects).unwrap_or(Value::Null));
+        map.insert("CustomBundlePaths".to_string(), serde_json::to_value(&self.custom_bundle_paths).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// HttpsCertificateExecutionConfigurationExportData
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HttpsCertificateExecutionConfigurationExportData {
+    #[serde(rename = "Subject")]
+    pub subject: String,
+    #[serde(rename = "Thumbprint")]
+    pub thumbprint: String,
+    #[serde(rename = "KeyPathExpression")]
+    pub key_path_expression: String,
+    #[serde(rename = "PfxPathExpression")]
+    pub pfx_path_expression: String,
+    #[serde(rename = "IsKeyPathReferenced")]
+    pub is_key_path_referenced: bool,
+    #[serde(rename = "IsPfxPathReferenced")]
+    pub is_pfx_path_referenced: bool,
+    #[serde(rename = "Password")]
+    pub password: String,
+}
+
+impl HttpsCertificateExecutionConfigurationExportData {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("Subject".to_string(), serde_json::to_value(&self.subject).unwrap_or(Value::Null));
+        map.insert("Thumbprint".to_string(), serde_json::to_value(&self.thumbprint).unwrap_or(Value::Null));
+        map.insert("KeyPathExpression".to_string(), serde_json::to_value(&self.key_path_expression).unwrap_or(Value::Null));
+        map.insert("PfxPathExpression".to_string(), serde_json::to_value(&self.pfx_path_expression).unwrap_or(Value::Null));
+        map.insert("IsKeyPathReferenced".to_string(), serde_json::to_value(&self.is_key_path_referenced).unwrap_or(Value::Null));
+        map.insert("IsPfxPathReferenced".to_string(), serde_json::to_value(&self.is_pfx_path_referenced).unwrap_or(Value::Null));
+        map.insert("Password".to_string(), serde_json::to_value(&self.password).unwrap_or(Value::Null));
+        map
+    }
+}
+
 /// ResourceEventDto
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ResourceEventDto {
@@ -536,6 +611,30 @@ impl ReferenceEnvironmentInjectionOptions {
         map.insert("ConnectionProperties".to_string(), serde_json::to_value(&self.connection_properties).unwrap_or(Value::Null));
         map.insert("ServiceDiscovery".to_string(), serde_json::to_value(&self.service_discovery).unwrap_or(Value::Null));
         map.insert("Endpoints".to_string(), serde_json::to_value(&self.endpoints).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// CertificateTrustExecutionConfigurationContext
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CertificateTrustExecutionConfigurationContext {
+    #[serde(rename = "CertificateBundlePath")]
+    pub certificate_bundle_path: ReferenceExpression,
+    #[serde(rename = "CertificateDirectoriesPath")]
+    pub certificate_directories_path: ReferenceExpression,
+    #[serde(rename = "RootCertificatesPath")]
+    pub root_certificates_path: String,
+    #[serde(rename = "IsContainer")]
+    pub is_container: bool,
+}
+
+impl CertificateTrustExecutionConfigurationContext {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("CertificateBundlePath".to_string(), serde_json::to_value(&self.certificate_bundle_path).unwrap_or(Value::Null));
+        map.insert("CertificateDirectoriesPath".to_string(), serde_json::to_value(&self.certificate_directories_path).unwrap_or(Value::Null));
+        map.insert("RootCertificatesPath".to_string(), serde_json::to_value(&self.root_certificates_path).unwrap_or(Value::Null));
+        map.insert("IsContainer".to_string(), serde_json::to_value(&self.is_container).unwrap_or(Value::Null));
         map
     }
 }
@@ -608,6 +707,27 @@ impl HttpCommandExportOptions {
         map.insert("EndpointName".to_string(), serde_json::to_value(&self.endpoint_name).unwrap_or(Value::Null));
         map.insert("MethodName".to_string(), serde_json::to_value(&self.method_name).unwrap_or(Value::Null));
         map.insert("ResultMode".to_string(), serde_json::to_value(&self.result_mode).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// HttpsCertificateExecutionConfigurationContext
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HttpsCertificateExecutionConfigurationContext {
+    #[serde(rename = "CertificatePath")]
+    pub certificate_path: ReferenceExpression,
+    #[serde(rename = "KeyPath")]
+    pub key_path: ReferenceExpression,
+    #[serde(rename = "PfxPath")]
+    pub pfx_path: ReferenceExpression,
+}
+
+impl HttpsCertificateExecutionConfigurationContext {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("CertificatePath".to_string(), serde_json::to_value(&self.certificate_path).unwrap_or(Value::Null));
+        map.insert("KeyPath".to_string(), serde_json::to_value(&self.key_path).unwrap_or(Value::Null));
+        map.insert("PfxPath".to_string(), serde_json::to_value(&self.pfx_path).unwrap_or(Value::Null));
         map
     }
 }
@@ -1814,6 +1934,15 @@ impl CSharpAppResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
     /// Adds an optional string parameter
     pub fn with_optional_string(&self, value: Option<&str>, enabled: Option<bool>) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -2612,6 +2741,15 @@ impl ConnectionStringResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
     /// Adds an optional string parameter
     pub fn with_optional_string(&self, value: Option<&str>, enabled: Option<bool>) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -3405,6 +3543,15 @@ impl ContainerRegistryResource {
         let result = self.client.invoke_capability("Aspire.Hosting/onResourceReady", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -4738,6 +4885,15 @@ impl ContainerResource {
         let result = self.client.invoke_capability("Aspire.Hosting/onResourceReady", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -6507,6 +6663,15 @@ impl DotnetToolResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
     /// Adds an optional string parameter
     pub fn with_optional_string(&self, value: Option<&str>, enabled: Option<bool>) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7291,6 +7456,72 @@ impl EnvironmentCallbackContext {
         let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EnvironmentCallbackContext.executionContext", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(DistributedApplicationExecutionContext::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext
+pub struct EventingSubscriberRegistrationContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for EventingSubscriberRegistrationContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl EventingSubscriberRegistrationContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Subscribes an eventing subscriber to the BeforeStart event
+    pub fn on_before_start(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<DistributedApplicationEventSubscription, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/eventingSubscriberOnBeforeStart", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(DistributedApplicationEventSubscription::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes an eventing subscriber to the AfterResourcesCreated event
+    pub fn on_after_resources_created(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<DistributedApplicationEventSubscription, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/eventingSubscriberOnAfterResourcesCreated", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(DistributedApplicationEventSubscription::new(handle, self.client.clone()))
+    }
+
+    /// Gets the ExecutionContext property
+    pub fn execution_context(&self) -> Result<DistributedApplicationExecutionContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.executionContext", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(DistributedApplicationExecutionContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the CancellationToken property
+    pub fn cancellation_token(&self) -> Result<CancellationToken, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.cancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CancellationToken::new(handle, self.client.clone()))
     }
 }
 
@@ -8182,6 +8413,15 @@ impl ExecutableResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
     /// Adds an optional string parameter
     pub fn with_optional_string(&self, value: Option<&str>, enabled: Option<bool>) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -8871,6 +9111,15 @@ impl ExternalServiceResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
     /// Adds an optional string parameter
     pub fn with_optional_string(&self, value: Option<&str>, enabled: Option<bool>) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -9121,6 +9370,42 @@ impl ExternalServiceResource {
         let result = self.client.invoke_capability("Aspire.Hosting.CodeGeneration.Rust.Tests/withMergeRouteMiddleware", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore
+pub struct IAspireStore {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for IAspireStore {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl IAspireStore {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets a deterministic file path for the specified file contents
+    pub fn get_file_name_with_content(&self, filename_template: &str, source_filename: &str) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("aspireStore".to_string(), self.handle.to_json());
+        args.insert("filenameTemplate".to_string(), serde_json::to_value(&filename_template).unwrap_or(Value::Null));
+        args.insert("sourceFilename".to_string(), serde_json::to_value(&source_filename).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/getFileNameWithContent", args)?;
+        Ok(serde_json::from_value(result)?)
     }
 }
 
@@ -9466,6 +9751,15 @@ impl IDistributedApplicationBuilder {
         let result = self.client.invoke_capability("Aspire.Hosting/IDistributedApplicationBuilder.environment", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IHostEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Gets the Services property
+    pub fn services(&self) -> Result<IServiceCollection, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/IDistributedApplicationBuilder.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceCollection::new(handle, self.client.clone()))
     }
 
     /// Gets the Eventing property
@@ -9839,6 +10133,131 @@ impl IDistributedApplicationResourceEvent {
 
     pub fn client(&self) -> &Arc<AspireClient> {
         &self.client
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder
+pub struct IExecutionConfigurationBuilder {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for IExecutionConfigurationBuilder {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl IExecutionConfigurationBuilder {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Builds the execution configuration
+    pub fn build(&self, execution_context: &DistributedApplicationExecutionContext, resource_logger: Option<&ILogger>, cancellation_token: Option<&CancellationToken>) -> Result<IExecutionConfigurationResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("executionContext".to_string(), execution_context.handle().to_json());
+        if let Some(ref v) = resource_logger {
+            args.insert("resourceLogger".to_string(), v.handle().to_json());
+        }
+        if let Some(token) = cancellation_token {
+            let token_id = register_cancellation(token, self.client.clone());
+            args.insert("cancellationToken".to_string(), Value::String(token_id));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/buildExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationResult::new(handle, self.client.clone()))
+    }
+
+    /// Adds an HTTPS certificate configuration gatherer
+    pub fn with_https_certificate_config(&self, config_context_factory: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(config_context_factory);
+        args.insert("configContextFactory".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfigExport", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Adds an arguments configuration gatherer
+    pub fn with_arguments_config(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/withArgumentsConfig", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Adds an environment variables configuration gatherer
+    pub fn with_environment_variables_config(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentVariablesConfig", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Adds a certificate trust configuration gatherer
+    pub fn with_certificate_trust_config(&self, config_context_factory: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(config_context_factory);
+        args.insert("configContextFactory".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withCertificateTrustConfig", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult
+pub struct IExecutionConfigurationResult {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for IExecutionConfigurationResult {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl IExecutionConfigurationResult {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets certificate trust execution-configuration data
+    pub fn get_certificate_trust_data(&self) -> Result<CertificateTrustExecutionConfigurationExportData, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("configuration".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/getCertificateTrustData", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Gets HTTPS certificate execution-configuration data
+    pub fn get_https_certificate_data(&self) -> Result<HttpsCertificateExecutionConfigurationExportData, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("configuration".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/getHttpsCertificateData", args)?;
+        Ok(serde_json::from_value(result)?)
     }
 }
 
@@ -10454,6 +10873,52 @@ impl IResourceWithWaitSupport {
     }
 }
 
+/// Wrapper for Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection
+pub struct IServiceCollection {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for IServiceCollection {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl IServiceCollection {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Adds an eventing subscriber
+    pub fn add_eventing_subscriber(&self, subscribe: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<(), Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("services".to_string(), self.handle.to_json());
+        let callback_id = register_callback(subscribe);
+        args.insert("subscribe".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/addEventingSubscriber", args)?;
+        Ok(())
+    }
+
+    /// Attempts to add an eventing subscriber
+    pub fn try_add_eventing_subscriber(&self, subscribe: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<(), Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("services".to_string(), self.handle.to_json());
+        let callback_id = register_callback(subscribe);
+        args.insert("subscribe".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/tryAddEventingSubscriber", args)?;
+        Ok(())
+    }
+}
+
 /// Wrapper for System.ComponentModel/System.IServiceProvider
 pub struct IServiceProvider {
     handle: Handle,
@@ -10522,6 +10987,15 @@ impl IServiceProvider {
         let result = self.client.invoke_capability("Aspire.Hosting/getResourceNotificationService", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ResourceNotificationService::new(handle, self.client.clone()))
+    }
+
+    /// Gets the Aspire store from the service provider
+    pub fn get_aspire_store(&self) -> Result<IAspireStore, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("serviceProvider".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/getAspireStore", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IAspireStore::new(handle, self.client.clone()))
     }
 
     /// Gets the user secrets manager from the service provider
@@ -11014,6 +11488,15 @@ impl ParameterResource {
         let result = self.client.invoke_capability("Aspire.Hosting/onResourceReady", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -12715,6 +13198,15 @@ impl ProjectResource {
         let result = self.client.invoke_capability("Aspire.Hosting/onResourceReady", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -14689,6 +15181,15 @@ impl TestDatabaseResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
     /// Adds an optional string parameter
     pub fn with_optional_string(&self, value: Option<&str>, enabled: Option<bool>) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -16163,6 +16664,15 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/onResourceReady", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
     }
 
     /// Adds a child database to a test Redis resource
@@ -17728,6 +18238,15 @@ impl TestVaultResource {
         let result = self.client.invoke_capability("Aspire.Hosting/onResourceReady", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Creates an execution configuration builder
+    pub fn create_execution_configuration(&self) -> Result<IExecutionConfigurationBuilder, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     CapabilityId: Aspire.Hosting/asHttp2Service,
     MethodName: asHttp2Service,

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
@@ -14,6 +14,20 @@
     ]
   },
   {
+    CapabilityId: Aspire.Hosting/createExecutionConfiguration,
+    MethodName: createExecutionConfiguration,
+    TargetType: {
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource,
+      IsInterface: true
+    },
+    ExpandedTargetTypes: [
+      {
+        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+        IsInterface: false
+      }
+    ]
+  },
+  {
     CapabilityId: Aspire.Hosting/excludeFromManifest,
     MethodName: excludeFromManifest,
     TargetType: {

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1,4 +1,4 @@
-// aspire.ts - Capability-based Aspire SDK
+﻿// aspire.ts - Capability-based Aspire SDK
 // This SDK uses the ATS (Aspire Type System) capability API.
 // Capabilities are endpoints like 'Aspire.Hosting/createBuilder'.
 //
@@ -121,11 +121,20 @@ type ExecutableResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Applicatio
 /** Handle to ExecuteCommandContext */
 type ExecuteCommandContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext'>;
 
+/** Handle to IAspireStore */
+type IAspireStoreHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore'>;
+
 /** Handle to IComputeResource */
 type IComputeResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IComputeResource'>;
 
 /** Handle to IContainerFilesDestinationResource */
 type IContainerFilesDestinationResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource'>;
+
+/** Handle to IExecutionConfigurationBuilder */
+type IExecutionConfigurationBuilderHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder'>;
+
+/** Handle to IExecutionConfigurationResult */
+type IExecutionConfigurationResultHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult'>;
 
 /** Handle to IExpressionValue */
 type IExpressionValueHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExpressionValue'>;
@@ -183,6 +192,9 @@ type ResourceUrlsCallbackContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.A
 
 /** Handle to UpdateCommandStateContext */
 type UpdateCommandStateContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.UpdateCommandStateContext'>;
+
+/** Handle to EventingSubscriberRegistrationContext */
+type EventingSubscriberRegistrationContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext'>;
 
 /** Handle to ConnectionStringResource */
 type ConnectionStringResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ConnectionStringResource'>;
@@ -246,6 +258,9 @@ type IConfigurationHandle = Handle<'Microsoft.Extensions.Configuration.Abstracti
 
 /** Handle to IConfigurationSection */
 type IConfigurationSectionHandle = Handle<'Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfigurationSection'>;
+
+/** Handle to IServiceCollection */
+type IServiceCollectionHandle = Handle<'Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection'>;
 
 /** Handle to IHostEnvironment */
 type IHostEnvironmentHandle = Handle<'Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.IHostEnvironment'>;
@@ -404,6 +419,21 @@ export interface AddContainerOptions {
     tag?: string;
 }
 
+/** DTO interface for CertificateTrustExecutionConfigurationContext */
+export interface CertificateTrustExecutionConfigurationContext {
+    certificateBundlePath?: ReferenceExpression;
+    certificateDirectoriesPath?: ReferenceExpression;
+    rootCertificatesPath?: string;
+    isContainer?: boolean;
+}
+
+/** DTO interface for CertificateTrustExecutionConfigurationExportData */
+export interface CertificateTrustExecutionConfigurationExportData {
+    scope?: CertificateTrustScope;
+    certificateSubjects?: string[];
+    customBundlePaths?: string[];
+}
+
 /** DTO interface for CommandOptions */
 export interface CommandOptions {
     description?: string;
@@ -469,6 +499,31 @@ export interface HttpCommandExportOptions {
     endpointName?: string;
     methodName?: string;
     resultMode?: HttpCommandResultMode;
+}
+
+/** DTO interface for HttpsCertificateExecutionConfigurationContext */
+export interface HttpsCertificateExecutionConfigurationContext {
+    certificatePath?: ReferenceExpression;
+    keyPath?: ReferenceExpression;
+    pfxPath?: ReferenceExpression;
+}
+
+/** DTO interface for HttpsCertificateExecutionConfigurationExportData */
+export interface HttpsCertificateExecutionConfigurationExportData {
+    subject?: string;
+    thumbprint?: string;
+    keyPathExpression?: string;
+    pfxPathExpression?: string;
+    isKeyPathReferenced?: boolean;
+    isPfxPathReferenced?: boolean;
+    password?: string;
+}
+
+/** DTO interface for HttpsCertificateInfo */
+export interface HttpsCertificateInfo {
+    subject?: string;
+    issuer?: string;
+    thumbprint?: string;
 }
 
 /** DTO interface for ReferenceEnvironmentInjectionOptions */
@@ -593,6 +648,11 @@ export interface AppendValueProviderOptions {
 
 export interface ArgOptions {
     defaultValue?: string;
+}
+
+export interface BuildOptions {
+    resourceLogger?: Awaitable<Logger>;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CompleteStepMarkdownOptions {
@@ -2785,6 +2845,119 @@ class EnvironmentCallbackContextImpl implements EnvironmentCallbackContext {
 }
 
 // ============================================================================
+// EventingSubscriberRegistrationContext
+// ============================================================================
+
+export interface EventingSubscriberRegistrationContext {
+    toJSON(): MarshalledHandle;
+    executionContext: {
+        get: () => Promise<DistributedApplicationExecutionContext>;
+    };
+    cancellationToken: {
+        get: () => Promise<CancellationToken>;
+    };
+    onBeforeStart(callback: (arg: BeforeStartEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle>;
+    onAfterResourcesCreated(callback: (arg: AfterResourcesCreatedEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle>;
+}
+
+export interface EventingSubscriberRegistrationContextPromise extends PromiseLike<EventingSubscriberRegistrationContext> {
+    onBeforeStart(callback: (arg: BeforeStartEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle>;
+    onAfterResourcesCreated(callback: (arg: AfterResourcesCreatedEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle>;
+}
+
+// ============================================================================
+// EventingSubscriberRegistrationContextImpl
+// ============================================================================
+
+/**
+ * Type class for EventingSubscriberRegistrationContext.
+ */
+class EventingSubscriberRegistrationContextImpl implements EventingSubscriberRegistrationContext {
+    constructor(private _handle: EventingSubscriberRegistrationContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Gets the ExecutionContext property */
+    executionContext = {
+        get: async (): Promise<DistributedApplicationExecutionContext> => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        },
+    };
+
+    /** Gets the CancellationToken property */
+    cancellationToken = {
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
+                'Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.cancellationToken',
+                { context: this._handle }
+            );
+            return CancellationToken.fromValue(result);
+        },
+    };
+
+    /** Subscribes an eventing subscriber to the BeforeStart event */
+    async onBeforeStart(callback: (arg: BeforeStartEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as BeforeStartEventHandle;
+            const arg = new BeforeStartEventImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { context: this._handle, callback: callbackId };
+        return await this._client.invokeCapability<DistributedApplicationEventSubscriptionHandle>(
+            'Aspire.Hosting/eventingSubscriberOnBeforeStart',
+            rpcArgs
+        );
+    }
+
+    /** Subscribes an eventing subscriber to the AfterResourcesCreated event */
+    async onAfterResourcesCreated(callback: (arg: AfterResourcesCreatedEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as AfterResourcesCreatedEventHandle;
+            const arg = new AfterResourcesCreatedEventImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { context: this._handle, callback: callbackId };
+        return await this._client.invokeCapability<DistributedApplicationEventSubscriptionHandle>(
+            'Aspire.Hosting/eventingSubscriberOnAfterResourcesCreated',
+            rpcArgs
+        );
+    }
+
+}
+
+/**
+ * Thenable wrapper for EventingSubscriberRegistrationContext that enables fluent chaining.
+ */
+class EventingSubscriberRegistrationContextPromiseImpl implements EventingSubscriberRegistrationContextPromise {
+    constructor(private _promise: Promise<EventingSubscriberRegistrationContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = EventingSubscriberRegistrationContext, TResult2 = never>(
+        onfulfilled?: ((value: EventingSubscriberRegistrationContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Subscribes an eventing subscriber to the BeforeStart event */
+    onBeforeStart(callback: (arg: BeforeStartEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle> {
+        return this._promise.then(obj => obj.onBeforeStart(callback));
+    }
+
+    /** Subscribes an eventing subscriber to the AfterResourcesCreated event */
+    onAfterResourcesCreated(callback: (arg: AfterResourcesCreatedEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle> {
+        return this._promise.then(obj => obj.onAfterResourcesCreated(callback));
+    }
+
+}
+
+// ============================================================================
 // ExecuteCommandContext
 // ============================================================================
 
@@ -4857,6 +5030,65 @@ class UpdateCommandStateContextImpl implements UpdateCommandStateContext {
 }
 
 // ============================================================================
+// AspireStore
+// ============================================================================
+
+export interface AspireStore {
+    toJSON(): MarshalledHandle;
+    getFileNameWithContent(filenameTemplate: string, sourceFilename: string): Promise<string>;
+}
+
+export interface AspireStorePromise extends PromiseLike<AspireStore> {
+    getFileNameWithContent(filenameTemplate: string, sourceFilename: string): Promise<string>;
+}
+
+// ============================================================================
+// AspireStoreImpl
+// ============================================================================
+
+/**
+ * Type class for AspireStore.
+ */
+class AspireStoreImpl implements AspireStore {
+    constructor(private _handle: IAspireStoreHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Gets a deterministic file path for the specified file contents */
+    async getFileNameWithContent(filenameTemplate: string, sourceFilename: string): Promise<string> {
+        const rpcArgs: Record<string, unknown> = { aspireStore: this._handle, filenameTemplate, sourceFilename };
+        return await this._client.invokeCapability<string>(
+            'Aspire.Hosting/getFileNameWithContent',
+            rpcArgs
+        );
+    }
+
+}
+
+/**
+ * Thenable wrapper for AspireStore that enables fluent chaining.
+ */
+class AspireStorePromiseImpl implements AspireStorePromise {
+    constructor(private _promise: Promise<AspireStore>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = AspireStore, TResult2 = never>(
+        onfulfilled?: ((value: AspireStore) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Gets a deterministic file path for the specified file contents */
+    getFileNameWithContent(filenameTemplate: string, sourceFilename: string): Promise<string> {
+        return this._promise.then(obj => obj.getFileNameWithContent(filenameTemplate, sourceFilename));
+    }
+
+}
+
+// ============================================================================
 // Configuration
 // ============================================================================
 
@@ -4991,6 +5223,9 @@ export interface DistributedApplicationBuilder {
     environment: {
         get: () => Promise<HostEnvironment>;
     };
+    services: {
+        get: () => Promise<ServiceCollection>;
+    };
     eventing: {
         get: () => Promise<DistributedApplicationEventing>;
     };
@@ -5095,6 +5330,17 @@ class DistributedApplicationBuilderImpl implements DistributedApplicationBuilder
                 { context: this._handle }
             );
             return new HostEnvironmentImpl(handle, this._client);
+        },
+    };
+
+    /** Gets the Services property */
+    services = {
+        get: async (): Promise<ServiceCollection> => {
+            const handle = await this._client.invokeCapability<IServiceCollectionHandle>(
+                'Aspire.Hosting/IDistributedApplicationBuilder.services',
+                { context: this._handle }
+            );
+            return new ServiceCollectionImpl(handle, this._client);
         },
     };
 
@@ -5936,6 +6182,249 @@ class DistributedApplicationPipelinePromiseImpl implements DistributedApplicatio
 }
 
 // ============================================================================
+// ExecutionConfigurationBuilder
+// ============================================================================
+
+export interface ExecutionConfigurationBuilder {
+    toJSON(): MarshalledHandle;
+    build(executionContext: Awaitable<DistributedApplicationExecutionContext>, options?: BuildOptions): ExecutionConfigurationResultPromise;
+    withHttpsCertificateConfig(configContextFactory: (arg: HttpsCertificateInfo) => Promise<HttpsCertificateExecutionConfigurationContext>): ExecutionConfigurationBuilderPromise;
+    withArgumentsConfig(): ExecutionConfigurationBuilderPromise;
+    withEnvironmentVariablesConfig(): ExecutionConfigurationBuilderPromise;
+    withCertificateTrustConfig(configContextFactory: (arg: CertificateTrustScope) => Promise<CertificateTrustExecutionConfigurationContext>): ExecutionConfigurationBuilderPromise;
+}
+
+export interface ExecutionConfigurationBuilderPromise extends PromiseLike<ExecutionConfigurationBuilder> {
+    build(executionContext: Awaitable<DistributedApplicationExecutionContext>, options?: BuildOptions): ExecutionConfigurationResultPromise;
+    withHttpsCertificateConfig(configContextFactory: (arg: HttpsCertificateInfo) => Promise<HttpsCertificateExecutionConfigurationContext>): ExecutionConfigurationBuilderPromise;
+    withArgumentsConfig(): ExecutionConfigurationBuilderPromise;
+    withEnvironmentVariablesConfig(): ExecutionConfigurationBuilderPromise;
+    withCertificateTrustConfig(configContextFactory: (arg: CertificateTrustScope) => Promise<CertificateTrustExecutionConfigurationContext>): ExecutionConfigurationBuilderPromise;
+}
+
+// ============================================================================
+// ExecutionConfigurationBuilderImpl
+// ============================================================================
+
+/**
+ * Type class for ExecutionConfigurationBuilder.
+ */
+class ExecutionConfigurationBuilderImpl implements ExecutionConfigurationBuilder {
+    constructor(private _handle: IExecutionConfigurationBuilderHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Builds the execution configuration */
+    /** @internal */
+    async _buildInternal(executionContext: Awaitable<DistributedApplicationExecutionContext>, resourceLogger?: Awaitable<Logger>, cancellationToken?: AbortSignal | CancellationToken): Promise<ExecutionConfigurationResult> {
+        executionContext = isPromiseLike(executionContext) ? await executionContext : executionContext;
+        resourceLogger = isPromiseLike(resourceLogger) ? await resourceLogger : resourceLogger;
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, executionContext };
+        if (resourceLogger !== undefined) rpcArgs.resourceLogger = resourceLogger;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        const result = await this._client.invokeCapability<IExecutionConfigurationResultHandle>(
+            'Aspire.Hosting/buildExecutionConfiguration',
+            rpcArgs
+        );
+        return new ExecutionConfigurationResultImpl(result, this._client);
+    }
+
+    build(executionContext: Awaitable<DistributedApplicationExecutionContext>, options?: BuildOptions): ExecutionConfigurationResultPromise {
+        let resourceLogger = options?.resourceLogger;
+        const cancellationToken = options?.cancellationToken;
+        const flushAndBuild = async () => { await this._client.flushPendingPromises(); return this._buildInternal(executionContext, resourceLogger, cancellationToken); };
+        return new ExecutionConfigurationResultPromiseImpl(flushAndBuild(), this._client, false);
+    }
+
+    /** Adds an HTTPS certificate configuration gatherer */
+    /** @internal */
+    async _withHttpsCertificateConfigInternal(configContextFactory: (arg: HttpsCertificateInfo) => Promise<HttpsCertificateExecutionConfigurationContext>): Promise<ExecutionConfigurationBuilder> {
+        const configContextFactoryId = registerCallback(async (argData: unknown) => {
+            const arg = wrapIfHandle(argData) as HttpsCertificateInfo;
+            return await configContextFactory(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, configContextFactory: configContextFactoryId };
+        const result = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfigExport',
+            rpcArgs
+        );
+        return new ExecutionConfigurationBuilderImpl(result, this._client);
+    }
+
+    withHttpsCertificateConfig(configContextFactory: (arg: HttpsCertificateInfo) => Promise<HttpsCertificateExecutionConfigurationContext>): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._withHttpsCertificateConfigInternal(configContextFactory), this._client);
+    }
+
+    /** Adds an arguments configuration gatherer */
+    /** @internal */
+    async _withArgumentsConfigInternal(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle };
+        const result = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+            'Aspire.Hosting/withArgumentsConfig',
+            rpcArgs
+        );
+        return new ExecutionConfigurationBuilderImpl(result, this._client);
+    }
+
+    withArgumentsConfig(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._withArgumentsConfigInternal(), this._client);
+    }
+
+    /** Adds an environment variables configuration gatherer */
+    /** @internal */
+    async _withEnvironmentVariablesConfigInternal(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle };
+        const result = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+            'Aspire.Hosting/withEnvironmentVariablesConfig',
+            rpcArgs
+        );
+        return new ExecutionConfigurationBuilderImpl(result, this._client);
+    }
+
+    withEnvironmentVariablesConfig(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._withEnvironmentVariablesConfigInternal(), this._client);
+    }
+
+    /** Adds a certificate trust configuration gatherer */
+    /** @internal */
+    async _withCertificateTrustConfigInternal(configContextFactory: (arg: CertificateTrustScope) => Promise<CertificateTrustExecutionConfigurationContext>): Promise<ExecutionConfigurationBuilder> {
+        const configContextFactoryId = registerCallback(async (argData: unknown) => {
+            const arg = wrapIfHandle(argData) as CertificateTrustScope;
+            return await configContextFactory(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, configContextFactory: configContextFactoryId };
+        const result = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+            'Aspire.Hosting/withCertificateTrustConfig',
+            rpcArgs
+        );
+        return new ExecutionConfigurationBuilderImpl(result, this._client);
+    }
+
+    withCertificateTrustConfig(configContextFactory: (arg: CertificateTrustScope) => Promise<CertificateTrustExecutionConfigurationContext>): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._withCertificateTrustConfigInternal(configContextFactory), this._client);
+    }
+
+}
+
+/**
+ * Thenable wrapper for ExecutionConfigurationBuilder that enables fluent chaining.
+ */
+class ExecutionConfigurationBuilderPromiseImpl implements ExecutionConfigurationBuilderPromise {
+    constructor(private _promise: Promise<ExecutionConfigurationBuilder>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ExecutionConfigurationBuilder, TResult2 = never>(
+        onfulfilled?: ((value: ExecutionConfigurationBuilder) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Builds the execution configuration */
+    build(executionContext: Awaitable<DistributedApplicationExecutionContext>, options?: BuildOptions): ExecutionConfigurationResultPromise {
+        return new ExecutionConfigurationResultPromiseImpl(this._promise.then(obj => obj.build(executionContext, options)), this._client);
+    }
+
+    /** Adds an HTTPS certificate configuration gatherer */
+    withHttpsCertificateConfig(configContextFactory: (arg: HttpsCertificateInfo) => Promise<HttpsCertificateExecutionConfigurationContext>): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfig(configContextFactory)), this._client);
+    }
+
+    /** Adds an arguments configuration gatherer */
+    withArgumentsConfig(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.withArgumentsConfig()), this._client);
+    }
+
+    /** Adds an environment variables configuration gatherer */
+    withEnvironmentVariablesConfig(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.withEnvironmentVariablesConfig()), this._client);
+    }
+
+    /** Adds a certificate trust configuration gatherer */
+    withCertificateTrustConfig(configContextFactory: (arg: CertificateTrustScope) => Promise<CertificateTrustExecutionConfigurationContext>): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.withCertificateTrustConfig(configContextFactory)), this._client);
+    }
+
+}
+
+// ============================================================================
+// ExecutionConfigurationResult
+// ============================================================================
+
+export interface ExecutionConfigurationResult {
+    toJSON(): MarshalledHandle;
+    getCertificateTrustData(): Promise<CertificateTrustExecutionConfigurationExportData>;
+    getHttpsCertificateData(): Promise<HttpsCertificateExecutionConfigurationExportData>;
+}
+
+export interface ExecutionConfigurationResultPromise extends PromiseLike<ExecutionConfigurationResult> {
+    getCertificateTrustData(): Promise<CertificateTrustExecutionConfigurationExportData>;
+    getHttpsCertificateData(): Promise<HttpsCertificateExecutionConfigurationExportData>;
+}
+
+// ============================================================================
+// ExecutionConfigurationResultImpl
+// ============================================================================
+
+/**
+ * Type class for ExecutionConfigurationResult.
+ */
+class ExecutionConfigurationResultImpl implements ExecutionConfigurationResult {
+    constructor(private _handle: IExecutionConfigurationResultHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Gets certificate trust execution-configuration data */
+    async getCertificateTrustData(): Promise<CertificateTrustExecutionConfigurationExportData> {
+        const rpcArgs: Record<string, unknown> = { configuration: this._handle };
+        return await this._client.invokeCapability<CertificateTrustExecutionConfigurationExportData>(
+            'Aspire.Hosting/getCertificateTrustData',
+            rpcArgs
+        );
+    }
+
+    /** Gets HTTPS certificate execution-configuration data */
+    async getHttpsCertificateData(): Promise<HttpsCertificateExecutionConfigurationExportData> {
+        const rpcArgs: Record<string, unknown> = { configuration: this._handle };
+        return await this._client.invokeCapability<HttpsCertificateExecutionConfigurationExportData>(
+            'Aspire.Hosting/getHttpsCertificateData',
+            rpcArgs
+        );
+    }
+
+}
+
+/**
+ * Thenable wrapper for ExecutionConfigurationResult that enables fluent chaining.
+ */
+class ExecutionConfigurationResultPromiseImpl implements ExecutionConfigurationResultPromise {
+    constructor(private _promise: Promise<ExecutionConfigurationResult>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ExecutionConfigurationResult, TResult2 = never>(
+        onfulfilled?: ((value: ExecutionConfigurationResult) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Gets certificate trust execution-configuration data */
+    getCertificateTrustData(): Promise<CertificateTrustExecutionConfigurationExportData> {
+        return this._promise.then(obj => obj.getCertificateTrustData());
+    }
+
+    /** Gets HTTPS certificate execution-configuration data */
+    getHttpsCertificateData(): Promise<HttpsCertificateExecutionConfigurationExportData> {
+        return this._promise.then(obj => obj.getHttpsCertificateData());
+    }
+
+}
+
+// ============================================================================
 // HostEnvironment
 // ============================================================================
 
@@ -6593,6 +7082,103 @@ class ReportingTaskPromiseImpl implements ReportingTaskPromise {
 }
 
 // ============================================================================
+// ServiceCollection
+// ============================================================================
+
+export interface ServiceCollection {
+    toJSON(): MarshalledHandle;
+    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise;
+    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise;
+}
+
+export interface ServiceCollectionPromise extends PromiseLike<ServiceCollection> {
+    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise;
+    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise;
+}
+
+// ============================================================================
+// ServiceCollectionImpl
+// ============================================================================
+
+/**
+ * Type class for ServiceCollection.
+ */
+class ServiceCollectionImpl implements ServiceCollection {
+    constructor(private _handle: IServiceCollectionHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Adds an eventing subscriber */
+    /** @internal */
+    async _addEventingSubscriberInternal(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): Promise<ServiceCollection> {
+        const subscribeId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as EventingSubscriberRegistrationContextHandle;
+            const arg = new EventingSubscriberRegistrationContextImpl(argHandle, this._client);
+            await subscribe(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { services: this._handle, subscribe: subscribeId };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/addEventingSubscriber',
+            rpcArgs
+        );
+        return this;
+    }
+
+    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise {
+        return new ServiceCollectionPromiseImpl(this._addEventingSubscriberInternal(subscribe), this._client);
+    }
+
+    /** Attempts to add an eventing subscriber */
+    /** @internal */
+    async _tryAddEventingSubscriberInternal(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): Promise<ServiceCollection> {
+        const subscribeId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as EventingSubscriberRegistrationContextHandle;
+            const arg = new EventingSubscriberRegistrationContextImpl(argHandle, this._client);
+            await subscribe(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { services: this._handle, subscribe: subscribeId };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/tryAddEventingSubscriber',
+            rpcArgs
+        );
+        return this;
+    }
+
+    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise {
+        return new ServiceCollectionPromiseImpl(this._tryAddEventingSubscriberInternal(subscribe), this._client);
+    }
+
+}
+
+/**
+ * Thenable wrapper for ServiceCollection that enables fluent chaining.
+ */
+class ServiceCollectionPromiseImpl implements ServiceCollectionPromise {
+    constructor(private _promise: Promise<ServiceCollection>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ServiceCollection, TResult2 = never>(
+        onfulfilled?: ((value: ServiceCollection) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Adds an eventing subscriber */
+    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise {
+        return new ServiceCollectionPromiseImpl(this._promise.then(obj => obj.addEventingSubscriber(subscribe)), this._client);
+    }
+
+    /** Attempts to add an eventing subscriber */
+    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise {
+        return new ServiceCollectionPromiseImpl(this._promise.then(obj => obj.tryAddEventingSubscriber(subscribe)), this._client);
+    }
+
+}
+
+// ============================================================================
 // ServiceProvider
 // ============================================================================
 
@@ -6603,6 +7189,7 @@ export interface ServiceProvider {
     getResourceLoggerService(): ResourceLoggerServicePromise;
     getDistributedApplicationModel(): DistributedApplicationModelPromise;
     getResourceNotificationService(): ResourceNotificationServicePromise;
+    getAspireStore(): AspireStorePromise;
     getUserSecretsManager(): UserSecretsManagerPromise;
 }
 
@@ -6612,6 +7199,7 @@ export interface ServiceProviderPromise extends PromiseLike<ServiceProvider> {
     getResourceLoggerService(): ResourceLoggerServicePromise;
     getDistributedApplicationModel(): DistributedApplicationModelPromise;
     getResourceNotificationService(): ResourceNotificationServicePromise;
+    getAspireStore(): AspireStorePromise;
     getUserSecretsManager(): UserSecretsManagerPromise;
 }
 
@@ -6703,6 +7291,21 @@ class ServiceProviderImpl implements ServiceProvider {
         return new ResourceNotificationServicePromiseImpl(this._getResourceNotificationServiceInternal(), this._client);
     }
 
+    /** Gets the Aspire store from the service provider */
+    /** @internal */
+    async _getAspireStoreInternal(): Promise<AspireStore> {
+        const rpcArgs: Record<string, unknown> = { serviceProvider: this._handle };
+        const result = await this._client.invokeCapability<IAspireStoreHandle>(
+            'Aspire.Hosting/getAspireStore',
+            rpcArgs
+        );
+        return new AspireStoreImpl(result, this._client);
+    }
+
+    getAspireStore(): AspireStorePromise {
+        return new AspireStorePromiseImpl(this._getAspireStoreInternal(), this._client);
+    }
+
     /** Gets the user secrets manager from the service provider */
     /** @internal */
     async _getUserSecretsManagerInternal(): Promise<UserSecretsManager> {
@@ -6758,6 +7361,11 @@ class ServiceProviderPromiseImpl implements ServiceProviderPromise {
     /** Gets the resource notification service from the service provider */
     getResourceNotificationService(): ResourceNotificationServicePromise {
         return new ResourceNotificationServicePromiseImpl(this._promise.then(obj => obj.getResourceNotificationService()), this._client);
+    }
+
+    /** Gets the Aspire store from the service provider */
+    getAspireStore(): AspireStorePromise {
+        return new AspireStorePromiseImpl(this._promise.then(obj => obj.getAspireStore()), this._client);
     }
 
     /** Gets the user secrets manager from the service provider */
@@ -6937,6 +7545,7 @@ export interface ConnectionStringResource {
     onConnectionStringAvailable(callback: (arg: ConnectionStringAvailableEvent) => Promise<void>): ConnectionStringResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ConnectionStringResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ConnectionStringResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ConnectionStringResourcePromise;
     withConfig(config: TestConfigDto): ConnectionStringResourcePromise;
     withConnectionString(connectionString: ReferenceExpression): ConnectionStringResourcePromise;
@@ -6996,6 +7605,7 @@ export interface ConnectionStringResourcePromise extends PromiseLike<ConnectionS
     onConnectionStringAvailable(callback: (arg: ConnectionStringAvailableEvent) => Promise<void>): ConnectionStringResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ConnectionStringResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ConnectionStringResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ConnectionStringResourcePromise;
     withConfig(config: TestConfigDto): ConnectionStringResourcePromise;
     withConnectionString(connectionString: ReferenceExpression): ConnectionStringResourcePromise;
@@ -7581,6 +8191,15 @@ class ConnectionStringResourceImpl extends ResourceBuilderBase<ConnectionStringR
         return new ConnectionStringResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ConnectionStringResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
@@ -8151,6 +8770,11 @@ class ConnectionStringResourcePromiseImpl implements ConnectionStringResourcePro
         return new ConnectionStringResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): ConnectionStringResourcePromise {
         return new ConnectionStringResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -8302,6 +8926,7 @@ export interface ContainerRegistryResource {
     onResourceStopped(callback: (arg: ResourceStoppedEvent) => Promise<void>): ContainerRegistryResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ContainerRegistryResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ContainerRegistryResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ContainerRegistryResourcePromise;
     withConfig(config: TestConfigDto): ContainerRegistryResourcePromise;
     withCreatedAt(createdAt: string): ContainerRegistryResourcePromise;
@@ -8350,6 +8975,7 @@ export interface ContainerRegistryResourcePromise extends PromiseLike<ContainerR
     onResourceStopped(callback: (arg: ResourceStoppedEvent) => Promise<void>): ContainerRegistryResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ContainerRegistryResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ContainerRegistryResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ContainerRegistryResourcePromise;
     withConfig(config: TestConfigDto): ContainerRegistryResourcePromise;
     withCreatedAt(createdAt: string): ContainerRegistryResourcePromise;
@@ -8790,6 +9416,15 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
     /** Subscribes to the ResourceReady event */
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
+    }
+
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
     }
 
     /** @internal */
@@ -9287,6 +9922,11 @@ class ContainerRegistryResourcePromiseImpl implements ContainerRegistryResourceP
         return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -9490,6 +10130,7 @@ export interface ContainerResource {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ContainerResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): ContainerResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ContainerResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ContainerResourcePromise;
     withConfig(config: TestConfigDto): ContainerResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ContainerResourcePromise;
@@ -9602,6 +10243,7 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ContainerResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): ContainerResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ContainerResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ContainerResourcePromise;
     withConfig(config: TestConfigDto): ContainerResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ContainerResourcePromise;
@@ -11143,6 +11785,15 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
         return new ContainerResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
@@ -11995,6 +12646,11 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -12192,6 +12848,7 @@ export interface CSharpAppResource {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): CSharpAppResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): CSharpAppResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): CSharpAppResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): CSharpAppResourcePromise;
     withConfig(config: TestConfigDto): CSharpAppResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): CSharpAppResourcePromise;
@@ -12288,6 +12945,7 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): CSharpAppResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): CSharpAppResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): CSharpAppResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): CSharpAppResourcePromise;
     withConfig(config: TestConfigDto): CSharpAppResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): CSharpAppResourcePromise;
@@ -13570,6 +14228,15 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
         return new CSharpAppResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
@@ -14342,6 +15009,11 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -14545,6 +15217,7 @@ export interface DotnetToolResource {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): DotnetToolResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): DotnetToolResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): DotnetToolResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): DotnetToolResourcePromise;
     withConfig(config: TestConfigDto): DotnetToolResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): DotnetToolResourcePromise;
@@ -14647,6 +15320,7 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): DotnetToolResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): DotnetToolResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): DotnetToolResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): DotnetToolResourcePromise;
     withConfig(config: TestConfigDto): DotnetToolResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): DotnetToolResourcePromise;
@@ -16016,6 +16690,15 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
         return new DotnetToolResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<DotnetToolResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
@@ -16818,6 +17501,11 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -17015,6 +17703,7 @@ export interface ExecutableResource {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ExecutableResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): ExecutableResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ExecutableResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ExecutableResourcePromise;
     withConfig(config: TestConfigDto): ExecutableResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ExecutableResourcePromise;
@@ -17111,6 +17800,7 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ExecutableResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): ExecutableResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ExecutableResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ExecutableResourcePromise;
     withConfig(config: TestConfigDto): ExecutableResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ExecutableResourcePromise;
@@ -18390,6 +19080,15 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
         return new ExecutableResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
@@ -19162,6 +19861,11 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -19314,6 +20018,7 @@ export interface ExternalServiceResource {
     onResourceStopped(callback: (arg: ResourceStoppedEvent) => Promise<void>): ExternalServiceResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ExternalServiceResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ExternalServiceResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ExternalServiceResourcePromise;
     withConfig(config: TestConfigDto): ExternalServiceResourcePromise;
     withCreatedAt(createdAt: string): ExternalServiceResourcePromise;
@@ -19363,6 +20068,7 @@ export interface ExternalServiceResourcePromise extends PromiseLike<ExternalServ
     onResourceStopped(callback: (arg: ResourceStoppedEvent) => Promise<void>): ExternalServiceResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ExternalServiceResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ExternalServiceResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ExternalServiceResourcePromise;
     withConfig(config: TestConfigDto): ExternalServiceResourcePromise;
     withCreatedAt(createdAt: string): ExternalServiceResourcePromise;
@@ -19822,6 +20528,15 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
     /** Subscribes to the ResourceReady event */
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
+    }
+
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
     }
 
     /** @internal */
@@ -20324,6 +21039,11 @@ class ExternalServiceResourcePromiseImpl implements ExternalServiceResourcePromi
         return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -20466,6 +21186,7 @@ export interface ParameterResource {
     onResourceStopped(callback: (arg: ResourceStoppedEvent) => Promise<void>): ParameterResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ParameterResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ParameterResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ParameterResourcePromise;
     withConfig(config: TestConfigDto): ParameterResourcePromise;
     withCreatedAt(createdAt: string): ParameterResourcePromise;
@@ -20515,6 +21236,7 @@ export interface ParameterResourcePromise extends PromiseLike<ParameterResource>
     onResourceStopped(callback: (arg: ResourceStoppedEvent) => Promise<void>): ParameterResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ParameterResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ParameterResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ParameterResourcePromise;
     withConfig(config: TestConfigDto): ParameterResourcePromise;
     withCreatedAt(createdAt: string): ParameterResourcePromise;
@@ -20972,6 +21694,15 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
     /** Subscribes to the ResourceReady event */
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
+    }
+
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
     }
 
     /** @internal */
@@ -21474,6 +22205,11 @@ class ParameterResourcePromiseImpl implements ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -21661,6 +22397,7 @@ export interface ProjectResource {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ProjectResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): ProjectResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ProjectResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ProjectResourcePromise;
     withConfig(config: TestConfigDto): ProjectResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ProjectResourcePromise;
@@ -21757,6 +22494,7 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ProjectResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): ProjectResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ProjectResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ProjectResourcePromise;
     withConfig(config: TestConfigDto): ProjectResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ProjectResourcePromise;
@@ -23039,6 +23777,15 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
         return new ProjectResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
@@ -23811,6 +24558,11 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -24024,6 +24776,7 @@ export interface TestDatabaseResource {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): TestDatabaseResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): TestDatabaseResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): TestDatabaseResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): TestDatabaseResourcePromise;
     withConfig(config: TestConfigDto): TestDatabaseResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): TestDatabaseResourcePromise;
@@ -24136,6 +24889,7 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): TestDatabaseResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): TestDatabaseResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): TestDatabaseResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): TestDatabaseResourcePromise;
     withConfig(config: TestConfigDto): TestDatabaseResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): TestDatabaseResourcePromise;
@@ -25677,6 +26431,15 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
         return new TestDatabaseResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
@@ -26529,6 +27292,11 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -26746,6 +27514,7 @@ export interface TestRedisResource {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): TestRedisResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): TestRedisResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): TestRedisResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     addTestChildDatabase(name: string, options?: AddTestChildDatabaseOptions): TestDatabaseResourcePromise;
     withPersistence(options?: WithPersistenceOptions): TestRedisResourcePromise;
     withOptionalString(options?: WithOptionalStringOptions): TestRedisResourcePromise;
@@ -26874,6 +27643,7 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): TestRedisResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): TestRedisResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): TestRedisResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     addTestChildDatabase(name: string, options?: AddTestChildDatabaseOptions): TestDatabaseResourcePromise;
     withPersistence(options?: WithPersistenceOptions): TestRedisResourcePromise;
     withOptionalString(options?: WithOptionalStringOptions): TestRedisResourcePromise;
@@ -28486,6 +29256,15 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
         return new TestRedisResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _addTestChildDatabaseInternal(name: string, databaseName?: string): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
@@ -29527,6 +30306,11 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds a child database to a test Redis resource */
     addTestChildDatabase(name: string, options?: AddTestChildDatabaseOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.addTestChildDatabase(name, options)), this._client);
@@ -29800,6 +30584,7 @@ export interface TestVaultResource {
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): TestVaultResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): TestVaultResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): TestVaultResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): TestVaultResourcePromise;
     withConfig(config: TestConfigDto): TestVaultResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): TestVaultResourcePromise;
@@ -29913,6 +30698,7 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): TestVaultResourcePromise;
     onResourceEndpointsAllocated(callback: (arg: ResourceEndpointsAllocatedEvent) => Promise<void>): TestVaultResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): TestVaultResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): TestVaultResourcePromise;
     withConfig(config: TestConfigDto): TestVaultResourcePromise;
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): TestVaultResourcePromise;
@@ -31455,6 +32241,15 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
         return new TestVaultResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
@@ -32322,6 +33117,11 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
+    }
+
     /** Adds an optional string parameter */
     withOptionalString(options?: WithOptionalStringOptions): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withOptionalString(options)), this._client);
@@ -32654,6 +33454,7 @@ export interface Resource {
     onResourceStopped(callback: (arg: ResourceStoppedEvent) => Promise<void>): ResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ResourcePromise;
     withConfig(config: TestConfigDto): ResourcePromise;
     withCreatedAt(createdAt: string): ResourcePromise;
@@ -32702,6 +33503,7 @@ export interface ResourcePromise extends PromiseLike<Resource> {
     onResourceStopped(callback: (arg: ResourceStoppedEvent) => Promise<void>): ResourcePromise;
     onInitializeResource(callback: (arg: InitializeResourceEvent) => Promise<void>): ResourcePromise;
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ResourcePromise;
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
     withOptionalString(options?: WithOptionalStringOptions): ResourcePromise;
     withConfig(config: TestConfigDto): ResourcePromise;
     withCreatedAt(createdAt: string): ResourcePromise;
@@ -33142,6 +33944,15 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
     /** Subscribes to the ResourceReady event */
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ResourcePromise {
         return new ResourcePromiseImpl(this._onResourceReadyInternal(callback), this._client);
+    }
+
+    /** Creates an execution configuration builder */
+    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
+            'Aspire.Hosting/createExecutionConfiguration',
+            rpcArgs
+        );
     }
 
     /** @internal */
@@ -33637,6 +34448,11 @@ class ResourcePromiseImpl implements ResourcePromise {
     /** Subscribes to the ResourceReady event */
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): ResourcePromise {
         return new ResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
+    }
+
+    /** Creates an execution configuration builder */
+    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
+        return this._promise.then(obj => obj.createExecutionConfiguration());
     }
 
     /** Adds an optional string parameter */
@@ -35372,6 +36188,7 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointRe
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReferenceExpression', (handle, client) => new EndpointReferenceExpressionImpl(handle as EndpointReferenceExpressionHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext', (handle, client) => new EndpointUpdateContextImpl(handle as EndpointUpdateContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext', (handle, client) => new EnvironmentCallbackContextImpl(handle as EnvironmentCallbackContextHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext', (handle, client) => new EventingSubscriberRegistrationContextImpl(handle as EventingSubscriberRegistrationContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext', (handle, client) => new ExecuteCommandContextImpl(handle as ExecuteCommandContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent', (handle, client) => new InitializeResourceEventImpl(handle as InitializeResourceEventHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigurationContext', (handle, client) => new PipelineConfigurationContextImpl(handle as PipelineConfigurationContextHandle, client));
@@ -35393,15 +36210,19 @@ registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hos
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext', (handle, client) => new TestEnvironmentContextImpl(handle as TestEnvironmentContextHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext', (handle, client) => new TestResourceContextImpl(handle as TestResourceContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.UpdateCommandStateContext', (handle, client) => new UpdateCommandStateContextImpl(handle as UpdateCommandStateContextHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore', (handle, client) => new AspireStoreImpl(handle as IAspireStoreHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfiguration', (handle, client) => new ConfigurationImpl(handle as IConfigurationHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder', (handle, client) => new DistributedApplicationBuilderImpl(handle as IDistributedApplicationBuilderHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationEventing', (handle, client) => new DistributedApplicationEventingImpl(handle as IDistributedApplicationEventingHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline', (handle, client) => new DistributedApplicationPipelineImpl(handle as IDistributedApplicationPipelineHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder', (handle, client) => new ExecutionConfigurationBuilderImpl(handle as IExecutionConfigurationBuilderHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult', (handle, client) => new ExecutionConfigurationResultImpl(handle as IExecutionConfigurationResultHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.IHostEnvironment', (handle, client) => new HostEnvironmentImpl(handle as IHostEnvironmentHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILogger', (handle, client) => new LoggerImpl(handle as ILoggerHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory', (handle, client) => new LoggerFactoryImpl(handle as ILoggerFactoryHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep', (handle, client) => new ReportingStepImpl(handle as IReportingStepHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingTask', (handle, client) => new ReportingTaskImpl(handle as IReportingTaskHandle, client));
+registerHandleWrapper('Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection', (handle, client) => new ServiceCollectionImpl(handle as IServiceCollectionHandle, client));
 registerHandleWrapper('System.ComponentModel/System.IServiceProvider', (handle, client) => new ServiceProviderImpl(handle as IServiceProviderHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IUserSecretsManager', (handle, client) => new UserSecretsManagerImpl(handle as IUserSecretsManagerHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ConnectionStringResource', (handle, client) => new ConnectionStringResourceImpl(handle as ConnectionStringResourceHandle, client));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -259,9 +259,6 @@ type IConfigurationHandle = Handle<'Microsoft.Extensions.Configuration.Abstracti
 /** Handle to IConfigurationSection */
 type IConfigurationSectionHandle = Handle<'Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfigurationSection'>;
 
-/** Handle to IServiceCollection */
-type IServiceCollectionHandle = Handle<'Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection'>;
-
 /** Handle to IHostEnvironment */
 type IHostEnvironmentHandle = Handle<'Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.IHostEnvironment'>;
 
@@ -5223,9 +5220,6 @@ export interface DistributedApplicationBuilder {
     environment: {
         get: () => Promise<HostEnvironment>;
     };
-    services: {
-        get: () => Promise<ServiceCollection>;
-    };
     eventing: {
         get: () => Promise<DistributedApplicationEventing>;
     };
@@ -5264,6 +5258,8 @@ export interface DistributedApplicationBuilder {
     getConfiguration(): ConfigurationPromise;
     subscribeBeforeStart(callback: (arg: BeforeStartEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle>;
     subscribeAfterResourcesCreated(callback: (arg: AfterResourcesCreatedEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle>;
+    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): DistributedApplicationBuilderPromise;
+    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): DistributedApplicationBuilderPromise;
     addTestRedis(name: string, options?: AddTestRedisOptions): TestRedisResourcePromise;
     addTestVault(name: string): TestVaultResourcePromise;
 }
@@ -5295,6 +5291,8 @@ export interface DistributedApplicationBuilderPromise extends PromiseLike<Distri
     getConfiguration(): ConfigurationPromise;
     subscribeBeforeStart(callback: (arg: BeforeStartEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle>;
     subscribeAfterResourcesCreated(callback: (arg: AfterResourcesCreatedEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle>;
+    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): DistributedApplicationBuilderPromise;
+    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): DistributedApplicationBuilderPromise;
     addTestRedis(name: string, options?: AddTestRedisOptions): TestRedisResourcePromise;
     addTestVault(name: string): TestVaultResourcePromise;
 }
@@ -5330,17 +5328,6 @@ class DistributedApplicationBuilderImpl implements DistributedApplicationBuilder
                 { context: this._handle }
             );
             return new HostEnvironmentImpl(handle, this._client);
-        },
-    };
-
-    /** Gets the Services property */
-    services = {
-        get: async (): Promise<ServiceCollection> => {
-            const handle = await this._client.invokeCapability<IServiceCollectionHandle>(
-                'Aspire.Hosting/IDistributedApplicationBuilder.services',
-                { context: this._handle }
-            );
-            return new ServiceCollectionImpl(handle, this._client);
         },
     };
 
@@ -5824,6 +5811,46 @@ class DistributedApplicationBuilderImpl implements DistributedApplicationBuilder
         );
     }
 
+    /** Adds an eventing subscriber */
+    /** @internal */
+    async _addEventingSubscriberInternal(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): Promise<DistributedApplicationBuilder> {
+        const subscribeId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as EventingSubscriberRegistrationContextHandle;
+            const arg = new EventingSubscriberRegistrationContextImpl(argHandle, this._client);
+            await subscribe(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, subscribe: subscribeId };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/addEventingSubscriber',
+            rpcArgs
+        );
+        return this;
+    }
+
+    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): DistributedApplicationBuilderPromise {
+        return new DistributedApplicationBuilderPromiseImpl(this._addEventingSubscriberInternal(subscribe), this._client);
+    }
+
+    /** Attempts to add an eventing subscriber */
+    /** @internal */
+    async _tryAddEventingSubscriberInternal(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): Promise<DistributedApplicationBuilder> {
+        const subscribeId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as EventingSubscriberRegistrationContextHandle;
+            const arg = new EventingSubscriberRegistrationContextImpl(argHandle, this._client);
+            await subscribe(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, subscribe: subscribeId };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/tryAddEventingSubscriber',
+            rpcArgs
+        );
+        return this;
+    }
+
+    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): DistributedApplicationBuilderPromise {
+        return new DistributedApplicationBuilderPromiseImpl(this._tryAddEventingSubscriberInternal(subscribe), this._client);
+    }
+
     /** Adds a test Redis resource */
     /** @internal */
     async _addTestRedisInternal(name: string, port?: number): Promise<TestRedisResource> {
@@ -6001,6 +6028,16 @@ class DistributedApplicationBuilderPromiseImpl implements DistributedApplication
     /** Subscribes to the AfterResourcesCreated event */
     subscribeAfterResourcesCreated(callback: (arg: AfterResourcesCreatedEvent) => Promise<void>): Promise<DistributedApplicationEventSubscriptionHandle> {
         return this._promise.then(obj => obj.subscribeAfterResourcesCreated(callback));
+    }
+
+    /** Adds an eventing subscriber */
+    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): DistributedApplicationBuilderPromise {
+        return new DistributedApplicationBuilderPromiseImpl(this._promise.then(obj => obj.addEventingSubscriber(subscribe)), this._client);
+    }
+
+    /** Attempts to add an eventing subscriber */
+    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): DistributedApplicationBuilderPromise {
+        return new DistributedApplicationBuilderPromiseImpl(this._promise.then(obj => obj.tryAddEventingSubscriber(subscribe)), this._client);
     }
 
     /** Adds a test Redis resource */
@@ -7077,103 +7114,6 @@ class ReportingTaskPromiseImpl implements ReportingTaskPromise {
     /** Completes the reporting task with Markdown-formatted completion text */
     completeTaskMarkdown(markdownString: string, options?: CompleteTaskMarkdownOptions): ReportingTaskPromise {
         return new ReportingTaskPromiseImpl(this._promise.then(obj => obj.completeTaskMarkdown(markdownString, options)), this._client);
-    }
-
-}
-
-// ============================================================================
-// ServiceCollection
-// ============================================================================
-
-export interface ServiceCollection {
-    toJSON(): MarshalledHandle;
-    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise;
-    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise;
-}
-
-export interface ServiceCollectionPromise extends PromiseLike<ServiceCollection> {
-    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise;
-    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise;
-}
-
-// ============================================================================
-// ServiceCollectionImpl
-// ============================================================================
-
-/**
- * Type class for ServiceCollection.
- */
-class ServiceCollectionImpl implements ServiceCollection {
-    constructor(private _handle: IServiceCollectionHandle, private _client: AspireClientRpc) {}
-
-    /** Serialize for JSON-RPC transport */
-    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
-
-    /** Adds an eventing subscriber */
-    /** @internal */
-    async _addEventingSubscriberInternal(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): Promise<ServiceCollection> {
-        const subscribeId = registerCallback(async (argData: unknown) => {
-            const argHandle = wrapIfHandle(argData) as EventingSubscriberRegistrationContextHandle;
-            const arg = new EventingSubscriberRegistrationContextImpl(argHandle, this._client);
-            await subscribe(arg);
-        });
-        const rpcArgs: Record<string, unknown> = { services: this._handle, subscribe: subscribeId };
-        await this._client.invokeCapability<void>(
-            'Aspire.Hosting/addEventingSubscriber',
-            rpcArgs
-        );
-        return this;
-    }
-
-    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise {
-        return new ServiceCollectionPromiseImpl(this._addEventingSubscriberInternal(subscribe), this._client);
-    }
-
-    /** Attempts to add an eventing subscriber */
-    /** @internal */
-    async _tryAddEventingSubscriberInternal(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): Promise<ServiceCollection> {
-        const subscribeId = registerCallback(async (argData: unknown) => {
-            const argHandle = wrapIfHandle(argData) as EventingSubscriberRegistrationContextHandle;
-            const arg = new EventingSubscriberRegistrationContextImpl(argHandle, this._client);
-            await subscribe(arg);
-        });
-        const rpcArgs: Record<string, unknown> = { services: this._handle, subscribe: subscribeId };
-        await this._client.invokeCapability<void>(
-            'Aspire.Hosting/tryAddEventingSubscriber',
-            rpcArgs
-        );
-        return this;
-    }
-
-    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise {
-        return new ServiceCollectionPromiseImpl(this._tryAddEventingSubscriberInternal(subscribe), this._client);
-    }
-
-}
-
-/**
- * Thenable wrapper for ServiceCollection that enables fluent chaining.
- */
-class ServiceCollectionPromiseImpl implements ServiceCollectionPromise {
-    constructor(private _promise: Promise<ServiceCollection>, private _client: AspireClientRpc, track = true) {
-        if (track) { _client.trackPromise(_promise); }
-    }
-
-    then<TResult1 = ServiceCollection, TResult2 = never>(
-        onfulfilled?: ((value: ServiceCollection) => TResult1 | PromiseLike<TResult1>) | null,
-        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
-    ): PromiseLike<TResult1 | TResult2> {
-        return this._promise.then(onfulfilled, onrejected);
-    }
-
-    /** Adds an eventing subscriber */
-    addEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise {
-        return new ServiceCollectionPromiseImpl(this._promise.then(obj => obj.addEventingSubscriber(subscribe)), this._client);
-    }
-
-    /** Attempts to add an eventing subscriber */
-    tryAddEventingSubscriber(subscribe: (arg: EventingSubscriberRegistrationContext) => Promise<void>): ServiceCollectionPromise {
-        return new ServiceCollectionPromiseImpl(this._promise.then(obj => obj.tryAddEventingSubscriber(subscribe)), this._client);
     }
 
 }
@@ -36222,7 +36162,6 @@ registerHandleWrapper('Microsoft.Extensions.Logging.Abstractions/Microsoft.Exten
 registerHandleWrapper('Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory', (handle, client) => new LoggerFactoryImpl(handle as ILoggerFactoryHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep', (handle, client) => new ReportingStepImpl(handle as IReportingStepHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingTask', (handle, client) => new ReportingTaskImpl(handle as IReportingTaskHandle, client));
-registerHandleWrapper('Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.IServiceCollection', (handle, client) => new ServiceCollectionImpl(handle as IServiceCollectionHandle, client));
 registerHandleWrapper('System.ComponentModel/System.IServiceProvider', (handle, client) => new ServiceProviderImpl(handle as IServiceProviderHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IUserSecretsManager', (handle, client) => new UserSecretsManagerImpl(handle as IUserSecretsManagerHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ConnectionStringResource', (handle, client) => new ConnectionStringResourceImpl(handle as ConnectionStringResourceHandle, client));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1,4 +1,4 @@
-﻿// aspire.ts - Capability-based Aspire SDK
+// aspire.ts - Capability-based Aspire SDK
 // This SDK uses the ATS (Aspire Type System) capability API.
 // Capabilities are endpoints like 'Aspire.Hosting/createBuilder'.
 //

--- a/tests/Aspire.Hosting.Tests/AtsServiceCollectionExportsTests.cs
+++ b/tests/Aspire.Hosting.Tests/AtsServiceCollectionExportsTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Aspire.Hosting.Lifecycle;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Tests;
+
+[Trait("Partition", "5")]
+public class AtsServiceCollectionExportsTests
+{
+    [Fact]
+    public void TryAddEventingSubscriber_AllowsDistinctCallbacks()
+    {
+        var services = new ServiceCollection();
+        var method = typeof(DistributedApplication).Assembly
+            .GetType("Aspire.Hosting.Ats.ServiceCollectionExports", throwOnError: true)!
+            .GetMethod("TryAddEventingSubscriber", BindingFlags.Public | BindingFlags.Static)!;
+
+        var firstSubscriber = CreateCallback(method.GetParameters()[1].ParameterType);
+        var secondSubscriber = CreateCallback(method.GetParameters()[1].ParameterType);
+
+        method.Invoke(null, [services, firstSubscriber]);
+        method.Invoke(null, [services, firstSubscriber]);
+        method.Invoke(null, [services, secondSubscriber]);
+
+        var subscribers = services
+            .Where(descriptor => descriptor.ServiceType == typeof(IDistributedApplicationEventingSubscriber))
+            .Select(descriptor => descriptor.ImplementationInstance)
+            .ToList();
+
+        Assert.Equal(2, subscribers.Count);
+    }
+
+    private static Delegate CreateCallback(Type delegateType)
+    {
+        var contextType = delegateType.GenericTypeArguments[0];
+        var contextParameter = Expression.Parameter(contextType, "context");
+        var completedTask = Expression.Property(null, typeof(Task).GetProperty(nameof(Task.CompletedTask))!);
+
+        return Expression.Lambda(delegateType, completedTask, contextParameter).Compile();
+    }
+}

--- a/tests/Aspire.Hosting.Tests/AtsServiceCollectionExportsTests.cs
+++ b/tests/Aspire.Hosting.Tests/AtsServiceCollectionExportsTests.cs
@@ -4,7 +4,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Aspire.Hosting.Lifecycle;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Tests;
 
@@ -14,20 +13,22 @@ public class AtsServiceCollectionExportsTests
     [Fact]
     public void TryAddEventingSubscriber_AllowsDistinctCallbacks()
     {
-        var services = new ServiceCollection();
+        var builder = DistributedApplication.CreateBuilder([]);
         var method = typeof(DistributedApplication).Assembly
             .GetType("Aspire.Hosting.Ats.ServiceCollectionExports", throwOnError: true)!
             .GetMethod("TryAddEventingSubscriber", BindingFlags.Public | BindingFlags.Static)!;
+        var callbackSubscriberType = method.DeclaringType!.GetNestedType("CallbackEventingSubscriber", BindingFlags.NonPublic)!;
 
         var firstSubscriber = CreateCallback(method.GetParameters()[1].ParameterType);
         var secondSubscriber = CreateCallback(method.GetParameters()[1].ParameterType);
 
-        method.Invoke(null, [services, firstSubscriber]);
-        method.Invoke(null, [services, firstSubscriber]);
-        method.Invoke(null, [services, secondSubscriber]);
+        method.Invoke(null, [builder, firstSubscriber]);
+        method.Invoke(null, [builder, firstSubscriber]);
+        method.Invoke(null, [builder, secondSubscriber]);
 
-        var subscribers = services
-            .Where(descriptor => descriptor.ServiceType == typeof(IDistributedApplicationEventingSubscriber))
+        var subscribers = builder.Services
+            .Where(descriptor => descriptor.ServiceType == typeof(IDistributedApplicationEventingSubscriber) &&
+                                 descriptor.ImplementationInstance?.GetType() == callbackSubscriberType)
             .Select(descriptor => descriptor.ImplementationInstance)
             .ToList();
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -100,6 +100,49 @@ void main() throws Exception {
         var builderExecutionContext = builder.executionContext();
         var executionContextServiceProvider = builderExecutionContext.serviceProvider();
         var _distributedApplicationModelFromExecutionContext = executionContextServiceProvider.getDistributedApplicationModel();
+        var builderServices = builder.services();
+        builderServices.addEventingSubscriber((registrationContext) -> {
+            var subscriberExecutionContext = registrationContext.executionContext();
+            var _subscriberIsRunMode = subscriberExecutionContext.isRunMode();
+            var _subscriberCancellationToken = registrationContext.cancellationToken();
+            registrationContext.onBeforeStart((beforeStartEvent) -> {
+                var subscriberServices = beforeStartEvent.services();
+                var aspireStore = subscriberServices.getAspireStore();
+                var _contentBackedFilename = aspireStore.getFileNameWithContent("validation-apphost.java", "AppHost.java");
+            });
+            registrationContext.onAfterResourcesCreated((afterResourcesCreatedEvent) -> {
+                var afterResourcesCreatedServices = afterResourcesCreatedEvent.services();
+                var afterResourcesCreatedModel = afterResourcesCreatedEvent.model();
+                var _afterResourcesCreatedEventing = afterResourcesCreatedServices.getEventing();
+                var _afterResourcesCreatedResources = afterResourcesCreatedModel.getResources();
+            });
+        });
+        builderServices.tryAddEventingSubscriber((_registrationContext) -> { });
+        container.withArgs(new String[] { "--validation" });
+        var executionConfigurationBuilder = container.createExecutionConfiguration();
+        executionConfigurationBuilder.withArgumentsConfig();
+        executionConfigurationBuilder.withEnvironmentVariablesConfig();
+        executionConfigurationBuilder.withCertificateTrustConfig((requestedTrustScope) -> {
+            var _requestedTrustScope = requestedTrustScope;
+            var trustContext = new CertificateTrustExecutionConfigurationContext();
+            trustContext.setCertificateBundlePath(ReferenceExpression.refExpr("/etc/ssl/certs/custom-bundle.pem"));
+            trustContext.setCertificateDirectoriesPath(ReferenceExpression.refExpr("/etc/ssl/certs/custom"));
+            trustContext.setRootCertificatesPath("/etc/ssl/certs");
+            trustContext.setIsContainer(true);
+            return trustContext;
+        });
+        executionConfigurationBuilder.withHttpsCertificateConfig((certificateInfo) -> {
+            var _certificateSubject = certificateInfo.getSubject();
+            var _certificateThumbprint = certificateInfo.getThumbprint();
+            var certificateContext = new HttpsCertificateExecutionConfigurationContext();
+            certificateContext.setCertificatePath(ReferenceExpression.refExpr("/certificates/tls.crt"));
+            certificateContext.setKeyPath(ReferenceExpression.refExpr("/certificates/tls.key"));
+            certificateContext.setPfxPath(ReferenceExpression.refExpr("/certificates/tls.pfx"));
+            return certificateContext;
+        });
+        var executionConfiguration = executionConfigurationBuilder.build(builderExecutionContext);
+        var _certificateTrustData = executionConfiguration.getCertificateTrustData();
+        var _httpsCertificateData = executionConfiguration.getHttpsCertificateData();
         var beforeStartSubscription = builder.subscribeBeforeStart((beforeStartEvent) -> { var beforeStartServices = beforeStartEvent.services(); var beforeStartModel = beforeStartEvent.model(); var _beforeStartResources = beforeStartModel.getResources(); var _beforeStartContainer = beforeStartModel.findResourceByName("mycontainer"); var _beforeStartEventing = beforeStartServices.getEventing(); var beforeStartLoggerFactory = beforeStartServices.getLoggerFactory(); var beforeStartLogger = beforeStartLoggerFactory.createLogger("ValidationAppHost.BeforeStart"); beforeStartLogger.logInformation("BeforeStart information"); beforeStartLogger.logWarning("BeforeStart warning"); beforeStartLogger.logError("BeforeStart error"); beforeStartLogger.logDebug("BeforeStart debug"); beforeStartLogger.log("critical", "BeforeStart critical"); var beforeStartResourceLoggerService = beforeStartServices.getResourceLoggerService(); beforeStartResourceLoggerService.completeLog(container); beforeStartResourceLoggerService.completeLogByName("mycontainer"); var beforeStartNotificationService = beforeStartServices.getResourceNotificationService(); beforeStartNotificationService.waitForResourceState("mycontainer", "Running"); var _matchedResourceState = beforeStartNotificationService.waitForResourceStates("mycontainer", new String[] { "Running", "FailedToStart" }); var _healthyResourceEvent = beforeStartNotificationService.waitForResourceHealthy("mycontainer"); beforeStartNotificationService.waitForDependencies(container); var _currentResourceState = beforeStartNotificationService.tryGetResourceState("mycontainer"); beforeStartNotificationService.publishResourceUpdate(container, new PublishResourceUpdateOptions().state("Validated").stateStyle("info")); var userSecretsManager = beforeStartServices.getUserSecretsManager(); var _userSecretsAvailable = userSecretsManager.isAvailable(); var _userSecretsFilePath = userSecretsManager.filePath(); var _secretSet = userSecretsManager.trySetSecret("Validation:Key", "value"); userSecretsManager.getOrSetSecret(container, "Validation:GeneratedKey", "generated-value"); var _generatedSecretValue = builderConfiguration.getConfigValue("Validation:GeneratedKey"); userSecretsManager.saveStateJson("{\"Validation\":\"Value\"}"); var _modelFromServices = beforeStartServices.getDistributedApplicationModel(); });
         var afterResourcesCreatedSubscription = builder.subscribeAfterResourcesCreated((afterResourcesCreatedEvent) -> { var afterResourcesCreatedServices = afterResourcesCreatedEvent.services(); var afterResourcesCreatedModel = afterResourcesCreatedEvent.model(); var _afterResources = afterResourcesCreatedModel.getResources(); var _afterResourcesContainer = afterResourcesCreatedModel.findResourceByName("mycontainer"); var afterResourcesCreatedLoggerFactory = afterResourcesCreatedServices.getLoggerFactory(); var afterResourcesCreatedLogger = afterResourcesCreatedLoggerFactory.createLogger("ValidationAppHost.AfterResourcesCreated"); afterResourcesCreatedLogger.logInformation("AfterResourcesCreated"); });
         var builderEventing = builder.eventing();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -100,8 +100,7 @@ void main() throws Exception {
         var builderExecutionContext = builder.executionContext();
         var executionContextServiceProvider = builderExecutionContext.serviceProvider();
         var _distributedApplicationModelFromExecutionContext = executionContextServiceProvider.getDistributedApplicationModel();
-        var builderServices = builder.services();
-        builderServices.addEventingSubscriber((registrationContext) -> {
+        builder.addEventingSubscriber((registrationContext) -> {
             var subscriberExecutionContext = registrationContext.executionContext();
             var _subscriberIsRunMode = subscriberExecutionContext.isRunMode();
             var _subscriberCancellationToken = registrationContext.cancellationToken();
@@ -117,7 +116,7 @@ void main() throws Exception {
                 var _afterResourcesCreatedResources = afterResourcesCreatedModel.getResources();
             });
         });
-        builderServices.tryAddEventingSubscriber((_registrationContext) -> { });
+        builder.tryAddEventingSubscriber((_registrationContext) -> { });
         container.withArgs(new String[] { "--validation" });
         var executionConfigurationBuilder = container.createExecutionConfiguration();
         executionConfigurationBuilder.withArgumentsConfig();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -190,7 +190,6 @@ with create_builder() as builder:
     builder_execution_context = builder.execution_context
     execution_context_service_provider = builder_execution_context.service_provider
     _distributed_application_model_from_execution_context = execution_context_service_provider.get_distributed_app_model()
-    builder_services = builder.services
 
     def configure_eventing_subscriber(registration_context):
         _subscriber_execution_context = registration_context.execution_context
@@ -209,8 +208,8 @@ with create_builder() as builder:
         registration_context.on_before_start(on_eventing_before_start)
         registration_context.on_after_resources_created(on_eventing_after_resources_created)
 
-    builder_services.add_eventing_subscriber(configure_eventing_subscriber)
-    builder_services.try_add_eventing_subscriber(lambda _registration_context: None)
+    builder.add_eventing_subscriber(configure_eventing_subscriber)
+    builder.try_add_eventing_subscriber(lambda _registration_context: None)
 
     container.with_args(["--validation"])
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -1,7 +1,7 @@
 # Aspire Python validation AppHost
 # Mirrors the top-level TypeScript playground surface with Python-style members.
 
-from aspire_app import create_builder
+from aspire_app import ReferenceExpression, create_builder
 
 
 with create_builder() as builder:
@@ -189,7 +189,57 @@ with create_builder() as builder:
     _config_exists = builder_configuration.exists()
     builder_execution_context = builder.execution_context
     execution_context_service_provider = builder_execution_context.service_provider
-    _distributed_application_model_from_execution_context = execution_context_service_provider.get_distributed_application_model()
+    _distributed_application_model_from_execution_context = execution_context_service_provider.get_distributed_app_model()
+    builder_services = builder.services
+
+    def configure_eventing_subscriber(registration_context):
+        _subscriber_execution_context = registration_context.execution_context
+
+        def on_eventing_before_start(before_start_event):
+            subscriber_services = before_start_event.services
+            aspire_store = subscriber_services.get_aspire_store()
+            _content_backed_filename = aspire_store.get_file_name_with_content("validation-apphost.py", "apphost.py")
+
+        def on_eventing_after_resources_created(after_resources_created_event):
+            after_resources_created_services = after_resources_created_event.services
+            after_resources_created_model = after_resources_created_event.model
+            _after_resources_created_eventing = after_resources_created_services.get_eventing()
+            _after_resources_created_resources = after_resources_created_model.get_resources()
+
+        registration_context.on_before_start(on_eventing_before_start)
+        registration_context.on_after_resources_created(on_eventing_after_resources_created)
+
+    builder_services.add_eventing_subscriber(configure_eventing_subscriber)
+    builder_services.try_add_eventing_subscriber(lambda _registration_context: None)
+
+    container.with_args(["--validation"])
+
+    def configure_certificate_trust(requested_trust_scope):
+        _requested_trust_scope = requested_trust_scope
+        return {
+            "CertificateBundlePath": ReferenceExpression.format_string("/etc/ssl/certs/custom-bundle.pem"),
+            "CertificateDirectoriesPath": ReferenceExpression.format_string("/etc/ssl/certs/custom"),
+            "RootCertificatesPath": "/etc/ssl/certs",
+            "IsContainer": True,
+        }
+
+    def configure_https_certificate(certificate_info):
+        _certificate_subject = certificate_info.get("Subject")
+        _certificate_thumbprint = certificate_info.get("Thumbprint")
+        return {
+            "CertificatePath": ReferenceExpression.format_string("/certificates/tls.crt"),
+            "KeyPath": ReferenceExpression.format_string("/certificates/tls.key"),
+            "PfxPath": ReferenceExpression.format_string("/certificates/tls.pfx"),
+        }
+
+    execution_config_builder = container.create_execution_config()
+    execution_config_builder.with_arguments_config()
+    execution_config_builder.with_env_vars_config()
+    execution_config_builder.with_certificate_trust_config(configure_certificate_trust)
+    execution_config_builder.with_https_certificate_config(configure_https_certificate)
+    execution_config = execution_config_builder.build(builder_execution_context)
+    _certificate_trust_data = execution_config.get_certificate_trust_data()
+    _https_certificate_data = execution_config.get_https_certificate_data()
     before_start_subscription = builder.subscribe_before_start(lambda *_args, **_kwargs: None)
     after_resources_created_subscription = builder.subscribe_after_resources_created(lambda *_args, **_kwargs: None)
     builder_eventing = builder.eventing

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
@@ -361,6 +361,59 @@ const _configExists: boolean = await builderConfiguration.exists("MyConfig:Key")
 const builderExecutionContext = await builder.executionContext.get();
 const executionContextServiceProvider = await builderExecutionContext.serviceProvider.get();
 const _distributedApplicationModelFromExecutionContext = await executionContextServiceProvider.getDistributedApplicationModel();
+const builderServices = await builder.services.get();
+
+await builderServices.addEventingSubscriber(async (registrationContext) => {
+    const subscriberExecutionContext = await registrationContext.executionContext.get();
+    const _subscriberIsRunMode: boolean = await subscriberExecutionContext.isRunMode.get();
+    const _subscriberCancellationToken = await registrationContext.cancellationToken.get();
+
+    await registrationContext.onBeforeStart(async (beforeStartEvent) => {
+        const subscriberServices = await beforeStartEvent.services.get();
+        const aspireStore = await subscriberServices.getAspireStore();
+        const _contentBackedFilename = await aspireStore.getFileNameWithContent("validation-apphost.ts", "apphost.ts");
+    });
+
+    await registrationContext.onAfterResourcesCreated(async (afterResourcesCreatedEvent) => {
+        const afterResourcesCreatedServices = await afterResourcesCreatedEvent.services.get();
+        const afterResourcesCreatedModel = await afterResourcesCreatedEvent.model.get();
+        const _afterResourcesCreatedEventing = await afterResourcesCreatedServices.getEventing();
+        const _afterResourcesCreatedResources = await afterResourcesCreatedModel.getResources();
+    });
+});
+
+await builderServices.tryAddEventingSubscriber(async (_registrationContext) => {
+});
+
+await container.withArgs(["--validation"]);
+
+const executionConfigurationBuilder = await container.createExecutionConfiguration();
+await executionConfigurationBuilder.withArgumentsConfig();
+await executionConfigurationBuilder.withEnvironmentVariablesConfig();
+await executionConfigurationBuilder.withCertificateTrustConfig(async (requestedTrustScope) => {
+    const _requestedTrustScope = requestedTrustScope;
+
+    return {
+        certificateBundlePath: refExpr`/etc/ssl/certs/custom-bundle.pem`,
+        certificateDirectoriesPath: refExpr`/etc/ssl/certs/custom`,
+        rootCertificatesPath: "/etc/ssl/certs",
+        isContainer: true,
+    };
+});
+await executionConfigurationBuilder.withHttpsCertificateConfig(async (certificateInfo) => {
+    const _certificateSubject = certificateInfo.subject;
+    const _certificateThumbprint = certificateInfo.thumbprint;
+
+    return {
+        certificatePath: refExpr`/certificates/tls.crt`,
+        keyPath: refExpr`/certificates/tls.key`,
+        pfxPath: refExpr`/certificates/tls.pfx`,
+    };
+});
+
+const executionConfiguration = await executionConfigurationBuilder.build(builderExecutionContext);
+const _certificateTrustData = await executionConfiguration.getCertificateTrustData();
+const _httpsCertificateData = await executionConfiguration.getHttpsCertificateData();
 
 const beforeStartSubscription = await builder.subscribeBeforeStart(async (beforeStartEvent) => {
     const beforeStartServices = await beforeStartEvent.services.get();
@@ -530,9 +583,6 @@ await container.withUrl("http://localhost:8080");
 
 // withUrlExpression
 await container.withUrlExpression(refExpr`http://${endpoint}`);
-
-// withHttpHealthCheck
-await container.withHttpHealthCheck();
 
 // withHttpHealthCheck
 await container.withHttpHealthCheck();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
@@ -361,9 +361,8 @@ const _configExists: boolean = await builderConfiguration.exists("MyConfig:Key")
 const builderExecutionContext = await builder.executionContext.get();
 const executionContextServiceProvider = await builderExecutionContext.serviceProvider.get();
 const _distributedApplicationModelFromExecutionContext = await executionContextServiceProvider.getDistributedApplicationModel();
-const builderServices = await builder.services.get();
 
-await builderServices.addEventingSubscriber(async (registrationContext) => {
+await builder.addEventingSubscriber(async (registrationContext) => {
     const subscriberExecutionContext = await registrationContext.executionContext.get();
     const _subscriberIsRunMode: boolean = await subscriberExecutionContext.isRunMode.get();
     const _subscriberCancellationToken = await registrationContext.cancellationToken.get();
@@ -382,7 +381,7 @@ await builderServices.addEventingSubscriber(async (registrationContext) => {
     });
 });
 
-await builderServices.tryAddEventingSubscriber(async (_registrationContext) => {
+await builder.tryAddEventingSubscriber(async (_registrationContext) => {
 });
 
 await container.withArgs(["--validation"]);


### PR DESCRIPTION
## Description

Polyglot guest apphosts were still missing several non-obsolete `Aspire.Hosting` extension methods that exist in the C# surface. This PR closes those ATS export gaps so the generated guest SDKs expose the same supported execution-configuration, Aspire store, and eventing-subscriber workflows as the C# AppHost.

The change adds ATS-specific shims where CLR-only shapes are not representable, marks incompatible overloads with redirecting ignores, updates the TypeScript, Python, and Java polyglot validation apphosts to exercise the new surface, and refreshes the generated SDK snapshots for TypeScript, Python, Java, Go, and Rust.

It also includes two follow-up correctness fixes from local review:
- `tryAddEventingSubscriber` now deduplicates only identical callback registrations instead of suppressing all later ATS callback subscribers.
- The Python validation AppHost now returns populated execution-configuration DTOs instead of empty dictionaries, and `AtsServiceCollectionExportsTests` covers the subscriber-registration behavior.

Validation:
- `./dotnet.sh build src/Aspire.Hosting/Aspire.Hosting.csproj -p:SkipNativeBuild=true`
- `npm run build --silent` in `tests/PolyglotAppHosts/Aspire.Hosting/TypeScript`
- `./.venv/bin/python -m py_compile apphost.py` in `tests/PolyglotAppHosts/Aspire.Hosting/Python`
- `javac --enable-preview --source 25 -d .build @.modules/sources.txt AppHost.java` in `tests/PolyglotAppHosts/Aspire.Hosting/Java`
- targeted codegen snapshot tests for TypeScript, Python, Java, Go, and Rust
- `./dotnet.sh test tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj -- --filter-class "*.AtsServiceCollectionExportsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Dependencies required: none.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No