### PR TITLE
Add PromptBinding infrastructure for non-interactive CLI mode

### DIFF
--- a/src/Aspire.Cli/Agents/SkillDefinition.cs
+++ b/src/Aspire.Cli/Agents/SkillDefinition.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 
@@ -9,6 +10,7 @@ namespace Aspire.Cli.Agents;
 /// <summary>
 /// Represents a skill that can be installed into a skill location.
 /// </summary>
+[DebuggerDisplay("Name = {Name}, Description = {Description}, IsDefault = {IsDefault}")]
 internal sealed class SkillDefinition
 {
     /// <summary>
@@ -151,4 +153,7 @@ internal sealed class SkillDefinition
     /// Gets all available skill definitions.
     /// </summary>
     public static IReadOnlyList<SkillDefinition> All { get; } = [Aspire, PlaywrightCli, DotnetInspect];
+
+    /// <inheritdoc />
+    public override string ToString() => Name;
 }

--- a/src/Aspire.Cli/Agents/SkillLocation.cs
+++ b/src/Aspire.Cli/Agents/SkillLocation.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Cli.Resources;
 
 namespace Aspire.Cli.Agents;
@@ -8,12 +9,14 @@ namespace Aspire.Cli.Agents;
 /// <summary>
 /// Represents a location where skill files can be installed.
 /// </summary>
+[DebuggerDisplay("Id = {Id}, DisplayName = {DisplayName}, Description = {Description}, IsDefault = {IsDefault}")]
 internal sealed class SkillLocation
 {
     /// <summary>
     /// Standard <c>.agents/skills/</c> location supported by VS Code, GitHub Copilot, and OpenCode.
     /// </summary>
     public static readonly SkillLocation Standard = new(
+        "standard",
         AgentCommandStrings.SkillLocation_StandardName,
         AgentCommandStrings.SkillLocation_StandardDescription,
         Path.Combine(".agents", "skills"),
@@ -24,6 +27,7 @@ internal sealed class SkillLocation
     /// Claude Code <c>.claude/skills/</c> location.
     /// </summary>
     public static readonly SkillLocation ClaudeCode = new(
+        "claudecode",
         AgentCommandStrings.SkillLocation_ClaudeCodeName,
         AgentCommandStrings.SkillLocation_ClaudeCodeDescription,
         Path.Combine(".claude", "skills"),
@@ -34,6 +38,7 @@ internal sealed class SkillLocation
     /// VS Code / GitHub Copilot <c>.github/skills/</c> location.
     /// </summary>
     public static readonly SkillLocation GitHubSkills = new(
+        "github",
         AgentCommandStrings.SkillLocation_GitHubSkillsName,
         AgentCommandStrings.SkillLocation_GitHubSkillsDescription,
         Path.Combine(".github", "skills"),
@@ -44,15 +49,17 @@ internal sealed class SkillLocation
     /// OpenCode <c>.opencode/skill/</c> location.
     /// </summary>
     public static readonly SkillLocation OpenCode = new(
+        "opencode",
         AgentCommandStrings.SkillLocation_OpenCodeName,
         AgentCommandStrings.SkillLocation_OpenCodeDescription,
         Path.Combine(".opencode", "skill"),
         isDefault: false,
         includeUserLevel: false);
 
-    private SkillLocation(string name, string description, string relativeSkillDirectory, bool isDefault, bool includeUserLevel)
+    private SkillLocation(string id, string name, string description, string relativeSkillDirectory, bool isDefault, bool includeUserLevel)
     {
-        Name = name;
+        Id = id;
+        DisplayName = name;
         Description = description;
         RelativeSkillDirectory = relativeSkillDirectory;
         IsDefault = isDefault;
@@ -60,9 +67,14 @@ internal sealed class SkillLocation
     }
 
     /// <summary>
+    /// Gets the non-localized identifier for this location, used for CLI option matching.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
     /// Gets the display name for this location.
     /// </summary>
-    public string Name { get; }
+    public string DisplayName { get; }
 
     /// <summary>
     /// Gets the description shown alongside the name in prompts.
@@ -88,4 +100,7 @@ internal sealed class SkillLocation
     /// Gets all available skill locations.
     /// </summary>
     public static IReadOnlyList<SkillLocation> All { get; } = [Standard, ClaudeCode, GitHubSkills, OpenCode];
+
+    /// <inheritdoc />
+    public override string ToString() => Id;
 }

--- a/src/Aspire.Cli/Agents/SkillLocation.cs
+++ b/src/Aspire.Cli/Agents/SkillLocation.cs
@@ -56,10 +56,10 @@ internal sealed class SkillLocation
         isDefault: false,
         includeUserLevel: false);
 
-    private SkillLocation(string id, string name, string description, string relativeSkillDirectory, bool isDefault, bool includeUserLevel)
+    private SkillLocation(string id, string displayName, string description, string relativeSkillDirectory, bool isDefault, bool includeUserLevel)
     {
         Id = id;
-        DisplayName = name;
+        DisplayName = displayName;
         Description = description;
         RelativeSkillDirectory = relativeSkillDirectory;
         IsDefault = isDefault;

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -191,7 +191,7 @@ internal sealed class AppHostConnectionResolver(
             selectPrompt,
             choices.Select(c => c.Display).ToArray(),
             c => c.EscapeMarkup(),
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         var selectedConnection = choices.FirstOrDefault(c => c.Display == selectedDisplay).Connection;
 

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -430,7 +430,7 @@ internal class AddCommandPrompter(IInteractionService interactionService) : IAdd
                 string.Format(CultureInfo.CurrentCulture, AddCommandStrings.SelectAVersionOfPackage, firstPackage.Package.Id),
                 choices,
                 c => c.Label,
-                ct);
+                cancellationToken: ct);
 
             return selection.Result;
         }
@@ -497,7 +497,7 @@ internal class AddCommandPrompter(IInteractionService interactionService) : IAdd
             string.Format(CultureInfo.CurrentCulture, AddCommandStrings.SelectAVersionOfPackage, firstPackage.Package.Id),
             rootChoices,
             c => c.Label,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         return await topSelection.Action(cancellationToken);
     }
@@ -514,7 +514,7 @@ internal class AddCommandPrompter(IInteractionService interactionService) : IAdd
             AddCommandStrings.SelectAnIntegrationToAdd,
             filteredPackages,
             PackageNameWithFriendlyNameIfAvailable,
-            cancellationToken);
+            cancellationToken: cancellationToken);
         return selectedIntegration;
     }
 

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -71,12 +71,18 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
 
     private static readonly Option<string?> s_skillLocationsOption = new("--skill-locations")
     {
-        Description = AgentCommandStrings.InitCommand_SkillLocationsOptionDescription
+        Description = string.Format(CultureInfo.InvariantCulture, AgentCommandStrings.InitCommand_SkillLocationsOptionDescription,
+            string.Join(",", SkillLocation.All.Select(l => l.Id)),
+            ConsoleInteractionService.AllChoice,
+            ConsoleInteractionService.NoneChoice)
     };
 
     private static readonly Option<string?> s_skillsOption = new("--skills")
     {
-        Description = AgentCommandStrings.InitCommand_SkillsOptionDescription
+        Description = string.Format(CultureInfo.InvariantCulture, AgentCommandStrings.InitCommand_SkillsOptionDescription,
+            string.Join(",", SkillDefinition.All.Select(s => s.Name)),
+            ConsoleInteractionService.AllChoice,
+            ConsoleInteractionService.NoneChoice)
     };
 
     protected override bool UpdateNotificationsEnabled => false;

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -58,7 +58,26 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         _playwrightCliInstaller = playwrightCliInstaller;
         _gitRepository = gitRepository;
         _languageDiscovery = languageDiscovery;
+
+        Options.Add(s_workspaceRootOption);
+        Options.Add(s_skillLocationsOption);
+        Options.Add(s_skillsOption);
     }
+
+    private static readonly Option<string?> s_workspaceRootOption = new("--workspace-root")
+    {
+        Description = AgentCommandStrings.InitCommand_WorkspaceRootOptionDescription
+    };
+
+    private static readonly Option<string?> s_skillLocationsOption = new("--skill-locations")
+    {
+        Description = AgentCommandStrings.InitCommand_SkillLocationsOptionDescription
+    };
+
+    private static readonly Option<string?> s_skillsOption = new("--skills")
+    {
+        Description = AgentCommandStrings.InitCommand_SkillsOptionDescription
+    };
 
     protected override bool UpdateNotificationsEnabled => false;
 
@@ -76,10 +95,10 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
     /// Used by commands (e.g. <c>aspire init</c>, <c>aspire new</c>) to offer agent init as a follow-up step.
     /// </summary>
     internal async Task<int> PromptAndChainAsync(
-        ICliHostEnvironment hostEnvironment,
         IInteractionService interactionService,
         int previousResultExitCode,
         DirectoryInfo workspaceRoot,
+        PromptBinding<bool> agentInitBinding,
         CancellationToken cancellationToken)
     {
         if (previousResultExitCode != ExitCodeConstants.Success)
@@ -87,19 +106,14 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             return previousResultExitCode;
         }
 
-        if (!hostEnvironment.SupportsInteractiveInput)
-        {
-            return ExitCodeConstants.Success;
-        }
-
         var runAgentInit = await interactionService.ConfirmAsync(
             SharedCommandStrings.PromptRunAgentInit,
-            defaultValue: true,
+            binding: agentInitBinding,
             cancellationToken: cancellationToken);
 
         if (runAgentInit)
         {
-            return await ExecuteAgentInitAsync(workspaceRoot, cancellationToken);
+            return await ExecuteAgentInitAsync(workspaceRoot, parseResult: null, cancellationToken);
         }
 
         return ExitCodeConstants.Success;
@@ -107,11 +121,11 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var workspaceRoot = await PromptForWorkspaceRootAsync(cancellationToken);
-        return await ExecuteAgentInitAsync(workspaceRoot, cancellationToken);
+        var workspaceRoot = await PromptForWorkspaceRootAsync(parseResult, cancellationToken);
+        return await ExecuteAgentInitAsync(workspaceRoot, parseResult, cancellationToken);
     }
 
-    private async Task<DirectoryInfo> PromptForWorkspaceRootAsync(CancellationToken cancellationToken)
+    private async Task<DirectoryInfo> PromptForWorkspaceRootAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Try to discover the git repository root to use as the default workspace root
         var gitRoot = await _gitRepository.GetRootAsync(cancellationToken);
@@ -120,7 +134,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         // Prompt the user for the workspace root
         var workspaceRootPath = await _interactionService.PromptForFilePathAsync(
             McpCommandStrings.InitCommand_WorkspaceRootPrompt,
-            defaultValue: defaultWorkspaceRoot.FullName,
+            binding: PromptBinding.Create(parseResult, s_workspaceRootOption, defaultWorkspaceRoot.FullName),
             validator: path =>
             {
                 if (string.IsNullOrWhiteSpace(path))
@@ -141,7 +155,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         return new DirectoryInfo(workspaceRootPath);
     }
 
-    private async Task<int> ExecuteAgentInitAsync(DirectoryInfo workspaceRoot, CancellationToken cancellationToken)
+    private async Task<int> ExecuteAgentInitAsync(DirectoryInfo workspaceRoot, ParseResult? parseResult, CancellationToken cancellationToken)
     {
         var context = new AgentEnvironmentScanContext
         {
@@ -180,13 +194,19 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         }
 
         // --- Phase 1: Skill location selection ---
+        var defaultLocationIds = string.Join(",", SkillLocation.All.Where(l => l.IsDefault).Select(l => l.Id));
+        var skillLocationsBinding = parseResult is not null
+            ? PromptBinding.Create(parseResult, s_skillLocationsOption, defaultLocationIds)
+            : PromptBinding.CreateDefault<string?>(defaultLocationIds);
+
         var selectedLocations = await _interactionService.PromptForSelectionsAsync(
             AgentCommandStrings.InitCommand_SelectSkillLocations,
             SkillLocation.All,
-            loc => $"{loc.Name} — {loc.Description}",
+            loc => $"{loc.DisplayName} — {loc.Description}",
             preSelected: SkillLocation.All.Where(l => l.IsDefault),
             optional: true,
-            cancellationToken);
+            binding: skillLocationsBinding,
+            cancellationToken: cancellationToken);
 
         // --- Phase 2: Skill and MCP server selection (only if locations were selected) ---
         IReadOnlyList<SkillDefinition> selectedSkills = [];
@@ -219,6 +239,11 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             preSelectedItems.AddRange(availableSkills.Where(s => s.IsDefault));
             // MCP is intentionally NOT pre-selected
 
+            var defaultSkillNames = string.Join(",", availableSkills.Where(s => s.IsDefault).Select(s => s.Name));
+            var skillsBinding = parseResult is not null
+                ? PromptBinding.Create(parseResult, s_skillsOption, defaultSkillNames)
+                : PromptBinding.CreateDefault<string?>(defaultSkillNames);
+
             var selectedItems = await _interactionService.PromptForSelectionsAsync(
                 AgentCommandStrings.InitCommand_SelectSkills,
                 skillChoices,
@@ -230,7 +255,8 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
                 },
                 preSelected: preSelectedItems,
                 optional: true,
-                cancellationToken);
+                binding: skillsBinding,
+                cancellationToken: cancellationToken);
 
             selectedSkills = selectedItems.OfType<SkillDefinition>().ToList();
 

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -106,7 +106,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             return previousResultExitCode;
         }
 
-        var runAgentInit = await interactionService.ConfirmAsync(
+        var runAgentInit = await interactionService.PromptConfirmAsync(
             SharedCommandStrings.PromptRunAgentInit,
             binding: agentInitBinding,
             cancellationToken: cancellationToken);

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -49,7 +49,16 @@ internal abstract class BaseCommand : Command
 
             // TODO: SDK install goes here in the future.
 
-            var exitCode = await ExecuteAsync(parseResult, cancellationToken);
+            int exitCode;
+            try
+            {
+                exitCode = await ExecuteAsync(parseResult, cancellationToken);
+            }
+            catch (NonInteractiveException)
+            {
+                // Error messages have already been displayed by the interaction service.
+                return ExitCodeConstants.MissingRequiredArgument;
+            }
 
             if (UpdateNotificationsEnabled && features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
             {

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -57,7 +57,7 @@ internal abstract class BaseCommand : Command
             catch (NonInteractiveException)
             {
                 // Error messages have already been displayed by the interaction service.
-                return ExitCodeConstants.MissingRequiredArgument;
+                exitCode = ExitCodeConstants.MissingRequiredArgument;
             }
 
             if (UpdateNotificationsEnabled && features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))

--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -61,7 +61,7 @@ internal sealed class ConfigCommand : BaseCommand
                 Debug.Assert(cmd.Description is not null);
                 return cmd.Description.TrimEnd('.');
             },
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         return await subcommand.InteractiveExecuteAsync(cancellationToken);
     }

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -107,6 +107,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         Options.Add(s_sourceOption);
         Options.Add(s_versionOption);
+        Options.Add(NewCommand.s_suppressAgentInitOption);
 
         // Customize description based on whether staging channel is enabled
         var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(features, configuration);
@@ -129,6 +130,8 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(this.Name);
+
+        var agentInitBinding = PromptBinding.CreateInvertedBoolConfirm(parseResult, NewCommand.s_suppressAgentInitOption, defaultValue: true);
 
         // Get the language selection (from command line, config, or prompt).
         var explicitLanguage = parseResult.GetValue(_languageOption);
@@ -155,7 +158,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 return polyglotResult;
             }
 
-            return await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, polyglotResult, _executionContext.WorkingDirectory, cancellationToken);
+            return await _agentInitCommand.PromptAndChainAsync(InteractionService, polyglotResult, _executionContext.WorkingDirectory, agentInitBinding, cancellationToken);
         }
 
         // For C#, we need the .NET SDK
@@ -195,7 +198,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return initResult;
         }
 
-        return await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, initResult, workspaceRoot, cancellationToken);
+        return await _agentInitCommand.PromptAndChainAsync(InteractionService, initResult, workspaceRoot, agentInitBinding, cancellationToken);
     }
 
     private async Task<int> InitializeExistingSolutionAsync(InitContext initContext, ParseResult parseResult, CancellationToken cancellationToken)
@@ -319,7 +322,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                     "Add ServiceDefaults reference?",
                     serviceDefaultsActions,
                     (action) => action.Value,
-                    cancellationToken
+                    cancellationToken: cancellationToken
                 );
 
                 switch (selection.Key)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -33,12 +33,12 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     private readonly AgentInitCommand _agentInitCommand;
     private readonly ICliHostEnvironment _hostEnvironment;
 
-    private static readonly Option<string> s_nameOption = new("--name", "-n")
+    internal static readonly Option<string?> s_nameOption = new("--name", "-n")
     {
         Description = NewCommandStrings.NameArgumentDescription,
         Recursive = true
     };
-    private static readonly Option<string?> s_outputOption = new("--output", "-o")
+    internal static readonly Option<string?> s_outputOption = new("--output", "-o")
     {
         Description = NewCommandStrings.OutputArgumentDescription,
         Recursive = true
@@ -51,6 +51,12 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     private static readonly Option<string?> s_versionOption = new("--version")
     {
         Description = NewCommandStrings.VersionArgumentDescription,
+        Recursive = true
+    };
+
+    internal static readonly Option<bool?> s_suppressAgentInitOption = new("--suppress-agent-init")
+    {
+        Description = SharedCommandStrings.AgentInitOptionDescription,
         Recursive = true
     };
 
@@ -94,6 +100,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         Options.Add(s_outputOption);
         Options.Add(s_sourceOption);
         Options.Add(s_versionOption);
+        Options.Add(s_suppressAgentInitOption);
 
         // Customize description based on whether staging channel is enabled
         var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(_features, configuration);
@@ -161,7 +168,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             "Which language would you like to use?",
             choices,
             choice => choice.DisplayName.EscapeMarkup(),
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         return selected.LanguageId;
     }
@@ -265,6 +272,14 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         {
             InteractionService.DisplayError("No templates are available for the current environment.");
             return null;
+        }
+
+        if (!_hostEnvironment.SupportsInteractiveInput)
+        {
+            InteractionService.DisplayError(NewCommandStrings.NonInteractiveTemplateRequired);
+            var templateNames = string.Join(", ", templatesForPrompt.Select(t => t.Name));
+            InteractionService.DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveAvailableValues, templateNames));
+            throw new NonInteractiveException("template");
         }
 
         var result = await _prompter.PromptForTemplateAsync(templatesForPrompt, cancellationToken);
@@ -399,7 +414,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
 
         var workspaceRoot = new DirectoryInfo(templateResult.OutputPath ?? ExecutionContext.WorkingDirectory.FullName);
-        var exitCode = await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, templateResult.ExitCode, workspaceRoot, cancellationToken);
+        var agentInitBinding = PromptBinding.CreateInvertedBoolConfirm(parseResult, s_suppressAgentInitOption, defaultValue: true);
+        var exitCode = await _agentInitCommand.PromptAndChainAsync(InteractionService, templateResult.ExitCode, workspaceRoot, agentInitBinding, cancellationToken);
 
         if (templateResult.OutputPath is not null && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _))
         {
@@ -419,8 +435,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 internal interface INewCommandPrompter
 {
     Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken);
-    Task<string> PromptForProjectNameAsync(string defaultName, CancellationToken cancellationToken);
-    Task<string> PromptForOutputPath(string v, CancellationToken cancellationToken);
+    Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken);
+    Task<string> PromptForOutputPath(string v, ParseResult parseResult, CancellationToken cancellationToken);
 }
 
 internal interface ITemplateVersionPrompter
@@ -484,7 +500,7 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
                 NewCommandStrings.SelectATemplateVersion,
                 packageChoices,
                 c => c.Label,
-                ct);
+                cancellationToken: ct);
 
             return selection.Result;
         }
@@ -528,30 +544,26 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
             NewCommandStrings.SelectATemplateVersion,
             rootChoices,
             c => c.Label,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         return await topSelection.Action(cancellationToken);
     }
 
-    public virtual async Task<string> PromptForOutputPath(string path, CancellationToken cancellationToken)
+    public virtual async Task<string> PromptForOutputPath(string path, ParseResult parseResult, CancellationToken cancellationToken)
     {
-        // Escape markup characters in the path to prevent Spectre.Console from trying to parse them as markup
-        // when displaying it as the default value in the prompt
         return await interactionService.PromptForFilePathAsync(
             NewCommandStrings.EnterTheOutputPath,
-            defaultValue: path.EscapeMarkup(),
+            binding: PromptBinding.Create(parseResult, NewCommand.s_outputOption, path),
             directory: true,
             cancellationToken: cancellationToken
             );
     }
 
-    public virtual async Task<string> PromptForProjectNameAsync(string defaultName, CancellationToken cancellationToken)
+    public virtual async Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken)
     {
-        // Escape markup characters in the default name to prevent Spectre.Console from trying to parse them as markup
-        // when displaying it as the default value in the prompt
         return await interactionService.PromptForStringAsync(
             NewCommandStrings.EnterTheProjectName,
-            defaultValue: defaultName.EscapeMarkup(),
+            binding: PromptBinding.Create(parseResult, NewCommand.s_nameOption, defaultName),
             validator: name => ProjectNameValidator.IsProjectNameValid(name)
                 ? ValidationResult.Success()
                 : ValidationResult.Error(NewCommandStrings.InvalidProjectName),
@@ -564,7 +576,7 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
             NewCommandStrings.SelectAProjectTemplate,
             validTemplates,
             t => t.Description.EscapeMarkup(),
-            cancellationToken
+            cancellationToken: cancellationToken
         );
     }
 }

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -947,7 +947,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
             InputType.Choice => await HandleSelectInputAsync(input, promptText, cancellationToken),
 
-            InputType.Boolean => (await InteractionService.ConfirmAsync(promptText, binding: PromptBinding.CreateDefault(ParseBooleanValue(input.Value)), cancellationToken: cancellationToken)).ToString().ToLowerInvariant(),
+            InputType.Boolean => (await InteractionService.PromptConfirmAsync(promptText, binding: PromptBinding.CreateDefault(ParseBooleanValue(input.Value)), cancellationToken: cancellationToken)).ToString().ToLowerInvariant(),
 
             InputType.Number => await HandleNumberInputAsync(input, promptText, cancellationToken),
 

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -934,24 +934,24 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             InputType.Text => await InteractionService.PromptForStringAsync(
                 promptText,
-                defaultValue: input.Value?.EscapeMarkup(),
+                binding: PromptBinding.CreateDefault(input.Value),
                 required: input.Required,
                 cancellationToken: cancellationToken),
 
             InputType.SecretText => await InteractionService.PromptForStringAsync(
                 promptText,
-                defaultValue: input.Value?.EscapeMarkup(),
+                binding: PromptBinding.CreateDefault(input.Value),
                 isSecret: true,
                 required: input.Required,
                 cancellationToken: cancellationToken),
 
             InputType.Choice => await HandleSelectInputAsync(input, promptText, cancellationToken),
 
-            InputType.Boolean => (await InteractionService.ConfirmAsync(promptText, defaultValue: ParseBooleanValue(input.Value), cancellationToken: cancellationToken)).ToString().ToLowerInvariant(),
+            InputType.Boolean => (await InteractionService.ConfirmAsync(promptText, binding: PromptBinding.CreateDefault(ParseBooleanValue(input.Value)), cancellationToken: cancellationToken)).ToString().ToLowerInvariant(),
 
             InputType.Number => await HandleNumberInputAsync(input, promptText, cancellationToken),
 
-            _ => await InteractionService.PromptForStringAsync(promptText, defaultValue: input.Value?.EscapeMarkup(), required: input.Required, cancellationToken: cancellationToken)
+            _ => await InteractionService.PromptForStringAsync(promptText, binding: PromptBinding.CreateDefault(input.Value), required: input.Required, cancellationToken: cancellationToken)
         };
     }
 
@@ -959,7 +959,7 @@ internal abstract class PipelineCommandBase : BaseCommand
     {
         if (input.Options is null || input.Options.Count == 0)
         {
-            return await InteractionService.PromptForStringAsync(promptText, defaultValue: input.Value?.EscapeMarkup(), required: input.Required, cancellationToken: cancellationToken);
+            return await InteractionService.PromptForStringAsync(promptText, binding: PromptBinding.CreateDefault(input.Value), required: input.Required, cancellationToken: cancellationToken);
         }
 
         // If AllowCustomChoice is enabled then add an "Other" option to the list.
@@ -977,11 +977,11 @@ internal abstract class PipelineCommandBase : BaseCommand
             promptText,
             options,
             choice => choice.Value.EscapeMarkup(),
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         if (value == CustomChoiceValue)
         {
-            return await InteractionService.PromptForStringAsync(promptText, defaultValue: input.Value?.EscapeMarkup(), required: input.Required, cancellationToken: cancellationToken);
+            return await InteractionService.PromptForStringAsync(promptText, binding: PromptBinding.CreateDefault(input.Value), required: input.Required, cancellationToken: cancellationToken);
         }
 
         AnsiConsole.MarkupLine($"{promptText} {displayText.EscapeMarkup()}");
@@ -1003,7 +1003,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
         return await InteractionService.PromptForStringAsync(
             promptText,
-            defaultValue: input.Value?.EscapeMarkup(),
+            binding: PromptBinding.CreateDefault(input.Value),
             validator: Validator,
             required: input.Required,
             cancellationToken: cancellationToken);

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -28,7 +28,7 @@ internal class PublishCommandPrompter(IInteractionService interactionService) : 
             PublishCommandStrings.SelectAPublisher,
             publishers,
             p => p.EscapeMarkup(),
-            cancellationToken
+            cancellationToken: cancellationToken
         );
     }
 }

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -328,7 +328,7 @@ internal sealed class RenderCommand : BaseCommand
 
         InteractionService.DisplayMessage(KnownEmojis.CheckMark, $"You entered: {name}");
 
-        var confirmed = await InteractionService.ConfirmAsync(
+        var confirmed = await InteractionService.PromptConfirmAsync(
             "Do you want to continue?",
             binding: PromptBinding.CreateDefault(true),
             cancellationToken: cancellationToken);

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -114,7 +114,7 @@ internal sealed class RenderCommand : BaseCommand
                 "What do you want to test?",
                 s_choices.Keys,
                 key => s_choices[key],
-                cancellationToken);
+                cancellationToken: cancellationToken);
 
             var exitCode = await ExecuteChoiceAsync(choice, parseResult.GetValue(s_consoleWidthOption), cancellationToken);
             if (choice == "exit" || exitCode != ExitCodeConstants.Success)
@@ -271,7 +271,7 @@ internal sealed class RenderCommand : BaseCommand
             "Select a [bold blue]package[/] to install:",
             packages,
             p => $"{p.Item1.EscapeMarkup()} [dim]v{p.Item2}[/] ({p.Item3})",
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         InteractionService.DisplayMessage(KnownEmojis.Package, $"Selected: {selected.Item1} v{selected.Item2}");
         return ExitCodeConstants.Success;
@@ -285,7 +285,7 @@ internal sealed class RenderCommand : BaseCommand
             "Select a target environment:",
             environments,
             e => e,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         InteractionService.DisplayMessage(KnownEmojis.Rocket, $"Deploying to {selected}...");
         return ExitCodeConstants.Success;
@@ -323,14 +323,14 @@ internal sealed class RenderCommand : BaseCommand
 
         var name = await InteractionService.PromptForStringAsync(
             "Enter a test value",
-            defaultValue: "hello",
+            binding: PromptBinding.CreateDefault<string?>("hello"),
             cancellationToken: cancellationToken);
 
         InteractionService.DisplayMessage(KnownEmojis.CheckMark, $"You entered: {name}");
 
         var confirmed = await InteractionService.ConfirmAsync(
             "Do you want to continue?",
-            defaultValue: true,
+            binding: PromptBinding.CreateDefault(true),
             cancellationToken: cancellationToken);
 
         if (confirmed)

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -38,6 +38,15 @@ internal sealed class UpdateCommand : BaseCommand
     {
         Description = UpdateCommandStrings.SelfOptionDescription
     };
+    private static readonly Option<bool> s_yesOption = new("--yes")
+    {
+        Description = UpdateCommandStrings.YesOptionDescription,
+        Aliases = { "-y" }
+    };
+    private static readonly Option<string?> s_nugetConfigDirOption = new("--nuget-config-dir")
+    {
+        Description = UpdateCommandStrings.NuGetConfigDirOptionDescription
+    };
     private readonly Option<string?> _channelOption;
     private readonly Option<string?> _qualityOption;
 
@@ -68,6 +77,8 @@ internal sealed class UpdateCommand : BaseCommand
 
         Options.Add(s_appHostOption);
         Options.Add(s_selfOption);
+        Options.Add(s_yesOption);
+        Options.Add(s_nugetConfigDirOption);
 
         // Customize description based on whether staging channel is enabled
         var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(_features, _configuration);
@@ -180,11 +191,13 @@ internal sealed class UpdateCommand : BaseCommand
                 if (hasHives)
                 {
                     // Prompt for channel selection
+                    var channelBinding = PromptBinding.Create(parseResult, _channelOption);
                     channel = await InteractionService.PromptForSelectionAsync(
                         UpdateCommandStrings.SelectChannelPrompt,
                         allChannels,
                         (c) => $"{c.Name.EscapeMarkup()} ({c.SourceDetails.EscapeMarkup()})",
-                        cancellationToken);
+                        binding: channelBinding,
+                        cancellationToken: cancellationToken);
                 }
                 else
                 {
@@ -195,24 +208,28 @@ internal sealed class UpdateCommand : BaseCommand
             }
 
             // Update packages using the appropriate project handler
+            var confirmBinding = PromptBinding.CreateWithInteractiveDefault(parseResult, s_yesOption, true);
+            var nugetConfigDirBinding = PromptBinding.Create(parseResult, s_nugetConfigDirOption);
             var updateContext = new UpdatePackagesContext
             {
                 AppHostFile = projectFile,
-                Channel = channel
+                Channel = channel,
+                ConfirmBinding = confirmBinding,
+                NuGetConfigDirBinding = nugetConfigDirBinding
             };
             await project.UpdatePackagesAsync(updateContext, cancellationToken);
 
             // After successful project update, check if CLI update is available and prompt
             // Only prompt if the channel supports CLI downloads (has a non-null CliDownloadBaseUrl)
-            if (_cliDownloader is not null && 
-                _updateNotifier.IsUpdateAvailable() && 
+            if (_cliDownloader is not null &&
+                _updateNotifier.IsUpdateAvailable() &&
                 !string.IsNullOrEmpty(channel.CliDownloadBaseUrl))
             {
                 var shouldUpdateCli = await InteractionService.ConfirmAsync(
                     UpdateCommandStrings.UpdateCliAfterProjectUpdatePrompt,
-                    defaultValue: true,
-                    cancellationToken);
-                
+                    binding: confirmBinding,
+                    cancellationToken: cancellationToken);
+
                 if (shouldUpdateCli)
                 {
                     // Use the same channel that was selected for the project update
@@ -244,16 +261,16 @@ internal sealed class UpdateCommand : BaseCommand
                 {
                     var shouldUpdateCli = await InteractionService.ConfirmAsync(
                         UpdateCommandStrings.NoAppHostFoundUpdateCliPrompt,
-                        defaultValue: true,
-                        cancellationToken);
-                    
+                        binding: PromptBinding.Create(parseResult, s_yesOption, false),
+                        cancellationToken: cancellationToken);
+
                     if (shouldUpdateCli)
                     {
                         return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
                     }
                 }
             }
