### PR TITLE
Handle describe --follow disconnects

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostFollowDisconnectHelpers.cs
+++ b/src/Aspire.Cli/Commands/AppHostFollowDisconnectHelpers.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using StreamJsonRpc;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Classifies expected follow disconnects from the AppHost auxiliary backchannel.
+/// </summary>
+internal static class AppHostFollowDisconnectHelpers
+{
+    /// <summary>
+    /// Determines whether an exception represents an expected disconnect.
+    /// </summary>
+    internal static bool IsExpectedDisconnect(Exception ex)
+    {
+        return ex is ConnectionLostException
+            || ex is ObjectDisposedException
+            || ex is OperationCanceledException { InnerException: ConnectionLostException };
+    }
+
+    /// <summary>
+    /// Determines whether the AppHost process has exited.
+    /// </summary>
+    internal static bool HasAppHostExited(IAppHostAuxiliaryBackchannel connection)
+    {
+        if (connection.AppHostInfo?.ProcessId is not int pid)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (NotSupportedException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Writes the follow termination message to stderr.
+    /// </summary>
+    internal static void WriteStatusMessage(IInteractionService interactionService, IAppHostAuxiliaryBackchannel connection)
+    {
+        interactionService.DisplayRawText(
+            HasAppHostExited(connection)
+                ? InteractionServiceStrings.AppHostShutDown
+                : InteractionServiceStrings.AppHostConnectionLostGeneric,
+            ConsoleOutput.Error);
+    }
+}

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -165,11 +165,20 @@ internal sealed class DescribeCommand : BaseCommand
             {
                 return await ExecuteWatchAsync(connection, resourceWatcher, dashboardBaseUrl, resourceName, format, cancellationToken);
             }
+            catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || cancellationToken.IsCancellationRequested)
+            {
+                _interactionService.DisplayCancellationMessage();
+                return ExitCodeConstants.Success;
+            }
             catch (Exception ex) when (!cancellationToken.IsCancellationRequested && IsExpectedBackchannelDisconnect(ex))
             {
                 // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
                 // describe --follow is active. Treat the lost watch as a normal end of stream
-                // rather than surfacing it as an unexpected CLI failure.
+                // rather than surfacing it as an unexpected CLI failure, while still
+                // explaining why the follow operation stopped.
+                _interactionService.DisplayMessage(
+                    KnownEmojis.Information,
+                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.AppHostConnectionLost, ex.Message));
                 return ExitCodeConstants.Success;
             }
         }

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -170,15 +171,23 @@ internal sealed class DescribeCommand : BaseCommand
                 _interactionService.DisplayCancellationMessage();
                 return ExitCodeConstants.Success;
             }
-            catch (Exception ex) when (!cancellationToken.IsCancellationRequested && IsExpectedBackchannelDisconnect(ex))
+            catch (Exception ex) when (IsExpectedBackchannelDisconnect(ex))
             {
-                // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
-                // describe --follow is active. Treat the lost watch as a normal end of stream
-                // rather than surfacing it as an unexpected CLI failure, while still
-                // explaining why the follow operation stopped.
-                _interactionService.DisplayMessage(
-                    KnownEmojis.Information,
-                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.AppHostConnectionLost, ex.Message));
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _interactionService.DisplayCancellationMessage();
+                }
+                else if (HasAppHostExited(connection))
+                {
+                    // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
+                    // describe --follow is active. Treat the lost watch as a normal end of stream
+                    // rather than surfacing it as an unexpected CLI failure, while still
+                    // explaining why the follow operation stopped.
+                    _interactionService.DisplayMessage(
+                        KnownEmojis.Information,
+                        string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.AppHostConnectionLost, ex.Message));
+                }
+
                 return ExitCodeConstants.Success;
             }
         }
@@ -287,6 +296,32 @@ internal sealed class DescribeCommand : BaseCommand
         return ex is ConnectionLostException
             || ex is ObjectDisposedException
             || ex is OperationCanceledException { InnerException: ConnectionLostException };
+    }
+
+    private static bool HasAppHostExited(IAppHostAuxiliaryBackchannel connection)
+    {
+        if (connection.AppHostInfo?.ProcessId is not int pid)
+        {
+            return true;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (NotSupportedException)
+        {
+            return true;
+        }
     }
 
     private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots, string? dashboardBaseUrl)

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -17,7 +16,6 @@ using Aspire.Shared;
 using Aspire.Shared.Model.Serialization;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
-using StreamJsonRpc;
 
 namespace Aspire.Cli.Commands;
 
@@ -170,7 +168,7 @@ internal sealed class DescribeCommand : BaseCommand
             {
                 return ExitCodeConstants.Success;
             }
-            catch (Exception ex) when (IsExpectedBackchannelDisconnect(ex))
+            catch (Exception ex) when (AppHostFollowDisconnectHelpers.IsExpectedDisconnect(ex))
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -181,11 +179,7 @@ internal sealed class DescribeCommand : BaseCommand
                 // describe --follow is active. Treat the lost watch as a normal end of stream
                 // rather than surfacing it as an unexpected CLI failure. Emit the status
                 // message on stderr so JSON output on stdout remains parseable.
