### PR TITLE
Surface process output on failure

### DIFF
--- a/src/Aspire.Hosting.Azure.Kubernetes/Aspire.Hosting.Azure.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Azure.Kubernetes/Aspire.Hosting.Azure.Kubernetes.csproj
@@ -17,6 +17,7 @@
     <Compile Include="$(SharedDir)PathLookupHelper.cs" Link="Utils\PathLookupHelper.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessResult.cs" Link="Process\ProcessResult.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Process\ProcessSpec.cs" />
+    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessOutputCapture.cs" Link="Process\ProcessOutputCapture.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Process\ProcessUtil.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessResult.cs" Link="Process\ProcessResult.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Process\ProcessSpec.cs" />
+    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessOutputCapture.cs" Link="Process\ProcessOutputCapture.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Process\ProcessUtil.cs" />
     <Compile Include="$(SharedDir)AzurePortalUrls.cs" Link="AzurePortalUrls.cs" />
     <Compile Include="$(SharedDir)CustomResourceSnapshotExtensions.cs" Link="Utils\CustomResourceSnapshotExtensions.cs" />

--- a/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
+++ b/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessResult.cs" Link="Shared\ProcessResult.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Shared\ProcessSpec.cs" />
+    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessOutputCapture.cs" Link="Shared\ProcessOutputCapture.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Shared\ProcessUtil.cs" />
     <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" LinkBase="Shared" />

--- a/src/Aspire.Hosting/Dcp/Process/ProcessOutputCapture.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessOutputCapture.cs
@@ -1,15 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Hosting.Publishing;
+namespace Aspire.Hosting.Utils;
 
 /// <summary>
-/// Retains a bounded tail of build output while tracking the total number of lines observed.
+/// Retains a bounded tail of process output while tracking the total number of lines observed.
 /// </summary>
-internal sealed class BuildOutputCapture(int maxRetainedLineCount = 256)
+internal sealed class ProcessOutputCapture(int maxRetainedLineCount)
 {
     private readonly object _lock = new();
-    private readonly CircularBuffer<string> _retainedLines = new(maxRetainedLineCount);
+    private readonly Queue<string> _retainedLines = new();
+    private readonly int _maxRetainedLineCount = maxRetainedLineCount;
 
     /// <summary>
     /// Gets the total number of stdout and stderr lines observed.
@@ -17,7 +18,7 @@ internal sealed class BuildOutputCapture(int maxRetainedLineCount = 256)
     public int TotalLineCount { get; private set; }
 
     /// <summary>
-    /// Adds a line of build output to the retained tail.
+    /// Adds a line of process output to the retained tail.
     /// </summary>
     /// <param name="line">The output line.</param>
     public void Add(string line)
@@ -25,7 +26,12 @@ internal sealed class BuildOutputCapture(int maxRetainedLineCount = 256)
         lock (_lock)
         {
             TotalLineCount++;
-            _retainedLines.Add(line);
+            _retainedLines.Enqueue(line);
+
+            while (_retainedLines.Count > _maxRetainedLineCount)
+            {
+                _retainedLines.Dequeue();
+            }
         }
     }
 
@@ -47,7 +53,7 @@ internal sealed class BuildOutputCapture(int maxRetainedLineCount = 256)
     /// <param name="maxLines">The maximum number of lines to include.</param>
     /// <param name="outputDescription">The label used when the output is truncated.</param>
     /// <returns>The formatted output.</returns>
-    public string GetFormattedOutput(int maxLines = 50, string outputDescription = "Build output")
+    public string GetFormattedOutput(int maxLines = 50, string outputDescription = "Command output")
     {
         return FormatOutput(ToArray(), TotalLineCount, maxLines, outputDescription);
     }
@@ -60,7 +66,7 @@ internal sealed class BuildOutputCapture(int maxRetainedLineCount = 256)
     /// <param name="maxLines">The maximum number of lines to include.</param>
     /// <param name="outputDescription">The label used when the output is truncated.</param>
     /// <returns>The formatted output.</returns>
-    internal static string FormatOutput(IReadOnlyList<string> output, int totalLineCount, int maxLines = 50, string outputDescription = "Build output")
+    internal static string FormatOutput(IReadOnlyList<string> output, int totalLineCount, int maxLines = 50, string outputDescription = "Command output")
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxLines);
 

--- a/src/Aspire.Hosting/Dcp/Process/ProcessResult.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessResult.cs
@@ -1,14 +1,27 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Utils;
+
 namespace Aspire.Hosting.Dcp.Process;
 
 internal sealed class ProcessResult
 {
-    public ProcessResult(int exitCode)
+    public ProcessResult(int exitCode, IReadOnlyList<string>? processOutput = null, int? totalProcessOutputLineCount = null)
     {
         ExitCode = exitCode;
+        ProcessOutput = processOutput ?? [];
+        TotalProcessOutputLineCount = totalProcessOutputLineCount ?? ProcessOutput.Count;
     }
 
     public int ExitCode { get; }
+
+    public IReadOnlyList<string> ProcessOutput { get; }
+
+    public int TotalProcessOutputLineCount { get; }
+
+    public string GetFormattedOutput(int maxLines = 50, string outputDescription = "Command output")
+    {
+        return ProcessOutputCapture.FormatOutput(ProcessOutput, TotalProcessOutputLineCount, maxLines, outputDescription);
+    }
 }

