### PR TITLE
Ignore package.json engines.node when generating Dockerfiles

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -1711,7 +1711,7 @@ public static class JavaScriptHostingExtensions
     private static string GetDefaultBaseImage(string appDirectory, string defaultSuffix, IServiceProvider serviceProvider)
     {
         var logger = serviceProvider.GetService<ILogger<JavaScriptAppResource>>() ?? NullLogger<JavaScriptAppResource>.Instance;
-        var nodeVersion = DetectNodeVersion(appDirectory, logger) ?? DefaultNodeVersion;
+        var nodeVersion = ResolveNodeVersion(appDirectory, logger);
         return $"node:{nodeVersion}-{defaultSuffix}";
     }
 
@@ -1827,13 +1827,31 @@ public static class JavaScriptHostingExtensions
     }
 
     /// <summary>
-    /// Detects the Node.js version to use for a project by checking common configuration files.
+    /// Resolves the Node.js version to use for a project by checking common configuration files.
     /// </summary>
     /// <param name="workingDirectory">The working directory of the Node.js project.</param>
     /// <param name="logger">The logger for diagnostic messages.</param>
-    /// <returns>The detected Node.js major version number as a string, or <c>null</c> if no version is detected.</returns>
-    private static string? DetectNodeVersion(string workingDirectory, ILogger logger)
+    /// <returns>The resolved Node.js major version number as a string.</returns>
+    private static string ResolveNodeVersion(string workingDirectory, ILogger logger)
     {
+        // Follow the same shape as Cloud Native Buildpacks-style tooling for Node selection:
+        // pinned toolchain files (.nvmrc, .node-version, .tool-versions) are treated as
+        // authoritative runtime intent, while package.json engines.node is compatibility
+        // metadata rather than a deployment image pin. If there is no explicit toolchain pin,
+        // generated Dockerfiles fall back to Aspire's preferred default Node major.
+        if (TryDetectPinnedNodeVersion(workingDirectory, logger, out var pinnedNodeVersion))
+        {
+            return pinnedNodeVersion;
+        }
+
+        logger.LogDebug("No Node.js version detected, using default version {DefaultVersion}", DefaultNodeVersion);
+        return DefaultNodeVersion;
+    }
+
+    private static bool TryDetectPinnedNodeVersion(string workingDirectory, ILogger logger, out string nodeVersion)
+    {
+        nodeVersion = string.Empty;
+
         // Check .nvmrc file
         var nvmrcPath = Path.Combine(workingDirectory, ".nvmrc");
         if (File.Exists(nvmrcPath))
@@ -1842,7 +1860,8 @@ public static class JavaScriptHostingExtensions
             if (TryParseNodeVersion(versionString, out var version))
             {
                 logger.LogDebug("Detected Node.js version {Version} from .nvmrc file", version);
-                return version;
+                nodeVersion = version;
+                return true;
             }
         }
 
@@ -1854,32 +1873,8 @@ public static class JavaScriptHostingExtensions
             if (TryParseNodeVersion(versionString, out var version))
             {
                 logger.LogDebug("Detected Node.js version {Version} from .node-version file", version);
-                return version;
-            }
-        }
-
-        // Check package.json for engines.node
-        var packageJsonPath = Path.Combine(workingDirectory, "package.json");
-        if (File.Exists(packageJsonPath))
-        {
-            try
-            {
-                using var stream = File.OpenRead(packageJsonPath);
-                using var packageJson = JsonDocument.Parse(stream);
-                if (packageJson.RootElement.TryGetProperty("engines", out var engines) &&
-                    engines.TryGetProperty("node", out var nodeVersion))
-                {
-                    var versionString = nodeVersion.GetString();
-                    if (!string.IsNullOrWhiteSpace(versionString) && TryParseNodeVersion(versionString, out var version))
-                    {
-                        logger.LogDebug("Detected Node.js version {Version} from package.json engines.node field", version);
-                        return version;
-                    }
-                }
-            }
-            catch
-            {
-                // If package.json parsing fails, continue to default
+                nodeVersion = version;
+                return true;
             }
         }
 
@@ -1898,15 +1893,14 @@ public static class JavaScriptHostingExtensions
                     if (parts.Length > 1 && TryParseNodeVersion(parts[1], out var version))
                     {
                         logger.LogDebug("Detected Node.js version {Version} from .tool-versions file", version);
-                        return version;
+                        nodeVersion = version;
+                        return true;
                     }
                 }
             }
         }
 