-                _interactionService.DisplayRawText(
-                    HasAppHostExited(connection)
-                        ? InteractionServiceStrings.AppHostShutDown
-                        : InteractionServiceStrings.AppHostConnectionLostGeneric,
-                    ConsoleOutput.Error);
+                AppHostFollowDisconnectHelpers.WriteStatusMessage(_interactionService, connection);
 
                 return ExitCodeConstants.Success;
             }
@@ -289,40 +283,6 @@ internal sealed class DescribeCommand : BaseCommand
 
         return ExitCodeConstants.Success;
     }
-
-    private static bool IsExpectedBackchannelDisconnect(Exception ex)
-    {
-        return ex is ConnectionLostException
-            || ex is ObjectDisposedException
-            || ex is OperationCanceledException { InnerException: ConnectionLostException };
-    }
-
-    private static bool HasAppHostExited(IAppHostAuxiliaryBackchannel connection)
-    {
-        if (connection.AppHostInfo?.ProcessId is not int pid)
-        {
-            return false;
-        }
-
-        try
-        {
-            using var process = Process.GetProcessById(pid);
-            return process.HasExited;
-        }
-        catch (ArgumentException)
-        {
-            return true;
-        }
-        catch (InvalidOperationException)
-        {
-            return true;
-        }
-        catch (NotSupportedException)
-        {
-            return true;
-        }
-    }
-
     private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots, string? dashboardBaseUrl)
     {
         if (snapshots.Count == 0)

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -16,6 +16,7 @@ using Aspire.Shared;
 using Aspire.Shared.Model.Serialization;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
+using StreamJsonRpc;
 
 namespace Aspire.Cli.Commands;
 
@@ -160,7 +161,17 @@ internal sealed class DescribeCommand : BaseCommand
 
         if (follow)
         {
-            return await ExecuteWatchAsync(connection, resourceWatcher, dashboardBaseUrl, resourceName, format, cancellationToken);
+            try
+            {
+                return await ExecuteWatchAsync(connection, resourceWatcher, dashboardBaseUrl, resourceName, format, cancellationToken);
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested && IsExpectedBackchannelDisconnect(ex))
+            {
+                // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
+                // describe --follow is active. Treat the lost watch as a normal end of stream
+                // rather than surfacing it as an unexpected CLI failure.
+                return ExitCodeConstants.Success;
+            }
         }
         else
         {
@@ -260,6 +271,13 @@ internal sealed class DescribeCommand : BaseCommand
         }
 
         return ExitCodeConstants.Success;
+    }
+
+    private static bool IsExpectedBackchannelDisconnect(Exception ex)
+    {
+        return ex is ConnectionLostException
+            || ex is ObjectDisposedException
+            || ex is OperationCanceledException { InnerException: ConnectionLostException };
     }
 
     private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots, string? dashboardBaseUrl)

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -166,28 +165,11 @@ internal sealed class DescribeCommand : BaseCommand
             {
                 return await ExecuteWatchAsync(connection, resourceWatcher, dashboardBaseUrl, resourceName, format, cancellationToken);
             }
-            catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || cancellationToken.IsCancellationRequested)
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested && IsExpectedBackchannelDisconnect(ex))
             {
-                _interactionService.DisplayCancellationMessage();
-                return ExitCodeConstants.Success;
-            }
-            catch (Exception ex) when (IsExpectedBackchannelDisconnect(ex))
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    _interactionService.DisplayCancellationMessage();
-                }
-                else if (HasAppHostExited(connection))
-                {
-                    // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
-                    // describe --follow is active. Treat the lost watch as a normal end of stream
-                    // rather than surfacing it as an unexpected CLI failure, while still
-                    // explaining why the follow operation stopped.
-                    _interactionService.DisplayMessage(
-                        KnownEmojis.Information,
-                        string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.AppHostConnectionLost, ex.Message));
-                }
-
+                // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
+                // describe --follow is active. Treat the lost watch as a normal end of stream
+                // rather than surfacing it as an unexpected CLI failure.
                 return ExitCodeConstants.Success;
             }
         }
@@ -296,32 +278,6 @@ internal sealed class DescribeCommand : BaseCommand
         return ex is ConnectionLostException
             || ex is ObjectDisposedException
             || ex is OperationCanceledException { InnerException: ConnectionLostException };
