### PR TITLE
Move user secrets descriptions to checkbox inputs

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/InteractionInputField.razor
+++ b/src/Aspire.Dashboard/Components/Controls/InteractionInputField.razor
@@ -11,7 +11,7 @@
 
 @if (InputViewModel.Input.InputType != InputType.Boolean)
 {
-    <FluentInputLabel ForId="@ForId" Label="@InputViewModel.Input.Label" AriaLabel="@InputViewModel.Input.Description" Required="@InputViewModel.Input.Required" />
+    <FluentInputLabel ForId="@ForId" Label="@InputViewModel.Input.Label" AriaLabel="@InputViewModel.Input.Label" Required="@InputViewModel.Input.Required" />
 }
 <div class="input-line-container">
     @ChildContent(new InteractionInputFieldContext { ViewModel = InputViewModel, DescriptionId = descriptionId })

--- a/src/Aspire.Dashboard/Components/Controls/InteractionInputField.razor
+++ b/src/Aspire.Dashboard/Components/Controls/InteractionInputField.razor
@@ -9,7 +9,10 @@
         : null;
 }
 
-<FluentInputLabel ForId="@ForId" Label="@InputViewModel.Input.Label" AriaLabel="@InputViewModel.Input.Description" Required="@InputViewModel.Input.Required" />
+@if (InputViewModel.Input.InputType != InputType.Boolean)
+{
+    <FluentInputLabel ForId="@ForId" Label="@InputViewModel.Input.Label" AriaLabel="@InputViewModel.Input.Description" Required="@InputViewModel.Input.Required" />
+}
 <div class="input-line-container">
     @ChildContent(new InteractionInputFieldContext { ViewModel = InputViewModel, DescriptionId = descriptionId })
     @if (InputViewModel.Input.Loading)

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -137,7 +137,7 @@
                                                 @bind-Value="input.ViewModel.IsChecked"
                                                 Label="@input.ViewModel.Input.Label"
                                                 Placeholder="@input.ViewModel.Input.Placeholder"
-                                                AriaLabel="@input.ViewModel.Input.Description"
+                                                AriaLabel="@input.ViewModel.Input.Label"
                                                 Disabled="input.ViewModel.InputDisabled"
                                                 aria-describedby="@input.DescriptionId" />
                             </InteractionInputField>

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -182,24 +182,3 @@
         </FluentButton>
     }
 </FluentDialogFooter>
-
-@code {
-    private RenderFragment? GetDescriptionContent(InteractionInput vm, string? id)
-    {
-        @if (!string.IsNullOrEmpty(vm.Description))
-        {
-            return
-            @<div class="input-description" id="@id">
-            @if (vm.EnableDescriptionMarkdown)
-            {
-                    <MarkdownRenderer MarkdownProcessor="@_markdownProcessor" Markdown="@vm.Description" SuppressParagraphOnNewLines="true" />
-            }
-            else
-            {
-                    <span>@vm.Description</span>
-            }
-            </div>;
-        }
-        return null;
-    }
-}

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
@@ -15,6 +15,10 @@
     max-width: 500px;
 }
 