--- a/src/Aspire.Hosting/Dcp/Process/ProcessSpec.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessSpec.cs
@@ -5,6 +5,8 @@ namespace Aspire.Hosting.Dcp.Process;
 
 internal sealed class ProcessSpec
 {
+    public const int DefaultRetainedOutputLineCount = 256;
+
     public string ExecutablePath { get; }
     public string? WorkingDirectory { get; init; }
     public IDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
@@ -16,6 +18,7 @@ internal sealed class ProcessSpec
     public Action<int>? OnStop { get; init; }
     public bool KillEntireProcessTree { get; init; } = true;
     public bool ThrowOnNonZeroReturnCode { get; init; } = true;
+    public int? RetainedOutputLineCount { get; init; }
     public string? StandardInputContent { get; init; }
 
     public ProcessSpec(string executablePath)

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Dcp.Process;
 
@@ -19,6 +20,13 @@ internal static partial class ProcessUtil
 
     public static (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec)
     {
+        var retainedOutputLineCount = processSpec.RetainedOutputLineCount ?? (processSpec.ThrowOnNonZeroReturnCode ? ProcessSpec.DefaultRetainedOutputLineCount : 0);
+        ArgumentOutOfRangeException.ThrowIfNegative(retainedOutputLineCount);
+
+        ProcessOutputCapture? outputCapture = retainedOutputLineCount > 0
+            ? new(retainedOutputLineCount)
+            : null;
+
         var process = new System.Diagnostics.Process()
         {
             StartInfo =
@@ -72,6 +80,7 @@ internal static partial class ProcessUtil
                 return;
             }
 
+            outputCapture?.Add(e.Data);
             processSpec.OnOutputData?.Invoke(e.Data);
         };
 
@@ -90,6 +99,7 @@ internal static partial class ProcessUtil
                 return;
             }
 
+            outputCapture?.Add(e.Data);
             processSpec.OnErrorData?.Invoke(e.Data);
         };
 
@@ -129,12 +139,18 @@ internal static partial class ProcessUtil
 
                     if (processSpec.ThrowOnNonZeroReturnCode && process.ExitCode != 0)
                     {
-                        processLifetimeTcs.TrySetException(new InvalidOperationException(
-                            $"Command {processSpec.ExecutablePath} {processSpec.Arguments} returned non-zero exit code {process.ExitCode}"));
+                        var message = $"Command {processSpec.ExecutablePath} {processSpec.Arguments} returned non-zero exit code {process.ExitCode}";
+
+                        if (outputCapture?.TotalLineCount > 0)
+                        {
+                            message = $"{message}{Environment.NewLine}{outputCapture.GetFormattedOutput()}";
+                        }
+
+                        processLifetimeTcs.TrySetException(new InvalidOperationException(message));
                     }
                     else
                     {
-                        processLifetimeTcs.TrySetResult(new ProcessResult(process.ExitCode));
+                        processLifetimeTcs.TrySetResult(CreateProcessResult(process.ExitCode, outputCapture));
                     }
                 }
                 catch (Exception ex)
@@ -152,6 +168,16 @@ internal static partial class ProcessUtil
         }
 
         return (processLifetimeTcs.Task, new ProcessDisposable(process, processLifetimeTcs.Task, processSpec.KillEntireProcessTree));
+    }
+
+    private static ProcessResult CreateProcessResult(int exitCode, ProcessOutputCapture? outputCapture)
+    {
+        if (outputCapture is null)
+        {
+            return new ProcessResult(exitCode);
+        }
+
+        return new ProcessResult(exitCode, outputCapture.ToArray(), outputCapture.TotalLineCount);
     }
 
     private sealed class ProcessDisposable : IAsyncDisposable

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -269,7 +269,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     }
 
     /// <summary>