-    }
-
-    private static bool HasAppHostExited(IAppHostAuxiliaryBackchannel connection)
-    {
-        if (connection.AppHostInfo?.ProcessId is not int pid)
-        {
-            return true;
-        }
-
-        try
-        {
-            using var process = Process.GetProcessById(pid);
-            return process.HasExited;
-        }
-        catch (ArgumentException)
-        {
-            return true;
-        }
-        catch (InvalidOperationException)
-        {
-            return true;
-        }
-        catch (NotSupportedException)
-        {
-            return true;
-        }
     }
 
     private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots, string? dashboardBaseUrl)

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -165,11 +166,27 @@ internal sealed class DescribeCommand : BaseCommand
             {
                 return await ExecuteWatchAsync(connection, resourceWatcher, dashboardBaseUrl, resourceName, format, cancellationToken);
             }
-            catch (Exception ex) when (!cancellationToken.IsCancellationRequested && IsExpectedBackchannelDisconnect(ex))
+            catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || cancellationToken.IsCancellationRequested)
             {
+                return ExitCodeConstants.Success;
+            }
+            catch (Exception ex) when (IsExpectedBackchannelDisconnect(ex))
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return ExitCodeConstants.Success;
+                }
+
                 // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
                 // describe --follow is active. Treat the lost watch as a normal end of stream
-                // rather than surfacing it as an unexpected CLI failure.
+                // rather than surfacing it as an unexpected CLI failure. Emit the status
+                // message on stderr so JSON output on stdout remains parseable.
+                _interactionService.DisplayRawText(
+                    HasAppHostExited(connection)
+                        ? InteractionServiceStrings.AppHostShutDown
+                        : InteractionServiceStrings.AppHostConnectionLostGeneric,
+                    ConsoleOutput.Error);
+
                 return ExitCodeConstants.Success;
             }
         }
@@ -278,6 +295,32 @@ internal sealed class DescribeCommand : BaseCommand
         return ex is ConnectionLostException
             || ex is ObjectDisposedException
             || ex is OperationCanceledException { InnerException: ConnectionLostException };
+    }
+
+    private static bool HasAppHostExited(IAppHostAuxiliaryBackchannel connection)
+    {
+        if (connection.AppHostInfo?.ProcessId is not int pid)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (NotSupportedException)
+        {
+            return true;
+        }
     }
 
     private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots, string? dashboardBaseUrl)

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -198,7 +198,29 @@ internal sealed class LogsCommand : BaseCommand
 
         if (follow)
         {
-            return await ExecuteWatchAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, cancellationToken);
+            try
+            {
+                return await ExecuteWatchAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, cancellationToken);
+            }
+            catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || cancellationToken.IsCancellationRequested)
+            {
+                return ExitCodeConstants.Success;
+            }
+            catch (Exception ex) when (AppHostFollowDisconnectHelpers.IsExpectedDisconnect(ex))
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return ExitCodeConstants.Success;
+                }
+
+                // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
+                // logs --follow is active. Treat the lost stream as a normal end of stream
+                // rather than surfacing it as an unexpected CLI failure. Emit the status
+                // message on stderr so JSON output on stdout remains parseable.
+                AppHostFollowDisconnectHelpers.WriteStatusMessage(_interactionService, connection);
+
+                return ExitCodeConstants.Success;
+            }
         }
         else
         {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -187,6 +187,24 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The connection to the application was lost..
+        /// </summary>
+        public static string AppHostConnectionLostGeneric {
+            get {
+                return ResourceManager.GetString("AppHostConnectionLostGeneric", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The application shut down..
+        /// </summary>
+        public static string AppHostShutDown {
+            get {
+                return ResourceManager.GetString("AppHostShutDown", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Finding apphosts....
         /// </summary>
         public static string FindingAppHosts {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -203,6 +203,12 @@
   <data name="AppHostConnectionLost" xml:space="preserve">
     <value>The connection to the AppHost was lost: {0}.</value>
   </data>
+  <data name="AppHostConnectionLostGeneric" xml:space="preserve">
+    <value>The connection to the application was lost.</value>
+  </data>
+  <data name="AppHostShutDown" xml:space="preserve">
+    <value>The application shut down.</value>
+  </data>
   <data name="UnexpectedErrorOccurred" xml:space="preserve">
     <value>An unexpected error occurred: {0}</value>
     <comment>{0} is the exception message</comment>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">Připojení k hostiteli aplikace bylo ztraceno: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">Verze AppHost není kompatibilní. Upgradujte prosím hostitele aplikací nebo rozhraní příkazového řádku Aspire.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">Die Verbindung mit dem App-Host wurde getrennt: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">Die AppHost-Version ist nicht kompatibel. Aktualisieren Sie den AppHost oder die Aspire-CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">Se perdió la conexión con el host de la aplicación: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">La versión de AppHost no es compatible. Actualice el apphost o la CLI de Aspire.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">La connexion à l’hôte de l’application a été perdue : {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">La version de l’AppHost n’est pas compatible. Veuillez mettre à jour l’AppHost ou l’interface CLI Aspire.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">La connessione all'host dell'app è stata interrotta: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">La versione di AppHost non è compatibile. Aggiornare AppHost o l'interfaccia della riga di comando di Aspire.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">アプリ ホストへの接続が失われました: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">AppHost のバージョンに互換性がありません。AppHost または Aspire CLI をアップグレードしてください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">앱 호스트에 대한 연결이 끊어졌습니다. {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">AppHost 버전이 호환되지 않습니다. AppHost 또는 Aspire CLI를 업그레이드해 주세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">Połączenie z hostem aplikacji zostało utracone: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">Wersja hosta AppHost jest niezgodna. Uaktualnij hosta AppHost lub interfejs wiersza polecenia platformy Aspire.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">A conexão com o host do aplicativo foi perdida: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">A versão do AppHost não é compatível. Atualize o apphost ou o Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">Потеряно подключение к узлу приложения: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">Версия AppHost несовместима. Обновите хост приложений или Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">Uygulama ana işleminin bağlantısı kesildi: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">AppHost sürümü uyumlu değil. Lütfen AppHost veya Aspire CLI'yı yükseltin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">与应用主机的连接已断开: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">AppHost 版本不兼容。请升级应用主机或 Aspire CLI。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -7,9 +7,19 @@
         <target state="needs-review-translation">與應用程式主機的連線已中斷: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostConnectionLostGeneric">
+        <source>The connection to the application was lost.</source>
+        <target state="new">The connection to the application was lost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostNotCompatibleConsiderUpgrading">
         <source>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</source>
         <target state="needs-review-translation">應用程式主機版本不相容。請升級應用程式主機或 Aspire CLI。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostShutDown">
+        <source>The application shut down.</source>
+        <target state="new">The application shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Runtime.CompilerServices;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared.Model.Serialization;
@@ -337,12 +338,15 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
+        var interactionService = new TestInteractionService();
+        var rawOutput = new List<string>();
+        interactionService.DisplayRawTextCallback = rawOutput.Add;
         using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
         ], configureConnection: connection =>
         {
             connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterSnapshot(cancellationToken);
-        });
+        }, interactionService: interactionService);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe --follow --format json");
@@ -350,13 +354,36 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Single(rawOutput);
+        Assert.Contains(interactionService.DisplayedMessages, m => m.Message.Contains("The connection to the AppHost was lost:", StringComparison.Ordinal));
+        Assert.DoesNotContain(interactionService.DisplayedErrors, e => e.Contains("unexpected error occurred", StringComparison.OrdinalIgnoreCase));
+    }
 
-        var jsonLines = outputWriter.Logs
-            .Where(l => l.TrimStart().StartsWith("{", StringComparison.Ordinal))
-            .ToList();
+    [Fact]
+    public async Task DescribeCommand_Follow_WhenCanceled_DisplaysCancellationMessage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var interactionService = new TestInteractionService();
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
+        ], configureConnection: connection =>
+        {
+            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => WaitForCancellationAsync(cancellationToken);
+        }, interactionService: interactionService);
 
-        Assert.Single(jsonLines);
-        Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("unexpected error occurred", StringComparison.OrdinalIgnoreCase));
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --follow --format json");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+        await Task.Yield();
+        cts.Cancel();
+
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(1, interactionService.DisplayCancellationMessageCallCount);
     }
 
     [Fact]
