### PR TITLE
Fix Homebrew cask audit livecheck failure

### DIFF
--- a/eng/homebrew/aspire.rb.template
+++ b/eng/homebrew/aspire.rb.template
@@ -11,6 +11,10 @@ cask "aspire" do
   desc "CLI for building observable, production-ready distributed applications"
   homepage "https://aspire.dev/"
 
+  livecheck do
+    skip "ci.dot.net artifact storage has no version index; Aspire release automation manages cask updates"
+  end
+
   binary "aspire"
 
   zap trash: "~/.aspire"


### PR DESCRIPTION
## Description

`brew audit --new --online` runs livecheck to auto-discover the latest version from the download URL. Since ci.dot.net blob storage has no version index, livecheck returns an empty string causing the audit to fail with:

```
Version '13.3.0-preview.1.26215.12' differs from '' retrieved by livecheck.
```

## Changes

Add a `livecheck do skip end` block to the Homebrew cask template to declare that version discovery is managed by the Aspire release pipeline, not by URL scraping.

## Validation

- [x] Ruby syntax check passes
- [x] Internal pipeline `prepare_installers` Homebrew job passes