### PR TITLE
[release/13.2] Temporarily disable Verify CLI archive step

### DIFF
--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -140,28 +140,10 @@ jobs:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken) # Needed for the signing task
 
-          # Verify the signed CLI archive can execute and create a project.
-          # Run for RIDs that can fully execute on the build agent:
-          #   macOS (Apple Silicon): osx-arm64 only (osx-x64 via Rosetta can run the CLI
-          #     but aspire-managed template resolution fails)
-          #   Linux (amd64): linux-x64 only (linux-arm64/linux-musl-x64 are cross-compiled)
-          - ${{ if or(and(eq(parameters.agentOs, 'macos'), eq(targetRid, 'osx-arm64')), and(eq(parameters.agentOs, 'linux'), eq(targetRid, 'linux-x64'))) }}:
-            - script: |
-                set -euo pipefail
-                echo "Finding CLI archive for ${{ targetRid }}..."
-                ARCHIVE=$(find "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)" -name "aspire-cli-${{ targetRid }}-*.tar.gz" -type f | head -1)
-                if [ -z "$ARCHIVE" ]; then
-                  echo "##[error]No CLI archive found for ${{ targetRid }}"
-                  exit 1
-                fi
-                echo "Found archive: $ARCHIVE"
-                chmod +x "$(Build.SourcesDirectory)/eng/scripts/verify-cli-archive.sh"
-                "$(Build.SourcesDirectory)/eng/scripts/verify-cli-archive.sh" "$ARCHIVE"
-              displayName: 🟣Verify CLI archive (${{ targetRid }})
-              condition: succeeded()
-              env:
-                ASPIRE_CLI_TELEMETRY_OPTOUT: 'true'
-                DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+          # NOTE: The 🟣Verify CLI archive step has been temporarily disabled on release/13.2.
+          # On osx-arm64 it hangs at "🔐 Trusting certificates..." during `aspire new`,
+          # consuming the entire 60 minute job timeout. Tracking issue: re-enable once the
+          # dev-cert trust hang on macOS hosted agents is resolved.
 
           - task: 1ES.PublishBuildArtifacts@1
             displayName: 🟣Publish Artifacts


### PR DESCRIPTION
## Description

The `Verify CLI archive (osx-arm64)` step in `eng/pipelines/templates/build_sign_native.yml` is hanging at `🔐 Trusting certificates...` during `aspire new aspire-starter` on the macOS hosted agents. Because this is the only long-running step after native build+sign, it consumes the entire 60 minute job timeout and fails every official build on `release/13.2` (e.g. build [2952311](https://dev.azure.com/dnceng/internal/_build/results?buildId=2952311)).

Root cause is in `dotnet dev-certs https --trust` (invoked transitively by `aspire new`) on headless macOS agents — it appears to prompt/hang indefinitely. This is separate from native binary signing/notarization, which completes fine.

## Change

Temporarily removes the `Verify CLI archive` step from the native build+sign job so that the release pipeline can produce signed artifacts. A comment is left in place referring to the regression.

## Follow-up

- Re-enable the step once the dev-cert trust hang on macOS hosted agents is resolved (likely needs a flag to skip cert trust in the verification script, or a non-interactive trust mechanism).