@@ -557,7 +584,8 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         List<ResourceSnapshot> resourceSnapshots,
         bool disableAnsi = false,
         DashboardUrlsState? dashboardUrlsState = null,
-        Action<TestAppHostAuxiliaryBackchannel>? configureConnection = null)
+        Action<TestAppHostAuxiliaryBackchannel>? configureConnection = null,
+        IInteractionService? interactionService = null)
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -579,6 +607,10 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
             options.OutputTextWriter = outputWriter;
             options.DisableAnsi = disableAnsi;
+            if (interactionService is not null)
+            {
+                options.InteractionServiceFactory = _ => interactionService;
+            }
         });
 
         return services.BuildServiceProvider();
@@ -598,5 +630,11 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         cancellationToken.ThrowIfCancellationRequested();
 
         throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
+    }
+
+    private static async IAsyncEnumerable<ResourceSnapshot> WaitForCancellationAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        yield break;
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Runtime.CompilerServices;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Tests.TestServices;
@@ -332,6 +333,33 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DescribeCommand_Follow_WhenBackchannelIsDisposed_ExitsSuccessfully()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
+        ], configureConnection: connection =>
+        {
+            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterSnapshot(cancellationToken);
+        });
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --follow --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonLines = outputWriter.Logs
+            .Where(l => l.TrimStart().StartsWith("{", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Single(jsonLines);
+        Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("unexpected error occurred", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task DescribeCommand_JsonFormat_StripsLoginPathFromDashboardUrl()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -528,7 +556,8 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         TestOutputTextWriter outputWriter,
         List<ResourceSnapshot> resourceSnapshots,
         bool disableAnsi = false,
-        DashboardUrlsState? dashboardUrlsState = null)
+        DashboardUrlsState? dashboardUrlsState = null,
+        Action<TestAppHostAuxiliaryBackchannel>? configureConnection = null)
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -542,6 +571,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
             ResourceSnapshots = resourceSnapshots,
             DashboardUrlsState = dashboardUrlsState
         };
