### PR TITLE
Pipeline: only cancel dependent steps on failure, not all steps

### DIFF
--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -678,7 +678,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
 
     /// <summary>
     /// Executes pipeline steps by building a Task DAG where each step waits on its dependencies.
-    /// Uses CancellationToken to stop remaining work when any step fails.
+    /// Failed steps prevent dependent steps from executing, while independent steps continue running.
     /// </summary>
     private static async Task ExecuteStepsAsTaskDag(
         List<PipelineStep> steps,
@@ -688,161 +688,135 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
         // Validate no cycles exist in the dependency graph
         ValidateDependencyGraph(steps, stepsByName);
 
-        // Create a linked CancellationTokenSource that will be cancelled when any step fails
-        // or when the original context token is cancelled
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
-
-        // Store the original token and set the linked token on the context
-        var originalToken = context.CancellationToken;
-        context.CancellationToken = linkedCts.Token;
-
-        try
+        // Create a TaskCompletionSource for each step
+        var stepCompletions = new Dictionary<string, TaskCompletionSource>(steps.Count, StringComparer.Ordinal);
+        var stepHierarchyByName = GetStepHierarchyByStep(steps, stepsByName);
+        foreach (var step in steps)
         {
-            // Create a TaskCompletionSource for each step
-            var stepCompletions = new Dictionary<string, TaskCompletionSource>(steps.Count, StringComparer.Ordinal);
-            var stepHierarchyByName = GetStepHierarchyByStep(steps, stepsByName);
-            foreach (var step in steps)
+            stepCompletions[step.Name] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        // Execute a step after its dependencies complete
+        async Task ExecuteStepWithDependencies(PipelineStep step)
+        {
+            var stepTcs = stepCompletions[step.Name];
+
+            // Wait for all dependencies to complete (will throw if any dependency failed)
+            if (step.DependsOnSteps.Count > 0)
             {
-                stepCompletions[step.Name] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            }
-
-            // Execute a step after its dependencies complete
-            async Task ExecuteStepWithDependencies(PipelineStep step)
-            {
-                var stepTcs = stepCompletions[step.Name];
-
-                // Wait for all dependencies to complete (will throw if any dependency failed)
-                if (step.DependsOnSteps.Count > 0)
-                {
-                    try
-                    {
-                        var depTasks = step.DependsOnSteps
-                            .Where(stepCompletions.ContainsKey)
-                            .Select(depName => stepCompletions[depName].Task);
-                        await Task.WhenAll(depTasks).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        // Find all dependencies that failed
-                        var failedDeps = step.DependsOnSteps
-                            .Where(depName => stepCompletions.ContainsKey(depName) && stepCompletions[depName].Task.IsFaulted)
-                            .ToList();
-
-                        var message = failedDeps.Count > 0
-                            ? $"Step '{step.Name}' cannot run because {(failedDeps.Count == 1 ? "dependency" : "dependencies")} {string.Join(", ", failedDeps.Select(d => $"'{d}'"))} failed"
-                            : $"Step '{step.Name}' cannot run because a dependency failed";
-
-                        // Wrap the dependency failure with context about this step
-                        var wrappedException = new InvalidOperationException(message, ex);
-                        stepTcs.TrySetException(wrappedException);
-                        return;
-                    }
-                }
-
                 try
                 {
-                    var activityReporter = context.Services.GetRequiredService<IPipelineActivityReporter>();
-                    var stepHierarchy = stepHierarchyByName.GetValueOrDefault(step.Name);
-                    var reportingStep = await activityReporter.CreateStepAsync(step.Name, stepHierarchy.ParentStepName, stepHierarchy.Level, context.CancellationToken).ConfigureAwait(false);
-
-                    await using (reportingStep.ConfigureAwait(false))
-                    {
-                        var stepContext = new PipelineStepContext
-                        {
-                            PipelineContext = context,
-                            ReportingStep = reportingStep
-                        };
-
-                        try
-                        {
-                            PipelineLoggerProvider.CurrentStep = reportingStep;
-
-                            await ExecuteStepAsync(step, stepContext).ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            stepContext.Logger.LogError(ex, "Step '{StepName}' failed.", step.Name);
-
-                            // Report the failure to the activity reporter before disposing
-                            await reportingStep.FailAsync(ex.Message).ConfigureAwait(false);
-                            throw;
-                        }
-                        finally
-                        {
-                            PipelineLoggerProvider.CurrentStep = null;
-                        }
-                    }
-
-                    stepTcs.TrySetResult();
+                    var depTasks = step.DependsOnSteps
+                        .Where(stepCompletions.ContainsKey)
+                        .Select(depName => stepCompletions[depName].Task);
+                    await Task.WhenAll(depTasks).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    // Execution failure - mark as failed, cancel all other work, and re-throw
-                    stepTcs.TrySetException(ex);
+                    // Find all dependencies that failed
+                    var failedDeps = step.DependsOnSteps
+                        .Where(depName => stepCompletions.ContainsKey(depName) && stepCompletions[depName].Task.IsFaulted)
+                        .ToList();
 
-                    // Cancel all remaining work
-                    try
-                    {
-                        linkedCts.Cancel();
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        // Ignore cancellation errors
-                    }
+                    var message = failedDeps.Count > 0
+                        ? $"Step '{step.Name}' cannot run because {(failedDeps.Count == 1 ? "dependency" : "dependencies")} {string.Join(", ", failedDeps.Select(d => $"'{d}'"))} failed"
+                        : $"Step '{step.Name}' cannot run because a dependency failed";
 
-                    throw;
+                    // Wrap the dependency failure with context about this step
+                    var wrappedException = new InvalidOperationException(message, ex);
+                    stepTcs.TrySetException(wrappedException);
+                    return;
                 }
             }
 
-            // Start all steps (they'll wait on their dependencies internally)
-            var allStepTasks = new Task[steps.Count];
-            for (var i = 0; i < steps.Count; i++)
-            {
-                var step = steps[i];
-                allStepTasks[i] = Task.Run(() => ExecuteStepWithDependencies(step));
-            }
-
-            // Wait for all steps to complete (or fail)
             try
             {
-                await Task.WhenAll(allStepTasks).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Collect all failed steps and their names
-                var failures = allStepTasks
-                    .Where(t => t.IsFaulted)
-                    .Select(t => t.Exception!)
-                    .SelectMany(ae => ae.InnerExceptions)
-                    .ToList();
+                var activityReporter = context.Services.GetRequiredService<IPipelineActivityReporter>();
+                var stepHierarchy = stepHierarchyByName.GetValueOrDefault(step.Name);
+                var reportingStep = await activityReporter.CreateStepAsync(step.Name, stepHierarchy.ParentStepName, stepHierarchy.Level, context.CancellationToken).ConfigureAwait(false);
 
-                if (failures.Count > 1)
+                await using (reportingStep.ConfigureAwait(false))
                 {
-                    // Match failures to steps to get their names
-                    var failedStepNames = new List<string>();
-                    for (var i = 0; i < allStepTasks.Length; i++)
+                    var stepContext = new PipelineStepContext
                     {
-                        if (allStepTasks[i].IsFaulted)
-                        {
-                            failedStepNames.Add(steps[i].Name);
-                        }
+                        PipelineContext = context,
+                        ReportingStep = reportingStep
+                    };
+
+                    try
+                    {
+                        PipelineLoggerProvider.CurrentStep = reportingStep;
+
+                        await ExecuteStepAsync(step, stepContext).ConfigureAwait(false);
                     }
+                    catch (Exception ex)
+                    {
+                        stepContext.Logger.LogError(ex, "Step '{StepName}' failed.", step.Name);
 
-                    var message = failedStepNames.Count > 0
-                        ? $"Multiple pipeline steps failed: {string.Join(", ", failedStepNames.Distinct())}"
-                        : "Multiple pipeline steps failed.";
-
-                    throw new AggregateException(message, failures);
+                        // Report the failure to the activity reporter before disposing
+                        await reportingStep.FailAsync(ex.Message).ConfigureAwait(false);
+                        throw;
+                    }
+                    finally
+                    {
+                        PipelineLoggerProvider.CurrentStep = null;
+                    }
                 }
 
-                // Single failure - just rethrow
+                stepTcs.TrySetResult();
+            }
+            catch (Exception ex)
+            {
+                // Execution failure - mark as faulted so dependent steps won't run.
+                // Independent steps continue — the dependency graph handles blocking.
+                stepTcs.TrySetException(ex);
                 throw;
             }
         }
-        finally
+
+        // Start all steps (they'll wait on their dependencies internally)
+        var allStepTasks = new Task[steps.Count];
+        for (var i = 0; i < steps.Count; i++)
         {
-            // Restore the original token
-            context.CancellationToken = originalToken;
+            var step = steps[i];
+            allStepTasks[i] = Task.Run(() => ExecuteStepWithDependencies(step));
+        }
+
+        // Wait for all steps to complete (or fail)
+        try
+        {
+            await Task.WhenAll(allStepTasks).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Collect all failed steps and their names
+            var failures = allStepTasks
+                .Where(t => t.IsFaulted)
+                .Select(t => t.Exception!)
+                .SelectMany(ae => ae.InnerExceptions)
+                .ToList();
+
+            if (failures.Count > 1)
+            {
+                // Match failures to steps to get their names
+                var failedStepNames = new List<string>();
+                for (var i = 0; i < allStepTasks.Length; i++)
+                {
+                    if (allStepTasks[i].IsFaulted)
+                    {
+                        failedStepNames.Add(steps[i].Name);
+                    }
+                }
+
+                var message = failedStepNames.Count > 0
+                    ? $"Multiple pipeline steps failed: {string.Join(", ", failedStepNames.Distinct())}"
+                    : "Multiple pipeline steps failed.";
+
+                throw new AggregateException(message, failures);
+            }
+
+            // Single failure - just rethrow
+            throw;
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -843,6 +843,116 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
     }
 
     [Fact]
+    public async Task ExecuteAsync_IndependentStepContinuesWhenSiblingFails()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: "deploy").WithTestAndResourceLogging(testOutputHelper);
+
+        builder.Services.AddSingleton(testOutputHelper);
+        builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
+        var pipeline = new DistributedApplicationPipeline();
+
+        var independentStepExecuted = false;
+        var failingStepStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Step that will fail
+        pipeline.AddStep("failing-step", (context) =>
+        {
+            failingStepStarted.SetResult();
+            throw new InvalidOperationException("This step fails");
+        }, requiredBy: "deploy");
+
+        // Independent step — no dependency on failing-step, waits for it to start
+        pipeline.AddStep("independent-step", async (context) =>
+        {
+            await failingStepStarted.Task.ConfigureAwait(false);
+            independentStepExecuted = true;
+        }, requiredBy: "deploy");
+
+        var context = CreateDeployingContext(builder.Build());
+
+        await Assert.ThrowsAnyAsync<Exception>(() => pipeline.ExecuteAsync(context)).DefaultTimeout();
+
+        // The independent step should have executed despite the sibling failure
+        Assert.True(independentStepExecuted, "Independent step should execute even when a sibling step fails");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IndependentStepIsNotCancelledWhenSiblingFails()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: "deploy").WithTestAndResourceLogging(testOutputHelper);
+
+        builder.Services.AddSingleton(testOutputHelper);
+        builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
+        var pipeline = new DistributedApplicationPipeline();
+
+        var wasCancelled = false;
+        var failingStepCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Step that fails
+        pipeline.AddStep("failing-step", (context) =>
+        {
+            failingStepCompleted.SetResult();
+            throw new InvalidOperationException("Immediate failure");
+        }, requiredBy: "deploy");
+
+        // Independent step that checks cancellation after the failing step has completed
+        pipeline.AddStep("long-running-step", async (context) =>
+        {
+            await failingStepCompleted.Task.ConfigureAwait(false);
+            wasCancelled = context.CancellationToken.IsCancellationRequested;
+        }, requiredBy: "deploy");
+
+        var context = CreateDeployingContext(builder.Build());
+
+        await Assert.ThrowsAnyAsync<Exception>(() => pipeline.ExecuteAsync(context)).DefaultTimeout();
+
+        // The long-running step's cancellation token should NOT have been triggered by the sibling failure
+        Assert.False(wasCancelled, "Independent step should not be cancelled when a sibling step fails");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DependentStepSkippedButIndependentContinues()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: "deploy").WithTestAndResourceLogging(testOutputHelper);
+
+        builder.Services.AddSingleton(testOutputHelper);
+        builder.Services.AddSingleton<IPipelineActivityReporter, TestPipelineActivityReporter>();
+        var pipeline = new DistributedApplicationPipeline();
+
+        var dependentExecuted = false;
+        var independentExecuted = false;
+        var failingStepCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Step that fails
+        pipeline.AddStep("failing-step", (context) =>
+        {
+            failingStepCompleted.SetResult();
+            throw new InvalidOperationException("Build failed");
+        }, requiredBy: "deploy");
+
+        // Dependent step — should NOT run
+        pipeline.AddStep("dependent-step", async (context) =>
+        {
+            dependentExecuted = true;
+            await Task.CompletedTask;
+        }, dependsOn: "failing-step", requiredBy: "deploy");
+
+        // Independent step — SHOULD run, waits for failing step to complete
+        pipeline.AddStep("independent-step", async (context) =>
+        {
+            await failingStepCompleted.Task.ConfigureAwait(false);
+            independentExecuted = true;
+        }, requiredBy: "deploy");
+
+        var context = CreateDeployingContext(builder.Build());
+
+        await Assert.ThrowsAnyAsync<Exception>(() => pipeline.ExecuteAsync(context)).DefaultTimeout();
+
+        Assert.False(dependentExecuted, "Dependent step should not execute when dependency fails");
+        Assert.True(independentExecuted, "Independent step should execute even when other steps fail");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WhenStepThrows_ReportsFailureToActivityReporter()
     {
         // Arrange


### PR DESCRIPTION
## Description

When any pipeline step fails, the pipeline was cancelling all other running steps via a shared `CancellationTokenSource`. This caused independent steps (like Azure provisioning) to fail with misleading errors when an unrelated step (like a container build) failed first.

This change removes the cancel-all behavior so that only dependent steps are blocked when a dependency fails. Independent steps continue to completion, matching the industry standard (GitHub Actions, Azure DevOps, Terraform). User-initiated cancellation (Ctrl+C) still works via the original context cancellation token.

The `linkedCts` wrapper was also removed as dead code since step failures no longer cancel it.

Fixes #16232

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
