### PR TITLE
Reproduce Hosting-1 hangs with full hangdump

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -242,6 +242,7 @@ jobs:
           ./dotnet.sh test --project tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
             -c Release \
             --results-directory ${{ github.workspace }}/testresults \
+            --output Detailed \
             -- \
             --report-trx --report-trx-filename "${{ matrix.shortname }}.trx" \
             --filter-not-trait "quarantined=true" \

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -242,7 +242,6 @@ jobs:
           ./dotnet.sh test --project tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
             -c Release \
             --results-directory ${{ github.workspace }}/testresults \
-            --output Detailed \
             -- \
             --report-trx --report-trx-filename "${{ matrix.shortname }}.trx" \
             --filter-not-trait "quarantined=true" \

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -239,11 +239,11 @@ jobs:
           Azure__Location: westus3
           GH_TOKEN: ${{ github.token }}
         run: |
-          ./dotnet.sh test tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
+          ./dotnet.sh test --project tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
             -c Release \
-            --logger "trx;LogFileName=${{ matrix.shortname }}.trx" \
             --results-directory ${{ github.workspace }}/testresults \
             -- \
+            --report-trx --report-trx-filename "${{ matrix.shortname }}.trx" \
             --filter-not-trait "quarantined=true" \
             ${{ matrix.extraTestArgs }} \
             || echo "test_failed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/reproduce-flaky-tests.yml
+++ b/.github/workflows/reproduce-flaky-tests.yml
@@ -218,6 +218,7 @@ jobs:
             ${{ env.DOTNET_SCRIPT }} test --project "${{ env.TEST_PROJECT_PATH }}" \
               --no-restore \
               --no-build \
+              --output Detailed \
               -- \
               --timeout 10m \
               --results-directory "${{ github.workspace }}/testresults" \
@@ -228,7 +229,7 @@ jobs:
 
             # Detect zero-test runs (--ignore-exit-code 8 in Testing.props masks exit code 8)
             if [ "$RESULT" -eq 0 ]; then
-              if ! grep -qE "Total:\s*[1-9]" "$ITER_OUTPUT" 2>/dev/null; then
+              if ! grep -qiE "total:\s*[1-9]" "$ITER_OUTPUT" 2>/dev/null; then
                 echo "::error::Iteration $i: Zero tests executed. Verify TEST_FILTER and quarantine settings."
                 RESULT=8
               fi
@@ -284,6 +285,7 @@ jobs:
             & ${{ env.DOTNET_SCRIPT }} test --project "${{ env.TEST_PROJECT_PATH }}" `
               --no-restore `
               --no-build `
+              --output Detailed `
               -- `
               --timeout 10m `
               --results-directory "${{ github.workspace }}/testresults" `
@@ -294,7 +296,7 @@ jobs:
             # Detect zero-test runs (--ignore-exit-code 8 in Testing.props masks exit code 8)
             if ($result -eq 0) {
               $content = Get-Content $iterOutput -Raw -ErrorAction SilentlyContinue
-              if (-not ($content -match 'Total:\s*[1-9]')) {
+              if (-not ($content -match '(?i)total:\s*[1-9]')) {
                 Write-Host "::error::Iteration ${i}: Zero tests executed. Verify TEST_FILTER and quarantine settings."
                 $result = 8
               }

--- a/.github/workflows/reproduce-flaky-tests.yml
+++ b/.github/workflows/reproduce-flaky-tests.yml
@@ -117,7 +117,7 @@ jobs:
     name: "${{ matrix.os }} #${{ matrix.index }}"
     needs: setup
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}

--- a/.github/workflows/reproduce-flaky-tests.yml
+++ b/.github/workflows/reproduce-flaky-tests.yml
@@ -32,7 +32,7 @@ env:
 
   # Target operating systems (comma-separated)
   # Options: ubuntu-latest, windows-latest, macos-latest
-  TARGET_OSES: "ubuntu-latest"
+  TARGET_OSES: "ubuntu-latest,windows-latest"
 
   # Number of parallel runners per OS
   # Total jobs = RUNNERS_PER_OS × number of OSes (must be ≤ 256)

--- a/.github/workflows/reproduce-flaky-tests.yml
+++ b/.github/workflows/reproduce-flaky-tests.yml
@@ -32,7 +32,7 @@ env:
 
   # Target operating systems (comma-separated)
   # Options: ubuntu-latest, windows-latest, macos-latest
-  TARGET_OSES: "ubuntu-latest,windows-latest"
+  TARGET_OSES: "windows-latest"
 
   # Number of parallel runners per OS
   # Total jobs = RUNNERS_PER_OS × number of OSes (must be ≤ 256)

--- a/.github/workflows/reproduce-flaky-tests.yml
+++ b/.github/workflows/reproduce-flaky-tests.yml
@@ -28,18 +28,18 @@ env:
   #   --filter-method "*.TestMethodName"
   #   --filter-class "*.TestClassName"
   #   --filter-method "*.Test1" --filter-method "*.Test2"
-  TEST_FILTER: '--filter-method "*.YourTestMethodName"'
+  TEST_FILTER: '--filter-trait "Partition=1"'
 
   # Target operating systems (comma-separated)
   # Options: ubuntu-latest, windows-latest, macos-latest
-  TARGET_OSES: "ubuntu-latest,windows-latest"
+  TARGET_OSES: "ubuntu-latest"
 
   # Number of parallel runners per OS
   # Total jobs = RUNNERS_PER_OS × number of OSes (must be ≤ 256)
-  RUNNERS_PER_OS: "3"
+  RUNNERS_PER_OS: "16"
 
   # Number of test iterations each runner executes
-  ITERATIONS_PER_RUNNER: "3"
+  ITERATIONS_PER_RUNNER: "1"
 
 jobs:
 
@@ -220,6 +220,10 @@ jobs:
               --no-build \
               -- \
               --timeout 10m \
+              --hangdump \
+              --hangdump-type full \
+              --hangdump-timeout 10m \
+              --crashdump \
               --results-directory "${{ github.workspace }}/testresults" \
               ${{ env.TEST_FILTER }} \
               2>&1 | tee "$ITER_OUTPUT"
@@ -286,6 +290,10 @@ jobs:
               --no-build `
               -- `
               --timeout 10m `