-    /// Executes a container runtime command and returns the process result without throwing exceptions.
+    /// Executes a container runtime command and returns the process result without throwing for non-zero exit codes.
     /// </summary>
     protected async Task<ProcessResult> ExecuteContainerCommandWithResultAsync(
         string arguments,

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -99,6 +99,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         {
             Arguments = arguments,
             StandardInputContent = password,
+            RetainedOutputLineCount = ProcessSpec.DefaultRetainedOutputLineCount,
             OnOutputData = output =>
             {
                 _logger.LogDebug("{RuntimeName} (stdout): {Output}", RuntimeExecutable, output);
@@ -124,7 +125,14 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
             if (processResult.ExitCode != 0)
             {
                 _logger.LogError("{RuntimeName} login to {RegistryServer} failed with exit code {ExitCode}.", Name, registryServer, processResult.ExitCode);
-                throw new DistributedApplicationException($"{Name} login failed with exit code {processResult.ExitCode}.");
+
+                var message = $"{Name} login failed with exit code {processResult.ExitCode}.";
+                if (processResult.TotalProcessOutputLineCount > 0)
+                {
+                    message = $"{message}{Environment.NewLine}{processResult.GetFormattedOutput()}";
+                }
+
+                throw new DistributedApplicationException(message);
             }
 
             _logger.LogInformation("{RuntimeName} login to {RegistryServer} succeeded.", Name, registryServer);
@@ -148,8 +156,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         CancellationToken cancellationToken,
         params object[] logArguments)
     {
-        var outputBuffer = new BuildOutputCapture();
-        var spec = CreateProcessSpec(arguments, outputBuffer);
+        var spec = CreateProcessSpec(arguments, retainOutput: true);
 
         _logger.LogDebug("Running {RuntimeName} with arguments: {ArgumentList}", Name, spec.Arguments);
         var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
@@ -166,9 +173,9 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
                 _logger.LogError(errorLogTemplate, errorArgs);
 
                 var message = string.Format(System.Globalization.CultureInfo.InvariantCulture, exceptionMessageTemplate, processResult.ExitCode);
-                if (outputBuffer.TotalLineCount > 0)
+                if (processResult.TotalProcessOutputLineCount > 0)
                 {
-                    message = $"{message}{Environment.NewLine}{outputBuffer.GetFormattedOutput(outputDescription: "Command output")}";
+                    message = $"{message}{Environment.NewLine}{processResult.GetFormattedOutput(outputDescription: "Command output")}";
                 }
 
                 throw new DistributedApplicationException(message);
@@ -187,7 +194,6 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="logArguments">Arguments to pass to the log templates.</param>
     /// <param name="environmentVariables">Optional environment variables to set for the process.</param>
-    /// <param name="outputBuffer">Optional buffer to retain stdout/stderr lines.</param>
     /// <returns>The exit code of the process.</returns>
     protected async Task<int> ExecuteContainerCommandWithExitCodeAsync(
         string arguments,
@@ -195,39 +201,17 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         string successLogTemplate,
         CancellationToken cancellationToken,
         object[] logArguments,
-        Dictionary<string, string>? environmentVariables = null,
-        BuildOutputCapture? outputBuffer = null)
+        Dictionary<string, string>? environmentVariables = null)
     {
-        var spec = CreateProcessSpec(arguments, outputBuffer);
+        var processResult = await ExecuteContainerCommandWithResultAsync(
+            arguments,
+            errorLogTemplate,
+            successLogTemplate,
+            cancellationToken,
+            logArguments,
+            environmentVariables).ConfigureAwait(false);
 
-        // Add environment variables if provided
-        if (environmentVariables is not null)
-        {
-            foreach (var (key, value) in environmentVariables)
-            {
-                spec.EnvironmentVariables[key] = value;
-            }
-        }
-
-        _logger.LogDebug("Running {RuntimeName} with arguments: {ArgumentList}", Name, spec.Arguments);
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
-
-        await using (processDisposable)
-        {
-            var processResult = await pendingProcessResult
-                .WaitAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            if (processResult.ExitCode != 0)
-            {
-                var errorArgs = logArguments.Concat(new object[] { processResult.ExitCode }).ToArray();
-                _logger.LogError(errorLogTemplate, errorArgs);
-                return processResult.ExitCode;
-            }
-
-            _logger.LogDebug(successLogTemplate, logArguments);
-            return processResult.ExitCode;
-        }
+        return processResult.ExitCode;
     }
 
     /// <summary>
@@ -284,20 +268,64 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         return !string.IsNullOrEmpty(stage) ? $" --target \"{stage}\"" : string.Empty;
     }
 
-    private ProcessSpec CreateProcessSpec(string arguments, BuildOutputCapture? outputBuffer)
+    /// <summary>
+    /// Executes a container runtime command and returns the process result without throwing exceptions.
+    /// </summary>
+    protected async Task<ProcessResult> ExecuteContainerCommandWithResultAsync(
+        string arguments,
+        string errorLogTemplate,
+        string successLogTemplate,
+        CancellationToken cancellationToken,
+        object[] logArguments,
+        Dictionary<string, string>? environmentVariables = null,
+        bool retainOutput = false)
+    {
+        var spec = CreateProcessSpec(arguments, retainOutput);
+
+        if (environmentVariables is not null)
+        {
+            foreach (var (key, value) in environmentVariables)
+            {
+                spec.EnvironmentVariables[key] = value;
+            }
+        }
+
+        _logger.LogDebug("Running {RuntimeName} with arguments: {ArgumentList}", Name, spec.Arguments);
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+
+        await using (processDisposable)
+        {
+            var processResult = await pendingProcessResult
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (processResult.ExitCode != 0)
+            {
+                var errorArgs = logArguments.Concat(new object[] { processResult.ExitCode }).ToArray();
+                _logger.LogError(errorLogTemplate, errorArgs);
+            }
+            else
+            {
+                _logger.LogDebug(successLogTemplate, logArguments);
+            }
+
+            return processResult;
+        }
+    }
+
+    private ProcessSpec CreateProcessSpec(string arguments, bool retainOutput = false)
     {
         return new ProcessSpec(RuntimeExecutable)
         {
             Arguments = arguments,
+            RetainedOutputLineCount = retainOutput ? ProcessSpec.DefaultRetainedOutputLineCount : null,
             OnOutputData = output =>
             {
                 _logger.LogDebug("{RuntimeName} (stdout): {Output}", RuntimeExecutable, output);
-                outputBuffer?.Add(output);
             },
             OnErrorData = error =>
             {
                 _logger.LogDebug("{RuntimeName} (stderr): {Error}", RuntimeExecutable, error);
-                outputBuffer?.Add(error);
             },
             ThrowOnNonZeroReturnCode = false,
             InheritEnv = true
@@ -319,6 +347,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
             Arguments = arguments,
             WorkingDirectory = context.WorkingDirectory,
             ThrowOnNonZeroReturnCode = false,
+            RetainedOutputLineCount = ProcessSpec.DefaultRetainedOutputLineCount,
             InheritEnv = true,
             OnOutputData = output =>
             {
@@ -344,10 +373,17 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
                     ? $"The container runtime is configured via ASPIRE_CONTAINER_RUNTIME (current: '{RuntimeExecutable}')."
                     : $"The container runtime was auto-detected as '{RuntimeExecutable}'. Set ASPIRE_CONTAINER_RUNTIME to override (e.g., 'docker' or 'podman').";
 
-                throw new DistributedApplicationException(
+                var message =
                     $"'{RuntimeExecutable} compose up' failed with exit code {processResult.ExitCode}. " +
                     $"Ensure '{RuntimeExecutable}' is installed and available on PATH. " +
-                    envHint);
+                    envHint;
+
+                if (processResult.TotalProcessOutputLineCount > 0)
+                {
+                    message = $"{message}{Environment.NewLine}{processResult.GetFormattedOutput()}";
+                }
+
+                throw new DistributedApplicationException(message);
             }
         }
     }

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -96,24 +96,22 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
                 }
             }
 