-            
+
             return HandleProjectLocatorException(ex, InteractionService, Telemetry);
         }
         catch (OperationCanceledException)
@@ -278,11 +295,13 @@ internal sealed class UpdateCommand : BaseCommand
             var channels = isStagingEnabled
                 ? new[] { PackageChannelNames.Stable, PackageChannelNames.Staging, PackageChannelNames.Daily }
                 : new[] { PackageChannelNames.Stable, PackageChannelNames.Daily };
+            var channelBinding = PromptBinding.Create(parseResult, _channelOption);
             channel = await InteractionService.PromptForSelectionAsync(
                 "Select the channel to update to:",
                 channels,
                 q => q,
-                cancellationToken);
+                binding: channelBinding,
+                cancellationToken: cancellationToken);
         }
 
         try
@@ -461,11 +480,11 @@ internal sealed class UpdateCommand : BaseCommand
 
         var pathSeparator = Path.PathSeparator;
         var paths = pathEnv.Split(pathSeparator, StringSplitOptions.RemoveEmptyEntries);
-        
-        return paths.Any(p => 
-            string.Equals(Path.GetFullPath(p.Trim()), Path.GetFullPath(directory), 
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
-                    ? StringComparison.OrdinalIgnoreCase 
+
+        return paths.Any(p =>
+            string.Equals(Path.GetFullPath(p.Trim()), Path.GetFullPath(directory),
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? StringComparison.OrdinalIgnoreCase
                     : StringComparison.Ordinal));
     }
 
@@ -507,14 +526,14 @@ internal sealed class UpdateCommand : BaseCommand
 
             var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
             await process.WaitForExitAsync(cancellationToken);
-            
+
             if (process.ExitCode == 0)
             {
                 var version = output.Trim();
                 InteractionService.DisplaySuccess($"Updated to version: {version}");
                 return version;
             }
-            
+
             return null;
         }
         catch

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -225,7 +225,7 @@ internal sealed class UpdateCommand : BaseCommand
                 _updateNotifier.IsUpdateAvailable() &&
                 !string.IsNullOrEmpty(channel.CliDownloadBaseUrl))
             {
-                var shouldUpdateCli = await InteractionService.ConfirmAsync(
+                var shouldUpdateCli = await InteractionService.PromptConfirmAsync(
                     UpdateCommandStrings.UpdateCliAfterProjectUpdatePrompt,
                     binding: confirmBinding,
                     cancellationToken: cancellationToken);
@@ -259,7 +259,7 @@ internal sealed class UpdateCommand : BaseCommand
                 // Only prompt for self-update if not running as dotnet tool and downloader is available
                 if (_cliDownloader is not null)
                 {
-                    var shouldUpdateCli = await InteractionService.ConfirmAsync(
+                    var shouldUpdateCli = await InteractionService.PromptConfirmAsync(
                         UpdateCommandStrings.NoAppHostFoundUpdateCliPrompt,
                         binding: PromptBinding.Create(parseResult, s_yesOption, false),
                         cancellationToken: cancellationToken);

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -26,4 +26,5 @@ internal static class ExitCodeConstants
     public const int WaitResourceFailed = 18;
     public const int FailedToLoadConfiguration = 19;
     public const int FailedToStartCli = 20;
+    public const int MissingRequiredArgument = 21;
 }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -464,7 +464,7 @@ internal class ConsoleInteractionService : IInteractionService
         DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{InteractionServiceStrings.StoppingAspire}[/]", allowMarkup: true);
     }
 
-    public async Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
+    public async Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
         var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
         if (wasProvided)

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -212,16 +212,19 @@ internal class ConsoleInteractionService : IInteractionService
         ArgumentNullException.ThrowIfNull(choices, nameof(choices));
         ArgumentNullException.ThrowIfNull(choiceFormatter, nameof(choiceFormatter));
 
+        // Materialize once to avoid re-enumerating the choices enumerable.
+        var choicesList = choices as IReadOnlyList<T> ?? choices.ToList();
+
         var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
         if (wasProvided && value is not null)
         {
-            var match = MatchChoice(value, choices, choiceFormatter);
+            var match = MatchChoice(value, choicesList, choiceFormatter);
             if (match is not null)
             {
                 return match;
             }
 
-            ThrowNonInteractiveInvalidValue(value, binding!.SymbolDisplayName, choices, choiceFormatter);
+            ThrowNonInteractiveInvalidValue(value, binding!.SymbolDisplayName, choicesList, choiceFormatter);
         }
 
         if (!_hostEnvironment.SupportsInteractiveInput)
@@ -230,13 +233,13 @@ internal class ConsoleInteractionService : IInteractionService
             {
                 if (defaultValue != null)
                 {
-                    var match = MatchChoice(defaultValue, choices, choiceFormatter);
+                    var match = MatchChoice(defaultValue, choicesList, choiceFormatter);
                     if (match is not null)
                     {
                         return match;
                     }
 
-                    ThrowNonInteractiveSelectionError(binding.SymbolDisplayName, choices, choiceFormatter);
+                    ThrowNonInteractiveSelectionError(binding.SymbolDisplayName, choicesList, choiceFormatter);
                 }
 
                 ThrowNonInteractiveError(binding.SymbolDisplayName);
@@ -246,7 +249,7 @@ internal class ConsoleInteractionService : IInteractionService
         }
 
         // Check if the choices collection is empty to avoid throwing an InvalidOperationException
-        if (!choices.Any())
+        if (choicesList.Count == 0)
         {
             throw new EmptyChoicesException(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NoItemsAvailableForSelection, promptText));
         }
@@ -256,7 +259,7 @@ internal class ConsoleInteractionService : IInteractionService
         var prompt = new SelectionPrompt<T>()
             .Title(promptText)
             .UseConverter(choiceFormatter)
-            .AddChoices(choices)
+            .AddChoices(choicesList)
             .PageSize(10)
             .EnableSearch();
 
@@ -273,17 +276,19 @@ internal class ConsoleInteractionService : IInteractionService
         ArgumentNullException.ThrowIfNull(choices, nameof(choices));
         ArgumentNullException.ThrowIfNull(choiceFormatter, nameof(choiceFormatter));
 
+        // Materialize once to avoid re-enumerating the choices enumerable.
+        var choicesList = choices as IReadOnlyList<T> ?? choices.ToList();
+
         var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
         if (wasProvided && value is not null)
         {
-            var fallbackChoices = choices.ToList();
-            var matched = MatchChoices(value, fallbackChoices, choiceFormatter);
+            var matched = MatchChoices(value, choicesList, choiceFormatter);
             if (matched is not null)
             {
                 return matched;
             }
 
-            ThrowNonInteractiveInvalidValue(value, binding!.SymbolDisplayName, choices, choiceFormatter);
+            ThrowNonInteractiveInvalidValue(value, binding!.SymbolDisplayName, choicesList, choiceFormatter);
         }
 
         if (!_hostEnvironment.SupportsInteractiveInput)
@@ -292,14 +297,13 @@ internal class ConsoleInteractionService : IInteractionService
             {
                 if (defaultValue != null)
                 {
-                    var fallbackChoices = choices.ToList();
-                    var matched = MatchChoices(defaultValue, fallbackChoices, choiceFormatter);
+                    var matched = MatchChoices(defaultValue, choicesList, choiceFormatter);
                     if (matched is not null)
                     {
                         return matched;
                     }
 
-                    ThrowNonInteractiveSelectionError(binding.SymbolDisplayName, choices, choiceFormatter);
+                    ThrowNonInteractiveSelectionError(binding.SymbolDisplayName, choicesList, choiceFormatter);
                 }
 
                 ThrowNonInteractiveError(binding.SymbolDisplayName);
@@ -307,8 +311,6 @@ internal class ConsoleInteractionService : IInteractionService
 
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
-
-        var choicesList = choices.ToList();
 
         if (choicesList.Count == 0)
         {
@@ -509,6 +511,13 @@ internal class ConsoleInteractionService : IInteractionService
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
+        // When no binding is provided, default to true (matching the historical behavior
+        // where the old ConfirmAsync signature had defaultValue = true).
+        if (binding is null)
+        {
+            defaultValue = true;
+        }
+
         MessageLogger.LogInformation("Confirm: {PromptText} (default: {DefaultValue})", promptText, defaultValue);
 
         // Use [Y/n] or [y/N] convention where the capitalized letter indicates the default value.
@@ -583,6 +592,8 @@ internal class ConsoleInteractionService : IInteractionService
             {
                 return null; // Signal that matching failed
             }
+            // MatchChoice returns the instance from the choices list via FirstOrDefault,
+            // so reference equality is correct here for deduplication.
             if (!matched.Contains(match))
             {
                 matched.Add(match);
@@ -598,7 +609,7 @@ internal class ConsoleInteractionService : IInteractionService
         throw new NonInteractiveException(symbolDisplayName);
     }
 
-    private void ValidateResolvedStringValue(string value, bool required, Func<string, ValidationResult>? validator, string symbolDisplayName)
+    internal void ValidateResolvedStringValue(string value, bool required, Func<string, ValidationResult>? validator, string symbolDisplayName)
     {
         if (required && string.IsNullOrEmpty(value))
         {

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -20,6 +20,9 @@ internal class ConsoleInteractionService : IInteractionService
     private static readonly Style s_errorMessageStyle = new Style(foreground: Color.Red, background: null, decoration: Decoration.Bold);
     private static readonly Style s_searchHighlightStyle = new Style(foreground: Color.Black, background: Color.Cyan1, decoration: Decoration.None);
 
+    internal const string AllChoice = "all";
+    internal const string NoneChoice = "none";
+
     private readonly IAnsiConsole _outConsole;
     private readonly IAnsiConsole _errorConsole;
     private readonly CliExecutionContext _executionContext;
@@ -549,12 +552,12 @@ internal class ConsoleInteractionService : IInteractionService
 
     internal static IReadOnlyList<T>? MatchChoices<T>(string commaSeparatedValues, IReadOnlyList<T> choices, Func<T, string> choiceFormatter) where T : notnull
     {
-        if (string.Equals(commaSeparatedValues, "all", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(commaSeparatedValues, AllChoice, StringComparison.OrdinalIgnoreCase))
         {
             return choices;
         }
 
-        if (string.Equals(commaSeparatedValues, "none", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(commaSeparatedValues, NoneChoice, StringComparison.OrdinalIgnoreCase))
         {
             return [];
         }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Resources;
@@ -141,16 +142,36 @@ internal class ConsoleInteractionService : IInteractionService
         }
     }
 
-    public async Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+    public async Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));
 
+        var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            ValidateResolvedStringValue(value, required, validator, binding!.SymbolDisplayName);
+            return value;
+        }
+
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
+            if (binding != null)
+            {
+                if (binding.DefaultValue != null)
+                {
+                    ValidateResolvedStringValue(binding.DefaultValue, required, validator, binding.SymbolDisplayName);
+                    return binding.DefaultValue;
+                }
+
+                ThrowNonInteractiveError(binding.SymbolDisplayName);
+            }
+
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
         MessageLogger.LogInformation("Prompt: {PromptText} (default: {DefaultValue}, secret: {IsSecret})", promptText, isSecret ? "****" : defaultValue ?? "(none)", isSecret);
+
+        var displayDefaultValue = defaultValue?.EscapeMarkup();
 
         var prompt = new TextPrompt<string>(promptText)
         {
@@ -158,9 +179,9 @@ internal class ConsoleInteractionService : IInteractionService
             AllowEmpty = !required
         };
 
-        if (defaultValue is not null)
+        if (displayDefaultValue != null)
         {
-            prompt.DefaultValue(defaultValue);
+            prompt.DefaultValue(displayDefaultValue);
             prompt.ShowDefaultValue();
             prompt.DefaultValueStyle(new Style(Color.Fuchsia));
         }
@@ -172,22 +193,55 @@ internal class ConsoleInteractionService : IInteractionService
 
         var result = await MessageConsole.PromptAsync(prompt, cancellationToken);
         MessageLogger.LogInformation("Prompt result: {Result}", isSecret ? "****" : result);
+        if (defaultValue is not null && string.Equals(result, displayDefaultValue, StringComparison.Ordinal))
+        {
+            return defaultValue;
+        }
+
         return result;
     }
 
-    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
+    public Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
-        return PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
+        return PromptForStringAsync(promptText, validator, isSecret: false, required, binding, cancellationToken);
     }
 
-    public async Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    public async Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
         ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));
         ArgumentNullException.ThrowIfNull(choices, nameof(choices));
         ArgumentNullException.ThrowIfNull(choiceFormatter, nameof(choiceFormatter));
 
+        var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            var match = MatchChoice(value, choices, choiceFormatter);
+            if (match is not null)
+            {
+                return match;
+            }
+
+            ThrowNonInteractiveInvalidValue(value, binding!.SymbolDisplayName, choices, choiceFormatter);
+        }
+
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
+            if (binding != null)
+            {
+                if (defaultValue != null)
+                {
+                    var match = MatchChoice(defaultValue, choices, choiceFormatter);
+                    if (match is not null)
+                    {
+                        return match;
+                    }
+
+                    ThrowNonInteractiveSelectionError(binding.SymbolDisplayName, choices, choiceFormatter);
+                }
+
+                ThrowNonInteractiveError(binding.SymbolDisplayName);
+            }
+
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
@@ -213,14 +267,44 @@ internal class ConsoleInteractionService : IInteractionService
         return result;
     }
 
-    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
         ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));
         ArgumentNullException.ThrowIfNull(choices, nameof(choices));
         ArgumentNullException.ThrowIfNull(choiceFormatter, nameof(choiceFormatter));
 
+        var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            var fallbackChoices = choices.ToList();
+            var matched = MatchChoices(value, fallbackChoices, choiceFormatter);
+            if (matched is not null)
+            {
+                return matched;
+            }
+
+            ThrowNonInteractiveInvalidValue(value, binding!.SymbolDisplayName, choices, choiceFormatter);
+        }
+
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
+            if (binding != null)
+            {
+                if (defaultValue != null)
+                {
+                    var fallbackChoices = choices.ToList();
+                    var matched = MatchChoices(defaultValue, fallbackChoices, choiceFormatter);
+                    if (matched is not null)
+                    {
+                        return matched;
+                    }
+
+                    ThrowNonInteractiveSelectionError(binding.SymbolDisplayName, choices, choiceFormatter);
+                }
+
+                ThrowNonInteractiveError(binding.SymbolDisplayName);
+            }
+
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
@@ -402,10 +486,26 @@ internal class ConsoleInteractionService : IInteractionService
         DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{InteractionServiceStrings.StoppingAspire}[/]", allowMarkup: true);
     }
 
-    public async Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
+    public async Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
+        var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
+        if (wasProvided)
+        {
+            return value;
+        }
+
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
+            if (binding is not null)
+            {
+                if (binding.HasExplicitDefault)
+                {
+                    return binding.DefaultValue;
+                }
+
+                ThrowNonInteractiveError(binding.SymbolDisplayName);
+            }
+
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
@@ -454,5 +554,108 @@ internal class ConsoleInteractionService : IInteractionService
         }
 
         _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.MoreInfoNewCliVersion, UpdateUrl));
+    }
+
+    internal static T? MatchChoice<T>(string value, IEnumerable<T> choices, Func<T, string> choiceFormatter) where T : notnull
+    {
+        return choices.FirstOrDefault(c => string.Equals(choiceFormatter(c), value, StringComparison.OrdinalIgnoreCase))
+            ?? choices.FirstOrDefault(c => string.Equals(c.ToString(), value, StringComparison.OrdinalIgnoreCase));
+    }
+
+    internal static IReadOnlyList<T>? MatchChoices<T>(string commaSeparatedValues, IReadOnlyList<T> choices, Func<T, string> choiceFormatter) where T : notnull
+    {
+        if (string.Equals(commaSeparatedValues, "all", StringComparison.OrdinalIgnoreCase))
+        {
+            return choices;
+        }
+
+        if (string.Equals(commaSeparatedValues, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            return [];
+        }
+
+        var values = commaSeparatedValues.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var matched = new List<T>();
+        foreach (var val in values)
+        {
+            var match = MatchChoice(val, choices, choiceFormatter);
+            if (match is null)
+            {
+                return null; // Signal that matching failed
+            }
+            if (!matched.Contains(match))
+            {
+                matched.Add(match);
+            }
+        }
+        return matched;
+    }
+
+    [DoesNotReturn]
+    private void ThrowNonInteractiveError(string symbolDisplayName)
+    {
+        DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveOptionRequired, symbolDisplayName));
+        throw new NonInteractiveException(symbolDisplayName);
+    }
+
+    private void ValidateResolvedStringValue(string value, bool required, Func<string, ValidationResult>? validator, string symbolDisplayName)
+    {
+        if (required && string.IsNullOrEmpty(value))
+        {
+            ThrowNonInteractiveError(symbolDisplayName);
+        }
+
+        if (validator is not null)
+        {
+            var result = validator(value);
+            if (!result.Successful)
+            {
+                DisplayError(result.Message ?? string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveInvalidValue, value, symbolDisplayName));
+                throw new NonInteractiveException(symbolDisplayName);
+            }
+        }
+    }
+
+    [DoesNotReturn]
+    internal void ThrowNonInteractiveInvalidValue<T>(string value, string symbolDisplayName, IEnumerable<T> choices, Func<T, string> choiceFormatter) where T : notnull
+    {
+        DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveInvalidValue, value, symbolDisplayName));
+        var availableChoices = string.Join(", ", choices.Select(c => choiceFormatter(c)));
+        DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveAvailableValues, availableChoices));
+        throw new NonInteractiveException(symbolDisplayName);
+    }
+
+    internal T MatchChoiceOrThrow<T>(string value, PromptBinding<string?> binding, IEnumerable<T> choices, Func<T, string> choiceFormatter) where T : notnull
+    {
+        var match = MatchChoice(value, choices, choiceFormatter);
+        if (match is not null)
+        {
+            return match;
+        }
+
+        ThrowNonInteractiveInvalidValue(value, binding.SymbolDisplayName, choices, choiceFormatter);
+        return default; // unreachable
+    }
+
+    internal IReadOnlyList<T> MatchChoicesOrThrow<T>(string value, PromptBinding<string?> binding, IEnumerable<T> choices, Func<T, string> choiceFormatter) where T : notnull
+    {
+        var choicesList = choices.ToList();
+        var matched = MatchChoices(value, choicesList, choiceFormatter);
+        if (matched is not null)
+        {
+            return matched;
+        }
+
+        ThrowNonInteractiveInvalidValue(value, binding.SymbolDisplayName, choicesList, choiceFormatter);
+        return default; // unreachable
+    }
+
+    [DoesNotReturn]
+    private void ThrowNonInteractiveSelectionError<T>(string symbolDisplayName, IEnumerable<T> choices, Func<T, string> choiceFormatter) where T : notnull
+    {
+        DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveOptionRequired, symbolDisplayName));
+        var availableChoices = string.Join(", ", choices.Select(c => choiceFormatter(c)));
+        DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveAvailableValues, availableChoices));
+        throw new NonInteractiveException(symbolDisplayName);
     }
 }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -218,13 +218,7 @@ internal class ConsoleInteractionService : IInteractionService
         var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
         if (wasProvided && value is not null)
         {
-            var match = MatchChoice(value, choicesList, choiceFormatter);
-            if (match is not null)
-            {
-                return match;
-            }
-
-            ThrowNonInteractiveInvalidValue(value, binding!.SymbolDisplayName, choicesList, choiceFormatter);
+            return MatchChoiceOrThrow(value, binding!, choicesList, choiceFormatter);
         }
 
         if (!_hostEnvironment.SupportsInteractiveInput)
@@ -233,13 +227,7 @@ internal class ConsoleInteractionService : IInteractionService
             {
                 if (defaultValue != null)
                 {
-                    var match = MatchChoice(defaultValue, choicesList, choiceFormatter);
-                    if (match is not null)
-                    {
-                        return match;
-                    }
-
-                    ThrowNonInteractiveSelectionError(binding.SymbolDisplayName, choicesList, choiceFormatter);
+                    return MatchChoiceOrThrow(defaultValue, binding, choicesList, choiceFormatter);
                 }
 
                 ThrowNonInteractiveError(binding.SymbolDisplayName);
@@ -282,13 +270,7 @@ internal class ConsoleInteractionService : IInteractionService
         var (wasProvided, value, defaultValue) = PromptBinding.Resolve(binding);
         if (wasProvided && value is not null)
         {
-            var matched = MatchChoices(value, choicesList, choiceFormatter);
-            if (matched is not null)
-            {
-                return matched;
-            }
-
-            ThrowNonInteractiveInvalidValue(value, binding!.SymbolDisplayName, choicesList, choiceFormatter);
+            return MatchChoicesOrThrow(value, binding!, choicesList, choiceFormatter);
         }
 
         if (!_hostEnvironment.SupportsInteractiveInput)
@@ -297,13 +279,7 @@ internal class ConsoleInteractionService : IInteractionService
             {
                 if (defaultValue != null)
                 {
-                    var matched = MatchChoices(defaultValue, choicesList, choiceFormatter);
-                    if (matched is not null)
-                    {
-                        return matched;
-                    }
-
-                    ThrowNonInteractiveSelectionError(binding.SymbolDisplayName, choicesList, choiceFormatter);
+                    return MatchChoicesOrThrow(defaultValue, binding, choicesList, choiceFormatter);
                 }
 
                 ThrowNonInteractiveError(binding.SymbolDisplayName);
@@ -659,14 +635,5 @@ internal class ConsoleInteractionService : IInteractionService
 
         ThrowNonInteractiveInvalidValue(value, binding.SymbolDisplayName, choicesList, choiceFormatter);
         return default; // unreachable
-    }
-
-    [DoesNotReturn]
-    private void ThrowNonInteractiveSelectionError<T>(string symbolDisplayName, IEnumerable<T> choices, Func<T, string> choiceFormatter) where T : notnull
-    {
-        DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveOptionRequired, symbolDisplayName));
-        var availableChoices = string.Join(", ", choices.Select(c => choiceFormatter(c)));
-        DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveAvailableValues, availableChoices));
-        throw new NonInteractiveException(symbolDisplayName);
     }
 }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -98,8 +98,16 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
     }
 
-    public async Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+    public async Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
+        // Check binding first — if a CLI arg was explicitly provided, return it immediately
+        // without prompting through either the extension or console path.
+        var (wasProvided, value, _) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            return value;
+        }
+
         if (_extensionPromptEnabled)
         {
             var tcs = new TaskCompletionSource<string>();
@@ -122,12 +130,12 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                         else
                         {
                             // Fallback to regular prompt for older extension versions
-                            result = await Backchannel.PromptForStringAsync(promptText.RemoveSpectreFormatting(), defaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
+                            result = await Backchannel.PromptForStringAsync(promptText.RemoveSpectreFormatting(), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
                         }
                     }
                     else
                     {
-                        result = await Backchannel.PromptForStringAsync(promptText.RemoveSpectreFormatting(), defaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
+                        result = await Backchannel.PromptForStringAsync(promptText.RemoveSpectreFormatting(), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
                     }
 
                     tcs.SetResult(result);
@@ -142,12 +150,18 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         else
         {
-            return await _consoleInteractionService.PromptForStringAsync(promptText, defaultValue, validator, isSecret, required, cancellationToken).ConfigureAwait(false);
+            return await _consoleInteractionService.PromptForStringAsync(promptText, validator, isSecret, required, binding, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    public async Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
+    public async Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
+        var (wasProvided, value, _) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            return value;
+        }
+
         if (_extensionPromptEnabled)
         {
             var hasFilePickersCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.FilePickers, _cancellationToken).ConfigureAwait(false);
@@ -160,7 +174,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     try
                     {
-                        var result = await Backchannel.PromptForFilePathAsync(promptText.RemoveSpectreFormatting(), defaultValue, directory, _cancellationToken).ConfigureAwait(false);
+                        var result = await Backchannel.PromptForFilePathAsync(promptText.RemoveSpectreFormatting(), binding?.DefaultValue, directory, _cancellationToken).ConfigureAwait(false);
                         tcs.SetResult(result);
                     }
                     catch (Exception ex)
@@ -192,14 +206,20 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             }
 
             // Fall back to string prompt for older extensions without file picker support
-            return await PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken).ConfigureAwait(false);
+            return await PromptForStringAsync(promptText, validator, isSecret: false, required, binding, cancellationToken).ConfigureAwait(false);
         }
 
-        return await _consoleInteractionService.PromptForFilePathAsync(promptText, defaultValue, validator, directory, required, cancellationToken).ConfigureAwait(false);
+        return await _consoleInteractionService.PromptForFilePathAsync(promptText, validator, directory, required, binding, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
+    public async Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
+        var (wasProvided, value, _) = PromptBinding.Resolve(binding);
+        if (wasProvided)
+        {
+            return value;
+        }
+
         if (_extensionPromptEnabled)
         {
             var tcs = new TaskCompletionSource<bool>();
@@ -208,7 +228,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             {
                 try
                 {
-                    var result = await Backchannel.ConfirmAsync(promptText.RemoveSpectreFormatting(), defaultValue, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.ConfirmAsync(promptText.RemoveSpectreFormatting(), binding?.DefaultValue ?? false, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -225,13 +245,19 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         else
         {
-            return await _consoleInteractionService.ConfirmAsync(promptText, defaultValue, cancellationToken);
+            return await _consoleInteractionService.ConfirmAsync(promptText, binding, cancellationToken);
         }
     }
 
     public async Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter,
-        CancellationToken cancellationToken = default) where T : notnull
+        PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
+        var (wasProvided, value, _) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            return _consoleInteractionService.MatchChoiceOrThrow(value, binding!, choices, choiceFormatter);
+        }
+
         if (_extensionPromptEnabled)
         {
             var tcs = new TaskCompletionSource<T>();
@@ -257,13 +283,19 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         else
         {
-            return await _consoleInteractionService.PromptForSelectionAsync(promptText, choices, choiceFormatter, cancellationToken);
+            return await _consoleInteractionService.PromptForSelectionAsync(promptText, choices, choiceFormatter, binding, cancellationToken);
         }
     }
 
     public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter,
-        IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+        IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
+        var (wasProvided, value, _) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            return _consoleInteractionService.MatchChoicesOrThrow(value, binding!, choices, choiceFormatter);
+        }
+
         if (_extensionPromptEnabled)
         {
             var tcs = new TaskCompletionSource<IReadOnlyList<T>>();
@@ -291,7 +323,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         else
         {
-            return await _consoleInteractionService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, preSelected, optional, cancellationToken);
+            return await _consoleInteractionService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, preSelected, optional, binding, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -214,7 +214,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         return await _consoleInteractionService.PromptForFilePathAsync(promptText, validator, directory, required, binding, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
+    public async Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
         var (wasProvided, value, _) = PromptBinding.Resolve(binding);
         if (wasProvided)
@@ -247,7 +247,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         else
         {
-            return await _consoleInteractionService.ConfirmAsync(promptText, binding, cancellationToken);
+            return await _consoleInteractionService.PromptConfirmAsync(promptText, binding, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -160,6 +160,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         var (wasProvided, value, _) = PromptBinding.Resolve(binding);
         if (wasProvided && value is not null)
         {
+            _consoleInteractionService.ValidateResolvedStringValue(value, required, validator, binding!.SymbolDisplayName);
             return value;
         }
 

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -105,6 +105,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         var (wasProvided, value, _) = PromptBinding.Resolve(binding);
         if (wasProvided && value is not null)
         {
+            _consoleInteractionService.ValidateResolvedStringValue(value, required, validator, binding!.SymbolDisplayName);
             return value;
         }
 

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -14,7 +14,7 @@ internal interface IInteractionService
     void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false);
     Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default);
     Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default);
-    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default);
+    public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default);
     Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull;
     Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion);

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -12,11 +12,11 @@ internal interface IInteractionService
 {
     Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false);
     void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false);
-    Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default);
-    Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default);
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default);
-    Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
-    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull;
+    Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default);
+    Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default);
+    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default);
+    Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull;
+    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion);
     void DisplayError(string errorMessage);
     void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false);

--- a/src/Aspire.Cli/Interaction/NonInteractiveException.cs
+++ b/src/Aspire.Cli/Interaction/NonInteractiveException.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Interaction;
+
+/// <summary>
+/// Thrown when a required value cannot be resolved in non-interactive mode.
+/// Caught centrally by BaseCommand to return a standard exit code.
+/// </summary>
+internal sealed class NonInteractiveException : Exception
+{
+    public NonInteractiveException(string symbolDisplayName)
+        : base($"Required input {symbolDisplayName} was not provided in non-interactive mode.")
+    {
+        SymbolDisplayName = symbolDisplayName;
+    }
+
+    public string SymbolDisplayName { get; }
+}

--- a/src/Aspire.Cli/Interaction/PromptBinding.cs
+++ b/src/Aspire.Cli/Interaction/PromptBinding.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Aspire.Cli.Resources;
 
 namespace Aspire.Cli.Interaction;
 
@@ -118,8 +119,12 @@ internal static class PromptBinding
     /// When the option is explicitly provided, resolves to <paramref name="trueValue"/> or <paramref name="falseValue"/>.
     /// When not provided in non-interactive mode, defaults to <paramref name="falseValue"/>.
     /// </summary>
-    public static PromptBinding<string?> CreateBoolAsSelection(ParseResult parseResult, Option<bool?> option, string trueValue, string falseValue) =>
-        new(parseResult, FormatOptionName(option), BuildBoolAsSelectionResolver(option, trueValue, falseValue), falseValue, hasExplicitDefault: true);
+    public static PromptBinding<string?> CreateBoolAsSelection(ParseResult parseResult, Option<bool?> option, string? trueValue = null, string? falseValue = null)
+    {
+        trueValue ??= TemplatingStrings.Yes;
+        falseValue ??= TemplatingStrings.No;
+        return new(parseResult, FormatOptionName(option), BuildBoolAsSelectionResolver(option, trueValue, falseValue), falseValue, hasExplicitDefault: true);
+    }
 
     private static string FormatOptionName<T>(Option<T> option) => $"'{option.Name}'";
 