+        configureConnection?.Invoke(connection);
         monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -552,5 +582,21 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         });
 
         return services.BuildServiceProvider();
+    }
+
+    private static async IAsyncEnumerable<ResourceSnapshot> ThrowObjectDisposedAfterSnapshot([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return new ResourceSnapshot
+        {
+            Name = "redis",
+            DisplayName = "redis",
+            ResourceType = "Container",
+            State = "Running"
+        };
+
+        await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using System.Runtime.CompilerServices;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
-using Aspire.Cli.Interaction;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared.Model.Serialization;
@@ -338,108 +337,26 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var interactionService = new TestInteractionService();
-        var rawOutput = new List<string>();
-        interactionService.DisplayRawTextCallback = rawOutput.Add;
         using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
         ], configureConnection: connection =>
         {
             connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterSnapshot(cancellationToken);
-        }, interactionService: interactionService);
-
+        });
+        
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe --follow --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        Assert.Single(rawOutput);
-        Assert.Contains(interactionService.DisplayedMessages, m => m.Message.Contains("The connection to the AppHost was lost:", StringComparison.Ordinal));
-        Assert.DoesNotContain(interactionService.DisplayedErrors, e => e.Contains("unexpected error occurred", StringComparison.OrdinalIgnoreCase));
-    }
 
-    [Fact]
-    public async Task DescribeCommand_Follow_WhenCanceled_DisplaysCancellationMessage()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var outputWriter = new TestOutputTextWriter(outputHelper);
-        var interactionService = new TestInteractionService();
-        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
-            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
-        ], configureConnection: connection =>
-        {
-            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => WaitForCancellationAsync(cancellationToken);
-        }, interactionService: interactionService);
+        var jsonLines = outputWriter.Logs
+            .Where(l => l.TrimStart().StartsWith("{", StringComparison.Ordinal))
+            .ToList();
 
-        var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("describe --follow --format json");
-
-        using var cts = new CancellationTokenSource();
-        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
-        await Task.Yield();
-        cts.Cancel();
-
-        var exitCode = await pendingRun.DefaultTimeout();
-
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
-        Assert.Equal(1, interactionService.DisplayCancellationMessageCallCount);
-    }
-
-    [Fact]
-    public async Task DescribeCommand_Follow_WhenCanceledAndBackchannelIsDisposed_DisplaysCancellationMessage()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var outputWriter = new TestOutputTextWriter(outputHelper);
-        var interactionService = new TestInteractionService();
-        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
-            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
-        ], configureConnection: connection =>
-        {
-            connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
-            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterCancellationAsync(cancellationToken);
-        }, interactionService: interactionService);
-
-        var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("describe --follow --format json");
-
-        using var cts = new CancellationTokenSource();
-        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
-        await Task.Yield();
-        cts.Cancel();
-
-        var exitCode = await pendingRun.DefaultTimeout();
-
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
-        Assert.Equal(1, interactionService.DisplayCancellationMessageCallCount);
-        Assert.DoesNotContain(interactionService.DisplayedMessages, m => m.Message.Contains("The connection to the AppHost was lost:", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task DescribeCommand_Follow_WhenBackchannelIsDisposedButAppHostStillRunning_DoesNotDisplayConnectionLostMessage()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var outputWriter = new TestOutputTextWriter(outputHelper);
-        var interactionService = new TestInteractionService();
-        var rawOutput = new List<string>();
-        interactionService.DisplayRawTextCallback = rawOutput.Add;
-        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
-            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
-        ], configureConnection: connection =>
-        {
-            connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
-            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterSnapshot(cancellationToken);
-        }, interactionService: interactionService);
-
-        var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("describe --follow --format json");
-
-        var exitCode = await result.InvokeAsync().DefaultTimeout();
-
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
-        Assert.Single(rawOutput);
-        Assert.Empty(interactionService.DisplayedMessages);
-        Assert.Equal(0, interactionService.DisplayCancellationMessageCallCount);
+        Assert.Single(jsonLines);
+        Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("unexpected error occurred", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -640,14 +557,17 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         List<ResourceSnapshot> resourceSnapshots,
         bool disableAnsi = false,
         DashboardUrlsState? dashboardUrlsState = null,
-        Action<TestAppHostAuxiliaryBackchannel>? configureConnection = null,
-        IInteractionService? interactionService = null)
+        Action<TestAppHostAuxiliaryBackchannel>? configureConnection = null)
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
         {
             IsInScope = true,
-            AppHostInfo = CreateAppHostInfo(workspace, 1234),
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
+                ProcessId = 1234
+            },
             ResourceSnapshots = resourceSnapshots,
             DashboardUrlsState = dashboardUrlsState
         };
@@ -659,22 +579,9 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
             options.OutputTextWriter = outputWriter;
             options.DisableAnsi = disableAnsi;