+.interaction-input-dialog .interaction-input ::deep .input-description {
+    margin-top: 2px;
+}
+
 .interaction-input-dialog .interaction-input ::deep .input-description,
 .interaction-input-dialog .interaction-input ::deep .input-description p {
     color: var(--foreground-settings-text);

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -314,7 +314,7 @@ public sealed class ParameterProcessor(
             Value = hasExistingValue ? "true" : null,
             Description = !userSecretsManager.IsAvailable
                 ? InteractionStrings.ParametersInputsRememberDescriptionNotConfigured
-                : null,
+                : InteractionStrings.ParametersInputsRememberDescriptionConfigured,
             EnableDescriptionMarkdown = true,
             Disabled = !userSecretsManager.IsAvailable
         };
@@ -348,7 +348,9 @@ public sealed class ParameterProcessor(
                 {
                     Name = DeleteFromUserSecretsName,
                     InputType = InputType.Boolean,
-                    Label = InteractionStrings.ParametersInputsDeleteLabel
+                    Label = InteractionStrings.ParametersInputsDeleteLabel,
+                    Description = InteractionStrings.ParametersInputsDeleteDescription,
+                    EnableDescriptionMarkdown = true
                 };
                 inputs.Add(deleteFromUserSecretsInput);
             }

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -333,10 +333,7 @@ public sealed class ParameterProcessor(
             var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
             var hasSavedState = parameterSection.Data.Count > 0;
 
-            // Show different message based on whether value is saved in user secrets
-            var message = hasSavedState
-                ? string.Format(CultureInfo.CurrentCulture, InteractionStrings.DeleteParameterMessageWithUserSecrets, parameterResource.Name)
-                : string.Format(CultureInfo.CurrentCulture, InteractionStrings.DeleteParameterMessage, parameterResource.Name);
+            var message = string.Format(CultureInfo.CurrentCulture, InteractionStrings.DeleteParameterMessage, parameterResource.Name);
 
             var inputs = new List<InteractionInput>();
             InteractionInput? deleteFromUserSecretsInput = null;

--- a/src/Aspire.Hosting/Resources/InteractionStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.Designer.cs
@@ -178,9 +178,7 @@ namespace Aspire.Hosting.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to delete the value for parameter `{0}`?
-        ///
-        ///The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there..
+        ///   Looks up a localized string similar to Are you sure you want to delete the value for parameter `{0}`?.
         /// </summary>
         internal static string DeleteParameterMessageWithUserSecrets {
             get {
@@ -230,6 +228,15 @@ namespace Aspire.Hosting.Resources {
         internal static string ParametersBarTitle {
             get {
                 return ResourceManager.GetString("ParametersBarTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets)..
+        /// </summary>
+        internal static string ParametersInputsDeleteDescription {
+            get {
+                return ResourceManager.GetString("ParametersInputsDeleteDescription", resourceCulture);
             }
         }
 
@@ -288,7 +295,16 @@ namespace Aspire.Hosting.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information..
+        ///   Looks up a localized string similar to Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use..
+        /// </summary>
+        internal static string ParametersInputsRememberDescriptionConfigured {
+            get {
+                return ResourceManager.GetString("ParametersInputsRememberDescriptionConfigured", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information..
         /// </summary>
         internal static string ParametersInputsRememberDescriptionNotConfigured {
             get {
@@ -306,7 +322,7 @@ namespace Aspire.Hosting.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        ///   Looks up a localized string similar to Please provide a value for the parameter.
         ///
         ///New parameter values may not be used until dependent resources are restarted..
         /// </summary>

--- a/src/Aspire.Hosting/Resources/InteractionStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.Designer.cs
@@ -169,20 +169,11 @@ namespace Aspire.Hosting.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to delete the value for parameter `{0}`? .
+        ///   Looks up a localized string similar to Are you sure you want to delete the value for parameter `{0}`?.
         /// </summary>
         internal static string DeleteParameterMessage {
             get {
                 return ResourceManager.GetString("DeleteParameterMessage", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to delete the value for parameter `{0}`?.
-        /// </summary>
-        internal static string DeleteParameterMessageWithUserSecrets {
-            get {
-                return ResourceManager.GetString("DeleteParameterMessageWithUserSecrets", resourceCulture);
             }
         }
 

--- a/src/Aspire.Hosting/Resources/InteractionStrings.resx
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.resx
@@ -205,9 +205,7 @@
     <value>Set parameter</value>
   </data>
   <data name="SetParameterMessage" xml:space="preserve">
-    <value>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</value>
+    <value>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</value>
     <comment>Contains markdown</comment>
   </data>
   <data name="ParametersInputsDeleteLabel" xml:space="preserve">
@@ -217,10 +215,6 @@ New parameter values may not be used until dependent resources are restarted.</v
     <value>Delete parameter value</value>
   </data>
   <data name="DeleteParameterMessage" xml:space="preserve">
-    <value>Are you sure you want to delete the value for parameter `{0}`? </value>
-    <comment>Contains markdown. {0} is the parameter name.</comment>
-  </data>
-  <data name="DeleteParameterMessageWithUserSecrets" xml:space="preserve">
     <value>Are you sure you want to delete the value for parameter `{0}`?</value>
     <comment>Contains markdown. {0} is the parameter name.</comment>
   </data>

--- a/src/Aspire.Hosting/Resources/InteractionStrings.resx
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.resx
@@ -142,8 +142,13 @@
   <data name="ParametersInputsRememberLabel" xml:space="preserve">
     <value>Save to user secrets</value>
   </data>
+  <data name="ParametersInputsRememberDescriptionConfigured" xml:space="preserve">
+    <value>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</value>
+    <comment>Contains markdown</comment>
+  </data>
   <data name="ParametersInputsRememberDescriptionNotConfigured" xml:space="preserve">
     <value>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</value>
+    <comment>Contains markdown</comment>
   </data>
   <data name="ParametersInputsTitle" xml:space="preserve">
     <value>Set unresolved parameters</value>
@@ -200,7 +205,7 @@
     <value>Set parameter</value>
   </data>
   <data name="SetParameterMessage" xml:space="preserve">
-    <value>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+    <value>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</value>
     <comment>Contains markdown</comment>
@@ -216,10 +221,12 @@ New parameter values may not be used until dependent resources are restarted.</v
     <comment>Contains markdown. {0} is the parameter name.</comment>
   </data>
   <data name="DeleteParameterMessageWithUserSecrets" xml:space="preserve">
-    <value>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</value>
+    <value>Are you sure you want to delete the value for parameter `{0}`?</value>
     <comment>Contains markdown. {0} is the parameter name.</comment>
+  </data>
+  <data name="ParametersInputsDeleteDescription" xml:space="preserve">
+    <value>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</value>
+    <comment>Contains markdown</comment>
   </data>
   <data name="DeleteParameterPrimaryButtonText" xml:space="preserve">
     <value>Delete</value>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">Opravdu chcete odstranit hodnotu parametru {0}?
 
 Hodnota je aktuálně uložena v [tajných klíčích uživatele](https://learn.microsoft.com/aspnet/core/security/app-secrets). Můžete se také rozhodnout ji odtud odstranit.</target>
@@ -101,6 +99,11 @@ Hodnota je aktuálně uložena v [tajných klíčích uživatele](https://learn.
         <target state="translated">Nerozpoznané parametry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Odstranit z tajných kódů uživatele</target>
@@ -126,10 +129,15 @@ Hodnota je aktuálně uložena v [tajných klíčích uživatele](https://learn.
         <target state="translated">Uložit</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ Hodnota je aktuálně uložena v [tajných klíčích uživatele](https://learn.
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Zadejte prosím hodnotu parametru. Parametr lze uložit do [tajných kódů uživatele](https://learn.microsoft.com/aspnet/core/security/app-secrets) pro budoucí použití.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">Opravdu chcete odstranit hodnotu parametru {0}? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">Opravdu chcete odstranit hodnotu parametru {0}?
-
-Hodnota je aktuálně uložena v [tajných klíčích uživatele](https://learn.microsoft.com/aspnet/core/security/app-secrets). Můžete se také rozhodnout ji odtud odstranit.</target>
+        <target state="needs-review-translation">Opravdu chcete odstranit hodnotu parametru {0}? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@ Hodnota je aktuálně uložena v [tajných klíčích uživatele](https://learn.
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Zadejte prosím hodnotu parametru. Parametr lze uložit do [tajných kódů uživatele](https://learn.microsoft.com/aspnet/core/security/app-secrets) pro budoucí použití.
 
 Nové hodnoty parametrů se nedají použít, dokud se nerestartují závislé prostředky.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">Möchten Sie den Wert für den Parameter „{0}“ wirklich löschen? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">Möchten Sie den Wert für den Parameter „{0}“ wirklich löschen?
-
-Der Wert wird derzeit in [Benutzergeheimnissen](https://learn.microsoft.com/aspnet/core/security/app-secrets) gespeichert. Sie können ihn auch von dort löschen.</target>
+        <target state="needs-review-translation">Möchten Sie den Wert für den Parameter „{0}“ wirklich löschen? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@ Der Wert wird derzeit in [Benutzergeheimnissen](https://learn.microsoft.com/aspn
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Geben Sie einen Wert für den Parameter ein. Parameter können zur zukünftigen Verwendung in [Benutzergeheimnissen](https://learn.microsoft.com/aspnet/core/security/app-secrets) gespeichert werden.
 
 Neue Parameterwerte dürfen erst verwendet werden, wenn abhängige Ressourcen neu gestartet werden.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">Möchten Sie den Wert für den Parameter „{0}“ wirklich löschen?
 
 Der Wert wird derzeit in [Benutzergeheimnissen](https://learn.microsoft.com/aspnet/core/security/app-secrets) gespeichert. Sie können ihn auch von dort löschen.</target>
@@ -101,6 +99,11 @@ Der Wert wird derzeit in [Benutzergeheimnissen](https://learn.microsoft.com/aspn
         <target state="translated">Nicht aufgelöste Parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Aus Benutzergeheimnissen löschen</target>
@@ -126,10 +129,15 @@ Der Wert wird derzeit in [Benutzergeheimnissen](https://learn.microsoft.com/aspn
         <target state="translated">Speichern</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ Der Wert wird derzeit in [Benutzergeheimnissen](https://learn.microsoft.com/aspn
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Geben Sie einen Wert für den Parameter ein. Parameter können zur zukünftigen Verwendung in [Benutzergeheimnissen](https://learn.microsoft.com/aspnet/core/security/app-secrets) gespeichert werden.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">¿Está seguro de que desea eliminar el valor del parámetro "{0}"?
 
 El valor se guarda actualmente en [secretos de usuario](https://learn.microsoft.com/aspnet/core/security/app-secrets). También puede eliminarla desde allí.</target>
@@ -101,6 +99,11 @@ El valor se guarda actualmente en [secretos de usuario](https://learn.microsoft.
         <target state="translated">Parámetros sin resolver</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Eliminar de los secretos del usuario</target>
@@ -126,10 +129,15 @@ El valor se guarda actualmente en [secretos de usuario](https://learn.microsoft.
         <target state="translated">Guardar</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ El valor se guarda actualmente en [secretos de usuario](https://learn.microsoft.
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Proporcione un valor para el parámetro. El parámetro se puede guardar en [secretos de usuario](https://learn.microsoft.com/aspnet/core/security/app-secrets) para su uso futuro.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">¿Está seguro de que desea eliminar el valor del parámetro "{0}"? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">¿Está seguro de que desea eliminar el valor del parámetro "{0}"?
-
-El valor se guarda actualmente en [secretos de usuario](https://learn.microsoft.com/aspnet/core/security/app-secrets). También puede eliminarla desde allí.</target>
+        <target state="needs-review-translation">¿Está seguro de que desea eliminar el valor del parámetro "{0}"? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@ El valor se guarda actualmente en [secretos de usuario](https://learn.microsoft.
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Proporcione un valor para el parámetro. El parámetro se puede guardar en [secretos de usuario](https://learn.microsoft.com/aspnet/core/security/app-secrets) para su uso futuro.
 
 Los nuevos valores de los parámetros no se pueden utilizar hasta que se reinicien los recursos dependientes.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">Voulez-vous vraiment supprimer la valeur du paramètre « {0} » ? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">Voulez-vous vraiment supprimer la valeur du paramètre «{0} » ?
-
-La valeur est actuellement enregistrée dans [secrets utilisateur](https://learn.microsoft.com/aspnet/core/security/app-secrets). Vous pouvez également choisir de le supprimer à partir de là.</target>
+        <target state="needs-review-translation">Voulez-vous vraiment supprimer la valeur du paramètre « {0} » ? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@ La valeur est actuellement enregistrée dans [secrets utilisateur](https://learn
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Veuillez fournir une valeur pour le paramètre. Le paramètre peut être enregistré dans [secrets utilisateur](https://learn.microsoft.com/aspnet/core/security/app-secrets) pour une utilisation ultérieure.
 
 Les nouvelles valeurs de paramètre ne peuvent pas être utilisées tant que les ressources dépendantes ne sont pas redémarrées.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">Voulez-vous vraiment supprimer la valeur du paramètre «{0} » ?
 
 La valeur est actuellement enregistrée dans [secrets utilisateur](https://learn.microsoft.com/aspnet/core/security/app-secrets). Vous pouvez également choisir de le supprimer à partir de là.</target>
@@ -101,6 +99,11 @@ La valeur est actuellement enregistrée dans [secrets utilisateur](https://learn
         <target state="translated">Paramètres non résolus</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Supprimer des secrets utilisateur</target>
@@ -126,10 +129,15 @@ La valeur est actuellement enregistrée dans [secrets utilisateur](https://learn
         <target state="translated">Enregistrer</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ La valeur est actuellement enregistrée dans [secrets utilisateur](https://learn
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Veuillez fournir une valeur pour le paramètre. Le paramètre peut être enregistré dans [secrets utilisateur](https://learn.microsoft.com/aspnet/core/security/app-secrets) pour une utilisation ultérieure.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">Eliminare il valore del parametro '{0}'?
 
 Il valore è attualmente salvato nei [segreti utente](https://learn.microsoft.com/aspnet/core/security/app-secrets). È possibile scegliere di eliminarlo anche da lì.</target>
@@ -101,6 +99,11 @@ Il valore è attualmente salvato nei [segreti utente](https://learn.microsoft.co
         <target state="translated">Parametri non risolti</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Elimina dai segreti utente</target>
@@ -126,10 +129,15 @@ Il valore è attualmente salvato nei [segreti utente](https://learn.microsoft.co
         <target state="translated">Salva</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ Il valore è attualmente salvato nei [segreti utente](https://learn.microsoft.co
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Specificare un valore per il parametro. I parametri possono essere salvati nei [segreti utente](https://learn.microsoft.com/aspnet/core/security/app-secrets) per usi futuri.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">Eliminare il valore del parametro '{0}'? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">Eliminare il valore del parametro '{0}'?
-
-Il valore è attualmente salvato nei [segreti utente](https://learn.microsoft.com/aspnet/core/security/app-secrets). È possibile scegliere di eliminarlo anche da lì.</target>
+        <target state="needs-review-translation">Eliminare il valore del parametro '{0}'? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@ Il valore è attualmente salvato nei [segreti utente](https://learn.microsoft.co
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Specificare un valore per il parametro. I parametri possono essere salvati nei [segreti utente](https://learn.microsoft.com/aspnet/core/security/app-secrets) per usi futuri.
 
 I nuovi valori del parametro potrebbero non essere usati finché le risorse dipendenti non vengono riavviate.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">パラメーター `{0}` の値を削除しますか?</target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">パラメーター `{0}` の値を削除しますか?
-
-現在、値は [ユーザー シークレット](https://learn.microsoft.com/aspnet/core/security/app-secrets) に保存されています。そこから削除することもできます。</target>
+        <target state="needs-review-translation">パラメーター `{0}` の値を削除しますか?</target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">パラメーターの値を指定してください。パラメーターは、将来使用するために [ユーザー シークレット](https://learn.microsoft.com/aspnet/core/security/app-secrets) に保存できます。
 
 依存するリソースが再起動されるまで、新しいパラメーター値は使用されない可能性があります。</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">パラメーター `{0}` の値を削除しますか?
 
 現在、値は [ユーザー シークレット](https://learn.microsoft.com/aspnet/core/security/app-secrets) に保存されています。そこから削除することもできます。</target>
@@ -101,6 +99,11 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">未解決のパラメーター</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">ユーザー シークレットから削除する</target>
@@ -126,10 +129,15 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">保存</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">パラメーターの値を指定してください。パラメーターは、将来使用するために [ユーザー シークレット](https://learn.microsoft.com/aspnet/core/security/app-secrets) に保存できます。

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">`{0}` 매개 변수의 값을 삭제하시겠습니까?
 
 이 값은 현재 [사용자 비밀](https://learn.microsoft.com/aspnet/core/security/app-secrets)에 저장되어 있습니다. 여기에서 삭제하도록 선택할 수도 있습니다.</target>
@@ -101,6 +99,11 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">해결되지 않은 매개 변수</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">사용자 비밀에서 삭제</target>
@@ -126,10 +129,15 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">저장</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">매개 변수에 대한 값을 제공하세요. 나중에 사용할 수 있도록 매개 변수를 [사용자 비밀](https://learn.microsoft.com/aspnet/core/security/app-secrets)에 저장할 수 있습니다.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">`{0}` 매개 변수의 값을 삭제하시겠습니까? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">`{0}` 매개 변수의 값을 삭제하시겠습니까?
-
-이 값은 현재 [사용자 비밀](https://learn.microsoft.com/aspnet/core/security/app-secrets)에 저장되어 있습니다. 여기에서 삭제하도록 선택할 수도 있습니다.</target>
+        <target state="needs-review-translation">`{0}` 매개 변수의 값을 삭제하시겠습니까? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">매개 변수에 대한 값을 제공하세요. 나중에 사용할 수 있도록 매개 변수를 [사용자 비밀](https://learn.microsoft.com/aspnet/core/security/app-secrets)에 저장할 수 있습니다.
 
 종속 리소스를 다시 시작할 때까지 새 매개 변수 값을 사용할 수 없습니다.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">Czy na pewno chcesz usunąć wartość parametru „{0}”?
 
 Wartość jest obecnie zapisana we [wpisach tajnych użytkownika](https://learn.microsoft.com/aspnet/core/security/app-secrets). Możesz też zdecydować się na jego usunięcie stamtąd.</target>
@@ -101,6 +99,11 @@ Wartość jest obecnie zapisana we [wpisach tajnych użytkownika](https://learn.
         <target state="translated">Nierozpoznane parametry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Usuń z wpisów tajnych użytkownika</target>
@@ -126,10 +129,15 @@ Wartość jest obecnie zapisana we [wpisach tajnych użytkownika](https://learn.
         <target state="translated">Zapisz</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ Wartość jest obecnie zapisana we [wpisach tajnych użytkownika](https://learn.
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Podaj wartość parametru. Parametr możesz zapisać we [wpisach tajnych użytkownika](https://learn.microsoft.com/aspnet/core/security/app-secrets), aby użyć go później.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">Czy na pewno chcesz usunąć wartość parametru „{0}”? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">Czy na pewno chcesz usunąć wartość parametru „{0}”?
-
-Wartość jest obecnie zapisana we [wpisach tajnych użytkownika](https://learn.microsoft.com/aspnet/core/security/app-secrets). Możesz też zdecydować się na jego usunięcie stamtąd.</target>
+        <target state="needs-review-translation">Czy na pewno chcesz usunąć wartość parametru „{0}”? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@ Wartość jest obecnie zapisana we [wpisach tajnych użytkownika](https://learn.
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Podaj wartość parametru. Parametr możesz zapisać we [wpisach tajnych użytkownika](https://learn.microsoft.com/aspnet/core/security/app-secrets), aby użyć go później.
 
 Nowe wartości parametrów nie będą używane, dopóki nie zostaną ponownie uruchomione zasoby zależne.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">Tem certeza de que deseja excluir o valor do parâmetro `{0}`? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">Tem certeza de que deseja excluir o valor do parâmetro `{0}`?
-
-O valor está atualmente salvo em [segredos do usuário](https://learn.microsoft.com/aspnet/core/security/app-secrets). Você pode optar por excluí-lo também de lá.</target>
+        <target state="needs-review-translation">Tem certeza de que deseja excluir o valor do parâmetro `{0}`? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@ O valor está atualmente salvo em [segredos do usuário](https://learn.microsof
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Forneça um valor para o parâmetro. O parâmetro pode ser salvo em [segredos do usuário](https://learn.microsoft.com/aspnet/core/security/app-secrets) para uso futuro.
 
 Novos valores de parâmetro não podem ser usados após a reinicialização dos recursos dependentes.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">Tem certeza de que deseja excluir o valor do parâmetro `{0}`?
 
 O valor está atualmente salvo em [segredos do usuário](https://learn.microsoft.com/aspnet/core/security/app-secrets). Você pode optar por excluí-lo também de lá.</target>
@@ -101,6 +99,11 @@ O valor está atualmente salvo em [segredos do usuário](https://learn.microsof
         <target state="translated">Parâmetros não resolvidos</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Excluir dos segredos do usuário</target>
@@ -126,10 +129,15 @@ O valor está atualmente salvo em [segredos do usuário](https://learn.microsof
         <target state="translated">Salvar</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ O valor está atualmente salvo em [segredos do usuário](https://learn.microsof
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Forneça um valor para o parâmetro. O parâmetro pode ser salvo em [segredos do usuário](https://learn.microsoft.com/aspnet/core/security/app-secrets) para uso futuro.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">Действительно удалить значение параметра "{0}"? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">Действительно удалить значение параметра "{0}"?
-
-Это значение сейчас сохранено в [пользовательских секретах](https://learn.microsoft.com/aspnet/core/security/app-secrets). Вы можете также удалить его оттуда.</target>
+        <target state="needs-review-translation">Действительно удалить значение параметра "{0}"? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Укажите значение параметра. Параметр можно сохранить в [пользовательских секретах](https://learn.microsoft.com/aspnet/core/security/app-secrets) для дальнейшего использования.
 
 Новые значения параметров могут не использоваться, пока не будут перезапущены зависимые ресурсы.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">Действительно удалить значение параметра "{0}"?
 
 Это значение сейчас сохранено в [пользовательских секретах](https://learn.microsoft.com/aspnet/core/security/app-secrets). Вы можете также удалить его оттуда.</target>
@@ -101,6 +99,11 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">Неразрешенные параметры</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Удалить из пользовательских секретов</target>
@@ -126,10 +129,15 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">Сохранить</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Укажите значение параметра. Параметр можно сохранить в [пользовательских секретах](https://learn.microsoft.com/aspnet/core/security/app-secrets) для дальнейшего использования.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">'{0}' parametresinin değerini silmek istediğinizden emin misiniz?
 
 Değer şu anda [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet/core/security/app-secrets) içinde kaydedilmiştir. Oradan da silmeyi seçebilirsiniz.</target>
@@ -101,6 +99,11 @@ Değer şu anda [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet
         <target state="translated">Çözülmemiş parametreler</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">Kullanıcı gizli dizilerinden sil</target>
@@ -126,10 +129,15 @@ Değer şu anda [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet
         <target state="translated">Kaydet</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ Değer şu anda [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Lütfen parametre için bir değer girin. Parametre, ileride kullanmak üzere [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet/core/security/app-secrets) bölümüne kaydedilebilir.

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">'{0}' parametresinin değerini silmek istediğinizden emin misiniz? </target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">'{0}' parametresinin değerini silmek istediğinizden emin misiniz?
-
-Değer şu anda [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet/core/security/app-secrets) içinde kaydedilmiştir. Oradan da silmeyi seçebilirsiniz.</target>
+        <target state="needs-review-translation">'{0}' parametresinin değerini silmek istediğinizden emin misiniz? </target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@ Değer şu anda [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">Lütfen parametre için bir değer girin. Parametre, ileride kullanmak üzere [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet/core/security/app-secrets) bölümüne kaydedilebilir.
 
 Bağımlı kaynaklar yeniden başlatılana kadar yeni parametre değerleri kullanılamaz.</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">确定要删除参数 `{0}` 的值吗?</target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">确定要删除参数 `{0}` 的值吗?
-
-该值当前保存在[用户机密](https://learn.microsoft.com/aspnet/core/security/app-secrets)中。你可以选择也从其中将它删除。</target>
+        <target state="needs-review-translation">确定要删除参数 `{0}` 的值吗?</target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">请为参数提供值。此参数可以保存到[用户机密](https://learn.microsoft.com/aspnet/core/security/app-secrets)以供将来使用。
 
 在重启从属资源之前，不能使用新的参数值。</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">确定要删除参数 `{0}` 的值吗?
 
 该值当前保存在[用户机密](https://learn.microsoft.com/aspnet/core/security/app-secrets)中。你可以选择也从其中将它删除。</target>
@@ -101,6 +99,11 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">未解析的参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">从用户机密中删除</target>
@@ -126,10 +129,15 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">保存</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">请为参数提供值。此参数可以保存到[用户机密](https://learn.microsoft.com/aspnet/core/security/app-secrets)以供将来使用。

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
@@ -48,9 +48,7 @@
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterMessageWithUserSecrets">
-        <source>Are you sure you want to delete the value for parameter `{0}`?
-
-The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets). You can choose to also delete it from there.</source>
+        <source>Are you sure you want to delete the value for parameter `{0}`?</source>
         <target state="needs-review-translation">確定要刪除參數 `{0}` 的值?
 
 值目前儲存於 [使用者祕密](https://learn.microsoft.com/aspnet/core/security/app-secrets)。您可以選擇也從該處刪除它。</target>
@@ -101,6 +99,11 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">未解析的參數</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsDeleteDescription">
+        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">
         <source>Delete from user secrets</source>
         <target state="translated">從使用者祕密刪除</target>
@@ -126,10 +129,15 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <target state="translated">儲存</target>
         <note />
       </trans-unit>
+      <trans-unit id="ParametersInputsRememberDescriptionConfigured">
+        <source>Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</source>
+        <target state="new">Save value to [user secrets](https://aka.ms/aspire/user-secrets) for future use.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
         <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
         <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
-        <note />
+        <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">
         <source>Save to user secrets</source>
@@ -162,7 +170,7 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use.
+        <source>Please provide a value for the parameter.
 
 New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">請提供參數的值。參數可以儲存到 [使用者祕密](https://learn.microsoft.com/aspnet/core/security/app-secrets) 供未來使用。

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
@@ -43,15 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DeleteParameterMessage">
-        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
-        <target state="translated">確定要刪除參數 `{0}` 的值?</target>
-        <note>Contains markdown. {0} is the parameter name.</note>
-      </trans-unit>
-      <trans-unit id="DeleteParameterMessageWithUserSecrets">
         <source>Are you sure you want to delete the value for parameter `{0}`?</source>
-        <target state="needs-review-translation">確定要刪除參數 `{0}` 的值?
-
-值目前儲存於 [使用者祕密](https://learn.microsoft.com/aspnet/core/security/app-secrets)。您可以選擇也從該處刪除它。</target>
+        <target state="needs-review-translation">確定要刪除參數 `{0}` 的值?</target>
         <note>Contains markdown. {0} is the parameter name.</note>
       </trans-unit>
       <trans-unit id="DeleteParameterPrimaryButtonText">
@@ -170,9 +163,7 @@
         <note />
       </trans-unit>
       <trans-unit id="SetParameterMessage">
-        <source>Please provide a value for the parameter.
-
-New parameter values may not be used until dependent resources are restarted.</source>
+        <source>Please provide a value for the parameter. New parameter values may not be used until dependent resources are restarted.</source>
         <target state="needs-review-translation">請提供參數的值。參數可以儲存到 [使用者祕密](https://learn.microsoft.com/aspnet/core/security/app-secrets) 供未來使用。
 
 除非重新啟動相依資源，否則無法使用新的參數值。</target>

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -566,7 +566,7 @@ public class ParameterProcessorTests
         Assert.Equal(InteractionStrings.ParametersInputsRememberLabel, saveCheckbox.Label);
         Assert.Equal(InputType.Boolean, saveCheckbox.InputType);
         Assert.False(saveCheckbox.Disabled); // Should be enabled when user secrets are available
-        Assert.Null(saveCheckbox.Description); // No description when enabled
+        Assert.Equal(InteractionStrings.ParametersInputsRememberDescriptionConfigured, saveCheckbox.Description);
         Assert.True(saveCheckbox.EnableDescriptionMarkdown);
     }
 


### PR DESCRIPTION
## Description

Move user secrets descriptions from dialog-level messages to the checkbox input descriptions, and skip rendering the redundant `FluentInputLabel` for boolean (checkbox) inputs since checkboxes already render their own label.

Previously, the "Save to user secrets" and "Delete from user secrets" checkboxes displayed the same text as both the section title label above the checkbox and the checkbox's own label, which looked redundant. This change:

- Skips rendering `FluentInputLabel` for `InputType.Boolean` inputs in `InteractionInputField` (the checkbox already has its own label)
- Moves the user secrets link from `SetParameterMessage` to a new `ParametersInputsRememberDescriptionConfigured` description on the "Save to user secrets" checkbox
- Moves the user secrets info from `DeleteParameterMessageWithUserSecrets` to a new `ParametersInputsDeleteDescription` description on the "Delete from user secrets" checkbox

After:
<img width="911" height="468" alt="image" src="https://github.com/user-attachments/assets/cdb4a34f-64ee-4ea0-aaa1-beba50b4acbc" />

<img width="914" height="351" alt="image" src="https://github.com/user-attachments/assets/79079a85-52fa-4de0-a409-ac34950e2ef4" />

Fixes #16272

@maddymontaquila 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