-        // Return null if no version is detected
-        logger.LogDebug("No Node.js version detected, using default version {DefaultVersion}", DefaultNodeVersion);
-        return null;
+        return false;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -1886,11 +1886,12 @@ public static class JavaScriptHostingExtensions
             foreach (var line in lines)
             {
                 var trimmedLine = line.Trim();
-                if (trimmedLine.StartsWith("nodejs ", StringComparison.Ordinal) ||
-                    trimmedLine.StartsWith("node ", StringComparison.Ordinal))
+                var parts = trimmedLine.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length > 1 &&
+                    (string.Equals(parts[0], "nodejs", StringComparison.Ordinal) ||
+                     string.Equals(parts[0], "node", StringComparison.Ordinal)))
                 {
-                    var parts = trimmedLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                    if (parts.Length > 1 && TryParseNodeVersion(parts[1], out var version))
+                    if (TryParseNodeVersion(parts[1], out var version))
                     {
                         logger.LogDebug("Detected Node.js version {Version} from .tool-versions file", version);
                         nodeVersion = version;

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppTests.cs
@@ -358,6 +358,57 @@ public class AddViteAppTests
     }
 
     [Fact]
+    public async Task VerifyDockerfileWithNodeVersionFromToolVersionsUsingTabs()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        // Create a .tool-versions file using tabs between the tool name and version
+        var toolVersions = string.Join(Environment.NewLine,
+        [
+            "ruby 3.2.0",
+            "nodejs\t19.8.1",
+            "python 3.11.0"
+        ]);
+        File.WriteAllText(Path.Combine(tempDir.Path, ".tool-versions"), toolVersions);
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path).WithResourceCleanUp(true);
+        var nodeApp = builder.AddViteApp("vite", tempDir.Path)
+            .WithNpm();
+
+        var manifest = await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfileContents = File.ReadAllText(Path.Combine(tempDir.Path, "vite.Dockerfile"));
+
+        Assert.Contains("FROM node:19-slim", dockerfileContents);
+    }
+
+    [Fact]
+    public async Task VerifyDockerfileIgnoresPackageJsonEnginesWhenNoPinnedVersionExists()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var packageJson = """
+            {
+              "name": "test-vite",
+              "engines": {
+                "node": "18.x"
+              }
+            }
+            """;
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"), packageJson);
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path).WithResourceCleanUp(true);
+        var nodeApp = builder.AddViteApp("vite", tempDir.Path)
+            .WithNpm();
+
+        var manifest = await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfileContents = File.ReadAllText(Path.Combine(tempDir.Path, "vite.Dockerfile"));
+
+        Assert.Contains("FROM node:22-slim", dockerfileContents);
+    }
+
+    [Fact]
     public async Task VerifyDockerfileDefaultsTo22WhenNoVersionFound()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppTests.cs
@@ -293,34 +293,6 @@ public class AddViteAppTests
     }
 
     [Fact]
-    public async Task VerifyDockerfileWithNodeVersionFromPackageJson()
-    {
-        using var tempDir = new TestTempDirectory();
-
-        // Create a package.json with engines.node specification
-        var packageJson = """
-            {
-              "name": "test-vite",
-              "engines": {
-                "node": ">=20.12"
-              }
-            }
-            """;
-        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"), packageJson);
-
-        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path).WithResourceCleanUp(true);
-        var nodeApp = builder.AddViteApp("vite", tempDir.Path)
-            .WithNpm();
-
-        var manifest = await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
-
-        var dockerfileContents = File.ReadAllText(Path.Combine(tempDir.Path, "vite.Dockerfile"));
-
-        // Should detect version 20 from package.json
-        Assert.Contains("FROM node:20-slim", dockerfileContents);
-    }
-
-    [Fact]
     public async Task VerifyDockerfileWithNodeVersionFromNvmrc()
     {
         using var tempDir = new TestTempDirectory();


### PR DESCRIPTION
## Description

This fixes the Node Dockerfile version selection bug in #15874.

Before this change, Aspire read `package.json` `engines.node` and treated the first parsed major version as the generated Dockerfile base image version. That made compatibility ranges like `>=18.0.0` produce `node:18-*`, which reflects the minimum compatible major rather than an intended deployment pin and can leave generated images on older runtimes.

This change switches generated JavaScript Dockerfiles to a buildpacks-style policy:

- explicit `WithDockerfileBaseImage(...)` / `withDockerfileBaseImage(...)` overrides still win
- pinned toolchain files (`.nvmrc`, `.node-version`, and `.tool-versions`) are treated as authoritative
- `.tool-versions` parsing now tokenizes on any whitespace so tab-delimited entries continue to work
- `package.json` `engines.node` is no longer used for Dockerfile base image selection because it is compatibility metadata rather than a deployment image pin
- when no toolchain pin is present, generated Dockerfiles fall back to Aspire's preferred default Node major (`22`)

The test updates remove the old `engines.node` expectation and add regression coverage that:

- `package.json` `engines.node` does not override the default image when no toolchain pin exists
- tab-delimited `.tool-versions` entries still drive Dockerfile Node image selection

Dependencies: none.

Validation:

- `./dotnet.sh test tests/Aspire.Hosting.JavaScript.Tests/Aspire.Hosting.JavaScript.Tests.csproj -tl:off -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes #15874

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
