### PR TITLE
Dispose ServiceProvider in CLI tests

### DIFF
--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -37,7 +37,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
 
         var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
@@ -95,7 +95,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
 
         var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
@@ -134,7 +134,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
 
         var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
@@ -193,7 +193,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
 
         var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
@@ -229,7 +229,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
 
         // If this does not throw then the code is behaving correctly.
@@ -281,7 +281,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
 
         var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
@@ -336,7 +336,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
 
         var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
@@ -391,7 +391,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
 
         var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -20,7 +20,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("add --help");
@@ -85,7 +85,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         var result = command.Parse("add");
@@ -160,7 +160,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         var result = command.Parse("add docker");
@@ -243,7 +243,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         var result = command.Parse("add docker --version 9.2.0");
@@ -324,7 +324,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         var result = command.Parse("add red");
@@ -393,7 +393,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<AddCommand>();
@@ -433,7 +433,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         var result = command.Parse("add");
@@ -509,7 +509,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         var result = command.Parse("add nonexistentpackage");
@@ -562,7 +562,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return mockInteraction;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
         var prompter = new AddCommandPrompter(interactionService);
@@ -610,7 +610,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return mockInteraction;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
         var prompter = new AddCommandPrompter(interactionService);
@@ -658,7 +658,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return mockInteraction;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
         var prompter = new AddCommandPrompter(interactionService);
@@ -733,7 +733,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             };
         });
         
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act - without hives, should automatically select from implicit channel without prompting
         var command = provider.GetRequiredService<AddCommand>();
@@ -801,7 +801,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<AddCommand>();
@@ -906,7 +906,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         // Use "postgre" instead of "postgresql" - should still find it via fuzzy search
@@ -991,7 +991,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         // Use "sql" - should match both PostgreSQL and MySql, but not Redis or RabbitMQ
@@ -1061,7 +1061,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<AddCommand>();
         // Use "azureapp" (Azure AppContainers) - should find Azure.AppContainers via fuzzy search

--- a/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
@@ -35,7 +35,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
             options.CliExecutionContextFactory = _ => CreateExecutionContext(workspace.WorkspaceRoot, homeDirectory);
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("agent init");
 
@@ -73,7 +73,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = _ => interactionService;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("agent init");
 

--- a/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
@@ -571,8 +571,7 @@ public class AgentMcpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var serviceProvider = services.BuildServiceProvider();
-        await using var _ = serviceProvider;
+        using var serviceProvider = services.BuildServiceProvider();
 
         var agentMcpCommand = serviceProvider.GetRequiredService<AgentMcpCommand>();
         var rootCommand = serviceProvider.GetRequiredService<RootCommand>();

--- a/tests/Aspire.Cli.Tests/Commands/ApiCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ApiCommandTests.cs
@@ -18,7 +18,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         {
             options.ApiDocsIndexServiceFactory = _ => new TestApiDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs api");
@@ -35,7 +35,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         {
             options.ApiDocsIndexServiceFactory = _ => new TestApiDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs api list csharp");
@@ -52,7 +52,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         {
             options.ApiDocsIndexServiceFactory = _ => new TestApiDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs api search emulator --language typescript --format json");
@@ -69,7 +69,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         {
             options.ApiDocsIndexServiceFactory = _ => new TestApiDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs api get csharp/aspire.test.package/testtype");
@@ -86,7 +86,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         {
             options.ApiDocsIndexServiceFactory = _ => new TestApiDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs api get missing/id");

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -26,7 +26,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
         {
             options.InteractionServiceFactory = _ => testInteractionService;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse(args);

--- a/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
@@ -15,7 +15,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("cache");
@@ -30,7 +30,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("cache --help");
@@ -51,7 +51,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
         {
             options.PackagesDirectory = packagesDir;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("cache clear");
@@ -72,7 +72,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
         {
             options.PackagesDirectory = packagesDir;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("cache clear");

--- a/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
@@ -14,7 +14,7 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("certs --help");
@@ -29,7 +29,7 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("certs clean --help");
@@ -44,7 +44,7 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("certs trust --help");

--- a/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
@@ -55,7 +55,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
                 options.ConfigurationServiceFactory = _ => new TestConfigurationService();
             });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("config");
@@ -69,7 +69,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("config");
@@ -83,7 +83,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("config set foo bar");
@@ -106,7 +106,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -131,7 +131,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("http://localhost:4321/sitemap-0.xml", docsObject["api"]?["sitemapUrl"]?.ToString());
 
         var reloadedServices = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var reloadedProvider = reloadedServices.BuildServiceProvider();
+        using var reloadedProvider = reloadedServices.BuildServiceProvider();
         var configuration = reloadedProvider.GetRequiredService<IConfiguration>();
 
         Assert.Equal("http://localhost:4321/llms-small.txt", DocsSourceConfiguration.GetLlmsTxtUrl(configuration));
@@ -143,7 +143,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("config set foo.bar baz");
@@ -168,7 +168,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("config set foo.bar.baz hello");
@@ -196,7 +196,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -226,7 +226,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services1 = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider1 = services1.BuildServiceProvider();
+        using var provider1 = services1.BuildServiceProvider();
 
         var command1 = provider1.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -237,7 +237,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         // Create a new service collection to reload config.
         var services2 = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider2 = services2.BuildServiceProvider();
+        using var provider2 = services2.BuildServiceProvider();
 
         var command2 = provider2.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -252,7 +252,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services1 = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider1 = services1.BuildServiceProvider();
+        using var provider1 = services1.BuildServiceProvider();
 
         var command1 = provider1.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -262,7 +262,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, setExitCode);
 
         var services2 = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider2 = services2.BuildServiceProvider();
+        using var provider2 = services2.BuildServiceProvider();
 
         var command2 = provider2.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -277,7 +277,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("config get nonexistent.key");
@@ -291,7 +291,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -316,7 +316,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -345,7 +345,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -377,7 +377,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         {
             options.OutputTextWriter = outputWriter;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -403,7 +403,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         {
             options.OutputTextWriter = outputWriter;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -429,7 +429,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         {
             options.OutputTextWriter = outputWriter;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -451,7 +451,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         {
             options.OutputTextWriter = outputWriter;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -473,7 +473,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
             outputHelper,
             options => options.EnabledFeatures = new[] { "testFeature" }
             );
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Set the feature flag to true
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
@@ -491,7 +491,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => options.DisabledFeatures = new[] { "testFeature" });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Set the feature flag to false
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
@@ -515,7 +515,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
             {
                 confing[$"{KnownFeatures.FeaturePrefix}:testFeature"] = "invalid"; // Set an invalid value
             });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Set the feature flag to an invalid value
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
@@ -533,7 +533,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var rootCommand = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -547,7 +547,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -558,7 +558,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         // Create new service provider to pick up the configuration change
         var newServices = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var newProvider = newServices.BuildServiceProvider();
+        using var newProvider = newServices.BuildServiceProvider();
 
         // Verify the feature flag is enabled
         var featureFlags = newProvider.GetRequiredService<IFeatures>();
@@ -570,7 +570,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Verify the feature flag defaults to false
         var featureFlags = provider.GetRequiredService<IFeatures>();
@@ -582,7 +582,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("config set features:polyglotSupportEnabled true");
@@ -608,7 +608,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -639,7 +639,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -670,7 +670,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
 
@@ -713,7 +713,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         // Loading configuration should succeed after normalizing the corrupted file
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Verify the file was normalized - flat key should be gone, existing nested value preserved
         var json = await File.ReadAllTextAsync(settingsPath);
@@ -746,7 +746,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         // Loading configuration triggers normalization
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // The existing nested value should be preserved; the flat key value should be dropped
         var json = await File.ReadAllTextAsync(settingsPath);

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -28,7 +28,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = _ => testInteractionService;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run");
 
@@ -44,7 +44,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run --help");
@@ -65,7 +65,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"dashboard run {args}");
@@ -78,7 +78,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run --ASPNETCORE_URLS=http://localhost:9999");
@@ -138,7 +138,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
         executionFactory.AssertionCallback = (args, _, _, _) => { capturedArgs = args; };
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run");
 
@@ -158,7 +158,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
         executionFactory.AssertionCallback = (args, _, _, _) => { capturedArgs = args; };
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run");
 
@@ -188,7 +188,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
         executionFactory.AssertionCallback = (args, _, _, _) => { capturedArgs = args; };
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"dashboard run {cliArgs}");
 
@@ -208,7 +208,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
         executionFactory.AssertionCallback = (_, env, _, _) => { capturedEnv = env; };
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run");
 
@@ -229,7 +229,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
         executionFactory.AssertionCallback = (args, _, _, _) => { capturedArgs = args; };
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run --CUSTOM_SETTING=myvalue");
 
@@ -254,7 +254,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
         executionFactory.AssertionCallback = (args, _, _, _) => { capturedArgs = args; };
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run --frontend-url http://localhost:5000 --otlp-grpc-url http://localhost:9317 --otlp-http-url http://localhost:9318 --allow-anonymous --enable-api --config-file-path /my/config.json");
 
@@ -281,7 +281,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace, interactionService: testInteractionService);
         executionFactory.AttemptCallback = (_, _) => (1, null);
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run");
 
@@ -306,7 +306,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
                 StartReturnValue = false
             };
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("dashboard run");
 

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
@@ -21,7 +21,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         using var tempRepo = TemporaryWorkspace.Create(outputHelper);
 
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("deploy --help");
@@ -51,7 +51,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -85,7 +85,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -119,7 +119,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -187,7 +187,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -256,7 +256,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -327,7 +327,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -387,7 +387,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -19,7 +19,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe --help");
@@ -33,7 +33,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe");
@@ -52,7 +52,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"describe --format {format} --help");
@@ -70,7 +70,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"describe --format {format} --help");
@@ -85,7 +85,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe --format invalid");
@@ -100,7 +100,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe --follow --help");
@@ -115,7 +115,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe --watch --help");
@@ -130,7 +130,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resources --help");
@@ -145,7 +145,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe --follow --format json --help");
@@ -160,7 +160,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe myresource --help");
@@ -175,7 +175,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe myresource --follow --format json --help");
@@ -258,7 +258,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
             // Duplicate - identical to the first snapshot
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
@@ -302,7 +302,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
             // Duplicate - identical to the first snapshot
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
@@ -336,7 +336,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
         ], dashboardUrlsState: new DashboardUrlsState
         {
@@ -364,7 +364,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
         ], dashboardUrlsState: new DashboardUrlsState
         {
@@ -395,7 +395,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
             new ResourceSnapshot { Name = "aspire-dashboard", DisplayName = "aspire-dashboard", ResourceType = "Executable", State = "Hidden" },
             new ResourceSnapshot { Name = "hidden-svc", DisplayName = "hidden-svc", ResourceType = "Project", State = "Running", IsHidden = true },
@@ -421,7 +421,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
             new ResourceSnapshot { Name = "aspire-dashboard", DisplayName = "aspire-dashboard", ResourceType = "Executable", State = "Hidden" },
             new ResourceSnapshot { Name = "hidden-svc", DisplayName = "hidden-svc", ResourceType = "Project", State = "Running", IsHidden = true },
@@ -449,7 +449,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
             new ResourceSnapshot { Name = "aspire-dashboard", DisplayName = "aspire-dashboard", ResourceType = "Executable", State = "Hidden" },
         ]);