--- a/src/Aspire.Cli/Interaction/PromptBinding.cs
+++ b/src/Aspire.Cli/Interaction/PromptBinding.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+
+namespace Aspire.Cli.Interaction;
+
+/// <summary>
+/// Binds a CLI option to an interactive prompt.
+/// When a prompt method receives this, it first checks the parse result for an explicitly provided value
+/// before prompting interactively. In non-interactive mode, it uses the default value or displays an
+/// actionable error naming the required option.
+/// </summary>
+internal sealed class PromptBinding<T>
+{
+    private readonly Func<ParseResult, (bool WasProvided, T? Value)> _resolver;
+    private readonly ParseResult? _parseResult;
+
+    internal PromptBinding(
+        ParseResult? parseResult,
+        string symbolDisplayName,
+        Func<ParseResult, (bool WasProvided, T? Value)> resolver,
+        T? defaultValue,
+        bool hasExplicitDefault)
+    {
+        _parseResult = parseResult;
+        SymbolDisplayName = symbolDisplayName;
+        _resolver = resolver;
+        DefaultValue = defaultValue;
+        HasExplicitDefault = hasExplicitDefault;
+    }
+
+    /// <summary>
+    /// Gets the display name of the CLI option, formatted for error messages
+    /// (e.g. "'--publisher'").
+    /// </summary>
+    public string SymbolDisplayName { get; }
+
+    /// <summary>
+    /// Gets the default value to use when non-interactive and the symbol was not provided.
+    /// </summary>
+    public T? DefaultValue { get; }
+
+    /// <summary>
+    /// Gets whether a default value was explicitly specified when this binding was created.
+    /// When <c>false</c>, prompt methods should throw in non-interactive mode instead of
+    /// silently using <c>default(T)</c>.
+    /// </summary>
+    public bool HasExplicitDefault { get; }
+
+    /// <summary>
+    /// Resolves the value from the parse result. Returns whether the symbol was explicitly
+    /// provided by the user and the resolved value.
+    /// </summary>
+    public (bool WasProvided, T? Value) Resolve()
+    {
+        if (_parseResult is null)
+        {
+            return (false, default);
+        }
+
+        return _resolver(_parseResult);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="PromptBinding{T}"/> with the same resolver but a different default value.
+    /// </summary>
+    public PromptBinding<T> WithDefault(T? newDefault) =>
+        new(_parseResult, SymbolDisplayName, _resolver, newDefault, hasExplicitDefault: true);
+}
+
+/// <summary>
+/// Factory methods for creating <see cref="PromptBinding{T}"/> instances.
+/// </summary>
+internal static class PromptBinding
+{
+    public static (bool WasProvided, T? OptionValue, T? DefaultValue) Resolve<T>(PromptBinding<T>? binding)
+    {
+        if (binding == null)
+        {
+            return default;
+        }
+
+        var (wasProvided, optionValue) = binding.Resolve();
+        return (wasProvided, optionValue, binding.DefaultValue);
+    }
+
+    public static PromptBinding<T> Create<T>(ParseResult parseResult, Option<T> option) =>
+        new(parseResult, FormatOptionName(option), BuildOptionResolver(option), default, hasExplicitDefault: false);
+
+    public static PromptBinding<T> Create<T>(ParseResult parseResult, Option<T> option, T defaultValue) =>
+        new(parseResult, FormatOptionName(option), BuildOptionResolver(option), defaultValue, hasExplicitDefault: true);
+
+    /// <summary>
+    /// Creates a <see cref="PromptBinding{T}"/> that uses <paramref name="interactiveDefault"/> as the
+    /// default for interactive prompts but still requires the CLI option in non-interactive mode.
+    /// </summary>
+    public static PromptBinding<T> CreateWithInteractiveDefault<T>(ParseResult parseResult, Option<T> option, T interactiveDefault) =>
+        new(parseResult, FormatOptionName(option), BuildOptionResolver(option), interactiveDefault, hasExplicitDefault: false);
+
+    /// <summary>
+    /// Creates a <see cref="PromptBinding{T}"/> with only a default value and no CLI symbol binding.
+    /// Use when there is no corresponding CLI option or argument for the prompt.
+    /// </summary>
+    public static PromptBinding<T> CreateDefault<T>(T defaultValue) =>
+        new(null, string.Empty, static _ => (false, default), defaultValue, hasExplicitDefault: true);
+
+    /// <summary>
+    /// Creates a <see cref="PromptBinding{T}"/> for a <c>bool?</c> option that resolves to the inverse of its value.
+    /// This is useful for suppress/disable options that should negate a confirmation result.
+    /// When not provided in non-interactive mode, defaults to <paramref name="defaultValue"/>.
+    /// </summary>
+    public static PromptBinding<bool> CreateInvertedBoolConfirm(ParseResult parseResult, Option<bool?> option, bool defaultValue) =>
+        new(parseResult, FormatOptionName(option), BuildInvertedBoolConfirmResolver(option), defaultValue, hasExplicitDefault: true);
+
+    /// <summary>
+    /// Creates a <see cref="PromptBinding{T}"/> for a <c>bool?</c> option that maps to Yes/No selection choices.
+    /// When the option is explicitly provided, resolves to <paramref name="trueValue"/> or <paramref name="falseValue"/>.
+    /// When not provided in non-interactive mode, defaults to <paramref name="falseValue"/>.
+    /// </summary>
+    public static PromptBinding<string?> CreateBoolAsSelection(ParseResult parseResult, Option<bool?> option, string trueValue, string falseValue) =>
+        new(parseResult, FormatOptionName(option), BuildBoolAsSelectionResolver(option, trueValue, falseValue), falseValue, hasExplicitDefault: true);
+
+    private static string FormatOptionName<T>(Option<T> option) => $"'--{option.Name}'";
+
+    private static Func<ParseResult, (bool, T?)> BuildOptionResolver<T>(Option<T> option) =>
+        parseResult =>
+        {
+            var result = parseResult.GetResult(option);
+            if (result is not null && !result.Implicit)
+            {
+                return (true, parseResult.GetValue(option));
+            }
+
+            return (false, default);
+        };
+
+    private static Func<ParseResult, (bool, string?)> BuildBoolAsSelectionResolver(Option<bool?> option, string trueValue, string falseValue) =>
+        parseResult =>
+        {
+            var result = parseResult.GetResult(option);
+            if (result is not null && !result.Implicit)
+            {
+                var value = parseResult.GetValue(option);
+                return (true, value == true ? trueValue : falseValue);
+            }
+
+            return (false, default);
+        };
+
+    private static Func<ParseResult, (bool, bool)> BuildInvertedBoolConfirmResolver(Option<bool?> option) =>
+        parseResult =>
+        {
+            var result = parseResult.GetResult(option);
+            if (result is not null && !result.Implicit)
+            {
+                var value = parseResult.GetValue(option);
+                return (true, value != true);
+            }
+
+            return (false, default);
+        };
+}

--- a/src/Aspire.Cli/Interaction/PromptBinding.cs
+++ b/src/Aspire.Cli/Interaction/PromptBinding.cs
@@ -7,9 +7,9 @@ namespace Aspire.Cli.Interaction;
 
 /// <summary>
 /// Binds a CLI option to an interactive prompt.
-/// When a prompt method receives this, it first checks the parse result for an explicitly provided value
-/// before prompting interactively. In non-interactive mode, it uses the default value or displays an
-/// actionable error naming the required option.
+/// When a prompt method receives this, it first checks the parse result for an explicitly provided
+/// option value before prompting interactively. In non-interactive mode, it uses the default value
+/// or displays an actionable error naming the required option.
 /// </summary>
 internal sealed class PromptBinding<T>
 {
@@ -121,7 +121,7 @@ internal static class PromptBinding
     public static PromptBinding<string?> CreateBoolAsSelection(ParseResult parseResult, Option<bool?> option, string trueValue, string falseValue) =>
         new(parseResult, FormatOptionName(option), BuildBoolAsSelectionResolver(option, trueValue, falseValue), falseValue, hasExplicitDefault: true);
 
-    private static string FormatOptionName<T>(Option<T> option) => $"'--{option.Name}'";
+    private static string FormatOptionName<T>(Option<T> option) => $"'{option.Name}'";
 
     private static Func<ParseResult, (bool, T?)> BuildOptionResolver<T>(Option<T> option) =>
         parseResult =>

--- a/src/Aspire.Cli/Interaction/PromptBinding.cs
+++ b/src/Aspire.Cli/Interaction/PromptBinding.cs
@@ -112,7 +112,7 @@ internal static class PromptBinding
     /// When not provided in non-interactive mode, defaults to <paramref name="defaultValue"/>.
     /// </summary>
     public static PromptBinding<bool> CreateInvertedBoolConfirm(ParseResult parseResult, Option<bool?> option, bool defaultValue) =>
-        new(parseResult, FormatOptionName(option), BuildInvertedBoolConfirmResolver(option), defaultValue, hasExplicitDefault: true);
+        new(parseResult, FormatOptionName(option), BuildResolver<bool?, bool>(option, value => value != true), defaultValue, hasExplicitDefault: true);
 
     /// <summary>
     /// Creates a <see cref="PromptBinding{T}"/> for a <c>bool?</c> option that maps to Yes/No selection choices.
@@ -123,46 +123,24 @@ internal static class PromptBinding
     {
         trueValue ??= TemplatingStrings.Yes;
         falseValue ??= TemplatingStrings.No;
-        return new(parseResult, FormatOptionName(option), BuildBoolAsSelectionResolver(option, trueValue, falseValue), falseValue, hasExplicitDefault: true);
+        return new(parseResult, FormatOptionName(option), BuildResolver<bool?, string?>(option, value => value == true ? trueValue : falseValue), falseValue, hasExplicitDefault: true);
     }
 
     private static string FormatOptionName<T>(Option<T> option) => $"'{option.Name}'";
 
+    private static Func<ParseResult, (bool, TResult?)> BuildResolver<TOption, TResult>(
+        Option<TOption> option, Func<TOption?, TResult?> transform) =>
+        parseResult =>
+        {
+            var result = parseResult.GetResult(option);
+            if (result is not null && !result.Implicit)
+            {
+                return (true, transform(parseResult.GetValue(option)));
+            }
+
+            return (false, default);
+        };
+
     private static Func<ParseResult, (bool, T?)> BuildOptionResolver<T>(Option<T> option) =>
-        parseResult =>
-        {
-            var result = parseResult.GetResult(option);
-            if (result is not null && !result.Implicit)
-            {
-                return (true, parseResult.GetValue(option));
-            }
-
-            return (false, default);
-        };
-
-    private static Func<ParseResult, (bool, string?)> BuildBoolAsSelectionResolver(Option<bool?> option, string trueValue, string falseValue) =>
-        parseResult =>
-        {
-            var result = parseResult.GetResult(option);
-            if (result is not null && !result.Implicit)
-            {
-                var value = parseResult.GetValue(option);
-                return (true, value == true ? trueValue : falseValue);
-            }
-
-            return (false, default);
-        };
-
-    private static Func<ParseResult, (bool, bool)> BuildInvertedBoolConfirmResolver(Option<bool?> option) =>
-        parseResult =>
-        {
-            var result = parseResult.GetResult(option);
-            if (result is not null && !result.Implicit)
-            {
-                var value = parseResult.GetValue(option);
-                return (true, value != true);
-            }
-
-            return (false, default);
-        };
+        BuildResolver<T, T>(option, static value => value);
 }

--- a/src/Aspire.Cli/Packaging/NuGetConfigPrompter.cs
+++ b/src/Aspire.Cli/Packaging/NuGetConfigPrompter.cs
@@ -47,14 +47,15 @@ internal class NuGetConfigPrompter
 
         if (!hasConfigInTargetDir)
         {
-            // Ask for confirmation before creating the file
             var choice = await _interactionService.PromptForSelectionAsync(
                 TemplatingStrings.CreateNugetConfigConfirmation,
                 [TemplatingStrings.Yes, TemplatingStrings.No],
                 c => c,
-                cancellationToken);
+                binding: PromptBinding.CreateDefault<string?>(TemplatingStrings.Yes),
+                cancellationToken: cancellationToken);
+            var shouldCreate = string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput);
 
-            if (string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput))
+            if (shouldCreate)
             {
                 await NuGetConfigMerger.CreateOrUpdateAsync(targetDirectory, channel, cancellationToken: cancellationToken);
                 _interactionService.DisplayMessage(KnownEmojis.Package, TemplatingStrings.NuGetConfigCreatedConfirmationMessage);
@@ -66,9 +67,11 @@ internal class NuGetConfigPrompter
                 TemplatingStrings.UpdateNuGetConfigConfirmation,
                 [TemplatingStrings.Yes, TemplatingStrings.No],
                 c => c,
-                cancellationToken);
+                binding: PromptBinding.CreateDefault<string?>(TemplatingStrings.Yes),
+                cancellationToken: cancellationToken);
+            var shouldUpdate = string.Equals(updateChoice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput);
 
-            if (string.Equals(updateChoice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput))
+            if (shouldUpdate)
             {
                 await NuGetConfigMerger.CreateOrUpdateAsync(targetDirectory, channel, cancellationToken: cancellationToken);
                 _interactionService.DisplayMessage(KnownEmojis.Package, TemplatingStrings.NuGetConfigUpdatedConfirmationMessage);

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -574,7 +574,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     /// <inheritdoc />
     public async Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken)
     {
-        var result = await _projectUpdater.UpdateProjectAsync(context.AppHostFile, context.Channel, cancellationToken);
+        var result = await _projectUpdater.UpdateProjectAsync(context, cancellationToken);
         return new UpdatePackagesResult { UpdatesApplied = result.UpdatedApplied };
     }
 

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1207,7 +1207,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         _interactionService.DisplayEmptyLine();
 
         // Confirm with user
-        if (!await _interactionService.ConfirmAsync(UpdateCommandStrings.PerformUpdatesPrompt, context.ConfirmBinding, cancellationToken: cancellationToken))
+        if (!await _interactionService.PromptConfirmAsync(UpdateCommandStrings.PerformUpdatesPrompt, context.ConfirmBinding, cancellationToken: cancellationToken))
         {
             return new UpdatePackagesResult { UpdatesApplied = false };
         }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1207,7 +1207,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         _interactionService.DisplayEmptyLine();
 
         // Confirm with user
-        if (!await _interactionService.ConfirmAsync(UpdateCommandStrings.PerformUpdatesPrompt, true, cancellationToken))
+        if (!await _interactionService.ConfirmAsync(UpdateCommandStrings.PerformUpdatesPrompt, context.ConfirmBinding, cancellationToken: cancellationToken))
         {
             return new UpdatePackagesResult { UpdatesApplied = false };
         }

--- a/src/Aspire.Cli/Projects/IAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/IAppHostProject.cs
@@ -29,6 +29,18 @@ internal sealed class UpdatePackagesContext
     /// Gets or sets the package channel to update to.
     /// </summary>
     public required Packaging.PackageChannel Channel { get; init; }
+
+    /// <summary>
+    /// Gets the prompt binding for confirmation prompts.
+    /// Enables non-interactive confirmation via CLI options (e.g. <c>--yes</c>).
+    /// </summary>
+    public required Interaction.PromptBinding<bool> ConfirmBinding { get; init; }
+
+    /// <summary>
+    /// Gets the prompt binding for the NuGet config directory prompt.
+    /// Enables non-interactive selection via CLI options (e.g. <c>--nuget-config-dir</c>).
+    /// </summary>
+    public required Interaction.PromptBinding<string?> NuGetConfigDirBinding { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -98,7 +98,7 @@ internal sealed class LanguageService : ILanguageService
             "Which language would you like to use?",
             languages,
             lang => lang.DisplayName,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         return (_projectFactory.GetProject(selected), selected);
     }

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -297,7 +297,7 @@ internal sealed class ProjectLocator(
                             InteractionServiceStrings.SelectAppHostToUse,
                             appHostProjects,
                             file => $"{file.Name.EscapeMarkup()} ({Path.GetRelativePath(executionContext.WorkingDirectory.FullName, file.FullName).EscapeMarkup()})",
-                            cancellationToken
+                            cancellationToken: cancellationToken
                         );
                     }
                     else if (multipleAppHostProjectsFoundBehavior is MultipleAppHostProjectsFoundBehavior.None)
@@ -388,7 +388,7 @@ internal sealed class ProjectLocator(
             selectedAppHost = multipleAppHostProjectsFoundBehavior switch
             {
                 MultipleAppHostProjectsFoundBehavior.Throw => throw new ProjectLocatorException(ErrorStrings.MultipleProjectFilesFound, ProjectLocatorFailureReason.MultipleProjectFilesFound),
-                MultipleAppHostProjectsFoundBehavior.Prompt => await interactionService.PromptForSelectionAsync(InteractionServiceStrings.SelectAppHostToUse, results.BuildableAppHost, projectFile => $"{projectFile.Name.EscapeMarkup()} ({Path.GetRelativePath(executionContext.WorkingDirectory.FullName, projectFile.FullName).EscapeMarkup()})", cancellationToken),
+                MultipleAppHostProjectsFoundBehavior.Prompt => await interactionService.PromptForSelectionAsync(InteractionServiceStrings.SelectAppHostToUse, results.BuildableAppHost, projectFile => $"{projectFile.Name.EscapeMarkup()} ({Path.GetRelativePath(executionContext.WorkingDirectory.FullName, projectFile.FullName).EscapeMarkup()})", cancellationToken: cancellationToken),
                 MultipleAppHostProjectsFoundBehavior.None => null,
                 _ => selectedAppHost
             };

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -20,13 +20,15 @@ namespace Aspire.Cli.Projects;
 
 internal interface IProjectUpdater
 {
-    Task<ProjectUpdateResult> UpdateProjectAsync(FileInfo projectFile, PackageChannel channel, CancellationToken cancellationToken = default);
+    Task<ProjectUpdateResult> UpdateProjectAsync(UpdatePackagesContext context, CancellationToken cancellationToken = default);
 }
 
 internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDotNetCliRunner runner, IInteractionService interactionService, IMemoryCache cache, CliExecutionContext executionContext, FallbackProjectParser fallbackParser) : IProjectUpdater
 {
-    public async Task<ProjectUpdateResult> UpdateProjectAsync(FileInfo projectFile, PackageChannel channel, CancellationToken cancellationToken = default)
+    public async Task<ProjectUpdateResult> UpdateProjectAsync(UpdatePackagesContext context, CancellationToken cancellationToken = default)
     {
+        var projectFile = context.AppHostFile;
+        var channel = context.Channel;
         logger.LogDebug("Fetching '{AppHostPath}' items and properties.", projectFile.FullName);
 
         var (updateSteps, fallbackUsed) = await interactionService.ShowStatusAsync(UpdateCommandStrings.AnalyzingProjectStatus, () => GetUpdateStepsAsync(projectFile, channel, cancellationToken));
@@ -70,7 +72,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
             interactionService.DisplayEmptyLine();
         }
 
-        if (!await interactionService.ConfirmAsync(UpdateCommandStrings.PerformUpdatesPrompt, true, cancellationToken))
+        if (!await interactionService.ConfirmAsync(UpdateCommandStrings.PerformUpdatesPrompt, context.ConfirmBinding, cancellationToken: cancellationToken))
         {
             return new ProjectUpdateResult { UpdatedApplied = false };
         }
@@ -106,16 +108,21 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
             interactionService.DisplayEmptyLine();
 
+            // Carry the recommended directory as the default on the binding.
+            // The original binding (from UpdateCommand) may not have a default because
+            // the recommended directory is computed here, after NuGet config discovery.
+            var nugetConfigDirBinding = context.NuGetConfigDirBinding.WithDefault(recommendedNuGetConfigFileDirectory);
+
             var selectedPathForNewNuGetConfigFile = await interactionService.PromptForFilePathAsync(
                 promptText: UpdateCommandStrings.WhichDirectoryNuGetConfigPrompt,
-                defaultValue: recommendedNuGetConfigFileDirectory.EscapeMarkup(),
+                binding: nugetConfigDirBinding,
                 validator: null,
                 directory: true,
                 required: true,
                 cancellationToken: cancellationToken);
 
             var nugetConfigDirectory = new DirectoryInfo(selectedPathForNewNuGetConfigFile);
-            await NuGetConfigMerger.CreateOrUpdateAsync(nugetConfigDirectory, channel, AnalyzeAndConfirmNuGetConfigChanges, cancellationToken: cancellationToken);
+            await NuGetConfigMerger.CreateOrUpdateAsync(nugetConfigDirectory, channel, (_, orig, proposed, ct) => AnalyzeAndConfirmNuGetConfigChanges(context, orig, proposed, ct), cancellationToken: cancellationToken);
         }
 
         interactionService.DisplayEmptyLine();
@@ -915,7 +922,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         }
     }
 
-    private async Task<bool> AnalyzeAndConfirmNuGetConfigChanges(FileInfo targetFile, XmlDocument? originalDocument, XmlDocument proposedDocument, CancellationToken cancellationToken)
+    private async Task<bool> AnalyzeAndConfirmNuGetConfigChanges(UpdatePackagesContext context, XmlDocument? originalDocument, XmlDocument proposedDocument, CancellationToken cancellationToken)
     {
         interactionService.DisplayEmptyLine();
 
@@ -931,8 +938,8 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
         var shouldProceed = await interactionService.ConfirmAsync(
             UpdateCommandStrings.ApplyChangesToNuGetConfig,
-            defaultValue: true,
-            cancellationToken);
+            binding: context.ConfirmBinding,
+            cancellationToken: cancellationToken);
 
         return shouldProceed;
     }

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -72,7 +72,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
             interactionService.DisplayEmptyLine();
         }
 
-        if (!await interactionService.ConfirmAsync(UpdateCommandStrings.PerformUpdatesPrompt, context.ConfirmBinding, cancellationToken: cancellationToken))
+        if (!await interactionService.PromptConfirmAsync(UpdateCommandStrings.PerformUpdatesPrompt, context.ConfirmBinding, cancellationToken: cancellationToken))
         {
             return new ProjectUpdateResult { UpdatedApplied = false };
         }
@@ -936,7 +936,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
         DisplayNuGetConfigChanges(changes);
 
-        var shouldProceed = await interactionService.ConfirmAsync(
+        var shouldProceed = await interactionService.PromptConfirmAsync(
             UpdateCommandStrings.ApplyChangesToNuGetConfig,
             binding: context.ConfirmBinding,
             cancellationToken: cancellationToken);

--- a/src/Aspire.Cli/Projects/SolutionLocator.cs
+++ b/src/Aspire.Cli/Projects/SolutionLocator.cs
@@ -41,7 +41,7 @@ internal sealed class SolutionLocator(ILogger<SolutionLocator> logger, IInteract
                 InitCommandStrings.MultipleSolutionsFound,
                 solutionFiles,
                 solutionFile => $"{solutionFile.Name.EscapeMarkup()} ({Path.GetRelativePath(startDirectory.FullName, solutionFile.FullName).EscapeMarkup()})",
-                cancellationToken);
+                cancellationToken: cancellationToken);
             
             return selectedSolution;
         }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -412,7 +412,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'.
