### PR TITLE
Fix Next.js standalone Dockerfile cache permissions

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -835,13 +835,17 @@ public static class JavaScriptHostingExtensions
                             {
                                 var runtimeImage = baseImageAnnotation?.RuntimeImage ?? GetDefaultBaseImage(appDirectory, "alpine", dockerfileContext.Services);
 
+                                // Match the ownership pattern from the official Next.js sample:
+                                // https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
                                 dockerfileContext.Builder
                                     .From(runtimeImage, "runtime")
                                     .WorkDir("/app")
                                     .Env("NODE_ENV", "production")
-                                    .CopyFrom("build", "/app/public", "./public")
-                                    .CopyFrom("build", "/app/.next/standalone", "./")
-                                    .CopyFrom("build", "/app/.next/static", "./.next/static")
+                                    .CopyFrom("build", "/app/public", "./public", "node:node")
+                                    .Run("mkdir .next")
+                                    .Run("chown node:node .next")
+                                    .CopyFrom("build", "/app/.next/standalone", "./", "node:node")
+                                    .CopyFrom("build", "/app/.next/static", "./.next/static", "node:node")
                                     .User("node")
                                     .Entrypoint(["node", "server.js"]);
                                 break;

--- a/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddViteAppTests.VerifyDockerfileWhenNextJsAppUsesPnpm.verified.txt
+++ b/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddViteAppTests.VerifyDockerfileWhenNextJsAppUsesPnpm.verified.txt
@@ -9,8 +9,10 @@ RUN pnpm run build
 FROM node:22-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
-COPY --from=build /app/public ./public
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
+COPY --from=build --chown=node:node /app/public ./public
+RUN mkdir .next
+RUN chown node:node .next
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
 USER node
 ENTRYPOINT ["node","server.js"]

--- a/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddViteAppTests.VerifyDockerfileWhenPublishedAsNextStandalone.verified.txt
+++ b/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddViteAppTests.VerifyDockerfileWhenPublishedAsNextStandalone.verified.txt
@@ -8,8 +8,10 @@ RUN npm run build
 FROM node:22-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
-COPY --from=build /app/public ./public
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
+COPY --from=build --chown=node:node /app/public ./public
+RUN mkdir .next
+RUN chown node:node .next
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
 USER node
 ENTRYPOINT ["node","server.js"]


### PR DESCRIPTION
## Description

Update the generated Dockerfile for Next.js standalone publish so the runtime image follows the ownership pattern from the official Next.js sample and allows the non-root `node` user to write to `.next` at runtime.

- copy `public`, `.next/standalone`, and `.next/static` with `--chown=node:node`
- create `.next` in the runtime image and assign it to `node:node` before switching to `USER node`
- update the Next.js standalone Dockerfile snapshots for both npm and pnpm cases

Validation:
- `dotnet test tests/Aspire.Hosting.JavaScript.Tests/Aspire.Hosting.JavaScript.Tests.csproj -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- LocalHive-based manual `aspire deploy` of a TypeScript AppHost with a real Next.js app, including:
  - a real `/api/hello` route
  - a real `next/image` optimization request returning `X-Nextjs-Cache: MISS` then `X-Nextjs-Cache: HIT`
  - verification that the running `node` user can write files under `/app/.next/cache`
  - clean Next.js container logs after startup

Fixes #16277

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
