### PR TITLE
Use libicu-dev in Ubuntu Dockerfiles

### DIFF
--- a/eng/scripts/aspire-pr-container/Dockerfile
+++ b/eng/scripts/aspire-pr-container/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
         docker.io \
         gh \
         git \
-        libicu74 \
+        libicu-dev \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/Shared/Docker/Dockerfile.e2e-polyglot-base
+++ b/tests/Shared/Docker/Dockerfile.e2e-polyglot-base
@@ -51,7 +51,7 @@ FROM ubuntu:24.04 AS runtime
 # Install base tools and Docker CLI.
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
-      ca-certificates curl gpg docker.io git libicu74 && \
+      ca-certificates curl gpg docker.io git libicu-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI (needed by get-aspire-cli-pr.sh to download PR artifacts).


### PR DESCRIPTION
## Description

Replace the hardcoded `libicu74` package with `libicu-dev` in the Ubuntu Dockerfiles used by the E2E polyglot base image and the Aspire PR container image.

This avoids pinning to a distro-specific ICU runtime package and fixes the build failure affecting:

- #16125
- #16224

Validated with local `docker build --no-cache` runs for both Dockerfiles.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