@@ -474,7 +474,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
             new ResourceSnapshot { Name = "aspire-dashboard", DisplayName = "aspire-dashboard", ResourceType = "Executable", State = "Hidden" },
         ]);
@@ -502,7 +502,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
             new ResourceSnapshot { Name = "aspire-dashboard", DisplayName = "aspire-dashboard", ResourceType = "Executable", State = "Hidden" },
         ]);

--- a/tests/Aspire.Cli.Tests/Commands/DestroyCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DestroyCommandTests.cs
@@ -19,7 +19,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
         using var tempRepo = TemporaryWorkspace.Create(outputHelper);
 
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("destroy --help");
@@ -48,7 +48,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         var result = command.Parse("destroy --apphost invalid.csproj");
@@ -107,7 +107,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         var result = command.Parse("destroy");
@@ -164,7 +164,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         var result = command.Parse("destroy --yes");
@@ -222,7 +222,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         var result = command.Parse($"destroy --output-path {testOutputPath}");

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -19,7 +19,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         using var tempRepo = TemporaryWorkspace.Create(outputHelper);
 
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("do --help");
@@ -75,7 +75,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -128,7 +128,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -181,7 +181,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -239,7 +239,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -271,7 +271,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -322,7 +322,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act - no step argument needed with --list-steps
@@ -373,7 +373,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act - step argument with --list-steps
@@ -428,7 +428,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         var result = command.Parse("do --list-steps");
@@ -486,7 +486,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         var result = command.Parse("do --list-steps");
@@ -501,7 +501,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         using var tempRepo = TemporaryWorkspace.Create(outputHelper);
 
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("do --help");

