### PR TITLE
Disable browser autocomplete on dashboard search and input fields

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -14,6 +14,7 @@
         <FluentSearch Placeholder="@ControlStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"
                       Autofocus="true"
+                      AutoComplete="off"
                       @bind-Value="_filter"
                       slot="end" />
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -26,6 +26,7 @@
             <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                           Immediate="true"
                           Autofocus="true"
+                          AutoComplete="off"
                           @bind-Value="_filter"
                           slot="end" />
             <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
@@ -16,6 +16,7 @@
         <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"
                       Autofocus="true"
+                      AutoComplete="off"
                       @bind-Value="_filter"
                       slot="end" />
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -43,6 +43,7 @@
                                                  @bind-Value="input.ViewModel.Value"
                                                  Placeholder="@input.ViewModel.Input.Placeholder"
                                                  Required="input.ViewModel.Input.Required"
+                                                 AutoComplete="off"
                                                  Immediate="true"
                                                  Disabled="input.ViewModel.InputDisabled"
                                                  aria-describedby="@input.DescriptionId"

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
@@ -37,6 +37,10 @@
     background-color: transparent;
 }
 
+.interaction-input-dialog .interaction-input ::deep fluent-checkbox {
+    margin-top: 4px;
+}
+
 .interaction-input-dialog .interaction-input ::deep fluent-text-field::part(end) {
     margin-inline-end: 0;
 }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -23,6 +23,7 @@
             <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
                           Immediate="true"
                           ImmediateDelay="@FluentUIExtensions.InputDelay"
+                          Name="resources-search"
                           @bind-Value="_filter"
                           slot="end"
                           Label="@(ViewportInformation.IsDesktop ? null : ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)].Value)"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -42,6 +42,7 @@
             <ExplainErrorsButton @ref="_explainErrorsButton" OnClick="ExplainErrorsAsync" HasErrors="@ViewModel.HasErrors()" />
             <FluentSearch @bind-Value="_filter"
                           @bind-Value:after="HandleAfterFilterBindAsync"
+                          Name="structured-logs-search"
                           Immediate="true"
                           ImmediateDelay="@FluentUIExtensions.InputDelay"
                           Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -46,6 +46,7 @@
                             }
                             <FluentSearch @bind-Value="_filter"
                                           @bind-Value:after="HandleAfterFilterBindAsync"
+                                          Name="spans-search"
                                           Immediate="true"
                                           ImmediateDelay="@FluentUIExtensions.InputDelay"
                                           Placeholder="@ControlStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
@@ -71,6 +72,7 @@
                 {
                     <FluentSearch @bind-Value="_filter"
                                   @bind-Value:after="HandleAfterFilterBindAsync"
+                                  Name="spans-search"
                                   Immediate="true"
                                   ImmediateDelay="@FluentUIExtensions.InputDelay"
                                   Placeholder="@ControlStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -41,6 +41,7 @@
             <ExplainErrorsButton @ref="_explainErrorsButton" OnClick="ExplainErrorsAsync" HasErrors="@TracesViewModel.HasErrors()" />
             <FluentSearch @bind-Value="_filter"
                           @bind-Value:after="HandleAfterFilterBindAsync"
+                          AutoComplete="off"
                           Immediate="true"
                           ImmediateDelay="@FluentUIExtensions.InputDelay"
                           Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -41,7 +41,7 @@
             <ExplainErrorsButton @ref="_explainErrorsButton" OnClick="ExplainErrorsAsync" HasErrors="@TracesViewModel.HasErrors()" />
             <FluentSearch @bind-Value="_filter"
                           @bind-Value:after="HandleAfterFilterBindAsync"
-                          AutoComplete="off"
+                          Name="traces-search"
                           Immediate="true"
                           ImmediateDelay="@FluentUIExtensions.InputDelay"
                           Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"


### PR DESCRIPTION
## Description

Don't combine autocomplete with autofocus.

Changes:
- Add `AutoComplete="off"` to `FluentSearch` components in `ResourceDetails`, `SpanDetails`, `StructuredLogDetails`, `Traces`, and `InteractionsInputDialog`
- Add `Name` attributes to `FluentSearch` components in `Resources`, `StructuredLogs`, and `TraceDetail` pages to give them unique identities and further discourage autocomplete

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
