### PR TITLE
Fix list_console_logs MCP tool to accept resolved resource instance names

### DIFF
--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -630,26 +630,30 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
 
         if (resourceName is not null)
         {
-            var resource = appModel.Resources.FirstOrDefault(r => string.Equals(r.Name, resourceName, StringComparisons.ResourceName));
-            if (resource is not null)
+            // Match by logical name (stream all instances) or resolved instance name like
+            // "apiservice-abc123" (stream just that one) — MCP advertises the resolved form.
+            foreach (var resource in appModel.Resources)
             {
-                resourcesToLog.AddRange(resource.GetResolvedResourceNames());
-            }
-            else
-            {
-                // Fall back to resolved instance names (e.g. "apiservice-abc123") so callers such
-                // as the MCP server, which advertises resources by their resolved names, still match.
-                var matchedInstance = appModel.Resources
-                    .SelectMany(r => r.GetResolvedResourceNames())
-                    .FirstOrDefault(n => string.Equals(n, resourceName, StringComparisons.ResourceName));
+                var resolvedNames = resource.GetResolvedResourceNames();
 
-                if (matchedInstance is null)
+                if (string.Equals(resource.Name, resourceName, StringComparisons.ResourceName))
                 {
-                    logger.LogWarning("Resource '{ResourceName}' not found. No logs will be returned.", resourceName);
-                    yield break;
+                    resourcesToLog.AddRange(resolvedNames);
+                    break;
                 }
 
-                resourcesToLog.Add(matchedInstance);
+                var matchedInstance = resolvedNames.FirstOrDefault(n => string.Equals(n, resourceName, StringComparisons.ResourceName));
+                if (matchedInstance is not null)
+                {
+                    resourcesToLog.Add(matchedInstance);
+                    break;
+                }
+            }
+
+            if (resourcesToLog.Count == 0)
+            {
+                logger.LogWarning("Resource '{ResourceName}' not found. No logs will be returned.", resourceName);
+                yield break;
             }
         }
         else

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -631,13 +631,26 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         if (resourceName is not null)
         {
             var resource = appModel.Resources.FirstOrDefault(r => string.Equals(r.Name, resourceName, StringComparisons.ResourceName));
-            if (resource is null)
+            if (resource is not null)
             {
-                logger.LogWarning("Resource '{ResourceName}' not found. No logs will be returned.", resourceName);
-                yield break;
+                resourcesToLog.AddRange(resource.GetResolvedResourceNames());
             }
+            else
+            {
+                // Fall back to resolved instance names (e.g. "apiservice-abc123") so callers such
+                // as the MCP server, which advertises resources by their resolved names, still match.
+                var matchedInstance = appModel.Resources
+                    .SelectMany(r => r.GetResolvedResourceNames())
+                    .FirstOrDefault(n => string.Equals(n, resourceName, StringComparisons.ResourceName));
 
-            resourcesToLog.AddRange(resource.GetResolvedResourceNames());
+                if (matchedInstance is null)
+                {
+                    logger.LogWarning("Resource '{ResourceName}' not found. No logs will be returned.", resourceName);
+                    yield break;
+                }
+
+                resourcesToLog.Add(matchedInstance);
+            }
         }
         else
         {

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -363,6 +363,49 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task GetResourceLogsAsync_ReturnsLogsForSingleReplica_WhenResolvedInstanceNameIsPassed()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+
+        var resourceWithReplicas = builder.AddResource(new CustomResource("myresource"));
+        resourceWithReplicas.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myresource-abc123", "abc123", 0),
+            new DcpInstance("myresource-def456", "def456", 1)
+        ]));
+
+        using var app = builder.Build();
+
+        var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
+        resourceLoggerService.TimeProvider = new FixedTimeProvider();
+
+        await app.StartAsync();
+
+        var logger1 = resourceLoggerService.GetLogger("myresource-abc123");
+        logger1.LogInformation("Log from replica 1");
+        resourceLoggerService.Complete("myresource-abc123");
+
+        var logger2 = resourceLoggerService.GetLogger("myresource-def456");
+        logger2.LogInformation("Log from replica 2");
+        resourceLoggerService.Complete("myresource-def456");
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services);
+
+        var logs = new List<ResourceLogLine>();
+        await foreach (var logLine in target.GetResourceLogsAsync("myresource-def456", follow: false))
+        {
+            logs.Add(logLine);
+        }
+
+        var log = Assert.Single(logs);
+        Assert.Equal("myresource-def456", log.ResourceName);
+        Assert.Equal($"{TestTimestamp} Log from replica 2", log.Content);
+
+        await app.StopAsync();
+    }
+
+    [Fact]
     public async Task GetResourceLogsAsync_FollowMode_StreamsLogs()
     {
         using var builder = TestDistributedApplicationBuilder.Create(outputHelper);


### PR DESCRIPTION
## Description

`list_console_logs` MCP tool returned `Returned 0 console logs.` for Running+Healthy resources, even when `aspire logs <resource>` for the same resource returned the stream.

`AuxiliaryBackchannelRpcTarget.GetResourceLogsAsync` matched only `Resource.Name`, but `GetResourceSnapshotsAsync` (same class) advertises resources by `GetResolvedResourceNames()` — so MCP clients calling `list_console_logs` with a suffixed name like `apiservice-abc123` missed the lookup and got empty results. This mirrors the earlier fix to `WaitForResourceAsync` in 4d41cb8c2; apply the same tolerance here by falling back to scanning resolved instance names when the primary `Resource.Name` match misses.

Fixes #16246

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No