--- a/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
@@ -18,7 +18,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
         {
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs");
@@ -36,7 +36,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
         {
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs list");
@@ -53,7 +53,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
         {
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs list --format json");
@@ -71,7 +71,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
             options.DocsSearchServiceFactory = _ => new TestDocsSearchService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs search redis");
@@ -89,7 +89,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
             options.DocsSearchServiceFactory = _ => new TestDocsSearchService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs search redis -n 3");
@@ -107,7 +107,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
             options.DocsSearchServiceFactory = _ => new TestDocsSearchService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs search redis --format json");
@@ -124,7 +124,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
         {
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs get redis-integration");
@@ -141,7 +141,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
         {
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs get redis-integration --section \"Getting Started\"");
@@ -185,7 +185,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
         {
             options.DocsIndexServiceFactory = _ => new TestDocsIndexService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("docs get nonexistent-page");

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -14,7 +14,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
         var result = command.Parse("doctor --help");

--- a/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
@@ -25,7 +25,7 @@ public class ExecCommandTests
     {
         using var workspace = TemporaryWorkspace.Create(_outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, _outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var invokeConfiguration = new InvocationConfiguration();
@@ -46,7 +46,7 @@ public class ExecCommandTests
             options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("exec --resource api cmd");
@@ -64,7 +64,7 @@ public class ExecCommandTests
             options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
             options.ProjectLocatorFactory = _ => new MultipleProjectFilesProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("exec --resource api cmd");
@@ -82,7 +82,7 @@ public class ExecCommandTests
             options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
             options.ProjectLocatorFactory = _ => new ProjectFileDoesNotExistLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("exec --resource api cmd");
@@ -99,7 +99,7 @@ public class ExecCommandTests
         {
             options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var invokeConfiguration = new InvocationConfiguration();
@@ -122,7 +122,7 @@ public class ExecCommandTests
         {
             options.ProjectLocatorFactory = _ => new TestProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var invokeConfiguration = new InvocationConfiguration();
@@ -157,7 +157,7 @@ public class ExecCommandTests
                 }
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("exec --apphost test.csproj --resource myresource --command echo");

--- a/tests/Aspire.Cli.Tests/Commands/ExportCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExportCommandTests.cs
@@ -39,7 +39,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         var tracesJson = BuildTracesJson(
             ("apiservice", null, "span001", "GET /api/products", s_testTime, s_testTime.AddMilliseconds(50), false));
 
-        var provider = CreateExportTestServices(workspace, resources,
+        using var provider = CreateExportTestServices(workspace, resources,
             telemetryEndpoints: new Dictionary<string, string>
             {
                 ["/api/telemetry/logs"] = logsJson,
@@ -115,7 +115,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         var customDir = Path.Combine(workspace.WorkspaceRoot.FullName, "custom", "nested");
         var outputPath = Path.Combine(customDir, "my-export.zip");
 
-        var provider = CreateExportTestServices(workspace,
+        using var provider = CreateExportTestServices(workspace,
             resources: [new ResourceInfoJson { Name = "redis", InstanceId = null }],
             telemetryEndpoints: new Dictionary<string, string>
             {
@@ -159,7 +159,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
             options.OutputTextWriter = outputWriter;
             options.DisableAnsi = true;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"export --apphost {appHostProjectPath} --output {outputPath}");
@@ -274,7 +274,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"export --output {outputPath}");
@@ -319,7 +319,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
             ("apiservice", "abc", "span001", "GET /api/products", s_testTime, s_testTime.AddMilliseconds(50), false),
             ("apiservice", "def", "span002", "GET /api/orders", s_testTime.AddSeconds(1), s_testTime.AddSeconds(1).AddMilliseconds(80), false));
 
-        var provider = CreateExportTestServices(workspace, resources,
+        using var provider = CreateExportTestServices(workspace, resources,
             telemetryEndpoints: new Dictionary<string, string>
             {
                 ["/api/telemetry/logs"] = logsJson,
@@ -439,7 +439,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         var filteredTracesJson = BuildTracesJson(
             ("redis", null, "span001", "SET mykey", s_testTime, s_testTime.AddMilliseconds(10), false));
 
-        var provider = CreateExportTestServices(workspace, resources,
+        using var provider = CreateExportTestServices(workspace, resources,
             telemetryEndpoints: new Dictionary<string, string>
             {
                 ["/api/telemetry/logs"] = filteredLogsJson,
@@ -496,7 +496,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         var tracesJson = BuildTracesJson(
             ("apiservice", null, "span001", "GET /api/products", s_testTime, s_testTime.AddMilliseconds(50), false));
 
-        var provider = CreateExportTestServices(workspace, resources,
+        using var provider = CreateExportTestServices(workspace, resources,
             telemetryEndpoints: new Dictionary<string, string>
             {
                 ["/api/telemetry/logs"] = logsJson,
@@ -554,7 +554,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
             ("apiservice", "abc", "span002", "GET /api/products", s_testTime, s_testTime.AddMilliseconds(50), false),
             ("apiservice", "def", "span003", "GET /api/orders", s_testTime.AddSeconds(1), s_testTime.AddSeconds(1).AddMilliseconds(80), false));
 
-        var provider = CreateExportTestServices(workspace, resources,
+        using var provider = CreateExportTestServices(workspace, resources,
             telemetryEndpoints: new Dictionary<string, string>
             {
                 ["/api/telemetry/logs"] = filteredLogsJson,
@@ -603,7 +603,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "export.zip");
 
-        var provider = CreateExportTestServices(workspace,
+        using var provider = CreateExportTestServices(workspace,
             resources: [],
             telemetryEndpoints: new Dictionary<string, string>
             {
@@ -647,7 +647,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "export.zip");
 
-        var provider = CreateExportTestServices(workspace,
+        using var provider = CreateExportTestServices(workspace,
             resources: [],
             telemetryEndpoints: new Dictionary<string, string>
             {
@@ -691,7 +691,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "export.zip");
 
-        var provider = CreateExportTestServices(workspace,
+        using var provider = CreateExportTestServices(workspace,
             resources: [],
             telemetryEndpoints: new Dictionary<string, string>
             {
@@ -733,7 +733,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "export.zip");
 
-        var provider = CreateExportTestServices(workspace,
+        using var provider = CreateExportTestServices(workspace,
             resources: [new ResourceInfoJson { Name = "redis", InstanceId = null }],
             telemetryEndpoints: new Dictionary<string, string>
             {
@@ -770,7 +770,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
             ("redis", null, 9, "Information", "Ready to accept connections", s_testTime));
 
         // CreateExportTestServices sets up a backchannel, but --dashboard-url bypasses it entirely
-        var provider = CreateExportTestServices(workspace, resources,
+        using var provider = CreateExportTestServices(workspace, resources,
             telemetryEndpoints: new Dictionary<string, string>
             {
                 ["/api/telemetry/logs"] = logsJson,
@@ -816,7 +816,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var testInteractionService = new TestInteractionService();
 
-        var provider = CreateExportTestServices(workspace,
+        using var provider = CreateExportTestServices(workspace,
             resources: [],
             telemetryEndpoints: new Dictionary<string, string>(),
             resourceSnapshots:

--- a/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
@@ -18,7 +18,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<ExtensionInternalCommand>();
         
@@ -30,7 +30,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("extension --help");
@@ -44,7 +44,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("extension");
@@ -65,7 +65,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
             options.ProjectLocatorFactory = _ => new SingleProjectFileProjectLocator(projectFile);
             options.OutputTextWriter = capturedOutput;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("extension get-apphosts");
@@ -107,7 +107,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
             options.ProjectLocatorFactory = _ => new MultipleProjectsProjectLocator([projectFile1, projectFile2]);
             options.OutputTextWriter = capturedOutput;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("extension get-apphosts");
@@ -146,7 +146,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         {
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("extension get-apphosts");
@@ -164,7 +164,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         {
             options.ProjectLocatorFactory = _ => new ThrowingProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("extension get-apphosts");
@@ -178,7 +178,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("extension get-apphosts --help");

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -49,7 +49,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var initCommand = serviceProvider.GetRequiredService<InitCommand>();
 
         // Act
@@ -101,7 +101,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var initCommand = serviceProvider.GetRequiredService<InitCommand>();
 
         // Act
@@ -200,7 +200,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var initCommand = serviceProvider.GetRequiredService<InitCommand>();
 
         // Act - Invoke init command
@@ -282,7 +282,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var initCommand = serviceProvider.GetRequiredService<InitCommand>();
 
         // Act - Invoke init command
@@ -378,7 +378,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var initCommand = serviceProvider.GetRequiredService<InitCommand>();
 
         // Act - Invoke init command
@@ -511,7 +511,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<InitCommand>();
         var result = command.Parse("init --channel stable");
@@ -536,7 +536,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 return new TestPackagingServiceWithChannelTracking(_ => { });
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<InitCommand>();
         var result = command.Parse("init --channel invalid-channel");
@@ -585,7 +585,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var initCommand = serviceProvider.GetRequiredService<InitCommand>();
 
         var parseResult = initCommand.Parse("init");
@@ -636,7 +636,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             }
         });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var initCommand = serviceProvider.GetRequiredService<InitCommand>();
 
         var parseResult = initCommand.Parse("init");

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -19,7 +19,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --help");
@@ -121,7 +121,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"logs --tail {tailValue}");
@@ -141,7 +141,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         // Use --help to avoid needing a running AppHost
@@ -158,7 +158,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         // Without --follow and no running AppHost, should succeed (like Unix ps with no processes)
@@ -178,7 +178,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         // Use --help to verify the option is parsed correctly
@@ -197,7 +197,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"logs --format {format} --help");
@@ -212,7 +212,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --format invalid");
@@ -228,7 +228,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --follow --tail 50 --help");
@@ -243,7 +243,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs myresource --follow --tail 100 --format json --help");
@@ -258,7 +258,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         // -f is short for --follow, -n is short for --tail
@@ -373,7 +373,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter);
+        using var provider = CreateLogsTestServices(workspace, outputWriter);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --format json");
@@ -403,7 +403,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
+        using var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs");
@@ -430,7 +430,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter);
+        using var provider = CreateLogsTestServices(workspace, outputWriter);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"logs {resourceName} --format json");
@@ -452,7 +452,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter);
+        using var provider = CreateLogsTestServices(workspace, outputWriter);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --format json --timestamps");
@@ -490,7 +490,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter);
+        using var provider = CreateLogsTestServices(workspace, outputWriter);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --format json");
@@ -529,7 +529,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
+        using var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --timestamps");
@@ -551,7 +551,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
+        using var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs");
@@ -641,7 +641,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServicesWithHidden(workspace, outputWriter);
+        using var provider = CreateLogsTestServicesWithHidden(workspace, outputWriter);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --format json");
@@ -666,7 +666,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServicesWithHidden(workspace, outputWriter);
+        using var provider = CreateLogsTestServicesWithHidden(workspace, outputWriter);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --format json --include-hidden");
@@ -691,7 +691,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServicesWithHidden(workspace, outputWriter);
+        using var provider = CreateLogsTestServicesWithHidden(workspace, outputWriter);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs aspire-dashboard --format json");
@@ -777,7 +777,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
             options.DisableAnsi = false;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --format json");
 
@@ -886,7 +886,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
             options.DisableAnsi = true;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --follow");
 

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -574,7 +574,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(
+        using var provider = CreateLogsTestServices(
             workspace,
             outputWriter,
             disableAnsi: true,
@@ -606,7 +606,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(
+        using var provider = CreateLogsTestServices(
             workspace,
             outputWriter,
             disableAnsi: true,

--- a/tests/Aspire.Cli.Tests/Commands/McpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/McpCommandTests.cs
@@ -15,7 +15,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("mcp");
@@ -30,7 +30,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("mcp --help");
@@ -44,7 +44,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("mcp start --help");
@@ -58,7 +58,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var rootCommand = provider.GetRequiredService<RootCommand>();
         var mcpCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name == "mcp");
@@ -72,7 +72,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var rootCommand = provider.GetRequiredService<RootCommand>();
         var mcpCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name == "mcp");
@@ -88,7 +88,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var rootCommand = provider.GetRequiredService<RootCommand>();
         var mcpCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name == "mcp");
@@ -102,7 +102,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("agent");
@@ -117,7 +117,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("agent --help");
@@ -131,7 +131,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("agent mcp --help");
@@ -145,7 +145,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("agent init --help");
@@ -159,7 +159,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var rootCommand = provider.GetRequiredService<RootCommand>();
         var agentCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name == "agent");
@@ -174,7 +174,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var rootCommand = provider.GetRequiredService<RootCommand>();
         var agentCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name == "agent");
@@ -190,7 +190,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var rootCommand = provider.GetRequiredService<RootCommand>();
         var agentCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name == "agent");

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -31,7 +31,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new --help");
@@ -71,7 +71,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         Assert.NotEmpty(command.Subcommands);
@@ -85,7 +85,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         Assert.NotEmpty(command.Subcommands);
@@ -126,7 +126,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -183,7 +183,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -236,7 +236,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None");
@@ -291,7 +291,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --output notsrc --use-redis-cache --test-framework None");
@@ -369,7 +369,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --channel stable --use-redis-cache --test-framework None");
@@ -446,7 +446,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --channel stable --use-redis-cache --test-framework None");
@@ -504,7 +504,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None");
@@ -558,7 +558,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None --version 9.2.0");
@@ -589,7 +589,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new");
@@ -645,7 +645,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -698,7 +698,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -778,7 +778,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --name TestApp --output .");
@@ -856,7 +856,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -924,7 +924,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             }
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new --name TestApp --output .");
 
@@ -947,7 +947,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
 
         Assert.Contains(command.Subcommands, subcommand => subcommand.Name == "aspire-test");
@@ -998,7 +998,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new --name TestApp --output .");
 
@@ -1053,7 +1053,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             }
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-java-empty --name TestApp --output . --localhost-tld false");
 
@@ -1088,7 +1088,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-empty --name TestApp --output . --localhost-tld false");
@@ -1151,7 +1151,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-empty --name TestApp --output .");
 
@@ -1202,7 +1202,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             }
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-ts-empty --name TestApp --output . --localhost-tld false");
 
@@ -1258,7 +1258,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             }
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         // Do not pass --output so the default "./TestApp" path is used via the prompter
         var result = command.Parse("new aspire-ts-empty --name TestApp --localhost-tld false");
@@ -1355,7 +1355,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             }
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-ts-empty --name TestApp --output .");
 
@@ -1434,7 +1434,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             return Task.FromResult(true);
         }));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-ts-starter --name TestApp --output . --channel daily --localhost-tld false");
 
@@ -1499,7 +1499,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton<IInteractionService>(interactionService);
         services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((directory, cancellationToken) => Task.FromResult(false)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-ts-starter --name TestApp --output . --channel daily --localhost-tld false");
 
@@ -1544,7 +1544,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-empty --name TestApp --output .");
@@ -1601,7 +1601,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -1657,7 +1657,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             }
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-ts-empty --name TestApp --output .");
@@ -1721,7 +1721,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -1789,7 +1789,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -1853,7 +1853,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 return runner;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
@@ -1924,7 +1924,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                     return runner;
                 };
             });
-            var provider = services.BuildServiceProvider();
+            using var provider = services.BuildServiceProvider();
 
             var command = provider.GetRequiredService<RootCommand>();
             var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");

--- a/tests/Aspire.Cli.Tests/Commands/PipelineCommandListStepsTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PipelineCommandListStepsTests.cs
@@ -150,7 +150,7 @@ public partial class PipelineCommandListStepsTests(ITestOutputHelper outputHelpe
 
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
         services.AddSingleton<IAnsiConsole>(console);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         return (provider.GetRequiredService<DoCommand>(), writer);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -18,7 +18,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps --help");
@@ -33,7 +33,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps");
@@ -52,7 +52,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"ps --format {format}");
@@ -70,7 +70,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"ps --format {format}");
@@ -85,7 +85,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps --format invalid");
@@ -135,7 +135,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             options.OutputTextWriter = textWriter;
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps --format json");
@@ -193,7 +193,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             options.OutputTextWriter = textWriter;
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps --format json");
@@ -239,7 +239,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
             options.DisableAnsi = true;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps");
@@ -263,7 +263,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         {
             options.OutputTextWriter = textWriter;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps --format json");
@@ -329,7 +329,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             options.OutputTextWriter = textWriter;
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps --format json --resources");
@@ -391,7 +391,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             options.OutputTextWriter = textWriter;
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ps --format json");
@@ -444,7 +444,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             options.OutputTextWriter = textWriter;
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         // --resources with table format should not fetch resources

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -42,7 +42,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -88,7 +88,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -140,7 +140,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -187,7 +187,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -233,7 +233,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -291,7 +291,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -370,7 +370,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -438,7 +438,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -490,7 +490,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -545,7 +545,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -616,7 +616,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act - use the --debug flag
@@ -660,7 +660,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act
@@ -703,7 +703,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         services.AddSingleton<IInteractionService>(consoleService);
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var command = serviceProvider.GetRequiredService<RootCommand>();
 
         // Act

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
@@ -18,7 +18,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("publish --help");
@@ -45,7 +45,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -76,7 +76,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -107,7 +107,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -150,7 +150,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
@@ -219,7 +219,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -15,7 +15,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource --help");
@@ -30,7 +30,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource");
@@ -45,7 +45,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource myresource");
@@ -60,7 +60,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource myresource my-command --help");
@@ -74,7 +74,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource myresource my-command --apphost /path/to/project.csproj --help");
@@ -88,7 +88,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
 
@@ -113,7 +113,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource myresource start --apphost /path/to/project.csproj --help");

--- a/tests/Aspire.Cli.Tests/Commands/RestoreCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RestoreCommandTests.cs
@@ -33,7 +33,7 @@ public class RestoreCommandTests(ITestOutputHelper outputHelper)
                 }
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"restore --apphost {appHostFile.FullName}");
@@ -68,7 +68,7 @@ public class RestoreCommandTests(ITestOutputHelper outputHelper)
                 }
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"restore --apphost {appHostFile.FullName}");

--- a/tests/Aspire.Cli.Tests/Commands/RootCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RootCommandTests.cs
@@ -17,7 +17,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("--help");
@@ -31,7 +31,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("--nologo --help");
@@ -59,7 +59,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
                 config[CliConfigNames.NoLogo] = value;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var configuration = provider.GetRequiredService<IConfiguration>();
         var isNoLogo = configuration.GetBool(CliConfigNames.NoLogo, defaultValue: false);
@@ -88,7 +88,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.BannerServiceFactory = _ => bannerService;
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, []);
 
@@ -110,7 +110,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
             options.BannerServiceFactory = _ => bannerService;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, []);
 
@@ -132,7 +132,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
             options.BannerServiceFactory = _ => bannerService;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, [CommonOptionNames.NoLogo]);
 
@@ -158,7 +158,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
                 config[CliConfigNames.NoLogo] = "1";
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var configuration = provider.GetRequiredService<IConfiguration>();
         var noLogo = configuration.GetBool(CliConfigNames.NoLogo, defaultValue: false);
@@ -184,7 +184,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
             options.BannerServiceFactory = _ => bannerService;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, [CommonOptionNames.Banner]);
 
@@ -204,7 +204,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
         {
             options.BannerServiceFactory = _ => bannerService;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Invoke multiple times (simulating multiple --banner calls)
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, [CommonOptionNames.Banner]);
@@ -238,7 +238,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
             options.BannerServiceFactory = _ => bannerService;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, [CommonOptionNames.Banner]);
 
@@ -264,7 +264,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.BannerServiceFactory = _ => bannerService;
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, []);
 
@@ -286,7 +286,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
             options.BannerServiceFactory = _ => bannerService;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, []);
 
@@ -310,7 +310,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
             options.BannerServiceFactory = _ => bannerService;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, [flag]);
 
@@ -335,7 +335,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.BannerServiceFactory = _ => bannerService;
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // First invocation with --version: should not create sentinel
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, ["--version"]);
@@ -360,7 +360,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.BannerServiceFactory = _ => bannerService;
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, []);
 