+        ///   Looks up a localized string similar to Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'.
         /// </summary>
         internal static string InitCommand_SkillLocationsOptionDescription {
             get {
@@ -421,7 +421,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'.
+        ///   Looks up a localized string similar to Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'.
         /// </summary>
         internal static string InitCommand_SkillsOptionDescription {
             get {

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -401,5 +401,32 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("PlaywrightCliInstaller_InstalledWithMirrorWarnings", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Path to the workspace root directory.
+        /// </summary>
+        internal static string InitCommand_WorkspaceRootOptionDescription {
+            get {
+                return ResourceManager.GetString("InitCommand_WorkspaceRootOptionDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'.
+        /// </summary>
+        internal static string InitCommand_SkillLocationsOptionDescription {
+            get {
+                return ResourceManager.GetString("InitCommand_SkillLocationsOptionDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'.
+        /// </summary>
+        internal static string InitCommand_SkillsOptionDescription {
+            get {
+                return ResourceManager.GetString("InitCommand_SkillsOptionDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -178,9 +178,9 @@
     <value>Path to the workspace root directory</value>
   </data>
   <data name="InitCommand_SkillLocationsOptionDescription" xml:space="preserve">
-    <value>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</value>
+    <value>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</value>
   </data>
   <data name="InitCommand_SkillsOptionDescription" xml:space="preserve">
-    <value>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</value>
+    <value>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -174,4 +174,13 @@
   <data name="PlaywrightCliInstaller_InstalledWithMirrorWarnings" xml:space="preserve">
     <value>Installed Playwright CLI (some locations failed to mirror).</value>
   </data>
+  <data name="InitCommand_WorkspaceRootOptionDescription" xml:space="preserve">
+    <value>Path to the workspace root directory</value>
+  </data>
+  <data name="InitCommand_SkillLocationsOptionDescription" xml:space="preserve">
+    <value>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</value>
+  </data>
+  <data name="InitCommand_SkillsOptionDescription" xml:space="preserve">
+    <value>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -196,7 +196,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal..
+        ///   Looks up a localized string similar to This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution..
         /// </summary>
         public static string InteractiveInputNotSupported {
             get {
@@ -210,6 +210,33 @@ namespace Aspire.Cli.Resources {
         public static string MoreInfoNewCliVersion {
             get {
                 return ResourceManager.GetString("MoreInfoNewCliVersion", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Available values: {0}.
+        /// </summary>
+        public static string NonInteractiveAvailableValues {
+            get {
+                return ResourceManager.GetString("NonInteractiveAvailableValues", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; is not valid for {1}..
+        /// </summary>
+        public static string NonInteractiveInvalidValue {
+            get {
+                return ResourceManager.GetString("NonInteractiveInvalidValue", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The {0} option must be specified when running in non-interactive mode..
+        /// </summary>
+        public static string NonInteractiveOptionRequired {
+            get {
+                return ResourceManager.GetString("NonInteractiveOptionRequired", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -233,6 +233,18 @@
     <value>Other (specify next)</value>
   </data>
   <data name="InteractiveInputNotSupported" xml:space="preserve">
-    <value>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</value>
+    <value>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</value>
+  </data>
+  <data name="NonInteractiveOptionRequired" xml:space="preserve">
+    <value>The {0} option must be specified when running in non-interactive mode.</value>
+    <comment>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</comment>
+  </data>
+  <data name="NonInteractiveInvalidValue" xml:space="preserve">
+    <value>The value '{0}' is not valid for {1}.</value>
+    <comment>{0} is the provided value. {1} is the option/argument display name.</comment>
+  </data>
+  <data name="NonInteractiveAvailableValues" xml:space="preserve">
+    <value>Available values: {0}</value>
+    <comment>{0} is a comma-separated list of valid values</comment>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -144,5 +144,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ResolvingTemplateVersion", resourceCulture);
             }
         }
+
+        public static string NonInteractiveTemplateRequired {
+            get {
+                return ResourceManager.GetString("NonInteractiveTemplateRequired", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -151,4 +151,7 @@
   <data name="ResolvingTemplateVersion" xml:space="preserve">
     <value>Resolving template version...</value>
   </data>
+  <data name="NonInteractiveTemplateRequired" xml:space="preserve">
+    <value>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -105,6 +105,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        internal static string AgentInitOptionDescription {
+            get {
+                return ResourceManager.GetString("AgentInitOptionDescription", resourceCulture);
+            }
+        }
+
         internal static string PipelineLogLevelOptionDescription {
             get {
                 return ResourceManager.GetString("PipelineLogLevelOptionDescription", resourceCulture);

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -147,6 +147,9 @@
   <data name="PromptRunAgentInit" xml:space="preserve">
     <value>Would you like to configure AI agent environments for this project?</value>
   </data>
+  <data name="AgentInitOptionDescription" xml:space="preserve">
+    <value>Suppress AI agent environment configuration after project creation</value>
+  </data>
   <data name="PipelineLogLevelOptionDescription" xml:space="preserve">
     <value>Set the minimum log level for pipeline logging (trace, debug, information, warning, error, critical). The default is 'information'.</value>
   </data>

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -117,5 +117,7 @@ namespace Aspire.Cli.Resources {
     internal static string RegeneratingSdkCode => ResourceManager.GetString("RegeneratingSdkCode", resourceCulture);
     internal static string RegeneratedSdkCode => ResourceManager.GetString("RegeneratedSdkCode", resourceCulture);
     internal static string SelfOptionDescription => ResourceManager.GetString("SelfOptionDescription", resourceCulture);
+    internal static string YesOptionDescription => ResourceManager.GetString("YesOptionDescription", resourceCulture);
+    internal static string NuGetConfigDirOptionDescription => ResourceManager.GetString("NuGetConfigDirOptionDescription", resourceCulture);
     }
 }

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -168,4 +168,10 @@
   <data name="SelfOptionDescription" xml:space="preserve">
     <value>Update the Aspire CLI itself to the latest version</value>
   </data>
+  <data name="YesOptionDescription" xml:space="preserve">
+    <value>Automatically confirm all update prompts without asking</value>
+  </data>
+  <data name="NuGetConfigDirOptionDescription" xml:space="preserve">
+    <value>Directory to create or update the NuGet.config file in</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -63,13 +63,13 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillLocationsOptionDescription">
-        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <source>Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_SkillsOptionDescription">
-        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
-        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <source>Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. {0}), '{1}', or '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -62,6 +62,21 @@
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_SkillLocationsOptionDescription">
+        <source>Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skill locations to install (e.g. standard,claudecode,github,opencode), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_SkillsOptionDescription">
+        <source>Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</source>
+        <target state="new">Comma-separated list of skills to install (e.g. aspire,playwright-cli,dotnet-inspect), 'all', or 'none'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WorkspaceRootOptionDescription">
+        <source>Path to the workspace root directory</source>
+        <target state="new">Path to the workspace root directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_FailedToDownload">
         <source>Failed to download {0}.</source>
         <target state="new">Failed to download {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">Interaktivní vstup se v tomto prostředí nepodporuje. Použijte příznak --non-interactive nebo zajistěte, aby rozhraní příkazového řádku běželo v interaktivním terminálu.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">Interaktivní vstup se v tomto prostředí nepodporuje. Použijte příznak --non-interactive nebo zajistěte, aby rozhraní příkazového řádku běželo v interaktivním terminálu.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">Nejsou k dispozici žádné položky pro výběr: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">Interaktive Eingaben werden in dieser Umgebung nicht unterstützt. Verwenden Sie das Flag „--non-interactive“, oder stellen Sie sicher, dass die CLI in einem interaktiven Terminal ausgeführt wird.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">Interaktive Eingaben werden in dieser Umgebung nicht unterstützt. Verwenden Sie das Flag „--non-interactive“, oder stellen Sie sicher, dass die CLI in einem interaktiven Terminal ausgeführt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">Es sind keine Elemente zur Auswahl verfügbar: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">La entrada interactiva no es compatible con este entorno. Use la marca --non-interactive o asegúrese de que la CLI se esté ejecutando en un terminal interactivo.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">La entrada interactiva no es compatible con este entorno. Use la marca --non-interactive o asegúrese de que la CLI se esté ejecutando en un terminal interactivo.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">No hay elementos disponibles para la selección: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">La saisie interactive n'est pas prise en charge dans cet environnement. Utilisez l’indicateur --non-interactive ou assurez-vous que la CLI s’exécute dans un terminal interactif.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">La saisie interactive n'est pas prise en charge dans cet environnement. Utilisez l’indicateur --non-interactive ou assurez-vous que la CLI s’exécute dans un terminal interactif.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">Aucun élément disponible pour la sélection : {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">L'input interattivo non è supportato in questo ambiente. Usare il flag --non interattivo, oppure assicurarsi che l'interfaccia della riga di comando sia in esecuzione in un terminale interattivo.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">L'input interattivo non è supportato in questo ambiente. Usare il flag --non interattivo, oppure assicurarsi che l'interfaccia della riga di comando sia in esecuzione in un terminale interattivo.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">Nessun elemento disponibile per la selezione: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">対話型入力は、この環境ではサポートされていません。--non-interactive フラグを使用するか、CLI が対話型ターミナルで実行されていることを確認してください。</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">対話型入力は、この環境ではサポートされていません。--non-interactive フラグを使用するか、CLI が対話型ターミナルで実行されていることを確認してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">選択できる項目がありません: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">이 환경에서는 대화형 입력이 지원되지 않습니다. --non-interactive 플래그를 사용하거나 CLI가 대화형 터미널에서 실행되고 있는지 확인합니다.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">이 환경에서는 대화형 입력이 지원되지 않습니다. --non-interactive 플래그를 사용하거나 CLI가 대화형 터미널에서 실행되고 있는지 확인합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">선택할 수 있는 항목 없음: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">Interakcyjne dane wejściowe nie są obsługiwane w tym środowisku. Użyj flagi --non-interactive lub upewnij się, że interfejs wiersza polecenia jest uruchomiony w terminalu interaktywnym.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">Interakcyjne dane wejściowe nie są obsługiwane w tym środowisku. Użyj flagi --non-interactive lub upewnij się, że interfejs wiersza polecenia jest uruchomiony w terminalu interaktywnym.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">Brak dostępnych elementów do wyboru: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">Não há suporte para entrada interativa neste ambiente. Use o sinalizador --não-interativo ou verifique se a CLI está em execução em um terminal interativo.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">Não há suporte para entrada interativa neste ambiente. Use o sinalizador --não-interativo ou verifique se a CLI está em execução em um terminal interativo.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">Nenhum item disponível para seleção: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">Интерактивный ввод не поддерживается в этой среде. Используйте флаг --non-interactive или убедитесь, что CLI запущен в интерактивном терминале.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">Интерактивный ввод не поддерживается в этой среде. Используйте флаг --non-interactive или убедитесь, что CLI запущен в интерактивном терминале.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">Нет элементов, доступных для выбора: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">Bu ortamda etkileşimli giriş desteklenmemektedir. --non-interactive bayrağını kullanın veya CLI'nin etkileşimli bir terminalde çalıştığından emin olun.</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">Bu ortamda etkileşimli giriş desteklenmemektedir. --non-interactive bayrağını kullanın veya CLI'nin etkileşimli bir terminalde çalıştığından emin olun.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">Seçim için herhangi bir öğe mevcut değil: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">此环境中不支持交互式输入。使用 --non-interactive 标志或确保 CLI 在交互式终端中运行。</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">此环境中不支持交互式输入。使用 --non-interactive 标志或确保 CLI 在交互式终端中运行。</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">没有可供选择的项目: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InteractiveInputNotSupported">
-        <source>Interactive input is not supported in this environment. Use the --non-interactive flag or ensure the CLI is running in an interactive terminal.</source>
-        <target state="translated">此環境不支援互動輸入。請使用 --non-interactive 旗標，或確保 CLI 在互動終端中執行。</target>
+        <source>This prompt requires interactive input but the CLI is running in non-interactive mode. This operation does not yet support non-interactive execution.</source>
+        <target state="needs-review-translation">此環境不支援互動輸入。請使用 --non-interactive 旗標，或確保 CLI 在互動終端中執行。</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
@@ -91,6 +91,21 @@
         <source>No items available for selection: {0}</source>
         <target state="translated">沒有可供選取的項目: {0}</target>
         <note>{0} is the original selection prompt text.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveAvailableValues">
+        <source>Available values: {0}</source>
+        <target state="new">Available values: {0}</target>
+        <note>{0} is a comma-separated list of valid values</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveInvalidValue">
+        <source>The value '{0}' is not valid for {1}.</source>
+        <target state="new">The value '{0}' is not valid for {1}.</target>
+        <note>{0} is the provided value. {1} is the option/argument display name.</note>
+      </trans-unit>
+      <trans-unit id="NonInteractiveOptionRequired">
+        <source>The {0} option must be specified when running in non-interactive mode.</source>
+        <target state="new">The {0} option must be specified when running in non-interactive mode.</target>
+        <note>{0} is the option/argument display name like '--publisher' or '&lt;integration&gt;'</note>
       </trans-unit>
       <trans-unit id="OperationCancelled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">Název projektu, který se má vytvořit</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">Výstupní cesta pro projekt</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">Der Name des zu erstellenden Projekts.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">Der Ausgabepfad für das Projekt.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">El nombre del proyecto que se va a crear.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">La ruta de salida del proyecto.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">Nom du projet à créer.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">Le chemin de sortie du projet.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">Nome del progetto da creare.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">Percorso di output per il progetto.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">作成するプロジェクトの名前。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">プロジェクトの出力パス。</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">만들 프로젝트의 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">프로젝트의 출력 경로입니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">Nazwa projektu do utworzenia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">Ścieżka wyjściowa projektu.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">O nome do projeto a ser criado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">O caminho de saída para o projeto.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">Имя создаваемого проекта.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">Выходной путь для проекта.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">Oluşturulacak projenin adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">Projenin çıkış yolu.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">要创建的项目的名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">项目的输出路径。</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="needs-review-translation">要建立專案之名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveTemplateRequired">
+        <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
+        <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputArgumentDescription">
         <source>The output path for the project</source>
         <target state="needs-review-translation">專案的輸出路徑。</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../SharedCommandStrings.resx">
     <body>
+      <trans-unit id="AgentInitOptionDescription">
+        <source>Suppress AI agent environment configuration after project creation</source>
+        <target state="new">Suppress AI agent environment configuration after project creation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Nelze zapisovat do instalačního adresáře {0}. Spusťte prosím aktualizaci se zvýšenými oprávněními (např. pomocí sudo v Linuxu nebo macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Který adresář pro soubor NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Schreiben in das Installationsverzeichnis „{0}“ ist nicht möglich. Führen Sie das Update mit erhöhten Berechtigungen aus (zum Beispiel mit sudo unter Linux/macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Welches Verzeichnis für die NuGet.config-Datei?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -157,6 +157,11 @@
         <target state="translated">No se puede escribir en el directorio de instalación '{0}'. Ejecute la actualización con permisos elevados (por ejemplo, con sudo en Linux o macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">¿Qué directorio del archivo NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Impossible d’écrire dans le répertoire d’installation « {0} ». Exécutez la mise à jour avec des autorisations élevées (par exemple, en utilisant sudo sur Linux/macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Quel répertoire pour le fichier NuGet.config ?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Impossibile scrivere nella directory di installazione "{0}". Eseguire l'aggiornamento con autorizzazioni elevate, ad esempio usando sudo su Linux/macOS.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Quale directory per il file NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -157,6 +157,11 @@
         <target state="translated">インストール ディレクトリ '{0}' に書き込めません。管理者権限で更新を実行してください (例: Linux/macOS で sudo を使用)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">NuGet.config ファイル用の、どのディレクトリですか?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -157,6 +157,11 @@
         <target state="translated">설치 디렉터리 '{0}'에 쓸 수 없습니다. 관리자 권한으로 업데이트를 실행하세요(예: Linux/macOS에서 sudo 사용).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">NuGet.config 파일의 디렉터리는 무엇인가요?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Nie można zapisać w katalogu instalacyjnym „{0}”. Uruchom aktualizację z podniesionymi uprawnieniami (np. używając programu sudo w systemie Linux lub macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Który katalog dla pliku NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Não é possível gravar no diretório de instalação '{0}'. Execute a atualização com permissões elevadas (por exemplo, usando sudo no Linux/macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Qual diretório para o arquivo NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Не удается записать в каталог установки "{0}". Запустите обновление с повышенными правами (например, используя sudo в Linux или macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Какой каталог для файла NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -157,6 +157,11 @@
         <target state="translated">'{0}' yükleme dizinine yazılamıyor. Lütfen güncellemeyi yükseltilmiş izinlerle (örneğin Linux/macOS'ta sudo kullanarak) çalıştırın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">NuGet.config dosyası için hangi dizin kullanılsın?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -157,6 +157,11 @@
         <target state="translated">无法写入安装目录“{0}”。请使用提升的权限运行更新(例如，在 Linux/macOS 上使用 sudo)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">NuGet.config 文件位于哪个目录?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -157,6 +157,11 @@
         <target state="translated">無法寫入安裝目錄 '{0}'。請使用提高的權限來執行更新 (例如，在Linux/macOS上使用 sudo)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetConfigDirOptionDescription">
+        <source>Directory to create or update the NuGet.config file in</source>
+        <target state="new">Directory to create or update the NuGet.config file in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageNotFoundInChannelWarningFormat">
         <source>No package found with ID '{0}' in channel '{1}'. Skipping.</source>
         <target state="new">No package found with ID '{0}' in channel '{1}'. Skipping.</target>
@@ -260,6 +265,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">哪個目錄用於 NuGet.config 檔案?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YesOptionDescription">
+        <source>Automatically confirm all update prompts without asking</source>
+        <target state="new">Automatically confirm all update prompts without asking</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -32,14 +32,30 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(projectName))
         {
             var defaultName = _executionContext.WorkingDirectory.Name;
-            projectName = await _prompter.PromptForProjectNameAsync(defaultName, cancellationToken);
+
+            if (!_hostEnvironment.SupportsInteractiveInput)
+            {
+                projectName = defaultName;
+            }
+            else
+            {
+                projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
+            }
         }
 
         var outputPath = inputs.Output;
         if (string.IsNullOrWhiteSpace(outputPath))
         {
             var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken);
+
+            if (!_hostEnvironment.SupportsInteractiveInput)
+            {
+                outputPath = defaultOutputPath;
+            }
+            else
+            {
+                outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
+            }
         }
         outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
@@ -108,34 +124,23 @@ internal sealed partial class CliTemplateFactory
 
     private async Task<bool> ResolveUseLocalhostTldAsync(System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var localhostTldOptionSpecified = parseResult.Tokens.Any(token =>
-            string.Equals(token.Value, "--localhost-tld", StringComparisons.CliInputOrOutput));
-        var useLocalhostTld = parseResult.GetValue(_localhostTldOption);
-        if (!localhostTldOptionSpecified)
-        {
-            if (!_hostEnvironment.SupportsInteractiveInput)
-            {
-                return false;
-            }
+        var binding = PromptBinding.CreateBoolAsSelection(parseResult, _localhostTldOption, TemplatingStrings.Yes, TemplatingStrings.No);
 
-            useLocalhostTld = await _interactionService.PromptForSelectionAsync(
-                TemplatingStrings.UseLocalhostTld_Prompt,
-                [TemplatingStrings.No, TemplatingStrings.Yes],
-                choice => choice,
-                cancellationToken) switch
-            {
-                var choice when string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput) => true,
-                var choice when string.Equals(choice, TemplatingStrings.No, StringComparisons.CliInputOrOutput) => false,
-                _ => throw new InvalidOperationException(TemplatingStrings.UseLocalhostTld_UnexpectedChoice)
-            };
-        }
+        var selected = await _interactionService.PromptForSelectionAsync(
+            TemplatingStrings.UseLocalhostTld_Prompt,
+            [TemplatingStrings.No, TemplatingStrings.Yes],
+            choice => choice,
+            binding: binding,
+            cancellationToken: cancellationToken);
 
-        if (useLocalhostTld ?? false)
+        var useLocalhostTld = string.Equals(selected, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput);
+
+        if (useLocalhostTld)
         {
             _interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
         }
 
-        return useLocalhostTld ?? false;
+        return useLocalhostTld;
     }
 
     private async Task ApplyLocalhostTldToScaffoldedRunProfileAsync(string outputPath, string projectName, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -32,30 +32,14 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(projectName))
         {
             var defaultName = _executionContext.WorkingDirectory.Name;
-
-            if (!_hostEnvironment.SupportsInteractiveInput)
-            {
-                projectName = defaultName;
-            }
-            else
-            {
-                projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
-            }
+            projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
         var outputPath = inputs.Output;
         if (string.IsNullOrWhiteSpace(outputPath))
         {
             var defaultOutputPath = $"./{projectName}";
-
-            if (!_hostEnvironment.SupportsInteractiveInput)
-            {
-                outputPath = defaultOutputPath;
-            }
-            else
-            {
-                outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
-            }
+            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
         }
         outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -124,7 +124,7 @@ internal sealed partial class CliTemplateFactory
 
     private async Task<bool> ResolveUseLocalhostTldAsync(System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var binding = PromptBinding.CreateBoolAsSelection(parseResult, _localhostTldOption, TemplatingStrings.Yes, TemplatingStrings.No);
+        var binding = PromptBinding.CreateBoolAsSelection(parseResult, _localhostTldOption);
 
         var selected = await _interactionService.PromptForSelectionAsync(
             TemplatingStrings.UseLocalhostTld_Prompt,

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -137,7 +137,7 @@ internal sealed partial class CliTemplateFactory
 
     private async Task<bool> ResolveUseRedisCacheAsync(System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var binding = PromptBinding.CreateBoolAsSelection(parseResult, _useRedisCacheOption, TemplatingStrings.Yes, TemplatingStrings.No);
+        var binding = PromptBinding.CreateBoolAsSelection(parseResult, _useRedisCacheOption);
 
         var selected = await _interactionService.PromptForSelectionAsync(
             TemplatingStrings.UseRedisCache_Prompt,

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -18,15 +18,7 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(projectName))
         {
             var defaultName = _executionContext.WorkingDirectory.Name;
-
-            if (!_hostEnvironment.SupportsInteractiveInput)
-            {
-                projectName = defaultName;
-            }
-            else
-            {
-                projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
-            }
+            projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
         if (string.IsNullOrWhiteSpace(inputs.Version))
@@ -40,15 +32,7 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(outputPath))
         {
             var defaultOutputPath = $"./{projectName}";
-
-            if (!_hostEnvironment.SupportsInteractiveInput)
-            {
-                outputPath = defaultOutputPath;
-            }
-            else
-            {
-                outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
-            }
+            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
         }
         outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -18,7 +18,15 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(projectName))
         {
             var defaultName = _executionContext.WorkingDirectory.Name;
-            projectName = await _prompter.PromptForProjectNameAsync(defaultName, cancellationToken);
+
+            if (!_hostEnvironment.SupportsInteractiveInput)
+            {
+                projectName = defaultName;
+            }
+            else
+            {
+                projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
+            }
         }
 
         if (string.IsNullOrWhiteSpace(inputs.Version))
@@ -32,7 +40,15 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(outputPath))
         {
             var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken);
+
+            if (!_hostEnvironment.SupportsInteractiveInput)
+            {
+                outputPath = defaultOutputPath;
+            }
+            else
+            {
+                outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
+            }
         }
         outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
@@ -121,34 +137,23 @@ internal sealed partial class CliTemplateFactory
 
     private async Task<bool> ResolveUseRedisCacheAsync(System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var redisCacheOptionSpecified = parseResult.Tokens.Any(token =>
-            string.Equals(token.Value, "--use-redis-cache", StringComparisons.CliInputOrOutput));
-        var useRedisCache = parseResult.GetValue(_useRedisCacheOption);
-        if (!redisCacheOptionSpecified)
-        {
-            if (!_hostEnvironment.SupportsInteractiveInput)
-            {
-                return false;
-            }
+        var binding = PromptBinding.CreateBoolAsSelection(parseResult, _useRedisCacheOption, TemplatingStrings.Yes, TemplatingStrings.No);
 
-            useRedisCache = await _interactionService.PromptForSelectionAsync(
-                TemplatingStrings.UseRedisCache_Prompt,
-                [TemplatingStrings.Yes, TemplatingStrings.No],
-                choice => choice,
-                cancellationToken) switch
-            {
-                var choice when string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput) => true,
-                var choice when string.Equals(choice, TemplatingStrings.No, StringComparisons.CliInputOrOutput) => false,
-                _ => throw new InvalidOperationException(TemplatingStrings.UseRedisCache_UnexpectedChoice)
-            };
-        }
+        var selected = await _interactionService.PromptForSelectionAsync(
+            TemplatingStrings.UseRedisCache_Prompt,
+            [TemplatingStrings.Yes, TemplatingStrings.No],
+            choice => choice,
+            binding: binding,
+            cancellationToken: cancellationToken);
 
-        if (useRedisCache ?? false)
+        var useRedisCache = string.Equals(selected, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput);
+
+        if (useRedisCache)
         {
             _interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseRedisCache_UsingRedisCache);
         }
 
-        return useRedisCache ?? false;
+        return useRedisCache;
     }
 
     private static void AddRedisPackageToConfig(string outputPath, string aspireVersion)

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -18,7 +18,15 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(projectName))
         {
             var defaultName = _executionContext.WorkingDirectory.Name;
-            projectName = await _prompter.PromptForProjectNameAsync(defaultName, cancellationToken);
+
+            if (!_hostEnvironment.SupportsInteractiveInput)
+            {
+                projectName = defaultName;
+            }
+            else
+            {
+                projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
+            }
         }
 
         if (string.IsNullOrWhiteSpace(inputs.Version))
@@ -32,7 +40,15 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(outputPath))
         {
             var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken);
+
+            if (!_hostEnvironment.SupportsInteractiveInput)
+            {
+                outputPath = defaultOutputPath;
+            }
+            else
+            {
+                outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
+            }
         }
         outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -18,15 +18,7 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(projectName))
         {
             var defaultName = _executionContext.WorkingDirectory.Name;
-
-            if (!_hostEnvironment.SupportsInteractiveInput)
-            {
-                projectName = defaultName;
-            }
-            else
-            {
-                projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
-            }
+            projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
         if (string.IsNullOrWhiteSpace(inputs.Version))
@@ -40,15 +32,7 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(outputPath))
         {
             var defaultOutputPath = $"./{projectName}";
-
-            if (!_hostEnvironment.SupportsInteractiveInput)
-            {
-                outputPath = defaultOutputPath;
-            }
-            else
-            {
-                outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
-            }
+            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
         }
         outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -290,7 +290,7 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForDevLocalhostTldOptionAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var binding = PromptBinding.CreateBoolAsSelection(result, _localhostTldOption, TemplatingStrings.Yes, TemplatingStrings.No);
+        var binding = PromptBinding.CreateBoolAsSelection(result, _localhostTldOption);
 
         var selected = await interactionService.PromptForSelectionAsync(
             TemplatingStrings.UseLocalhostTld_Prompt,
@@ -308,7 +308,7 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForRedisCacheOptionAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var binding = PromptBinding.CreateBoolAsSelection(result, _useRedisCacheOption, TemplatingStrings.Yes, TemplatingStrings.No);
+        var binding = PromptBinding.CreateBoolAsSelection(result, _useRedisCacheOption);
 
         var selected = await interactionService.PromptForSelectionAsync(
             TemplatingStrings.UseRedisCache_Prompt,

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -582,12 +582,6 @@ internal class DotNetTemplateFactory(
         if (inputs.Name is not { } name || !ProjectNameValidator.IsProjectNameValid(name))
         {
             var defaultName = executionContext.WorkingDirectory.Name;
-
-            if (!hostEnvironment.SupportsInteractiveInput)
-            {
-                return defaultName;
-            }
-
             name = await prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
@@ -599,15 +593,7 @@ internal class DotNetTemplateFactory(
         if (inputs.Output is not { } outputPath)
         {
             var defaultPath = pathDeriver(projectName);
-
-            if (!hostEnvironment.SupportsInteractiveInput)
-            {
-                outputPath = defaultPath;
-            }
-            else
-            {
-                outputPath = await prompter.PromptForOutputPath(defaultPath, parseResult, cancellationToken);
-            }
+            outputPath = await prompter.PromptForOutputPath(defaultPath, parseResult, cancellationToken);
         }
 
         outputPath = Path.GetFullPath(outputPath);

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -64,8 +64,7 @@ internal class DotNetTemplateFactory(
         }
 
         var showAllTemplates = features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false);
-        var nonInteractive = !hostEnvironment.SupportsInteractiveInput;
-        return GetTemplatesCore(showAllTemplates, nonInteractive);
+        return GetTemplatesCore(showAllTemplates);
     }
 
     public async Task<IEnumerable<ITemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default)
@@ -76,8 +75,7 @@ internal class DotNetTemplateFactory(
         }
 
         var showAllTemplates = features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false);
-        var nonInteractive = !hostEnvironment.SupportsInteractiveInput;
-        return GetTemplatesCore(showAllTemplates, nonInteractive);
+        return GetTemplatesCore(showAllTemplates);
     }
 
     public async Task<IEnumerable<ITemplate>> GetInitTemplatesAsync(CancellationToken cancellationToken = default)
@@ -87,7 +85,7 @@ internal class DotNetTemplateFactory(
             return [];
         }
 
-        return [CreateSingleFileTemplate(nonInteractive: true)];
+        return [CreateSingleFileTemplate()];
     }
 
     private async Task<bool> IsDotNetSdkAvailableAsync(CancellationToken cancellationToken)
@@ -134,16 +132,14 @@ internal class DotNetTemplateFactory(
         return false;
     }
 
-    private IEnumerable<ITemplate> GetTemplatesCore(bool showAllTemplates, bool nonInteractive = false)
+    private IEnumerable<ITemplate> GetTemplatesCore(bool showAllTemplates)
     {
         yield return new CallbackTemplate(
             "aspire-starter",
             TemplatingStrings.AspireStarter_Description,
             projectName => $"./{projectName}",
             ApplyExtraAspireStarterOptions,
-            nonInteractive
-                ? ApplyTemplateWithNoExtraArgsAsync
-                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireStarterOptionsAsync, ct),
+            (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireStarterOptionsAsync, ct),
             languageId: KnownLanguageId.CSharp
             );
 
@@ -152,9 +148,7 @@ internal class DotNetTemplateFactory(
             TemplatingStrings.AspireJsFrontendStarter_Description,
             projectName => $"./{projectName}",
             ApplyExtraAspireJsFrontendStarterOptions,
-            nonInteractive
-                ? ApplyTemplateWithNoExtraArgsAsync
-                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireJsFrontendStarterOptionsAsync, ct),
+            (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireJsFrontendStarterOptionsAsync, ct),
             languageId: KnownLanguageId.CSharp
             );
 
@@ -215,9 +209,7 @@ internal class DotNetTemplateFactory(
             TemplatingStrings.AspireXUnit_Description,
             projectName => $"./{projectName}",
             _ => { },
-            nonInteractive
-                ? ApplyTemplateWithNoExtraArgsAsync
-                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireXUnitOptionsAsync, ct),
+            (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireXUnitOptionsAsync, ct),
             languageId: KnownLanguageId.CSharp
             );
 
@@ -244,16 +236,14 @@ internal class DotNetTemplateFactory(
         }
     }
 
-    private CallbackTemplate CreateSingleFileTemplate(bool nonInteractive)
+    private CallbackTemplate CreateSingleFileTemplate()
     {
         return new CallbackTemplate(
             "aspire-apphost-singlefile",
             TemplatingStrings.AspireAppHostSingleFile_Description,
             projectName => $"./{projectName}",
             ApplyDevLocalhostTldOption,
-            nonInteractive
-                ? ApplySingleFileTemplateWithNoExtraArgsAsync
-                : (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspireSingleFileOptionsAsync, ct),
+            (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspireSingleFileOptionsAsync, ct),
             languageId: KnownLanguageId.CSharp,
             isEmpty: true
             );
@@ -300,18 +290,16 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForDevLocalhostTldOptionAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var useLocalhostTld = result.GetValue(_localhostTldOption);
-        if (!useLocalhostTld.HasValue)
-        {
-            useLocalhostTld = await interactionService.PromptForSelectionAsync(TemplatingStrings.UseLocalhostTld_Prompt, [TemplatingStrings.No, TemplatingStrings.Yes], choice => choice, cancellationToken) switch
-            {
-                var choice when string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput) => true,
-                var choice when string.Equals(choice, TemplatingStrings.No, StringComparisons.CliInputOrOutput) => false,
-                _ => throw new InvalidOperationException(TemplatingStrings.UseLocalhostTld_UnexpectedChoice)
-            };
-        }
+        var binding = PromptBinding.CreateBoolAsSelection(result, _localhostTldOption, TemplatingStrings.Yes, TemplatingStrings.No);
 
-        if (useLocalhostTld ?? false)
+        var selected = await interactionService.PromptForSelectionAsync(
+            TemplatingStrings.UseLocalhostTld_Prompt,
+            [TemplatingStrings.No, TemplatingStrings.Yes],
+            choice => choice,
+            binding: binding,
+            cancellationToken: cancellationToken);
+
+        if (string.Equals(selected, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput))
         {
             interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
             extraArgs.Add("--localhost-tld");
@@ -320,18 +308,16 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForRedisCacheOptionAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var useRedisCache = result.GetValue(_useRedisCacheOption);
-        if (!useRedisCache.HasValue)
-        {
-            useRedisCache = await interactionService.PromptForSelectionAsync(TemplatingStrings.UseRedisCache_Prompt, [TemplatingStrings.Yes, TemplatingStrings.No], choice => choice, cancellationToken) switch
-            {
-                var choice when string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput) => true,
-                var choice when string.Equals(choice, TemplatingStrings.No, StringComparisons.CliInputOrOutput) => false,
-                _ => throw new InvalidOperationException(TemplatingStrings.UseRedisCache_UnexpectedChoice)
-            };
-        }
+        var binding = PromptBinding.CreateBoolAsSelection(result, _useRedisCacheOption, TemplatingStrings.Yes, TemplatingStrings.No);
 
-        if (useRedisCache ?? false)
+        var selected = await interactionService.PromptForSelectionAsync(
+            TemplatingStrings.UseRedisCache_Prompt,
+            [TemplatingStrings.Yes, TemplatingStrings.No],
+            choice => choice,
+            binding: binding,
+            cancellationToken: cancellationToken);
+
+        if (string.Equals(selected, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput))
         {
             interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseRedisCache_UsingRedisCache);
             extraArgs.Add("--use-redis-cache");
@@ -340,15 +326,21 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForTestFrameworkOptionsAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var testFramework = result.GetValue(_testFrameworkOption);
+        var binding = PromptBinding.Create(result, _testFrameworkOption);
+        var (wasProvided, _) = binding.Resolve();
 
-        if (testFramework is null)
+        if (!wasProvided)
         {
+            if (!hostEnvironment.SupportsInteractiveInput)
+            {
+                return;
+            }
+
             var createTestProject = await interactionService.PromptForSelectionAsync(
                 TemplatingStrings.PromptForTFMOptions_Prompt,
                 [TemplatingStrings.No, TemplatingStrings.Yes],
                 choice => choice,
-                cancellationToken);
+                cancellationToken: cancellationToken);
 
             if (string.Equals(createTestProject, TemplatingStrings.No, StringComparisons.CliInputOrOutput))
             {
@@ -356,18 +348,16 @@ internal class DotNetTemplateFactory(
             }
         }
 
-        if (string.IsNullOrEmpty(testFramework))
-        {
-            testFramework = await interactionService.PromptForSelectionAsync(
-                TemplatingStrings.PromptForTFM_Prompt,
-                ["MSTest", "NUnit", "xUnit.net", TemplatingStrings.None],
-                choice => choice,
-                cancellationToken);
-        }
+        var testFramework = await interactionService.PromptForSelectionAsync(
+            TemplatingStrings.PromptForTFM_Prompt,
+            ["MSTest", "NUnit", "xUnit.net", TemplatingStrings.None],
+            choice => choice,
+            binding: binding,
+            cancellationToken: cancellationToken);
 
-        if (testFramework is { } && !string.Equals(testFramework, TemplatingStrings.None, StringComparisons.CliInputOrOutput))
+        if (!string.Equals(testFramework, TemplatingStrings.None, StringComparisons.CliInputOrOutput))
         {
-            if (testFramework.ToLower() == "xunit.net")
+            if (string.Equals(testFramework, "xUnit.net", StringComparison.OrdinalIgnoreCase))
             {
                 await PromptForXUnitVersionOptionsAsync(result, extraArgs, cancellationToken);
             }
@@ -381,15 +371,14 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForXUnitVersionOptionsAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var xunitVersion = result.GetValue(_xunitVersionOption);
-        if (string.IsNullOrEmpty(xunitVersion))
-        {
-            xunitVersion = await interactionService.PromptForSelectionAsync(
-                TemplatingStrings.EnterXUnitVersion_Prompt,
-                ["v2", "v3", "v3mtp"],
-                choice => choice,
-                cancellationToken: cancellationToken);
-        }
+        var binding = PromptBinding.Create(result, _xunitVersionOption, "v3mtp");
+
+        var xunitVersion = await interactionService.PromptForSelectionAsync(
+            TemplatingStrings.EnterXUnitVersion_Prompt,
+            ["v2", "v3", "v3mtp"],
+            choice => choice,
+            binding: binding,
+            cancellationToken: cancellationToken);
 
         extraArgs.Add("--xunit-version");
         extraArgs.Add(xunitVersion);
@@ -456,16 +445,6 @@ internal class DotNetTemplateFactory(
         }
     }
 
-    private Task<TemplateResult> ApplySingleFileTemplateWithNoExtraArgsAsync(CallbackTemplate template, TemplateInputs inputs, ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        return ApplySingleFileTemplate(
-            template,
-            inputs,
-            parseResult,
-            (_, _) => Task.FromResult(Array.Empty<string>()),
-            cancellationToken);
-    }
-
     private async Task<TemplateResult> ApplyTemplateAsync(CallbackTemplate template, TemplateInputs inputs, ParseResult parseResult, Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback, CancellationToken cancellationToken)
     {
         if (!await SdkInstallHelper.EnsureSdkInstalledAsync(sdkInstaller, interactionService, telemetry, cancellationToken))
@@ -473,8 +452,8 @@ internal class DotNetTemplateFactory(
             return new TemplateResult(ExitCodeConstants.SdkNotInstalled);
         }
 
-        var name = await GetProjectNameAsync(inputs, cancellationToken);
-        var outputPath = await GetOutputPathAsync(inputs, template.PathDeriver, name, cancellationToken);
+        var name = await GetProjectNameAsync(inputs, parseResult, cancellationToken);
+        var outputPath = await GetOutputPathAsync(inputs, template.PathDeriver, name, parseResult, cancellationToken);
 
         return await ApplyTemplateAsync(template, inputs, name, outputPath, parseResult, extraArgsCallback, cancellationToken);
     }
@@ -598,22 +577,37 @@ internal class DotNetTemplateFactory(
         }
     }
 
-    private async Task<string> GetProjectNameAsync(TemplateInputs inputs, CancellationToken cancellationToken)
+    private async Task<string> GetProjectNameAsync(TemplateInputs inputs, ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (inputs.Name is not { } name || !ProjectNameValidator.IsProjectNameValid(name))
         {
             var defaultName = executionContext.WorkingDirectory.Name;
-            name = await prompter.PromptForProjectNameAsync(defaultName, cancellationToken);
+
+            if (!hostEnvironment.SupportsInteractiveInput)
+            {
+                return defaultName;
+            }
+
+            name = await prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
         return name;
     }
 
-    private async Task<string> GetOutputPathAsync(TemplateInputs inputs, Func<string, string> pathDeriver, string projectName, CancellationToken cancellationToken)
+    private async Task<string> GetOutputPathAsync(TemplateInputs inputs, Func<string, string> pathDeriver, string projectName, ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (inputs.Output is not { } outputPath)
         {
-            outputPath = await prompter.PromptForOutputPath(pathDeriver(projectName), cancellationToken);
+            var defaultPath = pathDeriver(projectName);
+
+            if (!hostEnvironment.SupportsInteractiveInput)
+            {
+                outputPath = defaultPath;
+            }
+            else
+            {
+                outputPath = await prompter.PromptForOutputPath(defaultPath, parseResult, cancellationToken);
+            }
         }
 
         outputPath = Path.GetFullPath(outputPath);
@@ -723,6 +717,12 @@ internal class DotNetTemplateFactory(
         // If channel was specified via --channel option or global setting (but no --version),
         // automatically select the highest version from that channel without prompting
         if (hasChannelSetting)
+        {
+            return orderedPackagesFromChannels.First();
+        }
+
+        // In non-interactive mode, automatically select the highest version
+        if (!hostEnvironment.SupportsInteractiveInput)
         {
             return orderedPackagesFromChannels.First();
         }

--- a/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
@@ -87,6 +87,159 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
             message => message.Contains(expectedSkillDirectoryPath, StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task AgentInitCommand_NonInteractive_WithAllLocationsAndSkills_InstallsSkillFiles()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations all --skills all");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        // Exit code is InvalidCommand because FakeNpmRunner cannot resolve Playwright CLI in tests.
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+
+        // Verify that the aspire skill was installed to all locations
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".claude", "skills", "aspire", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".github", "skills", "aspire", "SKILL.md")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".opencode", "skill", "aspire", "SKILL.md")));
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_NonInteractive_WithNoneLocations_SucceedsWithNoSkillsInstalled()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations none --skills all");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // No locations selected, so no skill directories should be created
+        var agentsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents");
+        Assert.False(Directory.Exists(agentsDir), $"Expected no .agents directory but found {agentsDir}");
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_NonInteractive_WithoutSkillLocations_UsesDefaultLocations()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skills none");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_NonInteractive_WithoutSkills_UsesDefaultSkills()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations all");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        // Default skill is Aspire, which gets installed. Playwright is not default so not selected.
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Verify the default aspire skill was installed
+        var aspireSkillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        Assert.True(File.Exists(aspireSkillPath), $"Expected skill file at {aspireSkillPath}");
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_NonInteractive_WithInvalidSkillLocations_FailsWithMissingArgument()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations invalid --skills all");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.MissingRequiredArgument, exitCode);
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_NonInteractive_WithoutWorkspaceRoot_UsesWorkingDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("agent init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Verify that the default aspire skill was installed under the working directory
+        var aspireSkillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        Assert.True(File.Exists(aspireSkillPath), $"Expected skill file at {aspireSkillPath}");
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_NonInteractive_WithNoneSkills_SucceedsWithNoSkillsInstalled()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations all --skills none");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // No skills selected, so no skill files should be created
+        var aspireSkillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire");
+        Assert.False(Directory.Exists(aspireSkillPath), $"Expected no aspire skill directory but found {aspireSkillPath}");
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_NonInteractive_ConfigureMcpDefaultsToFalse()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // --configure-mcp is not passed, should default to false in non-interactive mode
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations all --skills none");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo homeDirectory)
     {
         var hivesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "hives"));

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -96,10 +95,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 };
                 return runner;
             };
-            options.PackagingServiceFactory = (sp) =>
-            {
-                return new ImplicitChannelPackagingService();
-            };
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithTemplatePackages();
         });
 
         using var serviceProvider = services.BuildServiceProvider();
@@ -277,10 +273,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             };
 
             // Mock packaging service
-            options.PackagingServiceFactory = (sp) =>
-            {
-                return new ImplicitChannelPackagingService();
-            };
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithTemplatePackages();
         });
 
         using var serviceProvider = services.BuildServiceProvider();
@@ -373,10 +366,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             };
 
             // Mock packaging service to return fake channels
-            options.PackagingServiceFactory = (sp) =>
-            {
-                return new ImplicitChannelPackagingService();
-            };
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithTemplatePackages();
         });
 
         using var serviceProvider = services.BuildServiceProvider();
@@ -392,78 +382,43 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         Assert.False(promptedForOutputPath, "Should not have prompted for output path");
     }
 
-    // Test implementation of INewCommandPrompter
-    private sealed class TestNewCommandPrompter(IInteractionService interactionService) : NewCommandPrompter(interactionService)
+    private static TestPackagingService CreatePackagingServiceWithTemplatePackages() => new()
     {
-        public Func<IEnumerable<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)>, (Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)>? PromptForTemplatesVersionCallback { get; set; }
-        public Func<string, string>? PromptForProjectNameCallback { get; set; }
-        public Func<string, string>? PromptForOutputPathCallback { get; set; }
-
-        public override Task<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> PromptForTemplatesVersionAsync(IEnumerable<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> candidatePackages, CancellationToken cancellationToken)
+        GetChannelsAsyncCallback = _ =>
         {
-            return PromptForTemplatesVersionCallback switch
+            var cache = new FakeNuGetPackageCache
             {
-                { } callback => Task.FromResult(callback(candidatePackages)),
-                _ => Task.FromResult(candidatePackages.First())
+                GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                    Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([
+                        new Aspire.Shared.NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = "10.0.0" }
+                    ])
             };
+            return Task.FromResult<IEnumerable<PackageChannel>>([PackageChannel.CreateImplicitChannel(cache)]);
         }
+    };
 
-        public override Task<string> PromptForProjectNameAsync(string defaultName, CancellationToken cancellationToken)
-        {
-            return PromptForProjectNameCallback switch
-            {
-                { } callback => Task.FromResult(callback(defaultName)),
-                _ => Task.FromResult(defaultName)
-            };
-        }
-
-        public override Task<string> PromptForOutputPath(string defaultPath, CancellationToken cancellationToken)
-        {
-            return PromptForOutputPathCallback switch
-            {
-                { } callback => Task.FromResult(callback(defaultPath)),
-                _ => Task.FromResult(defaultPath)
-            };
-        }
-    }
-
-    private sealed class ImplicitChannelPackagingService : IPackagingService
+    private static TestPackagingService CreatePackagingServiceWithChannelTracking(Action<string> onChannelUsed)
     {
-        public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default)
+        FakeNuGetPackageCache CreateTrackingCache(string channelName) => new()
         {
-            // Return a fake channel with the implicit type (meaning use default NuGet sources)
-            var testChannel = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache());
-            return Task.FromResult<IEnumerable<PackageChannel>>(new[] { testChannel });
-        }
-    }
-
-    private sealed class FakeNuGetPackageCache : INuGetPackageCache
-    {
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            var package = new Aspire.Shared.NuGetPackageCli
+            GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
             {
-                Id = "Aspire.ProjectTemplates",
-                Source = "nuget",
-                Version = "10.0.0"
-            };
-            return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(new[] { package });
-        }
+                onChannelUsed(channelName);
+                return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([
+                    new Aspire.Shared.NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = "10.0.0" }
+                ]);
+            }
+        };
 
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
+        return new TestPackagingService
         {
-            return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(Array.Empty<Aspire.Shared.NuGetPackageCli>());
-        }
-
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(Array.Empty<Aspire.Shared.NuGetPackageCli>());
-        }
-
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(Array.Empty<Aspire.Shared.NuGetPackageCli>());
-        }
+            GetChannelsAsyncCallback = _ =>
+            {
+                var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], CreateTrackingCache("stable"));
+                var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], CreateTrackingCache("daily"));
+                return Task.FromResult<IEnumerable<PackageChannel>>([stableChannel, dailyChannel]);
+            }
+        };
     }
 
     [Fact]