+              --hangdump `
+              --hangdump-type full `
+              --hangdump-timeout 10m `
+              --crashdump `
               --results-directory "${{ github.workspace }}/testresults" `
               ${{ env.TEST_FILTER }} *> $iterOutput
             $result = $LASTEXITCODE
@@ -325,11 +333,19 @@ jobs:
           if ($fail -gt 0) { exit 1 }
 
       - name: Upload failure logs
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: failures-${{ matrix.os }}-${{ matrix.index }}
           path: all-results/
+          if-no-files-found: ignore
+
+      - name: Upload testresults (hangdumps, crashdumps)
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: testresults-${{ matrix.os }}-${{ matrix.index }}
+          path: testresults/
           if-no-files-found: ignore
 
   results:

--- a/.github/workflows/reproduce-flaky-tests.yml
+++ b/.github/workflows/reproduce-flaky-tests.yml
@@ -195,6 +195,8 @@ jobs:
           ASPIRE__TEST__DCPLOGBASEPATH: ${{ github.workspace }}/testresults/dcp
           NUGET_PACKAGES: ${{ github.workspace }}/.packages
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
+          # Skip default quarantine/outerloop exclusion filters so the target test can run
+          SkipDefaultTestFilters: true
         run: |
           PASS=0
           FAIL=0
@@ -213,10 +215,7 @@ jobs:
             # Run test (capture output for zero-test detection)
             ITER_OUTPUT="${{ github.workspace }}/iter-output-$i.log"
             set +e  # Disable errexit so pipefail doesn't abort before PIPESTATUS capture
-            ${{ env.DOTNET_SCRIPT }} test "${{ env.TEST_PROJECT_PATH }}" \
-              /p:ContinuousIntegrationBuild=true \
-              /p:_NonQuarantinedTestRunAdditionalArgs="" \
-              -tl:false \
+            ${{ env.DOTNET_SCRIPT }} test --project "${{ env.TEST_PROJECT_PATH }}" \
               --no-restore \
               --no-build \
               -- \
@@ -265,6 +264,8 @@ jobs:
           ASPIRE__TEST__DCPLOGBASEPATH: ${{ github.workspace }}/testresults/dcp
           NUGET_PACKAGES: ${{ github.workspace }}/.packages
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
+          # Skip default quarantine/outerloop exclusion filters so the target test can run
+          SkipDefaultTestFilters: true
         run: |
           $pass = 0
           $fail = 0
@@ -280,10 +281,7 @@ jobs:
 
             # Run test (capture output for zero-test detection)
             $iterOutput = Join-Path "${{ github.workspace }}" "iter-output-$i.log"
-            & ${{ env.DOTNET_SCRIPT }} test "${{ env.TEST_PROJECT_PATH }}" `
-              /p:ContinuousIntegrationBuild=true `
-              /p:_NonQuarantinedTestRunAdditionalArgs="" `
-              -tl:false `
+            & ${{ env.DOTNET_SCRIPT }} test --project "${{ env.TEST_PROJECT_PATH }}" `
               --no-restore `
               --no-build `
               -- `

--- a/.github/workflows/reproduce-flaky-tests.yml
+++ b/.github/workflows/reproduce-flaky-tests.yml
@@ -218,7 +218,6 @@ jobs:
             ${{ env.DOTNET_SCRIPT }} test --project "${{ env.TEST_PROJECT_PATH }}" \
               --no-restore \
               --no-build \
-              --output Detailed \
               -- \
               --timeout 10m \
               --results-directory "${{ github.workspace }}/testresults" \
@@ -285,7 +284,6 @@ jobs:
             & ${{ env.DOTNET_SCRIPT }} test --project "${{ env.TEST_PROJECT_PATH }}" `
               --no-restore `
               --no-build `