@@ -381,7 +381,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.BannerServiceFactory = _ => bannerService;
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, [CommonOptionNames.Banner]);
 
@@ -393,7 +393,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var hasSetupCommand = command.Subcommands.Any(cmd => cmd.Name == "setup");
@@ -409,7 +409,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
         {
             options.BundleServiceFactory = _ => new TestBundleService(isBundle: true);
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var hasSetupCommand = command.Subcommands.Any(cmd => cmd.Name == "setup");
@@ -425,7 +425,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
         {
             options.BundleServiceFactory = _ => new TestBundleService(isBundle: true);
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
 
@@ -449,7 +449,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
         {
             options.BundleServiceFactory = _ => new TestBundleService(isBundle: true);
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var helpWriter = new StringWriter();

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -27,7 +27,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run --help");
@@ -44,7 +44,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
@@ -61,7 +61,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             options.ProjectLocatorFactory = _ => new MultipleProjectFilesProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
@@ -78,7 +78,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             options.ProjectLocatorFactory = _ => new ProjectFileDoesNotExistLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run --apphost /tmp/doesnotexist.csproj");
@@ -99,7 +99,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
             options.CliUpdateNotifierFactory = _ => testNotifier;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run --detach");
@@ -120,7 +120,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
             options.CliUpdateNotifierFactory = _ => testNotifier;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
@@ -200,7 +200,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.ProjectLocatorFactory = projectLocatorFactory;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
@@ -321,7 +321,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = runnerFactory;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -376,7 +376,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = runnerFactory;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -446,7 +446,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = (sp) => new TestInteractionService();
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -539,7 +539,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -609,7 +609,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -678,7 +678,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         // Pass --start-debug-session to avoid watch mode (which skips build)
         var result = command.Parse("run --start-debug-session");
@@ -741,7 +741,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.EnabledFeatures = [KnownFeatures.DefaultWatchEnabled];
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -800,7 +800,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.EnabledFeatures = [KnownFeatures.DefaultWatchEnabled];
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -859,7 +859,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.DisabledFeatures = [KnownFeatures.DefaultWatchEnabled];
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -918,7 +918,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             // Don't explicitly set the feature flag
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
@@ -938,7 +938,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
 
         var options = new ProcessInvocationOptions();
@@ -988,7 +988,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
 
         var options = new ProcessInvocationOptions();
@@ -1034,7 +1034,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
 
         var options = new ProcessInvocationOptions { Debug = true };
@@ -1084,7 +1084,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
 
         var options = new ProcessInvocationOptions { Debug = false };
@@ -1129,7 +1129,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
 
         var options = new ProcessInvocationOptions { Debug = true };
@@ -1175,7 +1175,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
 
         var options = new ProcessInvocationOptions();
@@ -1221,7 +1221,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
 
         var options = new ProcessInvocationOptions();
@@ -1323,7 +1323,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = runnerFactory;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run --no-build");
 
@@ -1395,7 +1395,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 options.DotNetCliRunnerFactory = runnerFactory;
             });
 
-            var provider = services.BuildServiceProvider();
+            using var provider = services.BuildServiceProvider();
             var command = provider.GetRequiredService<RootCommand>();
             var result = command.Parse("run --isolated");
 
@@ -1456,7 +1456,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.FeatureFlagsFactory = featuresFactory;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run --no-build");
 
@@ -1471,7 +1471,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run -- --custom-arg value");
@@ -1605,7 +1605,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             // without --non-interactive, this would trigger the early return.
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         // Parse with --non-interactive to simulate the child of `aspire start`
         var result = command.Parse("run --non-interactive");

--- a/tests/Aspire.Cli.Tests/Commands/SdkCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkCommandTests.cs
@@ -15,7 +15,7 @@ public class SdkCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk");
@@ -30,7 +30,7 @@ public class SdkCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk --help");

--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -21,7 +21,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump --help");
@@ -43,7 +43,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"sdk dump --format {format}");
@@ -56,7 +56,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump /nonexistent/path/to/integration.csproj");
@@ -71,7 +71,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump @13.2.0");
@@ -86,7 +86,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump Aspire.Hosting.Redis@");
@@ -101,7 +101,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump Aspire.Hosting.Redis@not-a-version!!!");
@@ -116,7 +116,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump some-random-string");
@@ -131,7 +131,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump Aspire.Hosting.Redis@13.2.0");
@@ -144,7 +144,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump Aspire.Hosting.Redis@13.2.0 Aspire.Hosting.PostgreSQL@13.2.0");
@@ -157,7 +157,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("sdk dump Aspire.Hosting.Redis@13.2.0-preview.1");
@@ -170,7 +170,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         // LastIndexOf('@') splits as "Aspire.Hosting.Redis@" and "13.2.0"