-            var buildOutput = new BuildOutputCapture();
-
-            var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
+            var processResult = await ExecuteContainerCommandWithResultAsync(
                 arguments,
                 "Docker build for {ImageName} failed with exit code {ExitCode}.",
                 "Docker build for {ImageName} succeeded.",
                 cancellationToken,
                 new object[] { imageName },
                 environmentVariables,
-                buildOutput).ConfigureAwait(false);
+                retainOutput: true).ConfigureAwait(false);
 
-            if (exitCode != 0)
+            if (processResult.ExitCode != 0)
             {
                 throw new ProcessFailedException(
-                    $"Docker build failed with exit code {exitCode}.",
-                    exitCode,
-                    buildOutput.ToArray(),
-                    buildOutput.TotalLineCount);
+                    $"Docker build failed with exit code {processResult.ExitCode}.",
+                    processResult.ExitCode,
+                    processResult.ProcessOutput,
+                    processResult.TotalProcessOutputLineCount);
             }
         }
         finally
@@ -194,23 +192,21 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
     private async Task CreateBuildkitInstanceAsync(string builderName, CancellationToken cancellationToken)
     {
         var arguments = $"buildx create --name \"{builderName}\" --driver docker-container";
-        var buildOutput = new BuildOutputCapture();
-
-        var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
+        var processResult = await ExecuteContainerCommandWithResultAsync(
             arguments,
             "Failed to create buildkit instance {BuilderName} with exit code {ExitCode}.",
             "Successfully created buildkit instance {BuilderName}.",
             cancellationToken,
             new object[] { builderName },
-            outputBuffer: buildOutput).ConfigureAwait(false);
+            retainOutput: true).ConfigureAwait(false);
 
-        if (exitCode != 0)
+        if (processResult.ExitCode != 0)
         {
             throw new ProcessFailedException(
-                $"Failed to create buildkit instance '{builderName}' with exit code {exitCode}.",
-                exitCode,
-                buildOutput.ToArray(),
-                buildOutput.TotalLineCount);
+                $"Failed to create buildkit instance '{builderName}' with exit code {processResult.ExitCode}.",
+                processResult.ExitCode,
+                processResult.ProcessOutput,
+                processResult.TotalProcessOutputLineCount);
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -195,24 +195,22 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
             }
         }
 
-        var buildOutput = new BuildOutputCapture();
-
-        var exitCode = await ExecuteContainerCommandWithExitCodeAsync(
+        var processResult = await ExecuteContainerCommandWithResultAsync(
             arguments,
             "Podman build for {ImageName} failed with exit code {ExitCode}.",
             "Podman build for {ImageName} succeeded.",
             cancellationToken,
             new object[] { imageName },
             environmentVariables,
-            buildOutput).ConfigureAwait(false);
+            retainOutput: true).ConfigureAwait(false);
 
-        if (exitCode != 0)
+        if (processResult.ExitCode != 0)
         {
             throw new ProcessFailedException(
-                $"Podman build failed with exit code {exitCode}.",
-                exitCode,
-                buildOutput.ToArray(),
-                buildOutput.TotalLineCount);
+                $"Podman build failed with exit code {processResult.ExitCode}.",
+                processResult.ExitCode,
+                processResult.ProcessOutput,
+                processResult.TotalProcessOutputLineCount);
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/ProcessFailedException.cs
+++ b/src/Aspire.Hosting/Publishing/ProcessFailedException.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Utils;
+
 namespace Aspire.Hosting.Publishing;
 
 /// <summary>
@@ -13,14 +15,14 @@ internal sealed class ProcessFailedException : DistributedApplicationException
     /// </summary>
     /// <param name="message">A summary of the failure (e.g., "Docker build failed with exit code 1.").</param>
     /// <param name="exitCode">The process exit code.</param>
-    /// <param name="buildOutput">The retained stdout/stderr lines from the build process.</param>
-    /// <param name="totalBuildOutputLineCount">The total number of stdout/stderr lines observed.</param>
-    public ProcessFailedException(string message, int exitCode, IReadOnlyList<string> buildOutput, int? totalBuildOutputLineCount = null)
+    /// <param name="processOutput">The retained stdout/stderr lines from the failed process.</param>
+    /// <param name="totalProcessOutputLineCount">The total number of stdout/stderr lines observed.</param>
+    public ProcessFailedException(string message, int exitCode, IReadOnlyList<string> processOutput, int? totalProcessOutputLineCount = null)
         : base(message)
     {
         ExitCode = exitCode;
-        BuildOutput = buildOutput;
-        TotalBuildOutputLineCount = totalBuildOutputLineCount ?? buildOutput.Count;
+        ProcessOutput = processOutput;
+        TotalProcessOutputLineCount = totalProcessOutputLineCount ?? processOutput.Count;
     }
 
     /// <summary>