-              --output Detailed `
               -- `
               --timeout 10m `
               --results-directory "${{ github.workspace }}/testresults" `

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -424,6 +424,7 @@ jobs:
           ${{ env.DOTNET_SCRIPT }} test --project ${{ env.TEST_PROJECT_PATH }} \
             --no-restore \
             --no-build \
+            --output Detailed \
             -- \
             --ignore-exit-code 8 \
             --report-trx \
@@ -478,6 +479,7 @@ jobs:
             & ${{ env.DOTNET_SCRIPT }} test --project ${{ env.TEST_PROJECT_PATH }} `
               --no-restore `
               --no-build `
+              --output Detailed `
               -- `
               --ignore-exit-code 8 `
               --report-trx `

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -413,17 +413,15 @@ jobs:
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.token || '' }}
+          # MSBuild properties passed via env vars (new MTP dotnet test mode doesn't support /p:)
+          TrxFileNamePrefix: ${{ inputs.testShortName }}
         run: |
           # Start heartbeat monitor in background (60s interval to reduce log noise)
           ${{ env.DOTNET_SCRIPT }} ${{ github.workspace }}/tools/scripts/Heartbeat.cs 60 &
           HEARTBEAT_PID=$!
 
-          # Run tests
-          ${{ env.DOTNET_SCRIPT }} test ${{ env.TEST_PROJECT_PATH }} \
-            /p:ContinuousIntegrationBuild=true \
-            /p:TrxFileNamePrefix="${{ inputs.testShortName }}" \
-            -bl:${{ github.workspace }}/testresults/test.binlog \
-            -tl:false \
+          # Run tests (using MTP-native dotnet test mode)
+          ${{ env.DOTNET_SCRIPT }} test --project ${{ env.TEST_PROJECT_PATH }} \
             --no-restore \
             --no-build \
             -- \
@@ -464,6 +462,8 @@ jobs:
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.token || '' }}
+          # MSBuild properties passed via env vars (new MTP dotnet test mode doesn't support /p:)
+          TrxFileNamePrefix: ${{ inputs.testShortName }}
         run: |
           # Start heartbeat monitor in background (output goes to console directly)
           # Use 60s interval on Windows to reduce overhead on constrained 2-core runners
@@ -474,12 +474,8 @@ jobs:
           try {
             # Ensure UTF-8 encoding for all output on Windows
             [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-            # Run tests
-            & ${{ env.DOTNET_SCRIPT }} test ${{ env.TEST_PROJECT_PATH }} `
-              /p:ContinuousIntegrationBuild=true `
-              /p:TrxFileNamePrefix="${{ inputs.testShortName }}" `
-              -bl:${{ github.workspace }}/testresults/test.binlog `
-              -tl:false `
+            # Run tests (using MTP-native dotnet test mode)
+            & ${{ env.DOTNET_SCRIPT }} test --project ${{ env.TEST_PROJECT_PATH }} `
               --no-restore `
               --no-build `
               -- `

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -424,7 +424,6 @@ jobs:
           ${{ env.DOTNET_SCRIPT }} test --project ${{ env.TEST_PROJECT_PATH }} \
             --no-restore \
             --no-build \
-            --output Detailed \
             -- \
             --ignore-exit-code 8 \
             --report-trx \
@@ -479,7 +478,6 @@ jobs:
             & ${{ env.DOTNET_SCRIPT }} test --project ${{ env.TEST_PROJECT_PATH }} `
               --no-restore `
               --no-build `
-              --output Detailed `
               -- `
               --ignore-exit-code 8 `
               --report-trx `

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -330,6 +330,7 @@ jobs:
             --report-trx --report-trx-filename "${{ inputs.testShortName }}.trx" \
             --crashdump \
             --hangdump \
+            --hangdump-type none \
             --hangdump-timeout ${{ env.EFFECTIVE_TEST_HANG_TIMEOUT }} \
             --results-directory ${{ github.workspace }}/testresults \
             --filter-not-trait "category=failing" \
@@ -378,6 +379,7 @@ jobs:
               --report-trx --report-trx-filename "${{ inputs.testShortName }}.trx" `
               --crashdump `
               --hangdump `