-            if (interactionService is not null)
-            {
-                options.InteractionServiceFactory = _ => interactionService;
-            }
         });
 
         return services.BuildServiceProvider();
-    }
-
-    private static AppHostInformation CreateAppHostInfo(TemporaryWorkspace workspace, int processId)
-    {
-        return new AppHostInformation
-        {
-            AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
-            ProcessId = processId
-        };
     }
 
     private static async IAsyncEnumerable<ResourceSnapshot> ThrowObjectDisposedAfterSnapshot([EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -689,29 +596,6 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         await Task.Yield();
         cancellationToken.ThrowIfCancellationRequested();
-
-        throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
-    }
-
-    private static async IAsyncEnumerable<ResourceSnapshot> WaitForCancellationAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-        yield break;
-    }
-
-    private static async IAsyncEnumerable<ResourceSnapshot> ThrowObjectDisposedAfterCancellationAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        yield return new ResourceSnapshot
-        {
-            Name = "redis",
-            DisplayName = "redis",
-            ResourceType = "Container",
-            State = "Running"
-        };
-
-        var waitForCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var registration = cancellationToken.Register(() => waitForCancellation.TrySetResult());
-        await waitForCancellation.Task;
 
         throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
     }

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Runtime.CompilerServices;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared.Model.Serialization;
@@ -337,13 +338,15 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
+        using var errorWriter = new StringWriter();
         using var provider = CreateDescribeTestServices(workspace, outputWriter, [
             new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
         ], configureConnection: connection =>
         {
+            connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
             connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterSnapshot(cancellationToken);
-        });
-        
+        }, errorTextWriter: errorWriter);
+
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("describe --follow --format json");
 
@@ -357,6 +360,60 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Single(jsonLines);
         Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("unexpected error occurred", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(InteractionServiceStrings.AppHostConnectionLostGeneric, errorWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DescribeCommand_Follow_WhenAppHostHasExited_WritesShutdownMessageToStderr()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        using var errorWriter = new StringWriter();
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
+        ], configureConnection: connection =>
+        {
+            connection.AppHostInfo = CreateAppHostInfo(workspace, int.MaxValue);
+            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterSnapshot(cancellationToken);
+        }, errorTextWriter: errorWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --follow --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Single(outputWriter.Logs, l => l.TrimStart().StartsWith("{", StringComparison.Ordinal));
+        Assert.Contains(InteractionServiceStrings.AppHostShutDown, errorWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DescribeCommand_Follow_WhenCanceledAndBackchannelIsDisposed_DoesNotWriteStatusToStderr()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        using var errorWriter = new StringWriter();
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
+        ], configureConnection: connection =>
+        {
+            connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
+            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterCancellationAsync(cancellationToken);
+        }, errorTextWriter: errorWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --follow --format json");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+        await Task.Yield();
+        cts.Cancel();
+
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.DoesNotContain(InteractionServiceStrings.AppHostConnectionLostGeneric, errorWriter.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(InteractionServiceStrings.AppHostShutDown, errorWriter.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -557,7 +614,8 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         List<ResourceSnapshot> resourceSnapshots,
         bool disableAnsi = false,
         DashboardUrlsState? dashboardUrlsState = null,
-        Action<TestAppHostAuxiliaryBackchannel>? configureConnection = null)
+        Action<TestAppHostAuxiliaryBackchannel>? configureConnection = null,
+        StringWriter? errorTextWriter = null)
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -578,10 +636,20 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
             options.OutputTextWriter = outputWriter;
+            options.ErrorTextWriter = errorTextWriter;
             options.DisableAnsi = disableAnsi;
         });
 
         return services.BuildServiceProvider();