@@ -29,25 +31,25 @@ internal sealed class ProcessFailedException : DistributedApplicationException
     public int ExitCode { get; }
 
     /// <summary>
-    /// The retained stdout/stderr lines from the build process.
+    /// The retained stdout/stderr lines from the failed process.
     /// </summary>
-    public IReadOnlyList<string> BuildOutput { get; }
+    public IReadOnlyList<string> ProcessOutput { get; }
 
     /// <summary>
     /// The total number of stdout/stderr lines observed for the failed process.
     /// </summary>
-    public int TotalBuildOutputLineCount { get; }
+    public int TotalProcessOutputLineCount { get; }
 
     /// <inheritdoc/>
-    public override string Message => BuildOutput.Count > 0
+    public override string Message => ProcessOutput.Count > 0
         ? $"{base.Message}{Environment.NewLine}{GetFormattedOutput()}"
         : base.Message;
 
     /// <summary>
-    /// Returns the last <paramref name="maxLines"/> lines of build output formatted for display.
+    /// Returns the last <paramref name="maxLines"/> lines of process output formatted for display.
     /// </summary>
     public string GetFormattedOutput(int maxLines = 50)
     {
-        return BuildOutputCapture.FormatOutput(BuildOutput, TotalBuildOutputLineCount, maxLines);
+        return ProcessOutputCapture.FormatOutput(ProcessOutput, TotalProcessOutputLineCount, maxLines, outputDescription: "Process output");
     }
 }

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -378,21 +378,18 @@ internal sealed class ResourceContainerImageManager(
         }
 #pragma warning restore ASPIREDOCKERFILEBUILDER001
 
-        var buildOutput = new BuildOutputCapture();
-
         var spec = new ProcessSpec("dotnet")
         {
             Arguments = arguments,
             ThrowOnNonZeroReturnCode = false,
+            RetainedOutputLineCount = ProcessSpec.DefaultRetainedOutputLineCount,
             OnOutputData = output =>
             {
                 logger.LogDebug("dotnet publish {ProjectPath} (stdout): {Output}", projectMetadata.ProjectPath, output);
-                buildOutput.Add(output);
             },
             OnErrorData = error =>
             {
                 logger.LogDebug("dotnet publish {ProjectPath} (stderr): {Error}", projectMetadata.ProjectPath, error);
-                buildOutput.Add(error);
             }
         };
 
@@ -414,8 +411,8 @@ internal sealed class ResourceContainerImageManager(
                 throw new ProcessFailedException(
                     $"Failed to build container image for resource '{resource.Name}' from project '{projectMetadata.ProjectPath}' with exit code {processResult.ExitCode}.",
                     processResult.ExitCode,
-                    buildOutput.ToArray(),
-                    buildOutput.TotalLineCount);
+                    processResult.ProcessOutput,
+                    processResult.TotalProcessOutputLineCount);
             }
             else
             {

--- a/src/Shared/CircularBuffer.cs
+++ b/src/Shared/CircularBuffer.cs
@@ -88,6 +88,7 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
             }
 
             var removedItem = this[0];
+            var removedItemCount = CountOccurrences(removedItem);
 
             var internalIndex = InternalIndex(index);
 
@@ -126,7 +127,9 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
             Increment(ref _end);
             _start = _end;
 
-            Debug.Assert(!_buffer.Contains(removedItem), "Item was not correctly removed.");
+            Debug.Assert(
+                CountOccurrences(removedItem) == removedItemCount - 1 + (EqualityComparer<T>.Default.Equals(item, removedItem) ? 1 : 0),
+                "Item was not correctly removed.");
             ItemRemovedForCapacity?.Invoke(removedItem);
         }
         else
@@ -194,12 +197,15 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
         if (IsFull)
         {
             var removedItem = this[0];
+            var removedItemCount = CountOccurrences(removedItem);
 
             _buffer[_end] = item;
             Increment(ref _end);
             _start = _end;
 
-            Debug.Assert(!_buffer.Contains(removedItem), "Item was not correctly removed.");
+            Debug.Assert(
+                CountOccurrences(removedItem) == removedItemCount - 1 + (EqualityComparer<T>.Default.Equals(item, removedItem) ? 1 : 0),
+                "Item was not correctly removed.");
             ItemRemovedForCapacity?.Invoke(removedItem);
         }
         else
@@ -264,6 +270,20 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
     private int InternalIndex(int index)
     {
         return (_start + index) % _buffer.Count;
+    }
+
+    private int CountOccurrences(T item)
+    {
+        var count = 0;
+        foreach (var existingItem in _buffer)
+        {
+            if (EqualityComparer<T>.Default.Equals(existingItem, item))
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     private void Increment(ref int index)

--- a/src/Shared/CircularBuffer.cs
+++ b/src/Shared/CircularBuffer.cs
@@ -88,7 +88,9 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
             }
 
             var removedItem = this[0];
+#if DEBUG
             var removedItemCount = CountOccurrences(removedItem);
+#endif
 
             var internalIndex = InternalIndex(index);
 
@@ -127,9 +129,11 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
             Increment(ref _end);
             _start = _end;
 
+#if DEBUG
             Debug.Assert(
                 CountOccurrences(removedItem) == removedItemCount - 1 + (EqualityComparer<T>.Default.Equals(item, removedItem) ? 1 : 0),
                 "Item was not correctly removed.");
+#endif
             ItemRemovedForCapacity?.Invoke(removedItem);
         }
         else