+              --hangdump-type none `
               --hangdump-timeout ${{ env.EFFECTIVE_TEST_HANG_TIMEOUT }} `
               --results-directory ${{ github.workspace }}/testresults `
               --filter-not-trait "category=failing" `
@@ -429,6 +431,7 @@ jobs:
             --report-trx \
             --crashdump \
             --hangdump \
+            --hangdump-type none \
             --hangdump-timeout ${{ env.EFFECTIVE_TEST_HANG_TIMEOUT }} \
             --results-directory ${{ github.workspace }}/testresults \
             --timeout ${{ env.EFFECTIVE_TEST_SESSION_TIMEOUT }} \
@@ -484,6 +487,7 @@ jobs:
               --report-trx `
               --crashdump `
               --hangdump `
+              --hangdump-type none `
               --hangdump-timeout ${{ env.EFFECTIVE_TEST_HANG_TIMEOUT }} `
               --results-directory ${{ github.workspace }}/testresults `
               --timeout ${{ env.EFFECTIVE_TEST_SESSION_TIMEOUT }} `

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
             --no-build \
+            --output Detailed \
             -- \
             --filter-class "*.SmokeTests" \
             --filter-not-trait "quarantined=true" \

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -53,7 +53,7 @@ jobs:
             --filter-class "*.SmokeTests" \
             --filter-not-trait "quarantined=true" \
             --filter-not-trait "outerloop=true" \
-            --hangdump --hangdump-timeout 15m
+            --hangdump --hangdump-type none --hangdump-timeout 15m
 
       - name: Upload test recordings
         if: always()

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
             --no-build \
-            --output Detailed \
             -- \
             --filter-class "*.SmokeTests" \
             --filter-not-trait "quarantined=true" \

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           ASPIRE_E2E_QUALITY: ${{ inputs.quality || 'dev' }}
         run: |
-          dotnet test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
+          dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
             --no-build \
             -- \
             --filter-class "*.SmokeTests" \

--- a/eng/Testing.props
+++ b/eng/Testing.props
@@ -34,7 +34,7 @@
   <PropertyGroup>
     <BlameHangTimeout Condition="'$(BlameHangTimeout)' == '' and '$(MSBuildProjectName)' == 'Aspire.Hosting.SqlServer.Tests'">20m</BlameHangTimeout>
     <BlameHangTimeout Condition="'$(BlameHangTimeout)' == ''">10m</BlameHangTimeout>
-    <_BlameArgs>--hangdump --hangdump-timeout $(BlameHangTimeout) --crashdump</_BlameArgs>
+    <_BlameArgs>--hangdump --hangdump-type none --hangdump-timeout $(BlameHangTimeout) --crashdump</_BlameArgs>
 
     <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter-not-trait &quot;category=failing&quot;</TestRunnerAdditionalArguments>
     <!-- ignore exit code 8 (zero tests ran)

--- a/eng/Testing.props
+++ b/eng/Testing.props
@@ -23,9 +23,9 @@
     <RunOnAzdoHelixLinux>true</RunOnAzdoHelixLinux>
 
     <_QuarantinedTestRunAdditionalArgs>--filter-trait "quarantined=true"</_QuarantinedTestRunAdditionalArgs>
-    <_NonQuarantinedTestRunAdditionalArgs>--filter-not-trait "quarantined=true"</_NonQuarantinedTestRunAdditionalArgs>
+    <_NonQuarantinedTestRunAdditionalArgs Condition="'$(SkipDefaultTestFilters)' != 'true'">--filter-not-trait "quarantined=true"</_NonQuarantinedTestRunAdditionalArgs>
     <_OuterloopTestRunAdditionalArgs>--filter-trait "outerloop=true"</_OuterloopTestRunAdditionalArgs>
-    <_NonOuterloopTestRunAdditionalArgs>--filter-not-trait "outerloop=true"</_NonOuterloopTestRunAdditionalArgs>
+    <_NonOuterloopTestRunAdditionalArgs Condition="'$(SkipDefaultTestFilters)' != 'true'">--filter-not-trait "outerloop=true"</_NonOuterloopTestRunAdditionalArgs>
 
     <_ShortName Condition="'$(TestShortName)' != ''">$(TestShortName)</_ShortName>
     <_ShortName Condition="'$(_ShortName)' == ''">$([System.IO.Path]::GetFileNameWithoutExtension('$(MSBuildProjectName)').Replace('Aspire.', '').Replace('.Tests', ''))</_ShortName>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,9 +15,9 @@
     <DotNetSdkPreviousVersionForTesting>8.0.415</DotNetSdkPreviousVersionForTesting>
     <!-- dotnet 9.0 versions for running tests - used for templates tests -->
     <DotNetSdkCurrentVersionForTesting>9.0.306</DotNetSdkCurrentVersionForTesting>
-    <XunitV3Version>3.1.0</XunitV3Version>
+    <XunitV3Version>3.2.2</XunitV3Version>
     <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
-    <XunitRunnerVisualStudioVersion>3.1.0</XunitRunnerVisualStudioVersion>
+    <XunitRunnerVisualStudioVersion>3.1.5</XunitRunnerVisualStudioVersion>
     <MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
     <MicrosoftNETTestSdkVersion>17.14.1</MicrosoftNETTestSdkVersion>
     <!-- Enable to remove prerelease label. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,7 @@
     <XunitV3Version>3.1.0</XunitV3Version>
     <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
     <XunitRunnerVisualStudioVersion>3.1.0</XunitRunnerVisualStudioVersion>
-    <MicrosoftTestingPlatformVersion>1.8.4</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
     <MicrosoftNETTestSdkVersion>17.14.1</MicrosoftNETTestSdkVersion>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>

--- a/eng/Xunit3/Xunit3.targets
+++ b/eng/Xunit3/Xunit3.targets
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="xunit.v3" Version="$(XunitV3Version)" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="$(XunitV3Version)" />
     <PackageVersion Include="xunit.v3.runner.console" Version="$(XunitV3Version)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)" />
     <PackageVersion Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
@@ -9,7 +9,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
 
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Platform" />
     <PackageReference Include="Microsoft.Testing.Platform.MSBuild" />

--- a/global.json
+++ b/global.json
@@ -30,6 +30,9 @@
       ]
     }
   },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.2.0",

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -314,6 +314,20 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         hostBuilderOptions.Configuration ??= new();
         hostBuilderOptions.Configuration.AddInMemoryCollection(additionalConfig);
 
+        // Also push launch profile values into Args so they have highest priority.
+        // In .NET 10 HostApplicationBuilder adds AddEnvironmentVariables() (all process env vars)
+        // which can override the in-memory collection above when the test host process has env vars
+        // set from the test project's own launchSettings.json (e.g., in MTP native test runner mode).
+        // Command-line args are the highest-priority configuration source in HostApplicationBuilder.
+        if (additionalConfig.Count > 0)
+        {
+            var launchProfileArgs = additionalConfig
+                .Where(kv => kv.Value is not null)
+                .Select(kv => $"--{kv.Key}={kv.Value}")
+                .ToArray();
+            hostBuilderOptions.Args = [.. hostBuilderOptions.Args ?? [], .. launchProfileArgs];
+        }
+
         void SetDefault(string key, string? value)
         {
             if (existingConfig[key] is null)

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -66,7 +66,7 @@
     <!-- in-repo-builds use Arcade which adds these package references for test projects implicitly.
          But when they are built without Arcade outside the repo, these need to be added
          explicitly. -->
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Platform" />
     <PackageReference Include="Microsoft.Testing.Platform.MSBuild" />

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -62,7 +62,7 @@
 
   <ItemGroup>
     <_TestBlameArguments Include="--hangdump" />
-    <_TestBlameArguments Include="--hangdump-type Full" />
+    <_TestBlameArguments Include="--hangdump-type none" />
     <_TestBlameArguments Include="--hangdump-timeout 20m" />
     <_TestBlameArguments Include="--crashdump" />
     <_TestBlameArguments Include="--crashdump-type Full" />


### PR DESCRIPTION
## Description

Investigate Hosting-1 test hangs by running partition 1 of Aspire.Hosting.Tests on 16 parallel Ubuntu runners with full hangdumps enabled.

### Changes to reproduce-flaky-tests workflow:
- **TEST_FILTER**: `--filter-trait "Partition=1"` (Hosting-1 partition)
- **hangdump-type**: `full` (complete dump for hang analysis)
- **16 runners** × 1 iteration each on ubuntu-latest
- **crashdump** enabled
- **Always upload** testresults artifacts (hangdumps, crashdumps)

### Goal
Reproduce test hangs and capture full dumps for analysis.

**DO NOT MERGE** — investigation-only PR.