--- a/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
@@ -40,7 +40,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = _ => new TestInteractionService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
@@ -65,7 +65,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
             // Need to provide a project locator since AddCommand checks for project first
             options.ProjectLocatorFactory = _ => new TestProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("add");
@@ -87,7 +87,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = _ => new TestInteractionService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         // With no SDK, aspire-starter shouldn't be a valid subcommand
@@ -127,7 +127,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = _ => new TestInteractionService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("publish");
@@ -165,7 +165,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = _ => new TestInteractionService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("deploy");
@@ -188,7 +188,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = _ => new TestInteractionService();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("exec");
@@ -210,7 +210,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
             // Make sure project locator doesn't find projects so it fails at the expected point
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");

--- a/tests/Aspire.Cli.Tests/Commands/SecretCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SecretCommandTests.cs
@@ -24,11 +24,13 @@ public class SecretCommandTests(ITestOutputHelper outputHelper)
 
         await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
 
-        var command = CreateRootCommand(
+        using var provider = CreateSecretTestServices(
             workspace,
             outputWriter,
             appHostFile,
             userSecretsId);
+
+        var command = provider.GetRequiredService<RootCommand>();
 
         var result = command.Parse($"secret path --apphost \"{appHostFile.FullName}\"");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
@@ -48,11 +50,13 @@ public class SecretCommandTests(ITestOutputHelper outputHelper)
 
         await File.WriteAllTextAsync(appHostFile.FullName, "export {};");
 
-        var command = CreateRootCommand(
+        using var provider = CreateSecretTestServices(
             workspace,
             outputWriter,
             appHostFile,
             userSecretsId);
+
+        var command = provider.GetRequiredService<RootCommand>();
 
         var result = command.Parse($"secret path --apphost \"{appHostFile.FullName}\"");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
@@ -61,7 +65,7 @@ public class SecretCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains(expectedPath, outputWriter.Logs);
     }
 
-    private RootCommand CreateRootCommand(
+    private ServiceProvider CreateSecretTestServices(
         TemporaryWorkspace workspace,
         TestOutputTextWriter outputWriter,
         FileInfo appHostFile,
@@ -77,7 +81,7 @@ public class SecretCommandTests(ITestOutputHelper outputHelper)
         services.Replace(ServiceDescriptor.Singleton<IAppHostProjectFactory>(
             new TestAppHostProjectFactory(new TestAppHostProject(userSecretsId))));
 
-        return services.BuildServiceProvider().GetRequiredService<RootCommand>();
+        return services.BuildServiceProvider();
     }
 
     private sealed class TestProjectLocator(FileInfo appHostFile) : IProjectLocator

--- a/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
@@ -15,7 +15,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("start --help");
@@ -30,7 +30,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("start --no-build --help");
@@ -44,7 +44,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("start --format json --help");
@@ -58,7 +58,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("start --isolated --help");
@@ -72,7 +72,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("start -- --custom-arg value");

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -15,7 +15,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("stop --help");
@@ -30,7 +30,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("stop myresource");

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -23,7 +23,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel");
@@ -215,7 +215,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"otel {otelCommand} --dashboard-url http://localhost:18888");
 

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -24,7 +24,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel logs");
@@ -42,7 +42,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"telemetry logs --limit {limitValue}");
@@ -57,7 +57,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
+        using var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
             resources:
             [
                 new ResourceInfoJson { Name = "redis", InstanceId = null },
@@ -92,7 +92,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
+        using var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
             resources:
             [
                 new ResourceInfoJson { Name = "apiservice", InstanceId = guid1.ToString() },
@@ -214,7 +214,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel logs --dashboard-url http://localhost:18888");
 
@@ -266,7 +266,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel logs --dashboard-url http://localhost:18888 --api-key my-secret-key");
 
@@ -288,7 +288,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = _ => testInteractionService;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel logs --dashboard-url http://localhost:18888 --apphost TestAppHost.csproj");
 
@@ -311,7 +311,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = _ => testInteractionService;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel logs --dashboard-url not-a-url");
 
@@ -349,7 +349,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel logs --dashboard-url http://localhost:18888");
 
@@ -392,7 +392,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel logs --dashboard-url http://localhost:18888");
 
@@ -431,7 +431,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel logs --dashboard-url http://localhost:18888");
 

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -124,7 +124,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
+        using var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
             resources:
             [
                 new ResourceInfoJson { Name = "apiservice", InstanceId = null },

--- a/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
@@ -23,7 +23,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel spans");
@@ -41,7 +41,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"telemetry spans --limit {limitValue}");
@@ -56,7 +56,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
+        using var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
             resources:
             [
                 new ResourceInfoJson { Name = "frontend", InstanceId = null },
@@ -91,7 +91,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
+        using var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
             resources:
             [
                 new ResourceInfoJson { Name = "apiservice", InstanceId = guid1.ToString() },
@@ -187,7 +187,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel spans --dashboard-url http://localhost:18888");
 
@@ -211,7 +211,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = _ => testInteractionService;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel spans --dashboard-url http://localhost:18888 --apphost TestAppHost.csproj");
 
@@ -249,7 +249,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel spans --dashboard-url http://localhost:18888");
 

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -23,7 +23,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel traces");
@@ -41,7 +41,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"telemetry traces --limit {limitValue}");
@@ -56,7 +56,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
+        using var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
             resources:
             [
                 new ResourceInfoJson { Name = "frontend", InstanceId = null },
@@ -107,7 +107,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
+        using var provider = TelemetryTestHelper.CreateTelemetryTestServices(workspace, outputHelper, outputWriter,
             resources:
             [
                 new ResourceInfoJson { Name = "apiservice", InstanceId = guid1.ToString() },
@@ -235,7 +235,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel traces --dashboard-url http://localhost:18888");
 
@@ -259,7 +259,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = _ => testInteractionService;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel traces --dashboard-url http://localhost:18888 --apphost TestAppHost.csproj");
 
@@ -297,7 +297,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton(handler);
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("otel traces --dashboard-url http://localhost:18888");
 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -26,7 +26,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("update --help");
@@ -66,7 +66,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             options.PackagingServiceFactory = _ => new TestPackagingService();
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -176,7 +176,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -249,7 +249,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -320,7 +320,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -367,7 +367,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -414,7 +414,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -455,7 +455,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -520,7 +520,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -587,7 +587,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -641,7 +641,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -709,7 +709,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act - specify both --channel and --quality, --channel should win
         var command = provider.GetRequiredService<RootCommand>();
@@ -769,7 +769,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -831,7 +831,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act - without hives, should automatically use implicit channel
         var command = provider.GetRequiredService<RootCommand>();
@@ -873,7 +873,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             options.CliDownloaderFactory = _ => new TestCliDownloader(workspace.WorkspaceRoot);
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Act
         var command = provider.GetRequiredService<RootCommand>();
@@ -915,7 +915,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("update --self");
@@ -960,7 +960,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("update --self");
@@ -993,7 +993,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         
         // Act - Parse command with --self option

--- a/tests/Aspire.Cli.Tests/Commands/WaitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/WaitCommandTests.cs
@@ -17,7 +17,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait --help");
@@ -32,7 +32,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait");
@@ -47,7 +47,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait myresource --help");
@@ -61,7 +61,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait myresource --apphost /path/to/project.csproj --help");
@@ -75,7 +75,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait myresource --status up --help");
@@ -89,7 +89,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait myresource --timeout 60 --help");
@@ -106,7 +106,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"wait myresource --status {status} --help");
@@ -123,7 +123,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"wait myresource --status {status} --help");
@@ -153,7 +153,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait nonexistent --timeout 5");
@@ -178,7 +178,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait myapp --status up --timeout 5");
@@ -203,7 +203,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait mydb --status healthy --timeout 5");
@@ -233,7 +233,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait mydb --status healthy --timeout 2");
@@ -258,7 +258,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait worker --status down --timeout 5");
@@ -288,7 +288,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("wait myapp --status up --timeout 5");

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -33,7 +33,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions()
         {
@@ -73,7 +73,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -102,7 +102,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -140,7 +140,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             });
             return configBuilder.Build();
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -169,7 +169,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -198,7 +198,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -227,7 +227,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -265,7 +265,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -306,7 +306,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -349,7 +349,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -387,7 +387,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         {
             options.DisabledFeatures = [KnownFeatures.UpdateNotificationsEnabled];
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -427,7 +427,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         {
             options.EnabledFeatures = [KnownFeatures.UpdateNotificationsEnabled];
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -469,7 +469,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         {
             options.DisabledFeatures = [KnownFeatures.UpdateNotificationsEnabled];
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -535,7 +535,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             options.AppHostBackchannelFactory = _ => new TestAppHostBackchannel();
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
 
         var exitCode = await runner.RunAsync(
@@ -561,7 +561,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -614,7 +614,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -681,7 +681,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -747,7 +747,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -829,7 +829,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(project2File.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions
         {
@@ -870,7 +870,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(referencedProject.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -900,7 +900,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions()
         {
@@ -946,7 +946,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions()
         {
@@ -991,7 +991,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Use watch=true and NoLaunchProfile=false to ensure some empty strings are generated
         var options = new ProcessInvocationOptions()
@@ -1036,7 +1036,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions()
         {
@@ -1087,7 +1087,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions()
         {
@@ -1136,7 +1136,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions()
         {
@@ -1184,7 +1184,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -1220,7 +1220,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -1254,7 +1254,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
@@ -1300,7 +1300,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
@@ -1341,7 +1341,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
@@ -1399,7 +1399,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -1437,7 +1437,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -1475,7 +1475,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 
@@ -1515,7 +1515,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var options = new ProcessInvocationOptions();
 

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
@@ -34,7 +34,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var nuGetPackageCache = provider.GetRequiredService<INuGetPackageCache>();
         var packages = await nuGetPackageCache.GetCliPackagesAsync(workspace.WorkspaceRoot, prerelease: true, nugetConfigFile: null, CancellationToken.None).DefaultTimeout();
@@ -69,7 +69,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var nuGetPackageCache = provider.GetRequiredService<INuGetPackageCache>();
         var packages = await nuGetPackageCache.GetPackagesAsync(workspace.WorkspaceRoot, "Aspire.Hosting", null, prerelease: false, nugetConfigFile: null, useCache: true, CancellationToken.None).DefaultTimeout();
@@ -109,7 +109,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var nuGetPackageCache = provider.GetRequiredService<INuGetPackageCache>();
         var packages = await nuGetPackageCache.GetPackagesAsync(workspace.WorkspaceRoot, "Aspire.Hosting", null, prerelease: false, nugetConfigFile: null, useCache: true, CancellationToken.None).DefaultTimeout();
@@ -145,7 +145,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var nuGetPackageCache = provider.GetRequiredService<INuGetPackageCache>();
         
@@ -189,7 +189,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var nuGetPackageCache = provider.GetRequiredService<INuGetPackageCache>();
         var packages = await nuGetPackageCache.GetPackagesAsync(workspace.WorkspaceRoot, "Aspire.Hosting", null, prerelease: false, nugetConfigFile: null, useCache: true, CancellationToken.None).DefaultTimeout();

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -293,7 +293,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             options.DotNetCliRunnerFactory = _ => runner;
         });
 
-        using var provider = services.BuildServiceProvider();
+        var provider = services.BuildServiceProvider();
         _serviceProviders.Add(provider);
         return provider.GetRequiredService<DotNetAppHostProject>();
     }

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -293,7 +293,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             options.DotNetCliRunnerFactory = _ => runner;
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         _serviceProviders.Add(provider);
         return provider.GetRequiredService<DotNetAppHostProject>();
     }

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -109,7 +109,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Services we need for project updater.
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
@@ -221,7 +221,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Services we need for project updater.
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
@@ -360,7 +360,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         // Services we need for project updater.
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
@@ -513,7 +513,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -656,7 +656,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -761,7 +761,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -864,7 +864,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1007,7 +1007,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1130,7 +1130,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1244,7 +1244,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1354,7 +1354,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1452,7 +1452,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1554,7 +1554,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1633,7 +1633,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1715,7 +1715,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1794,7 +1794,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1877,7 +1877,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -1965,7 +1965,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();
@@ -2047,7 +2047,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var packagingService = provider.GetRequiredService<IPackagingService>();
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
@@ -2126,7 +2126,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var packagingService = provider.GetRequiredService<IPackagingService>();
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
@@ -2217,7 +2217,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var packagingService = provider.GetRequiredService<IPackagingService>();
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
@@ -2344,7 +2344,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
         });
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         var logger = provider.GetRequiredService<ILogger<ProjectUpdater>>();
         var runner = provider.GetRequiredService<IDotNetCliRunner>();

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -86,12 +86,12 @@ internal static class CliTestHelper
 
         services.AddLogging(b => b.SetMinimumLevel(LogLevel.Trace)).AddXunitLogging(outputHelper);
 
-        // Register logging options for test
+        // Register logging options for test. The FileLoggerProvider is created inside the
+        // factory callback so the DI container owns the instance and disposes it (closing
+        // the log file handle) when the ServiceProvider is disposed.
         var testLogsDirectory = Path.Combine(options.WorkingDirectory.FullName, ".aspire", "logs");
         var testLogFilePath = FileLoggerProvider.GenerateLogFilePath(testLogsDirectory, TimeProvider.System);
-        var fileLoggerProvider = new FileLoggerProvider(testLogFilePath, new TestStartupErrorWriter());
-        // Registered in a callback is important so it is disposed when the ServiceCollection is disposed.
-        services.AddSingleton(sp => fileLoggerProvider);
+        services.AddSingleton(sp => new FileLoggerProvider(testLogFilePath, new TestStartupErrorWriter()));
         services.AddSingleton(new Program.CliLoggingOptions(ConsoleLogLevel: null, DebugMode: false, LogsDirectory: testLogsDirectory, LogFilePath: testLogFilePath));
 
         services.AddMemoryCache();

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -89,7 +89,9 @@ internal static class CliTestHelper
         // Register logging options for test
         var testLogsDirectory = Path.Combine(options.WorkingDirectory.FullName, ".aspire", "logs");
         var testLogFilePath = FileLoggerProvider.GenerateLogFilePath(testLogsDirectory, TimeProvider.System);
-        services.AddSingleton(new FileLoggerProvider(testLogFilePath, new TestStartupErrorWriter()));
+        var fileLoggerProvider = new FileLoggerProvider(testLogFilePath, new TestStartupErrorWriter());
+        // Registered in a callback is important so it is disposed when the ServiceCollection is disposed.
+        services.AddSingleton(sp => fileLoggerProvider);
         services.AddSingleton(new Program.CliLoggingOptions(ConsoleLogLevel: null, DebugMode: false, LogsDirectory: testLogsDirectory, LogFilePath: testLogFilePath));
 
         services.AddMemoryCache();

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelperTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class CliTestHelperTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void ServiceProvider_CreatesLogFile_AndDisposalCleansUp()
+    {
+        string logFilePath;
+        string workspacePath;
+
+        using (var workspace = TemporaryWorkspace.Create(outputHelper))
+        {
+            workspacePath = workspace.WorkspaceRoot.FullName;
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+            using (var provider = services.BuildServiceProvider())
+            {
+                var fileLoggerProvider = provider.GetRequiredService<FileLoggerProvider>();
+                logFilePath = fileLoggerProvider.LogFilePath;
+
+                Assert.True(File.Exists(logFilePath), $"Log file should exist at {logFilePath}");
+                Assert.StartsWith(Path.Combine(workspacePath, ".aspire", "logs"), logFilePath);
+            }
+        }
+
+        // After workspace disposal, the entire temp directory (including log file) should be cleaned up
+        Assert.False(Directory.Exists(workspacePath), "Workspace directory should be deleted after disposal");
+        Assert.False(File.Exists(logFilePath), "Log file should be deleted after workspace disposal");
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -63,7 +63,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
 
         await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
@@ -118,7 +118,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
 
         await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
@@ -173,7 +173,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
 
         await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
@@ -224,7 +224,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
             };
         });
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
 
         await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
@@ -242,7 +242,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         services.AddSingleton<INuGetPackageCache, TestNuGetPackageCache>();
         services.AddSingleton<ICliUpdateNotifier, CliUpdateNotifier>();
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var service = provider.GetRequiredService<ICliUpdateNotifier>();
 
         // Mock packages with a newer stable version
@@ -267,7 +267,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         services.AddSingleton<INuGetPackageCache, TestNuGetPackageCache>();
         services.AddSingleton<ICliUpdateNotifier, CliUpdateNotifier>();
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var service = provider.GetRequiredService<ICliUpdateNotifier>();
 
         // Act & Assert (should not throw)

--- a/tests/Shared/TemporaryRepo.cs
+++ b/tests/Shared/TemporaryRepo.cs
@@ -45,13 +45,68 @@ internal sealed class TemporaryWorkspace(ITestOutputHelper outputHelper, Directo
 
     public void Dispose()
     {
+        // On Windows, file handles held by disposed StreamWriters may not be
+        // released instantly. Retry with backoff to handle transient locks.
+        // On Linux/macOS, Delete(true) can partially succeed (remove the directory)
+        // yet still throw IOException, so subsequent retries see DirectoryNotFoundException.
+        const int maxRetries = 5;
+        for (var i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                repoDirectory.Delete(true);
+                return;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Directory was already deleted (possibly by a previous attempt
+                // that removed the directory but still threw). Nothing to clean up.
+                return;
+            }
+            catch (IOException) when (i < maxRetries - 1)
+            {
+                Thread.Sleep(500 * (i + 1));
+            }
+            catch (IOException)
+            {
+                // Bulk delete failed after all retries. Delete files individually
+                // to surface the exact file name that is still locked.
+                DeleteContentsIndividually(repoDirectory);
+            }
+        }
+    }
+
+    private static void DeleteContentsIndividually(DirectoryInfo directory)
+    {
+        if (!directory.Exists)
+        {
+            return;
+        }
+
+        foreach (var child in directory.EnumerateDirectories())
+        {
+            DeleteContentsIndividually(child);
+        }
+
+        foreach (var file in directory.EnumerateFiles())
+        {
+            try
+            {
+                file.Delete();
+            }
+            catch (IOException ex)
+            {
+                throw new IOException($"Cannot delete '{file.FullName}': {ex.Message}", ex);
+            }
+        }
+
         try
         {
-            repoDirectory.Delete(true);
+            directory.Delete(false);
         }
-        catch (Exception ex)
+        catch (IOException ex)
         {
-            Console.WriteLine($"Error disposing TemporaryRepo: {ex.Message}");
+            throw new IOException($"Cannot delete directory '{directory.FullName}': {ex.Message}", ex);
         }
     }
 

--- a/tests/Shared/TemporaryRepo.cs
+++ b/tests/Shared/TemporaryRepo.cs
@@ -45,6 +45,8 @@ internal sealed class TemporaryWorkspace(ITestOutputHelper outputHelper, Directo
 
     public void Dispose()
     {
+        outputHelper.WriteLine($"Disposing temporary workspace at: {repoDirectory.FullName}");
+
         // On Windows, file handles held by disposed StreamWriters may not be
         // released instantly. Retry with backoff to handle transient locks.
         // On Linux/macOS, Delete(true) can partially succeed (remove the directory)


### PR DESCRIPTION
## Description

Add `using` to all `services.BuildServiceProvider()` calls across CLI test files so the `ServiceProvider` is properly disposed at the end of each test. This prevents potential resource leaks (e.g. `FileLoggerProvider` holding file handles) when tests complete.

Also adds a new `CliTestHelperTests` class that verifies the log file is created during service provider lifetime and cleaned up when the workspace is disposed.

**Changes:**
- 44 test files updated: `var provider = services.BuildServiceProvider()` → `using var provider = services.BuildServiceProvider()`
- 3 test files updated: `var provider = TelemetryTestHelper.CreateTelemetryTestServices(...)` → `using var provider = ...`
- New test file: `CliTestHelperTests.cs` with disposal verification test

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