@@ -490,10 +445,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 return prompter;
             };
 
-            options.PackagingServiceFactory = (sp) =>
-            {
-                return new TestPackagingServiceWithChannelTracking((channelName) => channelNameUsed = channelName);
-            };
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithChannelTracking((channelName) => channelNameUsed = channelName);
             
             options.DotNetCliRunnerFactory = (sp) =>
             {
@@ -525,189 +477,13 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task InitCommandWithPrChannelPrefersCurrentCliVersion()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var cliVersion = VersionHelper.GetDefaultSdkVersion();
-        string? selectedVersion = null;
-        bool promptedForVersion = false;
-
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
-        {
-            options.NewCommandPrompterFactory = (sp) =>
-            {
-                var interactionService = sp.GetRequiredService<IInteractionService>();
-                var prompter = new TestNewCommandPrompter(interactionService);
-
-                prompter.PromptForTemplatesVersionCallback = (packages) =>
-                {
-                    promptedForVersion = true;
-                    throw new InvalidOperationException("Should not prompt for version when a PR channel contains the current CLI version.");
-                };
-
-                return prompter;
-            };
-
-            options.PackagingServiceFactory = (sp) =>
-            {
-                return new TestPackagingService
-                {
-                    GetChannelsAsyncCallback = (ct) =>
-                    {
-                        var fakeCache = new CallbackNuGetPackageCache(
-                            (dir, prerelease, nugetConfig, ct) =>
-                            {
-                                var packages = new[]
-                                {
-                                    new Aspire.Shared.NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "pr-hive", Version = cliVersion },
-                                    new Aspire.Shared.NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "pr-hive", Version = "99.0.0" },
-                                };
-
-                                return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(packages);
-                            });
-
-                        var prChannel = PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Both, [], fakeCache);
-                        return Task.FromResult<IEnumerable<PackageChannel>>([prChannel]);
-                    }
-                };
-            };
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
-                {
-                    selectedVersion = version;
-                    return (0, version);
-                };
-                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
-                {
-                    var appHostFile = Path.Combine(outputPath, "apphost.cs");
-                    File.WriteAllText(appHostFile, "// Test apphost file");
-                    return 0;
-                };
-                return runner;
-            };
-        });
-        using var provider = services.BuildServiceProvider();
-
-        var command = provider.GetRequiredService<InitCommand>();
-        var result = command.Parse("init --channel pr-12345");
-
-        var exitCode = await result.InvokeAsync().DefaultTimeout();
-
-        Assert.Equal(0, exitCode);
-        Assert.Equal(cliVersion, selectedVersion);
-        Assert.False(promptedForVersion);
-    }
-
-    [Fact]
-    public async Task InitCommandWithPrHivePrefersCurrentCliVersionWithoutChannel()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var hivesDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives"));
-        hivesDir.Create();
-        hivesDir.CreateSubdirectory("pr-12345");
-
-        var cliVersion = VersionHelper.GetDefaultSdkVersion();
-        string? selectedVersion = null;
-        bool promptedForVersion = false;
-
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
-        {
-            options.NewCommandPrompterFactory = (sp) =>
-            {
-                var interactionService = sp.GetRequiredService<IInteractionService>();
-                var prompter = new TestNewCommandPrompter(interactionService);
-
-                prompter.PromptForTemplatesVersionCallback = (packages) =>
-                {
-                    promptedForVersion = true;
-                    throw new InvalidOperationException("Should not prompt for version when PR hives contain the current CLI version.");
-                };
-
-                return prompter;
-            };
-
-            options.PackagingServiceFactory = _ =>
-            {
-                return new TestPackagingService
-                {
-                    GetChannelsAsyncCallback = _ =>
-                    {
-                        var implicitCache = new CallbackNuGetPackageCache(
-                            (dir, prerelease, nugetConfig, ct) =>
-                            {
-                                var packages = new[]
-                                {
-                                    new Aspire.Shared.NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = "99.0.0" },
-                                };
-
-                                return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(packages);
-                            });
-                        var prCache = new CallbackNuGetPackageCache(
-                            (dir, prerelease, nugetConfig, ct) =>
-                            {
-                                var packages = new[]
-                                {
-                                    new Aspire.Shared.NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "pr-hive", Version = cliVersion },
-                                    new Aspire.Shared.NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "pr-hive", Version = "98.0.0" },
-                                };
-
-                                return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(packages);
-                            });
-
-                        return Task.FromResult<IEnumerable<PackageChannel>>(
-                        [
-                            PackageChannel.CreateImplicitChannel(implicitCache),
-                            PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Both, [], prCache)
-                        ]);
-                    }
-                };
-            };
-
-            options.DotNetCliRunnerFactory = _ =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
-                {
-                    selectedVersion = version;
-                    return (0, version);
-                };
-                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
-                {
-                    var appHostFile = Path.Combine(outputPath, "apphost.cs");
-                    File.WriteAllText(appHostFile, "// Test apphost file");
-                    return 0;
-                };
-                return runner;
-            };
-        });
-        using var provider = services.BuildServiceProvider();
-
-        var command = provider.GetRequiredService<InitCommand>();
-        var result = command.Parse("init");
-
-        var exitCode = await result.InvokeAsync().DefaultTimeout();
-
-        Assert.Equal(0, exitCode);
-        Assert.Equal(cliVersion, selectedVersion);
-        Assert.False(promptedForVersion);
-    }
-
-    [Fact]
     public async Task InitCommandWithInvalidChannelShowsError()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.PackagingServiceFactory = (sp) =>
-            {
-                return new TestPackagingServiceWithChannelTracking(_ => { });
-            };
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithChannelTracking(_ => { });
         });
         using var provider = services.BuildServiceProvider();
 
@@ -752,10 +528,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 };
                 return runner;
             };
-            options.PackagingServiceFactory = (sp) =>
-            {
-                return new ImplicitChannelPackagingService();
-            };
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithTemplatePackages();
         });
 
         using var serviceProvider = services.BuildServiceProvider();
@@ -823,47 +596,85 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains(expectedMessage, testInteractionService.DisplayedErrors);
     }
 
-    private sealed class TestPackagingServiceWithChannelTracking(Action<string> onChannelUsed) : IPackagingService
+    [Fact]
+    public async Task InitCommandNonInteractive_NoSuppressAgentInitOption_DefaultsToRunAgentInit()
     {
-        public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default)
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            var stableCache = new FakeNuGetPackageCacheWithTracking("stable", onChannelUsed);
-            var dailyCache = new FakeNuGetPackageCacheWithTracking("daily", onChannelUsed);
-            
-            var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], stableCache);
-            var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache);
-            
-            return Task.FromResult<IEnumerable<PackageChannel>>(new[] { stableChannel, dailyChannel });
-        }
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                {
+                    return (0, version);
+                };
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    File.WriteAllText(Path.Combine(outputPath, "apphost.cs"), "// Test apphost file");
+                    return 0;
+                };
+                return runner;
+            };
+
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithTemplatePackages();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<InitCommand>();
+        var result = command.Parse("init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md")));
     }
 
-    private sealed class FakeNuGetPackageCacheWithTracking(string channelName, Action<string> onChannelUsed) : INuGetPackageCache
+    [Fact]
+    public async Task InitCommandNonInteractive_SuppressAgentInitTrue_SkipsAgentInit()
     {
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            onChannelUsed(channelName);
-            var package = new Aspire.Shared.NuGetPackageCli
+            options.CliHostEnvironmentFactory = (sp) =>
             {
-                Id = "Aspire.ProjectTemplates",
-                Source = "nuget",
-                Version = "10.0.0"
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
             };
-            return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(new[] { package });
-        }
 
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(Array.Empty<Aspire.Shared.NuGetPackageCli>());
-        }
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                {
+                    return (0, version);
+                };
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    File.WriteAllText(Path.Combine(outputPath, "apphost.cs"), "// Test apphost file");
+                    return 0;
+                };
+                return runner;
+            };
 
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(Array.Empty<Aspire.Shared.NuGetPackageCli>());
-        }
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithTemplatePackages();
+        });
 
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-        {
-            return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(Array.Empty<Aspire.Shared.NuGetPackageCli>());
-        }
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<InitCommand>();
+        var result = command.Parse("init --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md")));
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -5,9 +5,9 @@ using System.Globalization;
 using Aspire.Cli.Utils;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
+using RootCommand = Aspire.Cli.Commands.RootCommand;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -17,9 +17,6 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Console;
-using Spectre.Console.Rendering;
-using Aspire.Cli.Backchannel;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -30,21 +27,21 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandWithHelpArgumentReturnsZero()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var services = CreateServiceCollection(workspace);
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
     public void NewCommandWithPolyglotEnabled_ExposesTemplateSubcommands()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.FeatureFlagsFactory = _ =>
             {
@@ -53,23 +50,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return features;
             };
 
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -84,7 +64,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public void NewCommandWithPolyglotDisabled_ExposesTemplateSubcommands()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var services = CreateServiceCollection(workspace);
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
@@ -96,43 +76,14 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandInteractiveFlowSmokeTest()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
-        {
-            // Set of options that we'll give when prompted.
-            options.NewCommandPrompterFactory = (sp) =>
-            {
-                var interactionService = sp.GetRequiredService<IInteractionService>();
-                return new TestNewCommandPrompter(interactionService);
-            };
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
-
-                return runner;
-            };
-        });
+        var services = CreateServiceCollection(workspace);
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -140,9 +91,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandDerivesOutputPathFromProjectNameForStarterTemplate()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
-
-            // Set of options that we'll give when prompted.
+        var services = CreateServiceCollection(workspace, options =>
+        {
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -161,27 +111,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 return prompter;
             };
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
-
-                return runner;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -189,7 +118,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -198,9 +127,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var promptedForName = false;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
-
-            // Set of options that we'll give when prompted.
+        var services = CreateServiceCollection(workspace, options =>
+        {
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -214,27 +142,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 return prompter;
             };
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
-
-                return runner;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -242,7 +149,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(promptedForName);
     }
 
@@ -252,10 +159,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         bool promptedForPath = false;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
-
-            // Set of options that we'll give when prompted.
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -269,27 +174,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 return prompter;
             };
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
-
-                return runner;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -297,7 +181,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --output notsrc --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(promptedForPath);
     }
 
@@ -309,7 +193,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         string? channelNameUsed = null;
         bool promptedForVersion = false;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.NewCommandPrompterFactory = (sp) =>
             {
@@ -327,10 +211,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.PackagingServiceFactory = (sp) =>
             {
-                var packagingService = new NewCommandTestPackagingService();
+                var packagingService = new TestPackagingService();
                 packagingService.GetChannelsAsyncCallback = (ct) =>
                 {
-                    var stableCache = new NewCommandTestFakeNuGetPackageCache();
+                    var stableCache = new FakeNuGetPackageCache();
                     stableCache.GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
                     {
                         channelNameUsed = "stable";
@@ -338,7 +222,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                         return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
                     };
                     
-                    var dailyCache = new NewCommandTestFakeNuGetPackageCache();
+                    var dailyCache = new FakeNuGetPackageCache();
                     dailyCache.GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
                     {
                         channelNameUsed = "daily";
@@ -377,7 +261,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         
         // Assert
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal("stable", channelNameUsed); // Verify the stable channel was used
         Assert.False(promptedForVersion); // Should not prompt when --channel is specified
     }
@@ -390,7 +274,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         string? selectedVersion = null;
         bool promptedForVersion = false;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.NewCommandPrompterFactory = (sp) =>
             {
@@ -408,10 +292,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.PackagingServiceFactory = (sp) =>
             {
-                var packagingService = new NewCommandTestPackagingService();
+                var packagingService = new TestPackagingService();
                 packagingService.GetChannelsAsyncCallback = (ct) =>
                 {
-                    var fakeCache = new NewCommandTestFakeNuGetPackageCache();
+                    var fakeCache = new FakeNuGetPackageCache();
                     fakeCache.GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
                     {
                         // Return multiple versions to test auto-selection of highest
@@ -454,7 +338,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         
         // Assert
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal("9.2.0", selectedVersion); // Should auto-select highest version (9.2.0)
         Assert.False(promptedForVersion); // Should not prompt when --channel is specified
     }
@@ -486,10 +370,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.PackagingServiceFactory = (sp) =>
             {
-                var packagingService = new NewCommandTestPackagingService();
+                var packagingService = new TestPackagingService();
                 packagingService.GetChannelsAsyncCallback = (ct) =>
                 {
-                    var fakeCache = new NewCommandTestFakeNuGetPackageCache();
+                    var fakeCache = new FakeNuGetPackageCache();
                     fakeCache.GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
                     {
                         var packages = new[]
@@ -542,9 +426,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         bool promptedForTemplate = false;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
-
-            // Set of options that we'll give when prompted.
+        var services = CreateServiceCollection(workspace, options =>
+        {
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -558,27 +441,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 return prompter;
             };
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
-
-                return runner;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -586,7 +448,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(promptedForTemplate);
     }
 
@@ -596,9 +458,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         bool promptedForTemplateVersion = false;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
-
-            // Set of options that we'll give when prompted.
+        var services = CreateServiceCollection(workspace, options =>
+        {
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -612,27 +473,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 return prompter;
             };
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetConfigFile, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
-
-                return runner;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -640,7 +480,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None --version 9.2.0");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(promptedForTemplateVersion);
     }
 
@@ -650,7 +490,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         TestInteractionService? testInteractionService = null;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
+        var services = CreateServiceCollection(workspace, options => {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.InteractionServiceFactory = (sp) => {
                 testInteractionService = new TestInteractionService();
                 return testInteractionService;
@@ -681,7 +522,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommand_WhenCertificateServiceThrows_ReturnsNonZeroExitCode()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.NewCommandPrompterFactory = (sp) => {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -692,21 +533,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
+                var runner = CreateTestRunnerWithStandardPackages();
 
                 runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, options, cancellationToken) =>
                 {
@@ -734,9 +561,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandWithExitCode73ShowsUserFriendlyError()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
-
-            // Set of options that we'll give when prompted.
+        var services = CreateServiceCollection(workspace, options =>
+        {
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -745,21 +571,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
+                var runner = CreateTestRunnerWithStandardPackages();
 
                 runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, options, cancellationToken) =>
                 {
@@ -783,6 +595,34 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
     }
 
+    private IServiceCollection CreateServiceCollection(
+        TemporaryWorkspace workspace,
+        Action<CliServiceCollectionTestOptions>? configure = null)
+    {
+        return CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => CreateTestRunnerWithStandardPackages();
+            configure?.Invoke(options);
+        });
+    }
+
+    private static TestDotNetCliRunner CreateTestRunnerWithStandardPackages()
+    {
+        var runner = new TestDotNetCliRunner();
+        runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+        {
+            var package = new NuGetPackage()
+            {
+                Id = "Aspire.ProjectTemplates",
+                Source = "nuget",
+                Version = "9.2.0"
+            };
+
+            return (0, new NuGetPackage[] { package });
+        };
+        return runner;
+    }
+
     private sealed class ThrowingCertificateService : ICertificateService
     {
         public Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
@@ -797,8 +637,9 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var operationOrder = new List<string>();
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -831,27 +672,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 };
                 return testInteractionService;
             };
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetConfigFile, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
-
-                return runner;
-            };
         });
 
         using var provider = services.BuildServiceProvider();
@@ -860,7 +680,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
 
         // Verify that template version was prompted before template options
         Assert.Contains("TemplateVersion", operationOrder);
@@ -888,8 +708,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var capturedOutputPathDefault = string.Empty;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -914,23 +736,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return prompter;
             };
 
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -938,7 +743,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
 
         // Verify that the default output path was derived from the project name with markup characters
         // The path parameter passed to the callback contains the unescaped markup characters
@@ -953,28 +758,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var scaffoldedLanguageId = string.Empty;
         (string Name, string Description)[]? promptedTemplates = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.InteractionServiceFactory = _ => new TestInteractionService
             {
                 PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) => choices.Cast<object>().First()
-            };
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, dotnetOptions, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
             };
             options.NewCommandPrompterFactory = (sp) =>
             {
@@ -1005,7 +794,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal(KnownLanguageId.TypeScript, scaffoldedLanguageId);
         Assert.NotNull(promptedTemplates);
         Assert.Contains((KnownTemplateId.CSharpEmptyAppHost, "Empty AppHost"), promptedTemplates);
@@ -1018,7 +807,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public void NewCommandTemplateSubcommandsListTechnicalNamesForNonInteractiveFlows()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
         });
@@ -1038,8 +827,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         string[]? promptedTemplateDescriptions = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
@@ -1055,23 +846,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 return prompter;
             };
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, dotnetOptions, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
         });
 
         using var provider = services.BuildServiceProvider();
@@ -1079,7 +853,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.NotNull(promptedTemplateDescriptions);
         Assert.Contains("Empty AppHost", promptedTemplateDescriptions);
         Assert.Contains("Empty (TypeScript AppHost)", promptedTemplateDescriptions);
@@ -1091,7 +865,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         string? scaffoldedLanguageId = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.FeatureFlagsFactory = _ =>
             {
@@ -1100,23 +874,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return features;
             };
 
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
         });
 
         services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
@@ -1134,7 +891,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-java-empty --name TestApp --output . --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal(KnownLanguageId.Java, scaffoldedLanguageId);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.java")));
     }
@@ -1144,33 +901,14 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
-        {
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
-        });
+        var services = CreateServiceCollection(workspace);
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-empty --name TestApp --output . --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs")));
     }
 
@@ -1180,7 +918,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var localhostPrompted = false;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
 
@@ -1208,23 +946,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 return prompter;
             };
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
         });
 
         using var provider = services.BuildServiceProvider();
@@ -1232,7 +953,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(localhostPrompted);
 
         var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
@@ -1248,26 +969,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var scaffoldingInvoked = false;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
-        {
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
-        });
+        var services = CreateServiceCollection(workspace);
 
         services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
         {
@@ -1283,7 +985,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-ts-empty --name TestApp --output . --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(scaffoldingInvoked);
     }
 
@@ -1293,7 +995,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         string? capturedTargetDirectory = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.NewCommandPrompterFactory = (sp) =>
             {
@@ -1306,23 +1008,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return prompter;
             };
 
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
         });
 
         services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
@@ -1340,7 +1025,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-ts-empty --name TestApp --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.NotNull(capturedTargetDirectory);
 
         // The output path should be properly normalized without "./" segments
@@ -1358,7 +1043,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var scaffoldingInvoked = false;
         var localhostPrompted = false;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
 
@@ -1385,23 +1070,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                     templates.Single(t => t.Name.Equals("aspire-ts-empty", StringComparison.OrdinalIgnoreCase));
 
                 return prompter;
-            };
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
             };
         });
 
@@ -1436,7 +1104,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-ts-empty --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(scaffoldingInvoked);
         Assert.True(localhostPrompted);
 
