### PR TITLE
Fix installer SHA-256 mismatch caused by MicroBuild repacking tar.gz on Windows

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,6 +8,9 @@
 
   <PropertyGroup>
     <_UploadPathRoot>aspire</_UploadPathRoot>
+    <!-- Already-signed native archives (macOS/Linux) are downloaded to a separate directory
+         so that MicroBuild's -sign step on Windows doesn't repack them. -->
+    <_SignedArchivesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'signed-archives', '$(Configuration)'))</_SignedArchivesDir>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -33,6 +36,9 @@
     <ItemGroup>
       <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.zip" />
       <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.tar.gz" />
+      <!-- Include already-signed native archives downloaded from build_sign_native -->
+      <_ArchiveFiles Include="$(_SignedArchivesDir)\**\aspire-cli-*.zip" />
+      <_ArchiveFiles Include="$(_SignedArchivesDir)\**\aspire-cli-*.tar.gz" />
       <!-- VS Code extension artifacts: VSIX, manifest, and signature file -->
       <_ExtensionFilesToPublish Include="$(ArtifactsPackagesDir)**\aspire-vscode-*.vsix" />
       <_ExtensionManifestFiles Include="$(ArtifactsPackagesDir)**\aspire-vscode-*.manifest" />
@@ -76,6 +82,16 @@
 
     <Error Condition="@(_InvalidWindowsArchiveFiles->Count()) > 0" Text="Windows aspire-cli archives must have .zip extension. Invalid files: @(_InvalidWindowsArchiveFiles, ', ')" />
     <Error Condition="@(_InvalidNonWindowsArchiveFiles->Count()) > 0" Text="Non-Windows aspire-cli archives must have .tar.gz extension. Invalid files: @(_InvalidNonWindowsArchiveFiles, ', ')" />
+
+    <!-- On Windows, only win-* archives should be in the packages directory (the signing scope).
+         Non-Windows archives must be in signed-archives/ to avoid MicroBuild repacking them. -->
+    <ItemGroup Condition="$([System.OperatingSystem]::IsWindows())">
+      <_PackagesDirArchives Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.zip" />
+      <_PackagesDirArchives Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.tar.gz" />
+      <_PackagesDirNonWinArchives Include="@(_PackagesDirArchives)" Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '^aspire-cli-win-'))" />
+    </ItemGroup>
+    <Error Condition="$([System.OperatingSystem]::IsWindows()) And @(_PackagesDirNonWinArchives->Count()) > 0"
+           Text="Non-Windows CLI archives found in packages directory (signing scope). These should be in signed-archives/ to prevent MicroBuild from repacking them: @(_PackagesDirNonWinArchives, ', ')" />
 
     <!--
       For blob items for the Dashboard, we want to make sure that the version we get back is not stable, even when the repo is producing stable versions.

--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -154,7 +154,11 @@ extends:
                   itemPattern: |
                     **/aspire-cli-*.zip
                     **/aspire-cli-*.tar.gz
-                  targetPath: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+                  # Download to a separate directory from artifacts/packages so that
+                  # MicroBuild's -sign step doesn't process these already-signed archives.
+                  # Repacking tar.gz on Windows changes their SHA-256, breaking installer
+                  # validation (Homebrew cask audit, WinGet manifest) against published URLs.
+                  targetPath: '$(Build.SourcesDirectory)/artifacts/signed-archives/$(_BuildConfig)'
 
               - task: PowerShell@2
                 displayName: 🟣List artifacts packages contents

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -242,7 +242,11 @@ extends:
                   itemPattern: |
                     **/aspire-cli-*.zip
                     **/aspire-cli-*.tar.gz
-                  targetPath: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+                  # Download to a separate directory from artifacts/packages so that
+                  # MicroBuild's -sign step doesn't process these already-signed archives.
+                  # Repacking tar.gz on Windows changes their SHA-256, breaking installer
+                  # validation (Homebrew cask audit, WinGet manifest) against published URLs.
+                  targetPath: '$(Build.SourcesDirectory)/artifacts/signed-archives/$(_BuildConfig)'
 
               - task: PowerShell@2
                 displayName: 🟣List artifacts packages contents


### PR DESCRIPTION
## Summary

The Windows `build` stage downloaded ALL native CLI archives (macOS/Linux tar.gz + Windows zip) into `artifacts/packages/`. When MicroBuild's `-sign` step ran, it opened the macOS/Linux tar.gz containers, found nothing to sign (`FileSignInfo` entries are OS-conditional), but repacked them — producing different SHA-256 hashes. These repacked archives got published to ci.dot.net, while `prepare_installers` computed hashes from the original pipeline artifacts, causing Homebrew cask audit and WinGet manifest validation to fail.

## Fix

Download already-signed native archives from `build_sign_native` into `artifacts/signed-archives/` instead of `artifacts/packages/`. This keeps them out of MicroBuild's signing scope on Windows. `Publishing.props` is updated to also glob `signed-archives/` for blob feed upload.

A validation check in `Publishing.props` ensures that on Windows, the packages directory (signing scope) only contains `win-*` CLI archives, preventing non-Windows archives from accidentally re-entering MicroBuild's scope.

## Changes

- **`eng/pipelines/azure-pipelines.yml`** / **`azure-pipelines-unofficial.yml`**: Download native archives to `artifacts/signed-archives/` instead of `artifacts/packages/`
- **`eng/Publishing.props`**: Add `_SignedArchivesDir` property, include its contents in `_ArchiveFiles` for blob feed publishing, and add validation that packages directory only contains `win-*` CLI archives on Windows

## Validation

Internal AzDO pipeline run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2952305