+    }
+
+    private static AppHostInformation CreateAppHostInfo(TemporaryWorkspace workspace, int processId)
+    {
+        return new AppHostInformation
+        {
+            AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
+            ProcessId = processId
+        };
     }
 
     private static async IAsyncEnumerable<ResourceSnapshot> ThrowObjectDisposedAfterSnapshot([EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -596,6 +664,23 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         await Task.Yield();
         cancellationToken.ThrowIfCancellationRequested();
+
+        throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
+    }
+
+    private static async IAsyncEnumerable<ResourceSnapshot> ThrowObjectDisposedAfterCancellationAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return new ResourceSnapshot
+        {
+            Name = "redis",
+            DisplayName = "redis",
+            ResourceType = "Container",
+            State = "Running"
+        };
+
+        var waitForCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(() => waitForCancellation.TrySetResult());
+        await waitForCancellation.Task;
 
         throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
     }

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -387,6 +387,62 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DescribeCommand_Follow_WhenCanceledAndBackchannelIsDisposed_DisplaysCancellationMessage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var interactionService = new TestInteractionService();
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
+        ], configureConnection: connection =>
+        {
+            connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
+            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterCancellationAsync(cancellationToken);
+        }, interactionService: interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --follow --format json");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+        await Task.Yield();
+        cts.Cancel();
+
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(1, interactionService.DisplayCancellationMessageCallCount);
+        Assert.DoesNotContain(interactionService.DisplayedMessages, m => m.Message.Contains("The connection to the AppHost was lost:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DescribeCommand_Follow_WhenBackchannelIsDisposedButAppHostStillRunning_DoesNotDisplayConnectionLostMessage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var interactionService = new TestInteractionService();
+        var rawOutput = new List<string>();
+        interactionService.DisplayRawTextCallback = rawOutput.Add;
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
+        ], configureConnection: connection =>
+        {
+            connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
+            connection.WatchResourceSnapshotsHandler = static (_, cancellationToken) => ThrowObjectDisposedAfterSnapshot(cancellationToken);
+        }, interactionService: interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --follow --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Single(rawOutput);
+        Assert.Empty(interactionService.DisplayedMessages);
+        Assert.Equal(0, interactionService.DisplayCancellationMessageCallCount);
+    }
+
+    [Fact]
     public async Task DescribeCommand_JsonFormat_StripsLoginPathFromDashboardUrl()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -591,11 +647,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         var connection = new TestAppHostAuxiliaryBackchannel
         {
             IsInScope = true,
-            AppHostInfo = new AppHostInformation
-            {
-                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
-                ProcessId = 1234
-            },
+            AppHostInfo = CreateAppHostInfo(workspace, 1234),
             ResourceSnapshots = resourceSnapshots,
             DashboardUrlsState = dashboardUrlsState
         };
@@ -614,6 +666,15 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         });
 
         return services.BuildServiceProvider();
+    }
+
+    private static AppHostInformation CreateAppHostInfo(TemporaryWorkspace workspace, int processId)
+    {
+        return new AppHostInformation
+        {
+            AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
+            ProcessId = processId
+        };
     }
 
     private static async IAsyncEnumerable<ResourceSnapshot> ThrowObjectDisposedAfterSnapshot([EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -636,5 +697,22 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
     {
         await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
         yield break;
+    }
+
+    private static async IAsyncEnumerable<ResourceSnapshot> ThrowObjectDisposedAfterCancellationAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return new ResourceSnapshot
+        {
+            Name = "redis",
+            DisplayName = "redis",
+            ResourceType = "Container",
+            State = "Running"
+        };
+
+        var waitForCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(() => waitForCancellation.TrySetResult());
+        await waitForCancellation.Task;
+
+        throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -897,6 +898,78 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("late-hidden", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task LogsCommand_Follow_WhenBackchannelIsDisposed_ExitsSuccessfully()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        using var errorWriter = new StringWriter();
+        using var provider = CreateLogsTestServices(workspace, outputWriter, configureConnection: connection =>
+        {
+            connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
+            connection.GetResourceLogsHandler = static (_, _, cancellationToken) => ThrowObjectDisposedAfterLogAsync(cancellationToken);
+        }, errorTextWriter: errorWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs --follow --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Single(outputWriter.Logs, l => l.TrimStart().StartsWith("{", StringComparison.Ordinal));
+        Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("unexpected error occurred", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(InteractionServiceStrings.AppHostConnectionLostGeneric, errorWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task LogsCommand_Follow_WhenAppHostHasExited_WritesShutdownMessageToStderr()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        using var errorWriter = new StringWriter();
+        using var provider = CreateLogsTestServices(workspace, outputWriter, configureConnection: connection =>
+        {
+            connection.AppHostInfo = CreateAppHostInfo(workspace, int.MaxValue);
+            connection.GetResourceLogsHandler = static (_, _, cancellationToken) => ThrowObjectDisposedAfterLogAsync(cancellationToken);
+        }, errorTextWriter: errorWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs --follow --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Single(outputWriter.Logs, l => l.TrimStart().StartsWith("{", StringComparison.Ordinal));
+        Assert.Contains(InteractionServiceStrings.AppHostShutDown, errorWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task LogsCommand_Follow_WhenCanceledAndBackchannelIsDisposed_DoesNotWriteStatusToStderr()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        using var errorWriter = new StringWriter();
+        using var provider = CreateLogsTestServices(workspace, outputWriter, configureConnection: connection =>
+        {
+            connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
+            connection.GetResourceLogsHandler = static (_, _, cancellationToken) => ThrowObjectDisposedAfterCancellationAsync(cancellationToken);
+        }, errorTextWriter: errorWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs --follow --format json");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+        await Task.Yield();
+        cts.Cancel();
+
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.DoesNotContain(InteractionServiceStrings.AppHostConnectionLostGeneric, errorWriter.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(InteractionServiceStrings.AppHostShutDown, errorWriter.ToString(), StringComparison.Ordinal);
+    }
+
     private ServiceProvider CreateLogsTestServicesWithHidden(
         TemporaryWorkspace workspace,
         TestOutputTextWriter outputWriter,
@@ -963,7 +1036,9 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         TestOutputTextWriter outputWriter,
         Action<Dictionary<string, string?>>? configureOptions = null,
         bool disableAnsi = false,
-        IEnumerable<ResourceLogLine>? logLines = null)
+        IEnumerable<ResourceLogLine>? logLines = null,
+        Action<TestAppHostAuxiliaryBackchannel>? configureConnection = null,
+        StringWriter? errorTextWriter = null)
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -1026,12 +1101,14 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
                 }
             ]
         };
+        configureConnection?.Invoke(connection);
         monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
             options.OutputTextWriter = outputWriter;
+            options.ErrorTextWriter = errorTextWriter;
             options.DisableAnsi = disableAnsi;
 
             if (configureOptions is not null)
@@ -1041,6 +1118,15 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         });
 
         return services.BuildServiceProvider();
+    }
+
+    private static AppHostInformation CreateAppHostInfo(TemporaryWorkspace workspace, int processId)
+    {
+        return new AppHostInformation
+        {
+            AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
+            ProcessId = processId
+        };
     }
 
     private static async IAsyncEnumerable<ResourceSnapshot> WatchWithLateHidden([EnumeratorCancellation] CancellationToken cancellationToken)
@@ -1059,5 +1145,38 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         {
             await tcs.Task.ConfigureAwait(false);
         }
+    }
+
+    private static async IAsyncEnumerable<ResourceLogLine> ThrowObjectDisposedAfterLogAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return new ResourceLogLine
+        {
+            ResourceName = "redis",
+            LineNumber = 1,
+            Content = "2025-01-15T10:30:00Z Ready to accept connections",
+            IsError = false
+        };
+
+        await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
+    }
+
+    private static async IAsyncEnumerable<ResourceLogLine> ThrowObjectDisposedAfterCancellationAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return new ResourceLogLine
+        {
+            ResourceName = "redis",
+            LineNumber = 1,
+            Content = "2025-01-15T10:30:00Z Ready to accept connections",
+            IsError = false
+        };
+
+        var waitForCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(() => waitForCancellation.TrySetResult());
+        await waitForCancellation.Task;
+
+        throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostAuxiliaryBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostAuxiliaryBackchannel.cs
@@ -57,6 +57,12 @@ internal sealed class TestAppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackcha
     /// </summary>
     public Func<bool, CancellationToken, IAsyncEnumerable<ResourceSnapshot>>? WatchResourceSnapshotsHandler { get; set; }
 