@@ -197,15 +201,19 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
         if (IsFull)
         {
             var removedItem = this[0];
+#if DEBUG
             var removedItemCount = CountOccurrences(removedItem);
+#endif
 
             _buffer[_end] = item;
             Increment(ref _end);
             _start = _end;
 
+#if DEBUG
             Debug.Assert(
                 CountOccurrences(removedItem) == removedItemCount - 1 + (EqualityComparer<T>.Default.Equals(item, removedItem) ? 1 : 0),
                 "Item was not correctly removed.");
+#endif
             ItemRemovedForCapacity?.Invoke(removedItem);
         }
         else
@@ -272,6 +280,7 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
         return (_start + index) % _buffer.Count;
     }
 
+#if DEBUG
     private int CountOccurrences(T item)
     {
         var count = 0;
@@ -285,6 +294,7 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
 
         return count;
     }
+#endif
 
     private void Increment(ref int index)
     {

--- a/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
+++ b/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
@@ -669,6 +669,38 @@ public class CircularBufferTests
     }
 
     [Fact]
+    public void AddWhenFull_WithDuplicateOldestValue_KeepsRemainingDuplicate()
+    {
+        var b = CreateBuffer(3);
+
+        b.Add("0");
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+
+        Assert.Collection(b,
+            i => Assert.Equal("0", i),
+            i => Assert.Equal("1", i),
+            i => Assert.Equal("2", i));
+    }
+
+    [Fact]
+    public void InsertWhenFull_WithDuplicateOldestValue_KeepsRemainingDuplicate()
+    {
+        var b = CreateBuffer(3);
+
+        b.Add("0");
+        b.Add("0");
+        b.Add("1");
+        b.Insert(1, "x");
+
+        Assert.Collection(b,
+            i => Assert.Equal("x", i),
+            i => Assert.Equal("0", i),
+            i => Assert.Equal("1", i));
+    }
+
+    [Fact]
     public void Clear_EmptiesBuffer_ResetsIndex()
     {
         var b = CreateBuffer(5);

--- a/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
@@ -66,12 +66,13 @@ public class ProcessUtilTests
         await using (processDisposable)
         {
             var processResult = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(10));
+            var normalizedOutput = processResult.ProcessOutput.Select(static line => line.TrimEnd()).ToArray();
 
             Assert.Equal(1, processResult.ExitCode);
             Assert.Equal(2, processResult.TotalProcessOutputLineCount);
             Assert.Equal(2, processResult.ProcessOutput.Count);
-            Assert.Contains("stdout-final-line", processResult.ProcessOutput);
-            Assert.Contains("stderr-final-line", processResult.ProcessOutput);
+            Assert.Contains("stdout-final-line", normalizedOutput);
+            Assert.Contains("stderr-final-line", normalizedOutput);
         }
     }
 
@@ -85,12 +86,13 @@ public class ProcessUtilTests
         {
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProcessResult).WaitAsync(TimeSpan.FromSeconds(10));
             var outputLines = exception.Message.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            var normalizedOutputLines = outputLines.Select(static line => line.TrimEnd()).ToArray();
 
             Assert.Contains("Command output truncated: showing last 50 of 52 lines.", exception.Message);
             Assert.DoesNotContain("line-1", outputLines);
             Assert.DoesNotContain("line-2", outputLines);
-            Assert.Contains("line-3", outputLines);
-            Assert.Contains("line-52", outputLines);
+            Assert.Contains("line-3", normalizedOutputLines);
+            Assert.Contains("line-52", normalizedOutputLines);
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
@@ -37,6 +37,63 @@ public class ProcessUtilTests
         }
     }
 