@@ -1455,7 +1123,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         string? channelSeenByProject = null;
         string? sdkVersionSeenByProject = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
             {
@@ -1472,11 +1140,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.PackagingServiceFactory = _ => new NewCommandTestPackagingService
+            options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = cancellationToken =>
                 {
-                    var dailyCache = new NewCommandTestFakeNuGetPackageCache
+                    var dailyCache = new FakeNuGetPackageCache
                     {
                         GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
                         {
@@ -1516,7 +1184,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(buildAndGenerateCalled);
         Assert.Equal("daily", channelSeenByProject);
         Assert.Equal("9.2.0", sdkVersionSeenByProject);
@@ -1530,7 +1198,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var interactionService = new TestInteractionService();
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
             {
@@ -1547,11 +1215,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.PackagingServiceFactory = _ => new NewCommandTestPackagingService
+            options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = cancellationToken =>
                 {
-                    var dailyCache = new NewCommandTestFakeNuGetPackageCache
+                    var dailyCache = new FakeNuGetPackageCache
                     {
                         GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
                         {
@@ -1590,7 +1258,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandNonInteractiveDoesNotPrompt()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             // Configure non-interactive host environment
             options.CliHostEnvironmentFactory = (sp) =>
@@ -1599,26 +1267,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return new CliHostEnvironment(configuration, nonInteractive: true);
             };
 
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (
-                        0, // Exit code.
-                        new NuGetPackage[] { package } // Single package.
-                        );
-                };
-
-                return runner;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -1630,7 +1278,170 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         // GetTemplates() did not pass the nonInteractive flag, causing
         // the template to try to prompt for options.
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task NewCommandNonInteractiveWithoutTemplate_DisplaysErrorWithAvailableTemplates()
+    {
+        TestInteractionService? testInteractionService = null;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+
+            options.InteractionServiceFactory = (sp) =>
+            {
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
+            };
+
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.MissingRequiredArgument, exitCode);
+        Assert.NotNull(testInteractionService);
+        Assert.Contains(testInteractionService.DisplayedErrors,
+            e => string.Equals(e, NewCommandStrings.NonInteractiveTemplateRequired, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task NewCommandNonInteractiveUsesDefaultNameWhenNotProvided()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedProjectName = null;
+        string? capturedOutputPath = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = CreateTestRunnerWithStandardPackages();
+
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    capturedProjectName = projectName;
+                    capturedOutputPath = outputPath;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        // Neither --name nor --output is provided, so both use their defaults
+        var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        // The default project name is derived from the workspace directory name
+        Assert.Equal(workspace.WorkspaceRoot.Name, capturedProjectName);
+        // The default output path ends with the project name subdirectory
+        Assert.Equal(workspace.WorkspaceRoot.Name, Path.GetFileName(capturedOutputPath));
+    }
+
+    [Fact]
+    public async Task NewCommandNonInteractiveWithAllOptions_Succeeds()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedProjectName = null;
+        string? capturedOutputPath = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = CreateTestRunnerWithStandardPackages();
+
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    capturedProjectName = projectName;
+                    capturedOutputPath = outputPath;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse($"new aspire-starter --name MyProject --output {Path.Combine(workspace.WorkspaceRoot.FullName, "my-project")} --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal("MyProject", capturedProjectName);
+        Assert.NotNull(capturedOutputPath);
+        Assert.Contains("my-project", capturedOutputPath);
+
+        // Agent init runs by default after project creation
+        var skillPath = Path.Combine(capturedOutputPath, ".agents", "skills", "aspire", "SKILL.md");
+        Assert.True(File.Exists(skillPath));
+    }
+
+    [Fact]
+    public async Task NewCommandNonInteractiveWithAllOptions_SuppressAgentInitTrue_SkipsAgentInit()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = CreateTestRunnerWithStandardPackages();
+
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse($"new aspire-starter --name MyProject --output {workspace.WorkspaceRoot.FullName} --use-redis-cache --test-framework None --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Agent init should not have run — no skill files should exist
+        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        Assert.False(File.Exists(skillPath));
     }
 
     [Fact]
@@ -1639,7 +1450,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         TestInteractionService? testInteractionService = null;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.InteractionServiceFactory = (sp) =>
             {
@@ -1655,18 +1466,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
+                var runner = CreateTestRunnerWithStandardPackages();
 
                 runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
                 {
@@ -1698,7 +1498,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         TestInteractionService? testInteractionService = null;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
             options.InteractionServiceFactory = (sp) =>
             {
@@ -1706,23 +1506,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return testInteractionService;
             };
 
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
         });
 
         services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
@@ -1750,8 +1533,9 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         string? capturedOutputPath = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
             {
@@ -1774,17 +1558,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-                    return (0, new NuGetPackage[] { package });
-                };
+                var runner = CreateTestRunnerWithStandardPackages();
                 runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
                 {
                     return (0, version);
@@ -1804,7 +1578,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.NotNull(capturedOutputPath);
 
         // Output path should have the project name appended as a subdirectory
@@ -1818,8 +1592,9 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         string? capturedOutputPath = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
             {
@@ -1842,17 +1617,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-                    return (0, new NuGetPackage[] { package });
-                };
+                var runner = CreateTestRunnerWithStandardPackages();
                 runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
                 {
                     return (0, version);
@@ -1872,7 +1637,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.NotNull(capturedOutputPath);
 
         // Output path should NOT have the project name double-appended
@@ -1886,8 +1651,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         string? capturedOutputPath = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateServiceCollection(workspace, options =>
         {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            // Use TestInteractionService (not ExtensionInteractionService) to stay in console/non-extension mode
+            options.InteractionServiceFactory = _ => new TestInteractionService();
             // Default InteractionServiceFactory creates ConsoleInteractionService (not extension mode)
 
             options.NewCommandPrompterFactory = (sp) =>
@@ -1906,17 +1674,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-                    return (0, new NuGetPackage[] { package });
-                };
+                var runner = CreateTestRunnerWithStandardPackages();
                 runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
                 {
                     return (0, version);
@@ -1936,7 +1694,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.NotNull(capturedOutputPath);
 
         // In console mode, the output path should NOT have project name appended
@@ -1954,8 +1712,9 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             using var workspace = TemporaryWorkspace.Create(outputHelper);
             string? capturedOutputPath = null;
 
-            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            var services = CreateServiceCollection(workspace, options =>
             {
+                options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
                 options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
                 options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
                 {
@@ -1977,17 +1736,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 options.DotNetCliRunnerFactory = (sp) =>
                 {
-                    var runner = new TestDotNetCliRunner();
-                    runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
-                    {
-                        var package = new NuGetPackage()
-                        {
-                            Id = "Aspire.ProjectTemplates",
-                            Source = "nuget",
-                            Version = "9.2.0"
-                        };
-                        return (0, new NuGetPackage[] { package });
-                    };
+                    var runner = CreateTestRunnerWithStandardPackages();
                     runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
                     {
                         return (0, version);
@@ -2007,7 +1756,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-            Assert.Equal(0, exitCode);
+            Assert.Equal(ExitCodeConstants.Success, exitCode);
             Assert.NotNull(capturedOutputPath);
             Assert.Equal(expectedPathFactory(workspace.WorkspaceRoot.FullName), capturedOutputPath);
         }
@@ -2022,288 +1771,83 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             workspaceRoot => Path.Combine(workspaceRoot, projectName) + Path.DirectorySeparatorChar,
             workspaceRoot => Path.Combine(workspaceRoot, projectName));
     }
-}
 
-internal sealed class TestNewCommandPrompter(IInteractionService interactionService) : NewCommandPrompter(interactionService)
-{
-    public Func<IEnumerable<(NuGetPackage Package, PackageChannel Channel)>, (NuGetPackage Package, PackageChannel Channel)>? PromptForTemplatesVersionCallback { get; set; }
-    public Func<ITemplate[], ITemplate>? PromptForTemplateCallback { get; set; }
-    public Func<string, string>? PromptForProjectNameCallback { get; set; }
-    public Func<string, string>? PromptForOutputPathCallback { get; set; }
-
-    public override Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken)
+    [Fact]
+    public async Task NewCommandNonInteractive_SuppressAgentInitTrue_SkipsAgentInit()
     {
-        return PromptForTemplateCallback switch
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace, options =>
         {
-            { } callback => Task.FromResult(callback(validTemplates)),
-            _ => Task.FromResult(validTemplates[0]) // If no callback is provided just accept the first template.
-        };
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output . --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Agent init should not have run — no skill files should exist
+        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        Assert.False(File.Exists(skillPath));
     }
 
-    public override Task<string> PromptForProjectNameAsync(string defaultName, CancellationToken cancellationToken)
+    [Fact]
+    public async Task NewCommandNonInteractive_SuppressAgentInitFalse_RunsAgentInit()
     {
-        return PromptForProjectNameCallback switch
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace, options =>
         {
-            { } callback => Task.FromResult(callback(defaultName)),
-            _ => Task.FromResult(defaultName) // If no callback is provided just accept the default.
-        };
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output . --suppress-agent-init=false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Agent init should have run — default skill files should exist
+        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        Assert.True(File.Exists(skillPath));
     }
 
-    public override Task<string> PromptForOutputPath(string path, CancellationToken cancellationToken)
+    [Fact]
+    public async Task NewCommandNonInteractive_NoSuppressAgentInitOption_DefaultsToRunAgentInit()
     {
-        return PromptForOutputPathCallback switch
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace, options =>
         {
-            { } callback => Task.FromResult(callback(path)),
-            _ => Task.FromResult(path) // If no callback is provided just accept the default.
-        };
-    }
+            options.CliHostEnvironmentFactory = (sp) =>
+            {
+                var configuration = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+        });
+        using var provider = services.BuildServiceProvider();
 
-    public override Task<(NuGetPackage Package, PackageChannel Channel)> PromptForTemplatesVersionAsync(IEnumerable<(NuGetPackage Package, PackageChannel Channel)> candidatePackages, CancellationToken cancellationToken)
-    {
-        return PromptForTemplatesVersionCallback switch
-        {
-            { } callback => Task.FromResult(callback(candidatePackages)),
-            _ => Task.FromResult(candidatePackages.First()) // If no callback is provided just accept the first package.
-        };
-    }
-}
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output .");
 
-internal sealed class OrderTrackingInteractionService(List<string> operationOrder) : IInteractionService
-{
-    public ConsoleOutput Console { get; set; }
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
-    {
-        return action();
-    }
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
-    {
-        action();
-    }
-
-    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
-    {
-        return Task.FromResult(defaultValue ?? string.Empty);
-    }
-
-    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
-    {
-        if (!choices.Any())
-        {
-            throw new EmptyChoicesException($"No items available for selection: {promptText}");
-        }
-
-        // Track template option prompts
-        if (promptText?.Contains("Redis") == true ||
-            promptText?.Contains("test framework") == true ||
-            promptText?.Contains("Create a test project") == true ||
-            promptText?.Contains("xUnit") == true)
-        {
-            operationOrder.Add("TemplateOption");
-        }
-
-        return Task.FromResult(choices.First());
-    }
-
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
-    {
-        if (!choices.Any())
-        {
-            throw new EmptyChoicesException($"No items available for selection: {promptText}");
-        }
-
-        if (preSelected is not null)
-        {
-            return Task.FromResult<IReadOnlyList<T>>(preSelected.ToList());
-        }
-
-        return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
-    }
-
-    public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
-    public void DisplayError(string errorMessage) { }
-    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
-    public void DisplaySuccess(string message, bool allowMarkup = false) { }
-    public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) { }
-    public void DisplayCancellationMessage() { }
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => Task.FromResult(true);
-    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
-        => PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
-    public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
-    public void DisplayEmptyLine() { }
-    public void DisplayPlainText(string text) { }
-    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
-    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null) { }
-    public void DisplayMarkupLine(string markup) { }
-    public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
-    public void DisplayRenderable(IRenderable renderable) { }
-    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
-}
-
-internal sealed class NewCommandTestPackagingService : IPackagingService
-{
-    public Func<CancellationToken, Task<IEnumerable<PackageChannel>>>? GetChannelsAsyncCallback { get; set; }
-
-    public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default)
-    {
-        if (GetChannelsAsyncCallback is not null)
-        {
-            return GetChannelsAsyncCallback(cancellationToken);
-        }
-        
-        // Default: Return a fake channel
-        var testChannel = PackageChannel.CreateImplicitChannel(new NewCommandTestFakeNuGetPackageCache());
-        return Task.FromResult<IEnumerable<PackageChannel>>(new[] { testChannel });
+        // Default is to run agent init
+        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        Assert.True(File.Exists(skillPath));
     }
 }
 
-internal sealed class NewCommandTestFakeNuGetPackageCache : INuGetPackageCache
-{
-    public Func<DirectoryInfo, bool, FileInfo?, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetTemplatePackagesAsyncCallback { get; set; }
-
-    public Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-    {
-        if (GetTemplatePackagesAsyncCallback is not null)
-        {
-            return GetTemplatePackagesAsyncCallback(workingDirectory, prerelease, nugetConfigFile, cancellationToken);
-        }
-
-        var package = new NuGetPackage
-        {
-            Id = "Aspire.ProjectTemplates",
-            Source = "nuget",
-            Version = "10.0.0"
-        };
-        return Task.FromResult<IEnumerable<NuGetPackage>>(new[] { package });
-    }
-
-    public Task<IEnumerable<NuGetPackage>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-    {
-        return Task.FromResult<IEnumerable<NuGetPackage>>(Array.Empty<NuGetPackage>());
-    }
-
-    public Task<IEnumerable<NuGetPackage>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-    {
-        return Task.FromResult<IEnumerable<NuGetPackage>>(Array.Empty<NuGetPackage>());
-    }
-
-    public Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-    {
-        return Task.FromResult<IEnumerable<NuGetPackage>>(Array.Empty<NuGetPackage>());
-    }
-}
-
-internal sealed class TestScaffoldingService : IScaffoldingService
-{
-    public Func<ScaffoldContext, CancellationToken, Task<bool>>? ScaffoldAsyncCallback { get; set; }
-
-    public Task<bool> ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
-    {
-        if (ScaffoldAsyncCallback is not null)
-        {
-            return ScaffoldAsyncCallback(context, cancellationToken);
-        }
-
-        return Task.FromResult(true);
-    }
-}
-
-internal sealed class TestTypeScriptStarterProjectFactory(Func<DirectoryInfo, CancellationToken, Task<bool>> buildAndGenerateSdkAsync) : IAppHostProjectFactory
-{
-    private readonly TestTypeScriptStarterProject _project = new(buildAndGenerateSdkAsync);
-
-    public IAppHostProject GetProject(LanguageInfo language)
-    {
-        ArgumentNullException.ThrowIfNull(language);
-
-        if (!string.Equals(language.LanguageId, KnownLanguageId.TypeScript, StringComparison.Ordinal))
-        {
-            throw new NotSupportedException($"No handler available for language '{language.LanguageId}'.");
-        }
-
-        return _project;
-    }
-
-    public IAppHostProject? TryGetProject(FileInfo appHostFile)
-    {
-        return appHostFile.Name.Equals("apphost.ts", StringComparison.OrdinalIgnoreCase) ? _project : null;
-    }
-
-    public IAppHostProject GetProject(FileInfo appHostFile)
-    {
-        return TryGetProject(appHostFile) ?? throw new NotSupportedException($"No handler available for AppHost file '{appHostFile.Name}'.");
-    }
-}
-
-internal sealed class TestTypeScriptStarterProject(Func<DirectoryInfo, CancellationToken, Task<bool>> buildAndGenerateSdkAsync) : IAppHostProject, IGuestAppHostSdkGenerator
-{
-    public bool IsUnsupported { get; set; }
-
-    public string LanguageId => KnownLanguageId.TypeScript;
-
-    public string DisplayName => "TypeScript (Node.js)";
-
-    public string? AppHostFileName => "apphost.ts";
-
-    public Task<string[]> GetDetectionPatternsAsync(CancellationToken cancellationToken = default)
-    {
-        return Task.FromResult<string[]>(["apphost.ts"]);
-    }
-
-    public bool CanHandle(FileInfo appHostFile)
-    {
-        return appHostFile.Name.Equals("apphost.ts", StringComparison.OrdinalIgnoreCase);
-    }
-
-    public bool IsUsingProjectReferences(FileInfo appHostFile)
-    {
-        return false;
-    }
-
-    public Task<int> RunAsync(AppHostProjectContext context, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<int> PublishAsync(PublishContext context, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(new AppHostValidationResult(IsValid: CanHandle(appHostFile)));
-    }
-
-    public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(RunningInstanceResult.NoRunningInstance);
-    }
-
-    public Task<string?> GetUserSecretsIdAsync(FileInfo appHostFile, bool autoInit, CancellationToken cancellationToken)
-    {
-        return Task.FromResult<string?>(null);
-    }
-
-    public Task<IReadOnlyList<(string PackageId, string Version)>> GetPackageReferencesAsync(FileInfo appHostFile, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<bool> BuildAndGenerateSdkAsync(DirectoryInfo directory, CancellationToken cancellationToken)
-    {
-        return buildAndGenerateSdkAsync(directory, cancellationToken);
-    }
-}

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -873,9 +873,9 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
         }
     }
 
-    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+    public Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
-        StringPromptCalls.Add(new StringPromptCall(promptText, defaultValue, isSecret));
+        StringPromptCalls.Add(new StringPromptCall(promptText, binding?.DefaultValue, isSecret));
 
         if (_shouldCancel || cancellationToken.IsCancellationRequested)
         {
@@ -887,13 +887,13 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
             return Task.FromResult(response.response);
         }
 
-        return Task.FromResult(defaultValue ?? string.Empty);
+        return Task.FromResult(binding?.DefaultValue ?? string.Empty);
     }
 
-    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
-        => PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
+    public Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
+        => PromptForStringAsync(promptText, validator, isSecret: false, required, binding, cancellationToken);
 
-    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
         if (_shouldCancel || cancellationToken.IsCancellationRequested)
         {
@@ -913,7 +913,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
         if (_shouldCancel || cancellationToken.IsCancellationRequested)
         {
@@ -931,8 +931,9 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
         return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
     }
 
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
+    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
+        var defaultValue = binding?.DefaultValue ?? false;
         BooleanPromptCalls.Add(new BooleanPromptCall(promptText, defaultValue));
 
         if (_shouldCancel || cancellationToken.IsCancellationRequested)

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -931,7 +931,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
         return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
     }
 
-    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
+    public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
         var defaultValue = binding?.DefaultValue ?? false;
         BooleanPromptCalls.Add(new BooleanPromptCall(promptText, defaultValue));

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1187,8 +1187,8 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         => _innerService.PromptForStringAsync(promptText, validator, isSecret, required, binding, cancellationToken);
     public Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
         => _innerService.PromptForFilePathAsync(promptText, validator, directory, required, binding, cancellationToken);
-    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default) 
-        => _innerService.ConfirmAsync(promptText, binding, cancellationToken);
+    public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default) 
+        => _innerService.PromptConfirmAsync(promptText, binding, cancellationToken);
     public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull 
         => _innerService.PromptForSelectionAsync(promptText, choices, choiceFormatter, binding, cancellationToken);
     public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -32,13 +32,15 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("update --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
     public async Task UpdateCommand_WhenProjectOptionSpecified_PassesProjectFileToProjectLocator()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        FileInfo? capturedProjectFile = null;
+        var projectLocatorInvoked = false;
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
@@ -46,7 +48,8 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             {
                 UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
                 {
-                    Assert.NotNull(projectFile);
+                    projectLocatorInvoked = true;
+                    capturedProjectFile = projectFile;
                     return Task.FromResult<FileInfo?>(projectFile);
                 }
             };
@@ -57,7 +60,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
             options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
             {
-                UpdateProjectAsyncCallback = (projectFile, channel, cancellationToken) =>
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
                 {
                     return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = false });
                 }
@@ -75,7 +78,10 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(projectLocatorInvoked);
+        Assert.NotNull(capturedProjectFile);
+        Assert.Equal("AppHost.csproj", capturedProjectFile.Name);
     }
 
     [Fact]
@@ -151,6 +157,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var confirmCallbackInvoked = false;
+        string? confirmPrompt = null;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.ProjectLocatorFactory = _ => new TestProjectLocator()
@@ -166,9 +173,8 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             {
                 ConfirmCallback = (prompt, defaultValue) =>
                 {
-                    // Verify the correct prompt is shown
                     confirmCallbackInvoked = true;
-                    Assert.Contains("Would you like to update the Aspire CLI", prompt);
+                    confirmPrompt = prompt;
                     return false; // User says no
                 }
             };
@@ -186,6 +192,8 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.True(confirmCallbackInvoked, "Confirm prompt should have been shown");
+        Assert.NotNull(confirmPrompt);
+        Assert.Contains("Would you like to update the Aspire CLI", confirmPrompt);
         Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
     }
 
@@ -195,6 +203,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var confirmCallbackInvoked = false;
+        string? confirmPrompt = null;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.ProjectLocatorFactory = _ => new TestProjectLocator()
@@ -210,8 +219,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 ConfirmCallback = (prompt, defaultValue) =>
                 {
                     confirmCallbackInvoked = true;
-                    // Verify the correct prompt is shown after project update
-                    Assert.Contains("An update is available for the Aspire CLI", prompt);
+                    confirmPrompt = prompt;
                     return false; // User says no
                 }
             };
@@ -220,7 +228,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
             options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
             {
-                UpdateProjectAsyncCallback = (projectFile, channel, cancellationToken) =>
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
                 {
                     return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = true });
                 }
@@ -259,7 +267,95 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.True(confirmCallbackInvoked, "Confirm prompt should have been shown after successful project update");
-        Assert.Equal(0, exitCode);
+        Assert.NotNull(confirmPrompt);
+        Assert.Contains("An update is available for the Aspire CLI", confirmPrompt);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_WithoutAutoConfirmOption_UsesFalseConfirmationDefault()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var updateProjectInvoked = false;
+        var confirmBindingResolved = false;
+        var confirmBindingValue = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator()
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
+                {
+                    return Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")));
+                }
+            };
+
+            options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
+            {
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
+                {
+                    updateProjectInvoked = true;
+                    (confirmBindingResolved, confirmBindingValue) = context.ConfirmBinding.Resolve();
+                    return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = false });
+                }
+            };
+
+            options.PackagingServiceFactory = _ => new TestPackagingService();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --apphost AppHost.csproj");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(updateProjectInvoked);
+        Assert.False(confirmBindingResolved);
+        Assert.False(confirmBindingValue);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_WithYesOption_ResolvesConfirmationFromCli()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var updateProjectInvoked = false;
+        var confirmBindingResolved = false;
+        var confirmBindingValue = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator()
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
+                {
+                    return Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")));
+                }
+            };
+
+            options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
+            {
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
+                {
+                    updateProjectInvoked = true;
+                    (confirmBindingResolved, confirmBindingValue) = context.ConfirmBinding.Resolve();
+                    return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = false });
+                }
+            };
+
+            options.PackagingServiceFactory = _ => new TestPackagingService();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --apphost AppHost.csproj --yes");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(updateProjectInvoked);
+        Assert.True(confirmBindingResolved);
+        Assert.True(confirmBindingValue);
     }
 
     [Fact]
@@ -291,7 +387,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
             options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
             {
-                UpdateProjectAsyncCallback = (projectFile, channel, cancellationToken) =>
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
                 {
                     return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = true });
                 }
@@ -330,7 +426,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.False(confirmCallbackInvoked, "Confirm prompt should NOT have been shown for channels without CLI download support");
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -348,8 +444,6 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
                     promptForSelectionInvoked = true;
-                    // If this is called, it means the channel prompt was shown
-                    Assert.Fail("Channel prompt should not be shown when --channel option is provided");
                     return "stable";
                 }
             };
@@ -395,8 +489,6 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
                     promptForSelectionInvoked = true;
-                    // If this is called, it means the quality prompt was shown
-                    Assert.Fail("Quality prompt should not be shown when --quality option is provided");
                     return "stable";
                 }
             };
@@ -491,8 +583,6 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
                     promptForSelectionInvoked = true;
-                    // If this is called, it means the channel prompt was shown
-                    Assert.Fail("Channel prompt should not be shown when --channel option is provided");
                     return choices.Cast<PackageChannel>().First();
                 }
             };
@@ -501,9 +591,9 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
             options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
             {
-                UpdateProjectAsyncCallback = (projectFile, channel, cancellationToken) =>
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
                 {
-                    capturedChannel = channel;
+                    capturedChannel = context.Channel;
                     return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = true });
                 }
             };
@@ -532,7 +622,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.False(promptForSelectionInvoked, "Channel prompt should not be shown when --channel is provided");
         Assert.NotNull(capturedChannel);
         Assert.Equal("daily", capturedChannel.Name);
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -558,8 +648,6 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
                     promptForSelectionInvoked = true;
-                    // If this is called, it means the channel prompt was shown
-                    Assert.Fail("Channel prompt should not be shown when --quality option is provided");
                     return choices.Cast<PackageChannel>().First();
                 }
             };
@@ -568,9 +656,9 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
             options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
             {
-                UpdateProjectAsyncCallback = (projectFile, channel, cancellationToken) =>
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
                 {
-                    capturedChannel = channel;
+                    capturedChannel = context.Channel;
                     return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = true });
                 }
             };
@@ -599,7 +687,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.False(promptForSelectionInvoked, "Channel prompt should not be shown when --quality is provided");
         Assert.NotNull(capturedChannel);
         Assert.Equal("daily", capturedChannel.Name);
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -682,7 +770,6 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
                     promptForSelectionInvoked = true;
-                    Assert.Fail("Channel prompt should not be shown when --channel option is provided");
                     return choices.Cast<PackageChannel>().First();
                 }
             };
@@ -691,9 +778,9 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
             options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
             {
-                UpdateProjectAsyncCallback = (projectFile, channel, cancellationToken) =>
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
                 {
-                    capturedChannel = channel;
+                    capturedChannel = context.Channel;
                     return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = true });
                 }
             };
@@ -721,7 +808,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.False(promptForSelectionInvoked, "Channel prompt should not be shown");
         Assert.NotNull(capturedChannel);
         Assert.Equal("stable", capturedChannel.Name);
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -813,9 +900,9 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
             options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
             {
-                UpdateProjectAsyncCallback = (projectFile, channel, cancellationToken) =>
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
                 {
-                    updatedWithChannel = channel.Name;
+                    updatedWithChannel = context.Channel.Name;
                     return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = false });
                 }
             };
@@ -840,7 +927,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(0, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(promptForSelectionInvoked, "Channel selection prompt should not be shown when there are no hives");
         Assert.Equal("default", updatedWithChannel); // Implicit channel is named "default"
     }
@@ -1002,6 +1089,78 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         // Assert - Command should parse successfully without errors
         Assert.Empty(result.Errors);
     }
+
+    [Fact]
+    public async Task UpdateCommand_NonInteractive_WithYesAndChannel_SucceedsWithoutPrompting()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var promptForSelectionInvoked = false;
+        var confirmCallbackInvoked = false;
+        PackageChannel? capturedChannel = null;
+        UpdatePackagesContext? capturedContext = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator()
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
+                {
+                    return Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")));
+                }
+            };
+
+            options.InteractionServiceFactory = _ => new TestInteractionService()
+            {
+                PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
+                {
+                    promptForSelectionInvoked = true;
+                    return choices.Cast<object>().First();
+                },
+                ConfirmCallback = (prompt, defaultValue) =>
+                {
+                    confirmCallbackInvoked = true;
+                    return true;
+                }
+            };
+
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
+
+            options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
+            {
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
+                {
+                    capturedContext = context;
+                    capturedChannel = context.Channel;
+                    return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = false });
+                }
+            };
+
+            options.PackagingServiceFactory = _ => new TestPackagingService()
+            {
+                GetChannelsAsyncCallback = (ct) =>
+                {
+                    var stableChannel = new PackageChannel("stable", PackageChannelQuality.Stable, null, null!);
+                    var dailyChannel = new PackageChannel("daily", PackageChannelQuality.Prerelease, null, null!);
+                    return Task.FromResult<IEnumerable<PackageChannel>>([stableChannel, dailyChannel]);
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --yes --channel stable --non-interactive");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptForSelectionInvoked, "No selection prompt should be shown in non-interactive mode with --channel");
+        Assert.False(confirmCallbackInvoked, "No confirm prompt should be shown in non-interactive mode with --yes");
+        Assert.NotNull(capturedChannel);
+        Assert.Equal("stable", capturedChannel.Name);
+        Assert.NotNull(capturedContext);
+    }
 }
 
 // Helper class to track DisplayCancellationMessage calls
@@ -1024,16 +1183,16 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
 
     public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false) => _innerService.ShowStatusAsync(statusText, action, emoji, allowMarkup);
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false) => _innerService.ShowStatus(statusText, action, emoji, allowMarkup);
-    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default) 
-        => _innerService.PromptForStringAsync(promptText, defaultValue, validator, isSecret, required, cancellationToken);
-    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
-        => _innerService.PromptForFilePathAsync(promptText, defaultValue, validator, directory, required, cancellationToken);
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) 
-        => _innerService.ConfirmAsync(promptText, defaultValue, cancellationToken);
-    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull 
-        => _innerService.PromptForSelectionAsync(promptText, choices, choiceFormatter, cancellationToken);
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull 
-        => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, preSelected, optional, cancellationToken);
+    public Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) 
+        => _innerService.PromptForStringAsync(promptText, validator, isSecret, required, binding, cancellationToken);
+    public Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
+        => _innerService.PromptForFilePathAsync(promptText, validator, directory, required, binding, cancellationToken);
+    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default) 
+        => _innerService.ConfirmAsync(promptText, binding, cancellationToken);
+    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull 
+        => _innerService.PromptForSelectionAsync(promptText, choices, choiceFormatter, binding, cancellationToken);
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull 
+        => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, preSelected, optional, binding, cancellationToken);
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) 
         => _innerService.DisplayIncompatibleVersionError(ex, appHostHostingVersion);
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);
@@ -1062,34 +1221,16 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
 // Test implementation of IProjectUpdater
 internal sealed class TestProjectUpdater : IProjectUpdater
 {
-    public Func<FileInfo, PackageChannel, CancellationToken, Task<ProjectUpdateResult>>? UpdateProjectAsyncCallback { get; set; }
+    public Func<UpdatePackagesContext, CancellationToken, Task<ProjectUpdateResult>>? UpdateProjectAsyncCallback { get; set; }
 
-    public Task<ProjectUpdateResult> UpdateProjectAsync(FileInfo projectFile, PackageChannel channel, CancellationToken cancellationToken = default)
+    public Task<ProjectUpdateResult> UpdateProjectAsync(UpdatePackagesContext context, CancellationToken cancellationToken = default)
     {
         if (UpdateProjectAsyncCallback != null)
         {
-            return UpdateProjectAsyncCallback(projectFile, channel, cancellationToken);
+            return UpdateProjectAsyncCallback(context, cancellationToken);
         }
 
         // Default behavior
         return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = false });
-    }
-}
-
-// Test implementation of IPackagingService
-internal sealed class TestPackagingService : IPackagingService
-{
-    public Func<CancellationToken, Task<IEnumerable<PackageChannel>>>? GetChannelsAsyncCallback { get; set; }
-
-    public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default)
-    {
-        if (GetChannelsAsyncCallback != null)
-        {
-            return GetChannelsAsyncCallback(cancellationToken);
-        }
-
-        // Default behavior - return a fake channel
-        var testChannel = new PackageChannel("test", PackageChannelQuality.Stable, null, null!);
-        return Task.FromResult<IEnumerable<PackageChannel>>(new[] { testChannel });
     }
 }

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -293,7 +293,7 @@ public class ConsoleInteractionServiceTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            interactionService.ConfirmAsync("Confirm?", cancellationToken: CancellationToken.None));
+            interactionService.PromptConfirmAsync("Confirm?", cancellationToken: CancellationToken.None));
         Assert.Contains(InteractionServiceStrings.InteractiveInputNotSupported, exception.Message);
     }
 
@@ -844,7 +844,7 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console);
 
         // Act
-        await interactionService.ConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
+        await interactionService.PromptConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
 
         // Assert - the output should contain the [Y/n] or [y/N] suffix
         var outputString = output.ToString();
@@ -862,7 +862,7 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console);
 
         // Act
-        var result = await interactionService.ConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
+        var result = await interactionService.PromptConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
 
         // Assert - pressing Enter should accept the default value
         Assert.Equal(defaultValue, result);
@@ -944,7 +944,7 @@ public class ConsoleInteractionServiceTests
         var binding = PromptBinding.Create(parseResult, option);
 
         await Assert.ThrowsAsync<NonInteractiveException>(() =>
-            interactionService.ConfirmAsync("Proceed?", binding: binding, cancellationToken: CancellationToken.None));
+            interactionService.PromptConfirmAsync("Proceed?", binding: binding, cancellationToken: CancellationToken.None));
     }
 
     [Fact]
@@ -956,7 +956,7 @@ public class ConsoleInteractionServiceTests
 
         var binding = PromptBinding.CreateDefault(true);
 
-        var result = await interactionService.ConfirmAsync("Proceed?", binding: binding, cancellationToken: CancellationToken.None);
+        var result = await interactionService.PromptConfirmAsync("Proceed?", binding: binding, cancellationToken: CancellationToken.None);
 
         Assert.True(result);
     }
@@ -1076,7 +1076,7 @@ public class ConsoleInteractionServiceTests
         var console = CreateInteractiveConsoleWithInput(output, "\n");
         var interactionService = CreateInteractionService(console);
 
-        var result = await interactionService.ConfirmAsync("Proceed?", binding: null, cancellationToken: CancellationToken.None);
+        var result = await interactionService.PromptConfirmAsync("Proceed?", binding: null, cancellationToken: CancellationToken.None);
 
         Assert.True(result);
         Assert.Contains("[Y/n]", output.ToString());

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -32,7 +32,7 @@ public class ConsoleInteractionServiceTests
 
         // Act & Assert
         await Assert.ThrowsAsync<EmptyChoicesException>(() =>
-            interactionService.PromptForSelectionAsync("Select an item:", choices, x => x, CancellationToken.None));
+            interactionService.PromptForSelectionAsync("Select an item:", choices, x => x, cancellationToken: CancellationToken.None));
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public class ConsoleInteractionServiceTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            interactionService.PromptForStringAsync("Enter value:", null, null, false, false, CancellationToken.None));
+            interactionService.PromptForStringAsync("Enter value:", null, false, false, binding: null, cancellationToken: CancellationToken.None));
         Assert.Contains(InteractionServiceStrings.InteractiveInputNotSupported, exception.Message);
     }
 
@@ -279,7 +279,7 @@ public class ConsoleInteractionServiceTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            interactionService.PromptForSelectionAsync("Select an item:", choices, x => x, CancellationToken.None));
+            interactionService.PromptForSelectionAsync("Select an item:", choices, x => x, cancellationToken: CancellationToken.None));
         Assert.Contains(InteractionServiceStrings.InteractiveInputNotSupported, exception.Message);
     }
 
@@ -308,7 +308,7 @@ public class ConsoleInteractionServiceTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            interactionService.ConfirmAsync("Confirm?", true, CancellationToken.None));
+            interactionService.ConfirmAsync("Confirm?", cancellationToken: CancellationToken.None));
         Assert.Contains(InteractionServiceStrings.InteractiveInputNotSupported, exception.Message);
     }
 
@@ -871,7 +871,7 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, executionContext);
 
         // Act
-        await interactionService.ConfirmAsync("Proceed?", defaultValue, CancellationToken.None);
+        await interactionService.ConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
 
         // Assert - the output should contain the [Y/n] or [y/N] suffix
         var outputString = output.ToString();
@@ -890,10 +890,207 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, executionContext);
 
         // Act
-        var result = await interactionService.ConfirmAsync("Proceed?", defaultValue, CancellationToken.None);
+        var result = await interactionService.ConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
 
         // Assert - pressing Enter should accept the default value
         Assert.Equal(defaultValue, result);