+    /// <summary>
+    /// Gets or sets the function to call when GetResourceLogsAsync is invoked.
+    /// If null, yields the LogLines list.
+    /// </summary>
+    public Func<string?, bool, CancellationToken, IAsyncEnumerable<ResourceLogLine>>? GetResourceLogsHandler { get; set; }
+
     public Task<DashboardUrlsState?> GetDashboardUrlsAsync(CancellationToken cancellationToken = default)
     {
         return Task.FromResult(DashboardUrlsState);
@@ -103,6 +109,15 @@ internal sealed class TestAppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackcha
         bool follow = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        if (GetResourceLogsHandler is not null)
+        {
+            await foreach (var line in GetResourceLogsHandler(resourceName, follow, cancellationToken).WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                yield return line;
+            }
+            yield break;
+        }
+
         var lines = resourceName is null
             ? LogLines
             : LogLines.Where(l => string.Equals(l.ResourceName, resourceName, StringComparison.OrdinalIgnoreCase)

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -41,7 +41,6 @@ internal sealed class TestInteractionService : IInteractionService
     public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];
     public List<string> DisplayedErrors { get; } = [];
     public List<(KnownEmoji Emoji, string Message)> DisplayedMessages { get; } = [];
-    public int DisplayCancellationMessageCallCount { get; private set; }
 
     // Response queue setup methods
     public void SetupStringPromptResponse(string response) => _responses.Enqueue((response, ResponseType.String));
@@ -174,7 +173,6 @@ internal sealed class TestInteractionService : IInteractionService
 
     public void DisplayCancellationMessage()
     {
-        DisplayCancellationMessageCallCount++;
     }
 
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -41,6 +41,7 @@ internal sealed class TestInteractionService : IInteractionService
     public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];
     public List<string> DisplayedErrors { get; } = [];
     public List<(KnownEmoji Emoji, string Message)> DisplayedMessages { get; } = [];
+    public int DisplayCancellationMessageCallCount { get; private set; }
 
     // Response queue setup methods
     public void SetupStringPromptResponse(string response) => _responses.Enqueue((response, ResponseType.String));
@@ -173,6 +174,7 @@ internal sealed class TestInteractionService : IInteractionService
 
     public void DisplayCancellationMessage()
     {
+        DisplayCancellationMessageCallCount++;
     }
 
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description

Handle `aspire describe --follow` disconnects gracefully when the AppHost stops or restarts.
Add a regression test for the disposed JSON-RPC backchannel case.

Fixes #16270

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