+    [Fact]
+    public async Task Run_IncludesCapturedOutputInNonZeroExitException()
+    {
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(CreateFailingProcessSpec(["stdout-final-line", "stderr-final-line"], emitSecondLineToStderr: true));
+
+        await using (processDisposable)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProcessResult).WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.Contains("returned non-zero exit code 1", exception.Message);
+            Assert.Contains("stdout-final-line", exception.Message);
+            Assert.Contains("stderr-final-line", exception.Message);
+        }
+    }
+
+    [Fact]
+    public async Task Run_ReturnsCapturedOutputInProcessResult_WhenRetentionEnabled()
+    {
+        var spec = CreateFailingProcessSpec(
+            ["stdout-final-line", "stderr-final-line"],
+            emitSecondLineToStderr: true,
+            throwOnNonZeroReturnCode: false,
+            retainedOutputLineCount: ProcessSpec.DefaultRetainedOutputLineCount);
+
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+
+        await using (processDisposable)
+        {
+            var processResult = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.Equal(1, processResult.ExitCode);
+            Assert.Equal(2, processResult.TotalProcessOutputLineCount);
+            Assert.Equal(2, processResult.ProcessOutput.Count);
+            Assert.Contains("stdout-final-line", processResult.ProcessOutput);
+            Assert.Contains("stderr-final-line", processResult.ProcessOutput);
+        }
+    }
+
+    [Fact]
+    public async Task Run_TruncatesCapturedOutputToLast50LinesInNonZeroExitException()
+    {
+        var lines = Enumerable.Range(1, 52).Select(i => $"line-{i}").ToArray();
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(CreateFailingProcessSpec(lines));
+
+        await using (processDisposable)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProcessResult).WaitAsync(TimeSpan.FromSeconds(10));
+            var outputLines = exception.Message.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.Contains("Command output truncated: showing last 50 of 52 lines.", exception.Message);
+            Assert.DoesNotContain("line-1", outputLines);
+            Assert.DoesNotContain("line-2", outputLines);
+            Assert.Contains("line-3", outputLines);
+            Assert.Contains("line-52", outputLines);
+        }
+    }
+
     private static ProcessSpec CreateSingleLineOutputProcessSpec(Action<string> onOutputData)
     {
         if (OperatingSystem.IsWindows())
@@ -54,6 +111,60 @@ public class ProcessUtilTests
             Arguments = "-c \"echo final-line\"",
             OnOutputData = onOutputData,
             ThrowOnNonZeroReturnCode = false
+        };
+    }
+
+    private static ProcessSpec CreateFailingProcessSpec(
+        string[] lines,
+        bool emitSecondLineToStderr = false,
+        bool throwOnNonZeroReturnCode = true,
+        int? retainedOutputLineCount = null)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var commandParts = new List<string>();
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (emitSecondLineToStderr && i == 1)
+                {
+                    commandParts.Add($"echo {lines[i]} 1>&2");
+                }
+                else
+                {
+                    commandParts.Add($"echo {lines[i]}");
+                }
+            }
+
+            commandParts.Add("exit /b 1");
+
+            return new ProcessSpec("cmd")
+            {
+                Arguments = $"/c \"{string.Join(" & ", commandParts)}\"",
+                ThrowOnNonZeroReturnCode = throwOnNonZeroReturnCode,
+                RetainedOutputLineCount = retainedOutputLineCount
+            };
+        }
+
+        var unixCommandParts = new List<string>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (emitSecondLineToStderr && i == 1)
+            {
+                unixCommandParts.Add($"echo {lines[i]} 1>&2");
+            }
+            else
+            {
+                unixCommandParts.Add($"echo {lines[i]}");
+            }
+        }
+
+        unixCommandParts.Add("exit 1");
+
+        return new ProcessSpec("sh")
+        {
+            Arguments = $"-c \"{string.Join("; ", unixCommandParts)}\"",
+            ThrowOnNonZeroReturnCode = throwOnNonZeroReturnCode,
+            RetainedOutputLineCount = retainedOutputLineCount
         };
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
@@ -25,9 +25,40 @@ public class ContainerRuntimeBaseTests
         Assert.Contains("stderr-final-line", exception.Message);
     }
 
-    private sealed class TestContainerRuntime() : ContainerRuntimeBase<TestContainerRuntime>(NullLogger<TestContainerRuntime>.Instance)
+    [Fact]
+    public async Task LoginToRegistryAsync_IncludesCapturedOutputInFailureMessage()
     {
-        protected override string RuntimeExecutable => OperatingSystem.IsWindows() ? "cmd" : "sh";
+        var runtime = new TestContainerRuntime("dotnet");
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+            runtime.LoginToRegistryAsync("registry.example.com", "user", "password", default)).WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.Contains("test-runtime login failed with exit code 1.", exception.Message);
+        Assert.Contains("Could not execute because the specified command or file was not found.", exception.Message);
+        Assert.Contains("dotnet-login", exception.Message);
+    }
+
+    [Fact]
+    public async Task ComposeUpAsync_IncludesCapturedOutputInFailureMessage()
+    {
+        var runtime = new TestContainerRuntime("dotnet");
+        var context = new ComposeOperationContext
+        {
+            ProjectName = "test-project",
+            WorkingDirectory = AppContext.BaseDirectory
+        };
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+            runtime.ComposeUpAsync(context, default)).WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.Contains("'dotnet compose up' failed with exit code 1.", exception.Message);
+        Assert.Contains("Could not execute because the specified command or file was not found.", exception.Message);
+        Assert.Contains("dotnet-compose", exception.Message);
+    }
+
+    private sealed class TestContainerRuntime(string? runtimeExecutable = null) : ContainerRuntimeBase<TestContainerRuntime>(NullLogger<TestContainerRuntime>.Instance)
+    {
+        protected override string RuntimeExecutable => runtimeExecutable ?? (OperatingSystem.IsWindows() ? "cmd" : "sh");
 
         public override string Name => "test-runtime";
 

--- a/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
@@ -25,37 +25,6 @@ public class ContainerRuntimeBaseTests
         Assert.Contains("stderr-final-line", exception.Message);
     }
 
