### PR TITLE
Increase VS Code test download timeout

### DIFF
--- a/extension/.vscode-test.mjs
+++ b/extension/.vscode-test.mjs
@@ -2,8 +2,11 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
+	download: {
+		timeout: 60000
+	},
 	mocha: {
-      ui: 'tdd',
-      timeout: 20000
-    }
+		ui: 'tdd',
+		timeout: 20000
+	}
 });


### PR DESCRIPTION
## Description

Increase the VS Code extension test download timeout.

This gives `@vscode/test-electron` more headroom on slower Windows runners when resolving and downloading VS Code for the extension test job.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