+    }
+
+    [Fact]
+    public async Task PromptForStringAsync_CliProvidedValue_RunsValidator()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var interactionService = CreateInteractionService(console, executionContext);
+
+        var option = new System.CommandLine.Option<string?>("--value");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("--value bad-value");
+        var binding = PromptBinding.Create(parseResult, option);
+        Func<string, ValidationResult> validator = v =>
+            v == "bad-value" ? ValidationResult.Error("Invalid!") : ValidationResult.Success();
+
+        await Assert.ThrowsAsync<NonInteractiveException>(() =>
+            interactionService.PromptForStringAsync("Enter value:", validator: validator, binding: binding, cancellationToken: CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PromptForStringAsync_CliProvidedEmptyValue_ThrowsWhenRequired()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+
+        var binding = PromptBinding.CreateDefault<string?>("");
+
+        await Assert.ThrowsAsync<NonInteractiveException>(() =>
+            interactionService.PromptForStringAsync("Enter name:", required: true, binding: binding, cancellationToken: CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PromptForStringAsync_NonInteractive_DefaultValuePassesValidation_ReturnsDefault()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+
+        var binding = PromptBinding.CreateDefault<string?>("good-value");
+        Func<string, ValidationResult> validator = v =>
+            v == "good-value" ? ValidationResult.Success() : ValidationResult.Error("Invalid!");
+
+        var result = await interactionService.PromptForStringAsync("Enter value:", validator: validator, binding: binding, cancellationToken: CancellationToken.None);
+
+        Assert.Equal("good-value", result);
+    }
+
+    [Fact]
+    public async Task PromptForStringAsync_WhenUserAcceptsEscapedDisplayDefault_ReturnsRawDefault()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "\n");
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var interactionService = CreateInteractionService(console, executionContext);
+        const string rawDefault = "./[27;5;13~";
+
+        var result = await interactionService.PromptForStringAsync(
+            "Enter value:",
+            binding: PromptBinding.CreateDefault<string?>(rawDefault),
+            cancellationToken: CancellationToken.None);
+
+        Assert.Equal(rawDefault, result);
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_NonInteractive_WithoutExplicitDefault_Throws()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+
+        var option = new System.CommandLine.Option<bool>("--confirm");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("");
+        var binding = PromptBinding.Create(parseResult, option);
+
+        await Assert.ThrowsAsync<NonInteractiveException>(() =>
+            interactionService.ConfirmAsync("Proceed?", binding: binding, cancellationToken: CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_NonInteractive_WithExplicitDefault_ReturnsDefault()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+
+        var binding = PromptBinding.CreateDefault(true);
+
+        var result = await interactionService.ConfirmAsync("Proceed?", binding: binding, cancellationToken: CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void MatchChoices_WithDuplicateValues_ReturnsDeduplicated()
+    {
+        var choices = new[] { "alpha", "beta", "gamma" };
+
+        var result = ConsoleInteractionService.MatchChoices("alpha,alpha,beta", choices, c => c);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("alpha", result[0]);
+        Assert.Equal("beta", result[1]);
+    }
+
+    [Fact]
+    public void MatchChoices_All_ReturnsAllChoices()
+    {
+        var choices = new[] { "alpha", "beta", "gamma" };
+
+        var result = ConsoleInteractionService.MatchChoices("all", choices, c => c);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public void MatchChoices_None_ReturnsEmpty()
+    {
+        var choices = new[] { "alpha", "beta" };
+
+        var result = ConsoleInteractionService.MatchChoices("none", choices, c => c);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MatchChoices_InvalidValue_ReturnsNull()
+    {
+        var choices = new[] { "alpha", "beta" };
+
+        var result = ConsoleInteractionService.MatchChoices("alpha,nonexistent", choices, c => c);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void MatchChoice_MatchesByToString()
+    {
+        var choices = new[] { new TestItem("id1", "Display One"), new TestItem("id2", "Display Two") };
+
+        var result = ConsoleInteractionService.MatchChoice("id1", choices, c => c.Display);
+
+        Assert.NotNull(result);
+        Assert.Equal("id1", result.Id);
+    }
+
+    [Fact]
+    public void PromptBinding_CreateDefault_ResolvesAsNotProvided()
+    {
+        var binding = PromptBinding.CreateDefault("test");
+        var (wasProvided, value) = binding.Resolve();
+
+        Assert.False(wasProvided);
+        Assert.Null(value);
+        Assert.Equal("test", binding.DefaultValue);
+        Assert.True(binding.HasExplicitDefault);
+    }
+
+    [Fact]
+    public void PromptBinding_CreateWithoutDefault_HasNoExplicitDefault()
+    {
+        var option = new System.CommandLine.Option<bool>("--flag");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("");
+
+        var binding = PromptBinding.Create(parseResult, option);
+
+        Assert.False(binding.HasExplicitDefault);
+    }
+
+    [Fact]
+    public void PromptBinding_CreateWithDefault_HasExplicitDefault()
+    {
+        var option = new System.CommandLine.Option<bool>("--flag");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("");
+
+        var binding = PromptBinding.Create(parseResult, option, true);
+
+        Assert.True(binding.HasExplicitDefault);
+        Assert.True(binding.DefaultValue);
+    }
+
+    private sealed record TestItem(string Id, string Display)
+    {
+        public override string ToString() => Id;
     }
 
     private static IAnsiConsole CreateInteractiveConsoleWithInput(StringBuilder output, string input)

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -16,8 +16,9 @@ namespace Aspire.Cli.Tests.Interaction;
 
 public class ConsoleInteractionServiceTests
 {
-    private static ConsoleInteractionService CreateInteractionService(IAnsiConsole console, CliExecutionContext executionContext, ICliHostEnvironment? hostEnvironment = null)
+    private static ConsoleInteractionService CreateInteractionService(IAnsiConsole console, CliExecutionContext? executionContext = null, ICliHostEnvironment? hostEnvironment = null)
     {
+        executionContext ??= new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var consoleEnvironment = new ConsoleEnvironment(console, console);
         return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment ?? TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance);
     }
@@ -26,8 +27,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForSelectionAsync_EmptyChoices_ThrowsEmptyChoicesException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext);
+        var interactionService = CreateInteractionService(AnsiConsole.Console);
         var choices = Array.Empty<string>();
 
         // Act & Assert
@@ -39,8 +39,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForSelectionsAsync_EmptyChoices_ThrowsEmptyChoicesException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext);
+        var interactionService = CreateInteractionService(AnsiConsole.Console);
         var choices = Array.Empty<string>();
 
         // Act & Assert
@@ -60,8 +59,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
         var errorMessage = "The JSON value could not be converted to <Type>. Path: $.values[0].Type | LineNumber: 0 | BytePositionInLine: 121.";
 
         // Act - this should not throw an exception due to markup parsing
@@ -85,8 +83,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
         var message = "Path with <brackets> and [markup] characters";
 
         // Act - this should not throw an exception due to markup parsing
@@ -110,8 +107,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
         var lines = new[]
         {
             (OutputLineStream.StdOut, "Command output with <angle> brackets"),
@@ -141,8 +137,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
         var markdown = "# Header\nThis is **bold** and *italic* text with `code`.";
 
         // Act
@@ -168,8 +163,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
         var plainText = "This is just plain text without any markdown.";
 
         // Act
@@ -192,8 +186,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
         interactionService.DisplayMarkdown("Visit [GitHub](https://github.com) for more info.");
 
@@ -258,9 +251,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForStringAsync_WhenInteractiveInputNotSupported_ThrowsInvalidOperationException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
-        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
+        var interactionService = CreateInteractionService(AnsiConsole.Console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -272,9 +263,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForSelectionAsync_WhenInteractiveInputNotSupported_ThrowsInvalidOperationException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
-        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
+        var interactionService = CreateInteractionService(AnsiConsole.Console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "option1", "option2" };
 
         // Act & Assert
@@ -287,9 +276,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForSelectionsAsync_WhenInteractiveInputNotSupported_ThrowsInvalidOperationException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
-        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
+        var interactionService = CreateInteractionService(AnsiConsole.Console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "option1", "option2" };
 
         // Act & Assert
@@ -302,9 +289,7 @@ public class ConsoleInteractionServiceTests
     public async Task ConfirmAsync_WhenInteractiveInputNotSupported_ThrowsInvalidOperationException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
-        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
+        var interactionService = CreateInteractionService(AnsiConsole.Console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -324,8 +309,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
         
         var outerStatusText = "Outer operation...";
         var innerStatusText = "Inner operation...";
@@ -357,8 +341,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
         
         var outerStatusText = "Outer synchronous operation...";
         var innerStatusText = "Inner synchronous operation...";
@@ -390,8 +373,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         var ex = new AppHostIncompatibleException("Incompatible [version]", "capability [Prod]");
 
@@ -417,8 +399,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // DisplayMessage now auto-escapes by default, so callers don't need to escape.
         var message = "See logs at C:\\Users\\test [Dev]\\logs\\aspire.log";
@@ -444,8 +425,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Version strings are unlikely to have brackets, but the method should handle it
         var version = "13.2.0-preview [beta]";
@@ -474,8 +454,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Error message with brackets (e.g., from an exception)
         var errorMessage = "Failed to connect to service [Prod]: Connection refused <timeout>";
@@ -503,8 +482,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Path with brackets that would be interpreted as Spectre markup if not escaped
         var path = @"C:\Users\[Dev Team]\logs\aspire.log";
@@ -530,8 +508,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Message with intentional Spectre markup tags
         var message = "[bold cyan]MyProject.csproj[/]:";
@@ -557,8 +534,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Dynamic content with brackets embedded in markup - NOT escaped
         var projectName = "MyProject [Beta]";
@@ -583,8 +559,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Success message with bracket characters that would break markup if not escaped
         var message = "Package Aspire.Hosting.Azure [1.0.0-preview] added successfully";
@@ -778,8 +753,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Message with all kinds of markup characters
         var message = "Error in [Module]: <Config> value $.items[0] invalid";
@@ -867,8 +841,7 @@ public class ConsoleInteractionServiceTests
         // Arrange - simulate pressing Enter (accepts default)
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "\n");
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Act
         await interactionService.ConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
@@ -886,8 +859,7 @@ public class ConsoleInteractionServiceTests
         // Arrange - simulate pressing Enter (empty input selects default)
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "\n");
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         // Act
         var result = await interactionService.ConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
@@ -901,8 +873,7 @@ public class ConsoleInteractionServiceTests
     {
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "");
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
 
         var option = new System.CommandLine.Option<string?>("--value");
         var command = new System.CommandLine.RootCommand { option };
@@ -920,8 +891,7 @@ public class ConsoleInteractionServiceTests
     {
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "");
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
         var binding = PromptBinding.CreateDefault<string?>("");
 
@@ -934,8 +904,7 @@ public class ConsoleInteractionServiceTests
     {
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "");
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
         var binding = PromptBinding.CreateDefault<string?>("good-value");
         Func<string, ValidationResult> validator = v =>
@@ -951,8 +920,7 @@ public class ConsoleInteractionServiceTests
     {
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "\n");
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext);
+        var interactionService = CreateInteractionService(console);
         const string rawDefault = "./[27;5;13~";
 
         var result = await interactionService.PromptForStringAsync(
@@ -968,8 +936,7 @@ public class ConsoleInteractionServiceTests
     {
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "");
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
         var option = new System.CommandLine.Option<bool>("--confirm");
         var command = new System.CommandLine.RootCommand { option };
@@ -985,8 +952,7 @@ public class ConsoleInteractionServiceTests
     {
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "");
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
-        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
         var binding = PromptBinding.CreateDefault(true);
 
@@ -1086,6 +1052,219 @@ public class ConsoleInteractionServiceTests
 
         Assert.True(binding.HasExplicitDefault);
         Assert.True(binding.DefaultValue);
+    }
+
+    [Theory]
+    [InlineData("--channel", "'--channel'")]
+    [InlineData("--yes", "'--yes'")]
+    [InlineData("--nuget-config-dir", "'--nuget-config-dir'")]
+    public void PromptBinding_SymbolDisplayName_DoesNotDoubleDash(string optionName, string expectedDisplay)
+    {
+        var option = new System.CommandLine.Option<string?>(optionName);
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("");
+
+        var binding = PromptBinding.Create(parseResult, option);
+
+        Assert.Equal(expectedDisplay, binding.SymbolDisplayName);
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_WithNullBinding_DefaultsToTrue()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "\n");
+        var interactionService = CreateInteractionService(console);
+
+        var result = await interactionService.ConfirmAsync("Proceed?", binding: null, cancellationToken: CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Contains("[Y/n]", output.ToString());
+    }
+
+    [Fact]
+    public async Task PromptForSelectionAsync_NonInteractive_CliProvidedInvalidValue_ShowsAvailableChoices()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
+        var choices = new[] { "option1", "option2", "option3" };
+
+        var option = new System.CommandLine.Option<string?>("--choice");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("--choice invalid");
+        var binding = PromptBinding.Create(parseResult, option);
+
+        var ex = await Assert.ThrowsAsync<NonInteractiveException>(() =>
+            interactionService.PromptForSelectionAsync("Select:", choices, x => x, binding, CancellationToken.None));
+
+        var outputString = output.ToString();
+        Assert.Contains("option1", outputString);
+        Assert.Contains("option2", outputString);
+        Assert.Contains("option3", outputString);
+    }
+
+    [Fact]
+    public async Task PromptForSelectionsAsync_NonInteractive_CliProvidedInvalidValue_ShowsAvailableChoices()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
+        var choices = new[] { "alpha", "beta", "gamma" };
+
+        var option = new System.CommandLine.Option<string?>("--items");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("--items invalid");
+        var binding = PromptBinding.Create(parseResult, option);
+
+        var ex = await Assert.ThrowsAsync<NonInteractiveException>(() =>
+            interactionService.PromptForSelectionsAsync("Select:", choices, x => x, binding: binding, cancellationToken: CancellationToken.None));
+
+        var outputString = output.ToString();
+        Assert.Contains("alpha", outputString);
+        Assert.Contains("beta", outputString);
+        Assert.Contains("gamma", outputString);
+    }
+
+    [Fact]
+    public async Task PromptForSelectionAsync_NonInteractive_WithDefaultValue_ReturnsMatch()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
+        var choices = new[] { "option1", "option2" };
+
+        var option = new System.CommandLine.Option<string?>("--choice");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("");
+        var binding = PromptBinding.Create(parseResult, option, "option2");
+
+        var result = await interactionService.PromptForSelectionAsync("Select:", choices, x => x, binding, CancellationToken.None);
+
+        Assert.Equal("option2", result);
+    }
+
+    [Fact]
+    public async Task PromptForSelectionAsync_CliProvidedValidValue_ReturnsMatch()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var interactionService = CreateInteractionService(console);
+        var choices = new[] { "option1", "option2" };
+
+        var option = new System.CommandLine.Option<string?>("--choice");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("--choice option1");
+        var binding = PromptBinding.Create(parseResult, option);
+
+        var result = await interactionService.PromptForSelectionAsync("Select:", choices, x => x, binding, CancellationToken.None);
+
+        Assert.Equal("option1", result);
+    }
+
+    [Fact]
+    public async Task PromptForSelectionsAsync_CliProvidedCommaSeparated_ReturnsMatches()
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var interactionService = CreateInteractionService(console);
+        var choices = new[] { "alpha", "beta", "gamma" };
+
+        var option = new System.CommandLine.Option<string?>("--items");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("--items alpha,gamma");
+        var binding = PromptBinding.Create(parseResult, option);
+
+        var result = await interactionService.PromptForSelectionsAsync("Select:", choices, x => x, binding: binding, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("alpha", result[0]);
+        Assert.Equal("gamma", result[1]);
+    }
+
+    [Fact]
+    public void PromptBinding_InvertedBoolConfirm_SymbolDisplayName_IsCorrect()
+    {
+        var option = new System.CommandLine.Option<bool?>("--yes");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("--yes");
+
+        var binding = PromptBinding.CreateInvertedBoolConfirm(parseResult, option, defaultValue: true);
+
+        Assert.Equal("'--yes'", binding.SymbolDisplayName);
+    }
+
+    [Fact]
+    public void PromptBinding_BoolAsSelection_SymbolDisplayName_IsCorrect()
+    {
+        var option = new System.CommandLine.Option<bool?>("--include");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("--include");
+
+        var binding = PromptBinding.CreateBoolAsSelection(parseResult, option, "Yes", "No");
+
+        Assert.Equal("'--include'", binding.SymbolDisplayName);
+    }
+
+    [Fact]
+    public void PromptBinding_WithDefault_ChangesDefault()
+    {
+        var binding = PromptBinding.CreateDefault("original");
+        var updated = binding.WithDefault("new-value");
+
+        Assert.Equal("new-value", updated.DefaultValue);
+        Assert.True(updated.HasExplicitDefault);
+    }
+
+    [Fact]
+    public void MatchChoices_CaseInsensitive_ReturnsMatches()
+    {
+        var choices = new[] { "Alpha", "Beta", "Gamma" };
+
+        var result = ConsoleInteractionService.MatchChoices("alpha,BETA", choices, c => c);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Alpha", result[0]);
+        Assert.Equal("Beta", result[1]);
+    }
+
+    [Fact]
+    public void MatchChoice_CaseInsensitive_ReturnsMatch()
+    {
+        var choices = new[] { "Alpha", "Beta" };
+
+        var result = ConsoleInteractionService.MatchChoice("ALPHA", choices, c => c);
+
+        Assert.NotNull(result);
+        Assert.Equal("Alpha", result);
+    }
+
+    [Fact]
+    public async Task PromptForStringAsync_NonInteractive_NoBinding_ThrowsInvalidOperationException()
+    {
+        var interactionService = CreateInteractionService(AnsiConsole.Console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
+
+        var binding = PromptBinding.CreateDefault<string?>("fallback");
+
+        var result = await interactionService.PromptForStringAsync("Enter value:", binding: binding, cancellationToken: CancellationToken.None);
+
+        Assert.Equal("fallback", result);
+    }
+
+    [Fact]
+    public async Task PromptForSelectionAsync_NonInteractive_WithoutBinding_ThrowsInvalidOperationException()
+    {
+        var interactionService = CreateInteractionService(AnsiConsole.Console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
+        var choices = new[] { "option1", "option2" };
+
+        var option = new System.CommandLine.Option<string?>("--choice");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("");
+        var binding = PromptBinding.Create(parseResult, option);
+
+        await Assert.ThrowsAsync<NonInteractiveException>(() =>
+            interactionService.PromptForSelectionAsync("Select:", choices, x => x, binding, CancellationToken.None));
     }
 
     private sealed record TestItem(string Id, string Display)

--- a/tests/Aspire.Cli.Tests/Mcp/ListIntegrationsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListIntegrationsToolTests.cs
@@ -13,7 +13,7 @@ public class ListIntegrationsToolTests
     [Fact]
     public void ListIntegrationsTool_HasCorrectName()
     {
-        var tool = new ListIntegrationsTool(new MockPackagingService(), TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
+        var tool = new ListIntegrationsTool(MockPackagingServiceFactory.Create(), TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
 
         Assert.Equal("list_integrations", tool.Name);
     }
@@ -21,7 +21,7 @@ public class ListIntegrationsToolTests
     [Fact]
     public void ListIntegrationsTool_HasCorrectDescription()
     {
-        var tool = new ListIntegrationsTool(new MockPackagingService(), TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
+        var tool = new ListIntegrationsTool(MockPackagingServiceFactory.Create(), TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
 
         Assert.Contains("List available Aspire hosting integrations", tool.Description);
         Assert.Contains("This tool does not require a running AppHost", tool.Description);
@@ -30,7 +30,7 @@ public class ListIntegrationsToolTests
     [Fact]
     public void ListIntegrationsTool_GetInputSchema_ReturnsValidSchema()
     {
-        var tool = new ListIntegrationsTool(new MockPackagingService(), TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
+        var tool = new ListIntegrationsTool(MockPackagingServiceFactory.Create(), TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
         var schema = tool.GetInputSchema();
 
         Assert.Equal(JsonValueKind.Object, schema.ValueKind);
@@ -47,7 +47,7 @@ public class ListIntegrationsToolTests
     [Fact]
     public async Task ListIntegrationsTool_CallToolAsync_ReturnsEmptyJsonArray_WhenNoPackagesFound()
     {
-        var mockPackagingService = new MockPackagingService();
+        var mockPackagingService = MockPackagingServiceFactory.Create();
         var tool = new ListIntegrationsTool(mockPackagingService, TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
 
         var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
@@ -68,7 +68,7 @@ public class ListIntegrationsToolTests
     [Fact]
     public async Task ListIntegrationsTool_CallToolAsync_ReturnsJsonWithPackages_WhenPackagesFound()
     {
-        var mockPackagingService = new MockPackagingService(new[]
+        var mockPackagingService = MockPackagingServiceFactory.Create(new[]
         {
             new Aspire.Shared.NuGetPackageCli { Id = "Aspire.Hosting.Redis", Version = "9.0.0" },
             new Aspire.Shared.NuGetPackageCli { Id = "Aspire.Hosting.PostgreSQL", Version = "9.0.0" }
@@ -107,7 +107,7 @@ public class ListIntegrationsToolTests
     public async Task ListIntegrationsTool_UsesDefaultChannelOnly()
     {
         // This test verifies that only the default (first) channel is used
-        var mockPackagingService = new MockPackagingService(new[]
+        var mockPackagingService = MockPackagingServiceFactory.Create(new[]
         {
             new Aspire.Shared.NuGetPackageCli { Id = "Aspire.Hosting.Redis", Version = "9.0.0" }
         });

--- a/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
@@ -2,49 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Backchannel;
-using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Shared;
 
 namespace Aspire.Cli.Tests.Mcp;
 
-internal sealed class MockPackagingService : IPackagingService
+internal static class MockPackagingServiceFactory
 {
-    private readonly NuGetPackageCli[] _packages;
-
-    public MockPackagingService(NuGetPackageCli[]? packages = null)
+    public static TestPackagingService Create(NuGetPackageCli[]? integrationPackages = null)
     {
-        _packages = packages ?? [];
+        var packages = integrationPackages ?? [];
+        return new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                var cache = new FakeNuGetPackageCache
+                {
+                    GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+                        Task.FromResult<IEnumerable<NuGetPackageCli>>(packages)
+                };
+                return Task.FromResult<IEnumerable<PackageChannel>>([PackageChannel.CreateImplicitChannel(cache)]);
+            }
+        };
     }
-
-    public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default)
-    {
-        var nugetCache = new MockNuGetPackageCache(_packages);
-        var channels = new[] { PackageChannel.CreateImplicitChannel(nugetCache) };
-        return Task.FromResult<IEnumerable<PackageChannel>>(channels);
-    }
-}
-
-internal sealed class MockNuGetPackageCache : INuGetPackageCache
-{
-    private readonly NuGetPackageCli[] _packages;
-
-    public MockNuGetPackageCache(NuGetPackageCli[]? packages = null)
-    {
-        _packages = packages ?? [];
-    }
-
-    public Task<IEnumerable<NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        => Task.FromResult<IEnumerable<NuGetPackageCli>>([]);
-
-    public Task<IEnumerable<NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        => Task.FromResult<IEnumerable<NuGetPackageCli>>(_packages);
-
-    public Task<IEnumerable<NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        => Task.FromResult<IEnumerable<NuGetPackageCli>>([]);
-
-    public Task<IEnumerable<NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-        => Task.FromResult<IEnumerable<NuGetPackageCli>>([]);
 }
 
 internal static class TestExecutionContextFactory

--- a/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerSnapshotTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerSnapshotTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.AspNetCore.InternalTesting;
 using System.Xml.Linq;
 using Aspire.Cli.Packaging;
-using Aspire.Cli.NuGet;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Configuration;
@@ -21,14 +20,6 @@ public class NuGetConfigMergerSnapshotTests
     public NuGetConfigMergerSnapshotTests(ITestOutputHelper output)
     {
         _output = output;
-    }
-
-    private sealed class FakeNuGetPackageCache : INuGetPackageCache
-    {
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
     }
 
     private static PackagingService CreatePackagingService(CliExecutionContext executionContext)

--- a/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using System.Xml.Linq;
 using System.Xml;
 using Aspire.Cli.Packaging;
-using Aspire.Cli.NuGet;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 
 namespace Aspire.Cli.Tests.Packaging;
@@ -24,26 +24,6 @@ public class NuGetConfigMergerTests
         var path = Path.Combine(dir.FullName, "nuget.config");
         await File.WriteAllTextAsync(path, content);
         return new FileInfo(path);
-    }
-
-    private sealed class FakeNuGetPackageCache : INuGetPackageCache
-    {
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            _ = workingDirectory; _ = prerelease; _ = nugetConfigFile; _ = cancellationToken; return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        }
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            _ = workingDirectory; _ = prerelease; _ = nugetConfigFile; _ = cancellationToken; return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        }
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            _ = workingDirectory; _ = prerelease; _ = nugetConfigFile; _ = cancellationToken; return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        }
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-        {
-            _ = workingDirectory; _ = packageId; _ = filter; _ = prerelease; _ = nugetConfigFile; _ = useCache; _ = cancellationToken; return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        }
     }
 
     private static PackageChannel CreateChannel(PackageMapping[] mappings) => PackageChannel.CreateExplicitChannel("test", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache());

--- a/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
@@ -1,23 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO.Compression;
-using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.TestServices;
 
 namespace Aspire.Cli.Tests.Packaging;
 
 public class PackageChannelTests
 {
-    private sealed class FakeNuGetPackageCache : INuGetPackageCache
-    {
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-    }
-
     [Fact]
     public void SourceDetails_ImplicitChannel_ReturnsBasedOnNuGetConfig()
     {
@@ -106,107 +97,5 @@ public class PackageChannelTests
         // Assert
         Assert.Equal(PackagingStrings.BasedOnNuGetConfig, channel.SourceDetails);
         Assert.Equal(PackageChannelType.Explicit, channel.Type);
-    }
-
-    [Fact]
-    public void CreateScopedChannelForPackage_PrHiveExpandsToTransitivePackagesInHive()
-    {
-        var cache = new FakeNuGetPackageCache();
-        var tempDir = Directory.CreateTempSubdirectory();
-        try
-        {
-            CreatePackage(tempDir.FullName, "Aspire.Hosting.Redis", "13.3.0-pr.16125.g5bef2f2f", "Aspire.Hosting");
-            CreatePackage(tempDir.FullName, "Aspire.Hosting", "13.3.0-pr.16125.g5bef2f2f");
-            CreatePackage(tempDir.FullName, "Aspire.Hosting.AppHost", "13.3.0-pr.16125.g5bef2f2f");
-
-            var mappings = new[]
-            {
-                new PackageMapping("Aspire*", tempDir.FullName.Replace('\\', '/')),
-                new PackageMapping("*", "https://api.nuget.org/v3/index.json")
-            };
-
-            var channel = PackageChannel.CreateExplicitChannel("pr-16125", PackageChannelQuality.Prerelease, mappings, cache);
-
-            var scopedChannel = channel.CreateScopedChannelForPackage("Aspire.Hosting.Redis");
-
-            var packageFilters = scopedChannel.Mappings!.Select(mapping => mapping.PackageFilter).ToArray();
-            Assert.Contains("Aspire.Hosting.Redis", packageFilters);
-            Assert.Contains("Aspire.Hosting", packageFilters);
-            Assert.DoesNotContain("Aspire.Hosting.AppHost", packageFilters);
-            Assert.Contains("*", packageFilters);
-            Assert.DoesNotContain("Aspire*", packageFilters);
-        }
-        finally
-        {
-            tempDir.Delete(recursive: true);
-        }
-    }
-
-    [Fact]
-    public void CreateScopedChannelForPackages_PrHiveIncludesExplicitRootPackages()
-    {
-        var cache = new FakeNuGetPackageCache();
-        var tempDir = Directory.CreateTempSubdirectory();
-        try
-        {
-            CreatePackage(tempDir.FullName, "Aspire.Hosting.Redis", "13.3.0-pr.16125.g5bef2f2f", "Aspire.Hosting");
-            CreatePackage(tempDir.FullName, "Aspire.Hosting", "13.3.0-pr.16125.g5bef2f2f");
-            CreatePackage(tempDir.FullName, "Aspire.AppHost.Sdk", "13.3.0-pr.16125.g5bef2f2f");
-            CreatePackage(tempDir.FullName, "Aspire.Hosting.AppHost", "13.3.0-pr.16125.g5bef2f2f");
-
-            var mappings = new[]
-            {
-                new PackageMapping("Aspire*", tempDir.FullName.Replace('\\', '/')),
-                new PackageMapping("*", "https://api.nuget.org/v3/index.json")
-            };
-
-            var channel = PackageChannel.CreateExplicitChannel("pr-16125", PackageChannelQuality.Prerelease, mappings, cache);
-
-            var scopedChannel = channel.CreateScopedChannelForPackages(["Aspire.Hosting.Redis", "Aspire.AppHost.Sdk"]);
-
-            var packageFilters = scopedChannel.Mappings!.Select(mapping => mapping.PackageFilter).ToArray();
-            Assert.Contains("Aspire.Hosting.Redis", packageFilters);
-            Assert.Contains("Aspire.Hosting", packageFilters);
-            Assert.Contains("Aspire.AppHost.Sdk", packageFilters);
-            Assert.DoesNotContain("Aspire.Hosting.AppHost", packageFilters);
-            Assert.Contains("*", packageFilters);
-            Assert.DoesNotContain("Aspire*", packageFilters);
-        }
-        finally
-        {
-            tempDir.Delete(recursive: true);
-        }
-    }
-
-    private static void CreatePackage(string directory, string packageId, string version, params string[] dependencies)
-    {
-        var packagePath = Path.Combine(directory, $"{packageId}.{version}.nupkg");
-        using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
-        var nuspecEntry = archive.CreateEntry($"{packageId}.nuspec");
-        using var writer = new StreamWriter(nuspecEntry.Open());
-
-        writer.Write($$"""
-            <?xml version="1.0" encoding="utf-8"?>
-            <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
-              <metadata>
-                <id>{{packageId}}</id>
-                <version>{{version}}</version>
-                <dependencies>
-            """);
-
-        foreach (var dependency in dependencies)
-        {
-            writer.Write($$"""
-                    <group targetFramework="net10.0">
-                      <dependency id="{{dependency}}" version="[{{version}}]" />
-                    </group>
-                """);
-        }
-
-        writer.Write("""
-                </dependencies>
-              </metadata>
-            </package>
-            """);
     }
 }

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -15,14 +15,6 @@ namespace Aspire.Cli.Tests.Packaging;
 public class PackagingServiceTests(ITestOutputHelper outputHelper)
 {
 
-    private sealed class FakeNuGetPackageCache : INuGetPackageCache
-    {
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-    }
-
     [Fact]
     public async Task GetChannelsAsync_WhenStagingChannelDisabled_DoesNotIncludeStagingChannel()
     {

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -6,14 +6,12 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Xml.Linq;
 using Aspire.Cli.Configuration;
-using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Utils;
 using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
-using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -33,7 +31,7 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
     {
         appPath ??= _workspace.WorkspaceRoot.FullName;
         var runner = new TestDotNetCliRunner();
-        var packagingService = new MockPackagingService();
+        var packagingService = MockPackagingServiceFactory.Create();
         var configurationService = new TestConfigurationService();
         var logger = NullLogger<DotNetBasedAppHostServerProject>.Instance;
 
@@ -279,9 +277,31 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         };
 
         // Create a packaging service that returns explicit channels for both PR hives
-        var packagingService = new MockPackagingServiceWithExplicitChannels(
-            prOldHive.FullName,
-            prNewHive.FullName);
+        var prOldHivePath = prOldHive.FullName;
+        var prNewHivePath = prNewHive.FullName;
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                var nugetCache = new FakeNuGetPackageCache();
+
+                var prOldChannel = PackageChannel.CreateExplicitChannel("pr-old", PackageChannelQuality.Prerelease, new[]
+                {
+                    new PackageMapping("Aspire*", prOldHivePath),
+                    new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
+                }, nugetCache);
+
+                var prNewChannel = PackageChannel.CreateExplicitChannel("pr-new", PackageChannelQuality.Prerelease, new[]
+                {
+                    new PackageMapping("Aspire*", prNewHivePath),
+                    new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
+                }, nugetCache);
+
+                var implicitChannel = PackageChannel.CreateImplicitChannel(nugetCache);
+
+                return Task.FromResult<IEnumerable<PackageChannel>>(new[] { implicitChannel, prOldChannel, prNewChannel });
+            }
+        };
 
         var runner = new TestDotNetCliRunner();
         
@@ -337,59 +357,6 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         Assert.NotNull(restoreSources);
         Assert.Contains(prNewHive.FullName, restoreSources);
         Assert.DoesNotContain(prOldHive.FullName, restoreSources);
-    }
-
-    /// <summary>
-    /// Mock packaging service that returns explicit PR channels with specific hive paths.
-    /// Used to test that the correct channel is selected based on project-local settings.
-    /// </summary>
-    private sealed class MockPackagingServiceWithExplicitChannels : IPackagingService
-    {
-        private readonly string _prOldHivePath;
-        private readonly string _prNewHivePath;
-
-        public MockPackagingServiceWithExplicitChannels(string prOldHivePath, string prNewHivePath)
-        {
-            _prOldHivePath = prOldHivePath;
-            _prNewHivePath = prNewHivePath;
-        }
-
-        public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default)
-        {
-            var nugetCache = new FakeNuGetPackageCache();
-
-            // Create explicit channels for both PR hives
-            var prOldChannel = PackageChannel.CreateExplicitChannel("pr-old", PackageChannelQuality.Prerelease, new[]
-            {
-                new PackageMapping("Aspire*", _prOldHivePath),
-                new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-            }, nugetCache);
-
-            var prNewChannel = PackageChannel.CreateExplicitChannel("pr-new", PackageChannelQuality.Prerelease, new[]
-            {
-                new PackageMapping("Aspire*", _prNewHivePath),
-                new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-            }, nugetCache);
-
-            var implicitChannel = PackageChannel.CreateImplicitChannel(nugetCache);
-
-            return Task.FromResult<IEnumerable<PackageChannel>>(new[] { implicitChannel, prOldChannel, prNewChannel });
-        }
-    }
-
-    private sealed class FakeNuGetPackageCache : INuGetPackageCache
-    {
-        public Task<IEnumerable<NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-            => Task.FromResult<IEnumerable<NuGetPackageCli>>([]);
-
-        public Task<IEnumerable<NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-            => Task.FromResult<IEnumerable<NuGetPackageCli>>([]);
-
-        public Task<IEnumerable<NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-            => Task.FromResult<IEnumerable<NuGetPackageCli>>([]);
-
-        public Task<IEnumerable<NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-            => Task.FromResult<IEnumerable<NuGetPackageCli>>([]);
     }
 
     private static void DumpDirectoryTree(string path, ITestOutputHelper output, string indent = "")

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -158,17 +158,17 @@ public class ExtensionGuestLauncherTests
         public ConsoleOutput Console { get; set; }
         public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false) => throw new NotImplementedException();
         public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false) => throw new NotImplementedException();
-        public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, Spectre.Console.ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, Spectre.Console.ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull => throw new NotImplementedException();
-        public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull => throw new NotImplementedException();
+        public Task<string> PromptForStringAsync(string promptText, Func<string, Spectre.Console.ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<string> PromptForFilePathAsync(string promptText, Func<string, Spectre.Console.ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull => throw new NotImplementedException();
+        public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull => throw new NotImplementedException();
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => throw new NotImplementedException();
         public void DisplayError(string errorMessage) => throw new NotImplementedException();
         public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplaySuccess(string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) => throw new NotImplementedException();
         public void DisplayCancellationMessage() => throw new NotImplementedException();
-        public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DisplaySubtleMessage(string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplayEmptyLine() => throw new NotImplementedException();
         public void DisplayPlainText(string text) => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -168,7 +168,7 @@ public class ExtensionGuestLauncherTests
         public void DisplaySuccess(string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) => throw new NotImplementedException();
         public void DisplayCancellationMessage() => throw new NotImplementedException();
-        public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DisplaySubtleMessage(string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplayEmptyLine() => throw new NotImplementedException();
         public void DisplayPlainText(string text) => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -164,7 +164,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             nugetService,
             new TestDotNetCliRunner(),
             new TestDotNetSdkInstaller(),
-            new Aspire.Cli.Tests.Mcp.MockPackagingService(),
+            Aspire.Cli.Tests.Mcp.MockPackagingServiceFactory.Create(),
             new TestConfigurationService(),
             Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
 
@@ -218,7 +218,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             nugetService,
             new TestDotNetCliRunner(),
             new TestDotNetSdkInstaller(),
-            new Aspire.Cli.Tests.Mcp.MockPackagingService(),
+            Aspire.Cli.Tests.Mcp.MockPackagingServiceFactory.Create(),
             configurationService,
             Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
 

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -126,7 +126,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         // If this throws then it means that the updater prompted
         // for confirmation to do an update when no update was required!
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
         Assert.False(updateResult.UpdatedApplied);
     }
 
@@ -238,7 +238,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         // If this throws then it means that the updater prompted
         // for confirmation to do an update when no update was required!
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
         // Note: Aspire.Hosting.AppHost is not updated because it's removed during SDK migration
@@ -377,7 +377,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         // If this throws then it means that the updater prompted
         // for confirmation to do an update when no update was required!
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
         // Note: Aspire.Hosting.AppHost is not updated because it's removed during SDK migration
@@ -497,7 +497,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
         // Should NOT throw even though Aspire.Hosting.ThirdParty is not in the channel.
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
         // Aspire.Hosting.Redis should still be updated; Aspire.Hosting.ThirdParty should be skipped with a warning.
@@ -641,7 +641,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -784,7 +784,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -889,7 +889,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -992,7 +992,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.False(updateResult.UpdatedApplied);
 
@@ -1000,6 +1000,15 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var content = await File.ReadAllTextAsync(directoryPackagesPropsFile.FullName);
         Assert.DoesNotContain("Aspire.Hosting.Redis", content);
     }
+
+    private static UpdatePackagesContext CreateUpdateContext(FileInfo appHostFile, PackageChannel channel) =>
+        new()
+        {
+            AppHostFile = appHostFile,
+            Channel = channel,
+            ConfirmBinding = PromptBinding.CreateDefault(true),
+            NuGetConfigDirBinding = PromptBinding.CreateDefault<string?>(null),
+        };
 
     private static Aspire.Cli.CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
     {
@@ -1135,7 +1144,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -1258,7 +1267,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -1376,7 +1385,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         // This should throw a ProjectUpdaterException
         var exception = await Assert.ThrowsAsync<ProjectUpdaterException>(async () =>
         {
-            await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+            await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
         });
 
         Assert.Contains("Unable to resolve MSBuild property 'InvalidVersionProperty' to a valid semantic version", exception.Message);
@@ -1486,7 +1495,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         // This should throw a ProjectUpdaterException
         var exception = await Assert.ThrowsAsync<ProjectUpdaterException>(async () =>
         {
-            await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+            await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
         });
 
         Assert.Contains("Unable to resolve MSBuild property 'NonExistentProperty' to a valid semantic version", exception.Message);
@@ -1581,7 +1590,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = new ProjectUpdater(logger, runner, interactionService, cache, executionContext, fallbackParser);
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         // Should not throw ProjectUpdaterException; should produce update steps including AppHost SDK
         Assert.True(updateResult.UpdatedApplied);
@@ -1683,7 +1692,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = new ProjectUpdater(logger, runner, interactionService, cache, executionContext, fallbackParser);
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         // Should discover package reference (version may be absent) and not crash
         Assert.True(updateResult.UpdatedApplied);
@@ -1765,7 +1774,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
         // Should throw ProjectUpdaterException due to invalid XML
         await Assert.ThrowsAsync<ProjectUpdaterException>(() =>
-            projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout());
+            projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout());
     }
 
     [Fact]
@@ -1844,7 +1853,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = new ProjectUpdater(logger, runner, interactionService, cache, executionContext, fallbackParser);
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         // Normal path unaffected - no updates needed since version is already current
         Assert.False(updateResult.UpdatedApplied);
@@ -1923,7 +1932,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = new ProjectUpdater(logger, runner, interactionService, cache, executionContext, fallbackParser);
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -2006,7 +2015,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = new ProjectUpdater(logger, runner, interactionService, cache, executionContext, fallbackParser);
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -2096,7 +2105,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var projectUpdater = new ProjectUpdater(logger, runner, interactionService, cache, executionContext, fallbackParser);
 
         // This should not throw and should handle the * version gracefully
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
     }
@@ -2169,7 +2178,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -2248,7 +2257,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 
@@ -2339,7 +2348,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         // Both packages should be updated - range expression is treated like wildcard
         Assert.True(updateResult.UpdatedApplied);
@@ -2472,7 +2481,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var selectedChannel = channels.Single(c => c.Name == "default");
 
         var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
-        var updateResult = await projectUpdater.UpdateProjectAsync(appHostProjectFile, selectedChannel).DefaultTimeout();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
 
         Assert.True(updateResult.UpdatedApplied);
 

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -427,7 +427,7 @@ public class DotNetTemplateFactoryTests
         public Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<bool> ConfirmAsync(string prompt, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
+        public Task<bool> PromptConfirmAsync(string prompt, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public Task<TResult> ShowStatusAsync<TResult>(string message, Func<Task<TResult>> work, KnownEmoji? emoji = null, bool allowMarkup = false)

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine;
 using Microsoft.AspNetCore.InternalTesting;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
@@ -9,7 +10,6 @@ using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Tests.Telemetry;
@@ -29,26 +29,6 @@ public class DotNetTemplateFactoryTests
     public DotNetTemplateFactoryTests(ITestOutputHelper outputHelper)
     {
         _outputHelper = outputHelper;
-    }
-
-    private sealed class FakeNuGetPackageCache : INuGetPackageCache
-    {
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            _ = workingDirectory; _ = prerelease; _ = nugetConfigFile; _ = cancellationToken; return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        }
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            _ = workingDirectory; _ = prerelease; _ = nugetConfigFile; _ = cancellationToken; return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        }
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        {
-            _ = workingDirectory; _ = prerelease; _ = nugetConfigFile; _ = cancellationToken; return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        }
-        public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-        {
-            _ = workingDirectory; _ = packageId; _ = filter; _ = prerelease; _ = nugetConfigFile; _ = useCache; _ = cancellationToken; return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>([]);
-        }
     }
 
     private static PackageChannel CreateExplicitChannel(PackageMapping[] mappings) =>
@@ -435,19 +415,19 @@ public class DotNetTemplateFactoryTests
     {
         public ConsoleOutput Console { get; set; }
 
-        public Task<T> PromptForSelectionAsync<T>(string prompt, IEnumerable<T> choices, Func<T, string> displaySelector, CancellationToken cancellationToken) where T : notnull
+        public Task<T> PromptForSelectionAsync<T>(string prompt, IEnumerable<T> choices, Func<T, string> displaySelector, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
             => throw new NotImplementedException();
 
-        public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+        public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
             => throw new NotImplementedException();
 
-        public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+        public Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
+        public Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<bool> ConfirmAsync(string prompt, bool defaultAnswer, CancellationToken cancellationToken)
+        public Task<bool> ConfirmAsync(string prompt, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public Task<TResult> ShowStatusAsync<TResult>(string message, Func<Task<TResult>> work, KnownEmoji? emoji = null, bool allowMarkup = false)
@@ -528,18 +508,12 @@ public class DotNetTemplateFactoryTests
             => Task.FromResult(new EnsureCertificatesTrustedResult { EnvironmentVariables = new Dictionary<string, string>() });
     }
 
-    private sealed class TestPackagingService : IPackagingService
-    {
-        public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken)
-            => throw new NotImplementedException();
-    }
-
     private sealed class TestNewCommandPrompter : INewCommandPrompter, ITemplateVersionPrompter
     {
-        public Task<string> PromptForProjectNameAsync(string defaultName, CancellationToken cancellationToken)
+        public Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<string> PromptForOutputPath(string defaultPath, CancellationToken cancellationToken)
+        public Task<string> PromptForOutputPath(string defaultPath, ParseResult parseResult, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
         public Task<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> PromptForTemplatesVersionAsync(IEnumerable<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> packages, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/TestServices/FakeNuGetPackageCache.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeNuGetPackageCache.cs
@@ -8,14 +8,21 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class FakeNuGetPackageCache : INuGetPackageCache
 {
+    public Func<DirectoryInfo, bool, FileInfo?, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetTemplatePackagesAsyncCallback { get; set; }
+    public Func<DirectoryInfo, bool, FileInfo?, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetIntegrationPackagesAsyncCallback { get; set; }
+    public Func<DirectoryInfo, bool, FileInfo?, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetCliPackagesAsyncCallback { get; set; }
+
     public Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        => Task.FromResult<IEnumerable<NuGetPackage>>([]);
+        => GetTemplatePackagesAsyncCallback?.Invoke(workingDirectory, prerelease, nugetConfigFile, cancellationToken)
+           ?? Task.FromResult<IEnumerable<NuGetPackage>>([]);
 
     public Task<IEnumerable<NuGetPackage>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        => Task.FromResult<IEnumerable<NuGetPackage>>([]);
+        => GetIntegrationPackagesAsyncCallback?.Invoke(workingDirectory, prerelease, nugetConfigFile, cancellationToken)
+           ?? Task.FromResult<IEnumerable<NuGetPackage>>([]);
 
     public Task<IEnumerable<NuGetPackage>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-        => Task.FromResult<IEnumerable<NuGetPackage>>([]);
+        => GetCliPackagesAsyncCallback?.Invoke(workingDirectory, prerelease, nugetConfigFile, cancellationToken)
+           ?? Task.FromResult<IEnumerable<NuGetPackage>>([]);
 
     public Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
         => Task.FromResult<IEnumerable<NuGetPackage>>([]);

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -121,7 +121,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     {
     }
 
-    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
+    public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
         return Task.FromResult(true);
     }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -35,17 +35,17 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         action();
     }
 
-    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+    public Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(defaultValue ?? string.Empty);
+        return Task.FromResult(binding?.DefaultValue ?? string.Empty);
     }
 
-    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
+    public Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
-        return PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
+        return PromptForStringAsync(promptText, validator, isSecret: false, required, binding, cancellationToken);
     }
 
-    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
         if (!choices.Any())
         {
@@ -55,7 +55,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
         if (!choices.Any())
         {
@@ -121,7 +121,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     {
     }
 
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
+    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
         return Task.FromResult(true);
     }

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -67,9 +67,15 @@ internal sealed class TestInteractionService : IInteractionService
         action();
     }
 
-    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+    public Task<string> PromptForStringAsync(string promptText, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
-        StringPromptCalls.Add(new StringPromptCall(promptText, defaultValue, isSecret));
+        var (wasProvided, value, _) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            return Task.FromResult(value);
+        }
+
+        StringPromptCalls.Add(new StringPromptCall(promptText, binding?.DefaultValue, isSecret));
 
         if (_shouldCancel || cancellationToken.IsCancellationRequested)
         {
@@ -81,16 +87,27 @@ internal sealed class TestInteractionService : IInteractionService
             return Task.FromResult(response.Response);
         }
 
-        return Task.FromResult(defaultValue ?? string.Empty);
+        return Task.FromResult(binding?.DefaultValue ?? string.Empty);
     }
 
-    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
+    public Task<string> PromptForFilePathAsync(string promptText, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default)
     {
-        return PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
+        return PromptForStringAsync(promptText, validator, isSecret: false, required, binding, cancellationToken);
     }
 
-    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
+        var (wasProvided, value, _) = PromptBinding.Resolve(binding);
+        if (wasProvided && value is not null)
+        {
+            var match = choices.FirstOrDefault(c => string.Equals(choiceFormatter(c), value, StringComparison.OrdinalIgnoreCase))
+                ?? choices.FirstOrDefault(c => string.Equals(c.ToString(), value, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                return Task.FromResult(match);
+            }
+        }
+
         if (_shouldCancel || cancellationToken.IsCancellationRequested)
         {
             throw new OperationCanceledException();
@@ -119,7 +136,7 @@ internal sealed class TestInteractionService : IInteractionService
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
     {
         if (_shouldCancel || cancellationToken.IsCancellationRequested)
         {
@@ -175,8 +192,15 @@ internal sealed class TestInteractionService : IInteractionService
     {
     }
 
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
+    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
+        var (wasProvided, value, _) = PromptBinding.Resolve(binding);
+        if (wasProvided)
+        {
+            return Task.FromResult(value);
+        }
+
+        var defaultValue = binding?.DefaultValue ?? false;
         BooleanPromptCalls.Add(new BooleanPromptCall(promptText, defaultValue));
 
         if (_shouldCancel || cancellationToken.IsCancellationRequested)

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -192,7 +192,7 @@ internal sealed class TestInteractionService : IInteractionService
     {
     }
 
-    public Task<bool> ConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
+    public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
         var (wasProvided, value, _) = PromptBinding.Resolve(binding);
         if (wasProvided)

--- a/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Packaging;
+using Aspire.Cli.Templating;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestNewCommandPrompter(IInteractionService interactionService) : NewCommandPrompter(interactionService)
+{
+    public Func<IEnumerable<(NuGetPackage Package, PackageChannel Channel)>, (NuGetPackage Package, PackageChannel Channel)>? PromptForTemplatesVersionCallback { get; set; }
+    public Func<ITemplate[], ITemplate>? PromptForTemplateCallback { get; set; }
+    public Func<string, string>? PromptForProjectNameCallback { get; set; }
+    public Func<string, string>? PromptForOutputPathCallback { get; set; }
+
+    public override Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken)
+    {
+        return PromptForTemplateCallback switch
+        {
+            { } callback => Task.FromResult(callback(validTemplates)),
+            _ => Task.FromResult(validTemplates[0]) // If no callback is provided just accept the first template.
+        };
+    }
+
+    public override Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        return PromptForProjectNameCallback switch
+        {
+            { } callback => Task.FromResult(callback(defaultName)),
+            _ => Task.FromResult(defaultName) // If no callback is provided just accept the default.
+        };
+    }
+
+    public override Task<string> PromptForOutputPath(string path, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        return PromptForOutputPathCallback switch
+        {
+            { } callback => Task.FromResult(callback(path)),
+            _ => Task.FromResult(path) // If no callback is provided just accept the default.
+        };
+    }
+
+    public override Task<(NuGetPackage Package, PackageChannel Channel)> PromptForTemplatesVersionAsync(IEnumerable<(NuGetPackage Package, PackageChannel Channel)> candidatePackages, CancellationToken cancellationToken)
+    {
+        return PromptForTemplatesVersionCallback switch
+        {
+            { } callback => Task.FromResult(callback(candidatePackages)),
+            _ => Task.FromResult(candidatePackages.First()) // If no callback is provided just accept the first package.
+        };
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
@@ -7,7 +7,7 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestPackagingService : IPackagingService
 {
-    public Func<CancellationToken, Task<IEnumerable<PackageChannel>>>? GetChannelsAsyncCallback { get; init; }
+    public Func<CancellationToken, Task<IEnumerable<PackageChannel>>>? GetChannelsAsyncCallback { get; set; }
 
     public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default)
     {
@@ -16,6 +16,8 @@ internal sealed class TestPackagingService : IPackagingService
             return GetChannelsAsyncCallback(cancellationToken);
         }
 
-        return Task.FromResult(Enumerable.Empty<PackageChannel>());
+        // Default: Return a fake channel with template packages
+        var testChannel = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache());
+        return Task.FromResult<IEnumerable<PackageChannel>>(new[] { testChannel });
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestScaffoldingService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestScaffoldingService.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Scaffolding;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestScaffoldingService : IScaffoldingService
+{
+    public Func<ScaffoldContext, CancellationToken, Task<bool>>? ScaffoldAsyncCallback { get; set; }
+
+    public Task<bool> ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
+    {
+        if (ScaffoldAsyncCallback is not null)
+        {
+            return ScaffoldAsyncCallback(context, cancellationToken);
+        }
+
+        return Task.FromResult(true);
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestTypeScriptStarterProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestTypeScriptStarterProjectFactory.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Projects;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestTypeScriptStarterProjectFactory(Func<DirectoryInfo, CancellationToken, Task<bool>> buildAndGenerateSdkAsync) : IAppHostProjectFactory
+{
+    private readonly TestTypeScriptStarterProject _project = new(buildAndGenerateSdkAsync);
+
+    public IAppHostProject GetProject(LanguageInfo language)
+    {
+        ArgumentNullException.ThrowIfNull(language);
+
+        if (!string.Equals(language.LanguageId, KnownLanguageId.TypeScript, StringComparison.Ordinal))
+        {
+            throw new NotSupportedException($"No handler available for language '{language.LanguageId}'.");
+        }
+
+        return _project;
+    }
+
+    public IAppHostProject? TryGetProject(FileInfo appHostFile)
+    {
+        return appHostFile.Name.Equals("apphost.ts", StringComparison.OrdinalIgnoreCase) ? _project : null;
+    }
+
+    public IAppHostProject GetProject(FileInfo appHostFile)
+    {
+        return TryGetProject(appHostFile) ?? throw new NotSupportedException($"No handler available for AppHost file '{appHostFile.Name}'.");
+    }
+}
+
+internal sealed class TestTypeScriptStarterProject(Func<DirectoryInfo, CancellationToken, Task<bool>> buildAndGenerateSdkAsync) : IAppHostProject, IGuestAppHostSdkGenerator
+{
+    public bool IsUnsupported { get; set; }
+
+    public string LanguageId => KnownLanguageId.TypeScript;
+
+    public string DisplayName => "TypeScript (Node.js)";
+
+    public string? AppHostFileName => "apphost.ts";
+
+    public Task<string[]> GetDetectionPatternsAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<string[]>(["apphost.ts"]);
+    }
+
+    public bool CanHandle(FileInfo appHostFile)
+    {
+        return appHostFile.Name.Equals("apphost.ts", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool IsUsingProjectReferences(FileInfo appHostFile)
+    {
+        return false;
+    }
+
+    public Task<int> RunAsync(AppHostProjectContext context, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int> PublishAsync(PublishContext context, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new AppHostValidationResult(IsValid: CanHandle(appHostFile)));
+    }
+
+    public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(RunningInstanceResult.NoRunningInstance);
+    }
+
+    public Task<string?> GetUserSecretsIdAsync(FileInfo appHostFile, bool autoInit, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<string?>(null);
+    }
+
+    public Task<IReadOnlyList<(string PackageId, string Version)>> GetPackageReferencesAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> BuildAndGenerateSdkAsync(DirectoryInfo directory, CancellationToken cancellationToken)
+    {
+        return buildAndGenerateSdkAsync(directory, cancellationToken);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -26,8 +26,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         {
             configure.NuGetPackageCacheFactory = (sp) =>
             {
-                var cache = new TestNuGetPackageCache();
-                cache.SetMockCliPackages([
+                var cache = new FakeNuGetPackageCache { GetCliPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([
                     // Should be ignored because it's lower than current prerelease version.
                     new NuGetPackage { Id = "Aspire.Cli", Version = "9.3.1", Source = "nuget.org" },
 
@@ -36,9 +35,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
 
                     // Should be ignored because it is lower than 9.4.0-dev (dev and preview sort using alpha).
                     new NuGetPackage { Id = "Aspire.Cli", Version = "9.4.0-beta", Source = "nuget.org" }
-                ]);
-
-                return cache;
+                ]) }; return cache;
             };
 
             configure.InteractionServiceFactory = (sp) =>
@@ -84,16 +81,13 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         {
             configure.NuGetPackageCacheFactory = (sp) =>
             {
-                var cache = new TestNuGetPackageCache();
-                cache.SetMockCliPackages([
+                var cache = new FakeNuGetPackageCache { GetCliPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([
                     // Should be selected because stable sorts higher than preview.
                     new NuGetPackage { Id = "Aspire.Cli", Version = "9.4.0", Source = "nuget.org" },
 
                     // Should be ignored because its prerelease but in a higher version family.
                     new NuGetPackage { Id = "Aspire.Cli", Version = "9.5.0-preview", Source = "nuget.org" },
-                ]);
-
-                return cache;
+                ]) }; return cache;
             };
 
             configure.InteractionServiceFactory = (sp) =>
@@ -139,16 +133,13 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         {
             configure.NuGetPackageCacheFactory = (sp) =>
             {
-                var cache = new TestNuGetPackageCache();
-                cache.SetMockCliPackages([
+                var cache = new FakeNuGetPackageCache { GetCliPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([
                     // Should be ignored because its stable in a higher version family.
                     new NuGetPackage { Id = "Aspire.Cli", Version = "9.5.0", Source = "nuget.org" }, 
 
                     // Should be ignored because its prerelease but in a (even) higher version family.
                     new NuGetPackage { Id = "Aspire.Cli", Version = "9.6.0-preview", Source = "nuget.org" },
-                ]);
-
-                return cache;
+                ]) }; return cache;
             };
 
             configure.InteractionServiceFactory = (sp) =>
@@ -193,13 +184,10 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         {
             configure.NuGetPackageCacheFactory = (sp) =>
             {
-                var cache = new TestNuGetPackageCache();
-                cache.SetMockCliPackages([
+                var cache = new FakeNuGetPackageCache { GetCliPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([
                     new NuGetPackage { Id = "Aspire.Cli", Version = "9.4.0-preview", Source = "nuget.org" },
                     new NuGetPackage { Id = "Aspire.Cli", Version = "9.5.0-preview", Source = "nuget.org" },
-                ]);
-
-                return cache;
+                ]) }; return cache;
             };
 
             configure.InteractionServiceFactory = (sp) =>
@@ -239,17 +227,17 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
 
         // Replace the NuGetPackageCache with our test implementation
-        services.AddSingleton<INuGetPackageCache, TestNuGetPackageCache>();
+        var nugetCache = new FakeNuGetPackageCache
+        {
+            GetCliPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([
+                new NuGetPackage { Id = "Aspire.Cli", Version = "9.0.0", Source = "nuget.org" }
+            ])
+        };
+        services.AddSingleton<INuGetPackageCache>(nugetCache);
         services.AddSingleton<ICliUpdateNotifier, CliUpdateNotifier>();
 
         using var provider = services.BuildServiceProvider();
         var service = provider.GetRequiredService<ICliUpdateNotifier>();
-
-        // Mock packages with a newer stable version
-        var nugetCache = provider.GetRequiredService<INuGetPackageCache>() as TestNuGetPackageCache;
-        nugetCache?.SetMockCliPackages([
-            new NuGetPackage { Id = "Aspire.Cli", Version = "9.0.0", Source = "nuget.org" }
-        ]);
 
         // Act & Assert (should not throw)
         await service.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
@@ -264,7 +252,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
 
         // Replace the NuGetPackageCache with our test implementation
-        services.AddSingleton<INuGetPackageCache, TestNuGetPackageCache>();
+        services.AddSingleton<INuGetPackageCache>(new FakeNuGetPackageCache());
         services.AddSingleton<ICliUpdateNotifier, CliUpdateNotifier>();
 
         using var provider = services.BuildServiceProvider();
@@ -281,35 +269,5 @@ internal sealed class CliUpdateNotifierWithPackageVersionOverride(string current
     protected override SemVersion? GetCurrentVersion()
     {
         return SemVersion.Parse(currentVersion, SemVersionStyles.Strict);
-    }
-}
-
-internal sealed class TestNuGetPackageCache : INuGetPackageCache
-{
-    private IEnumerable<NuGetPackage> _cliPackages = [];
-
-    public void SetMockCliPackages(IEnumerable<NuGetPackage> packages)
-    {
-        _cliPackages = packages;
-    }
-
-    public Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(Enumerable.Empty<NuGetPackage>());
-    }
-
-    public Task<IEnumerable<NuGetPackage>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(Enumerable.Empty<NuGetPackage>());
-    }
-
-    public Task<IEnumerable<NuGetPackage>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(_cliPackages);
-    }
-
-    public Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(Enumerable.Empty<NuGetPackage>());
     }
 }


### PR DESCRIPTION
## Description

Add `PromptBinding` infrastructure to centralize non-interactive CLI argument resolution in `IInteractionService` prompt methods.

Instead of each command independently checking CLI args → interactive mode → default → error, the interaction service prompt methods now handle this resolution internally via an optional `PromptBinding` parameter.

### Key changes

- **`PromptBinding<T>`** type with `Resolve()` method and factory methods for `Option` and `Argument` (from `System.CommandLine`)
- **`NonInteractiveException`** caught centrally in `BaseCommand.SetAction` → returns exit code 21
- All 5 `IInteractionService` prompt methods accept an optional `binding` parameter
- **`ConsoleInteractionService`** implements full resolution logic:
  - If CLI arg was explicitly provided → return immediately (even in interactive mode)
  - If non-interactive + binding has default → use default
  - If non-interactive + no default → display error with available values and throw
- **`ExtensionInteractionService`** resolves bindings before delegating to extension or console paths, so CLI args like `--yes` are honored even when running through the VS Code extension
- **`MatchChoice`/`MatchChoices`** helpers for case-insensitive selection matching (supports comma-separated values, "all", "none")
- Error strings added to `InteractionServiceStrings.resx` with XLF translations updated
- All ~48 existing call sites updated to named `cancellationToken:` syntax
- All test `IInteractionService` implementations updated

### Commands with new non-interactive options

- **`aspire update`**: `--yes` / `-y` (auto-confirm prompts), `--nuget-config-dir` (NuGet config directory)
- **`aspire agent init`**: `--workspace-root` (workspace root directory)
- **`aspire new`**: Displays actionable error with available templates when run non-interactively without a template

### `UpdatePackagesContext` bindings

`ConfirmBinding` and `NuGetConfigDirBinding` are `required` on `UpdatePackagesContext` so callers must explicitly provide bindings (with sensible defaults via `PromptBinding.CreateDefault`).

### Test infrastructure

- `ProjectUpdaterTests` uses a `CreateUpdateContext` helper that defaults `ConfirmBinding` to `true` and `NuGetConfigDirBinding` to `null`

This is the infrastructure-only change. Follow-up PRs will adopt `PromptBinding` in specific commands (e.g., `publish`, `add`).

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No