-    [Fact]
-    public async Task LoginToRegistryAsync_IncludesCapturedOutputInFailureMessage()
-    {
-        var runtime = new TestContainerRuntime("dotnet");
-
-        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
-            runtime.LoginToRegistryAsync("registry.example.com", "user", "password", default)).WaitAsync(TimeSpan.FromSeconds(30));
-
-        Assert.Contains("test-runtime login failed with exit code 1.", exception.Message);
-        Assert.Contains("Could not execute because the specified command or file was not found.", exception.Message);
-        Assert.Contains("dotnet-login", exception.Message);
-    }
-
-    [Fact]
-    public async Task ComposeUpAsync_IncludesCapturedOutputInFailureMessage()
-    {
-        var runtime = new TestContainerRuntime("dotnet");
-        var context = new ComposeOperationContext
-        {
-            ProjectName = "test-project",
-            WorkingDirectory = AppContext.BaseDirectory
-        };
-
-        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
-            runtime.ComposeUpAsync(context, default)).WaitAsync(TimeSpan.FromSeconds(30));
-
-        Assert.Contains("'dotnet compose up' failed with exit code 1.", exception.Message);
-        Assert.Contains("Could not execute because the specified command or file was not found.", exception.Message);
-        Assert.Contains("dotnet-compose", exception.Message);
-    }
-
     private sealed class TestContainerRuntime(string? runtimeExecutable = null) : ContainerRuntimeBase<TestContainerRuntime>(NullLogger<TestContainerRuntime>.Instance)
     {
         protected override string RuntimeExecutable => runtimeExecutable ?? (OperatingSystem.IsWindows() ? "cmd" : "sh");

--- a/tests/Aspire.Hosting.Tests/Publishing/ProcessFailedExceptionTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ProcessFailedExceptionTests.cs
@@ -11,14 +11,14 @@ public class ProcessFailedExceptionTests
     [Fact]
     public void Message_IncludesTruncationSummary_WhenOutputExceedsDefaultLimit()
     {
-        var buildOutput = Enumerable.Range(1, 60)
+        var processOutput = Enumerable.Range(1, 60)
             .Select(i => $"output-{i:000}")
             .ToArray();
 
-        var exception = new ProcessFailedException("Build failed.", 1, buildOutput, totalBuildOutputLineCount: 60);
+        var exception = new ProcessFailedException("Build failed.", 1, processOutput, totalProcessOutputLineCount: 60);
 
         Assert.Contains("Build failed.", exception.Message);
-        Assert.Contains("Build output truncated: showing last 50 of 60 lines.", exception.Message);
+        Assert.Contains("Process output truncated: showing last 50 of 60 lines.", exception.Message);
         Assert.DoesNotContain("output-001", exception.Message);
         Assert.Contains("output-011", exception.Message);
         Assert.Contains("output-060", exception.Message);

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -1470,10 +1470,10 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         Assert.NotEqual(0, ex.ExitCode);
         Assert.NotEmpty(ex.ProcessOutput);
-        Assert.Contains("Failed to build container image for resource 'broken-container'", ex.Message);
 
         var newlineIndex = ex.Message.IndexOf(Environment.NewLine, StringComparison.Ordinal);
         Assert.NotEqual(-1, newlineIndex);
+        Assert.Equal($"Docker build failed with exit code {ex.ExitCode}.", ex.Message[..newlineIndex]);
         Assert.Equal(ex.GetFormattedOutput(), ex.Message[(newlineIndex + Environment.NewLine.Length)..]);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -1441,7 +1441,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
     [Fact]
     [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
-    public async Task DockerBuildFailureIncludesBuildOutputInException()
+    public async Task DockerBuildFailureIncludesProcessOutputInException()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
 
@@ -1469,8 +1469,8 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
             () => imageBuilder.BuildImageAsync(container.Resource, cts.Token));
 
         Assert.NotEqual(0, ex.ExitCode);
-        Assert.NotEmpty(ex.BuildOutput);
-        Assert.Contains(ex.BuildOutput, line => line.Contains("nonexistent-file-12345.txt"));
+        Assert.NotEmpty(ex.ProcessOutput);
+        Assert.Contains(ex.ProcessOutput, line => line.Contains("nonexistent-file-12345.txt"));
     }
 }
 

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -1470,7 +1470,11 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         Assert.NotEqual(0, ex.ExitCode);
         Assert.NotEmpty(ex.ProcessOutput);
-        Assert.Contains(ex.ProcessOutput, line => line.Contains("nonexistent-file-12345.txt"));
+        Assert.Contains("Failed to build container image for resource 'broken-container'", ex.Message);
+
+        var newlineIndex = ex.Message.IndexOf(Environment.NewLine, StringComparison.Ordinal);
+        Assert.NotEqual(-1, newlineIndex);
+        Assert.Equal(ex.GetFormattedOutput(), ex.Message[(newlineIndex + Environment.NewLine.Length)..]);
     }
 }
 


### PR DESCRIPTION
## Description

- Generalize failed-process output retention into the DCP process layer by letting `ProcessSpec` opt into retained output and returning that retained output from `ProcessResult`.
- Surface the retained output tail for publishing and container-runtime failures, including `dotnet publish`, Docker/Podman build, registry login, and `compose up` failures.
- Rename the generic failure surface from build output to process output, and fix the shared `CircularBuffer` debug assertions so duplicate values do not trip incorrect invariants.

Motivation/context:
- This makes opaque failures like `az bicep build` and other process-driven deployment steps include the useful stderr/stdout tail by default.

Dependencies:
- None.

Validation:
- `./dotnet.sh build src/Aspire.Hosting/Aspire.Hosting.csproj -c Release`
- `./dotnet.sh build src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj -c Release`
- `./dotnet.sh build src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj -c Release`
- `./dotnet.sh build src/Aspire.Hosting.Azure.Kubernetes/Aspire.Hosting.Azure.Kubernetes.csproj -c Release`
- `./dotnet.sh test tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj -- --filter-class "*.ContainerRuntimeBaseTests" --filter-class "*.ProcessUtilTests" --filter-class "*.ProcessFailedExceptionTests" --filter-class "*.ResourceContainerImageManagerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh test tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj -- --filter-class "*.CircularBufferTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
