### PR TITLE
Fix aspire docs cache and output rendering

### DIFF
--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -121,7 +121,7 @@ internal sealed partial class DocsGetCommand : BaseCommand
                 continue;
             }
 
-            if (inCodeFence || string.IsNullOrWhiteSpace(trimmedLine) || IsHeading(trimmedLine))
+            if (inCodeFence || string.IsNullOrWhiteSpace(trimmedLine) || IsHeading(trimmedLine) || IsTableLine(trimmedLine))
             {
                 wrappedLines.Add(trimmedLine);
                 continue;
@@ -221,6 +221,11 @@ internal sealed partial class DocsGetCommand : BaseCommand
     private static bool IsHeading(string line)
     {
         return line.StartsWith('#');
+    }
+
+    private static bool IsTableLine(string line)
+    {
+        return line.StartsWith("|", StringComparison.Ordinal) && line.Count(static character => character == '|') >= 2;
     }
 
     private static bool IsTrailingPunctuation(string value)

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -153,20 +153,34 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
             _logger.LogDebug("Loading aspire.dev documentation");
 
             var cachedDocuments = await _docsCache.GetIndexAsync(cancellationToken).ConfigureAwait(false);
-            if (cachedDocuments is not null)
+            var cachedFingerprint = await _docsCache.GetIndexSourceFingerprintAsync(cancellationToken).ConfigureAwait(false);
+
+            var content = await _docsFetcher.FetchDocsAsync(cancellationToken).ConfigureAwait(false);
+            if (content is null)
+            {
+                if (cachedDocuments is not null)
+                {
+                    _indexedDocuments = [.. cachedDocuments.Select(static d => new IndexedDocument(d))];
+
+                    _logger.LogWarning(
+                        "Failed to refresh Aspire documentation. Using cached index with {Count} documents.",
+                        cachedDocuments.Length);
+
+                    return;
+                }
+
+                _logger.LogWarning("Failed to fetch documentation");
+
+                return;
+            }
+
+            var currentFingerprint = SourceContentFingerprint.Compute(content);
+            if (cachedDocuments is not null && string.Equals(cachedFingerprint, currentFingerprint, StringComparison.Ordinal))
             {
                 _indexedDocuments = [.. cachedDocuments.Select(static d => new IndexedDocument(d))];
 
                 var cacheElapsedTime = Stopwatch.GetElapsedTime(startTimestamp);
                 _logger.LogInformation("Loaded {Count} documents from cache in {ElapsedTime:ss\\.fff} seconds.", _indexedDocuments.Count, cacheElapsedTime);
-                return;
-            }
-
-            var content = await _docsFetcher.FetchDocsAsync(cancellationToken).ConfigureAwait(false);
-            if (content is null)
-            {
-                _logger.LogWarning("Failed to fetch documentation");
-
                 return;
             }
 
@@ -177,7 +191,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
             // Cache the parsed documents for next time
             await _docsCache.SetIndexAsync([.. documents], cancellationToken).ConfigureAwait(false);
-            await _docsCache.SetIndexSourceFingerprintAsync(SourceContentFingerprint.Compute(content), cancellationToken).ConfigureAwait(false);
+            await _docsCache.SetIndexSourceFingerprintAsync(currentFingerprint, cancellationToken).ConfigureAwait(false);
 
             var elapsedTime = Stopwatch.GetElapsedTime(startTimestamp);
 
@@ -547,6 +561,9 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         content = SectionTitledBookmarkRegex().Replace(content, "\n\n");
         content = InlineOrderedListRegex().Replace(content, "\n$1");
         content = InlineUnorderedListRegex().Replace(content, "\n* ");
+        content = InlineTableStartRegex().Replace(content, "$1\n$2");
+        content = InlineTableRowBoundaryRegex().Replace(content, "\n");
+        content = InlineTableEndRegex().Replace(content, "$1\n$2");
         content = LeadingWhitespaceRegex().Replace(content, "");
 
         return content;
@@ -614,6 +631,15 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
     [GeneratedRegex(@"(?<=\S)\s+\*\s+")]
     private static partial Regex InlineUnorderedListRegex();
+
+    [GeneratedRegex(@"(\S)\s+(\|(?:[^|\n]*\|){2,})")]
+    private static partial Regex InlineTableStartRegex();
+
+    [GeneratedRegex(@"(?<=\|)\s+(?=\|)")]
+    private static partial Regex InlineTableRowBoundaryRegex();
+
+    [GeneratedRegex(@"(\|(?:[^|\n]*\|){2,})\s+([^\s|][^|\n]*)$", RegexOptions.Multiline)]
+    private static partial Regex InlineTableEndRegex();
 
     [GeneratedRegex(@"[ \t]+\n")]
     private static partial Regex TrailingWhitespaceBeforeNewlineRegex();

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -307,9 +307,28 @@ internal class ConsoleInteractionService : IInteractionService
     public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null)
     {
         var effectiveConsole = consoleOverride ?? Console;
+        if (ShouldDisplayMarkdownAsPlainText(effectiveConsole))
+        {
+            var plainText = MarkdownToSpectreConverter.ConvertToPlainText(markdown);
+            DisplayRawText(plainText, effectiveConsole);
+            return;
+        }
+
         var target = effectiveConsole == ConsoleOutput.Error ? _errorConsole : _outConsole;
         var spectreMarkup = MarkdownToSpectreConverter.ConvertToSpectre(markdown);
         target.MarkupLine(spectreMarkup);
+    }
+
+    private bool ShouldDisplayMarkdownAsPlainText(ConsoleOutput effectiveConsole)
+    {
+        if (!_hostEnvironment.SupportsInteractiveOutput)
+        {
+            return true;
+        }
+
+        return effectiveConsole == ConsoleOutput.Error
+            ? System.Console.IsErrorRedirected
+            : System.Console.IsOutputRedirected;
     }
 
     public void DisplayMarkupLine(string markup)

--- a/src/Aspire.Cli/Utils/MarkdownToSpectreConverter.cs
+++ b/src/Aspire.Cli/Utils/MarkdownToSpectreConverter.cs
@@ -72,10 +72,10 @@ internal static partial class MarkdownToSpectreConverter
     }
 
     /// <summary>
-    /// Converts markdown to plain text suitable for redirected or non-interactive output.
+    /// Converts markdown to a lossy plain-text representation suitable for redirected or non-interactive output.
     /// </summary>
     /// <param name="markdown">The markdown text to convert.</param>
-    /// <returns>Markdown with links rewritten to plain text and image references removed.</returns>
+    /// <returns>Plain text with links rewritten to <c>text (url)</c>, image references removed, header markers stripped, and basic formatting markers for bold, italic, and strikethrough removed.</returns>
     public static string ConvertToPlainText(string markdown)
     {
         if (string.IsNullOrWhiteSpace(markdown))

--- a/src/Aspire.Cli/Utils/MarkdownToSpectreConverter.cs
+++ b/src/Aspire.Cli/Utils/MarkdownToSpectreConverter.cs
@@ -71,6 +71,36 @@ internal static partial class MarkdownToSpectreConverter
         return LinkRegex().Replace(markdown, "$1 ($2)");
     }
 
+    /// <summary>
+    /// Converts markdown to plain text suitable for redirected or non-interactive output.
+    /// </summary>
+    /// <param name="markdown">The markdown text to convert.</param>
+    /// <returns>Markdown with links rewritten to plain text and image references removed.</returns>
+    public static string ConvertToPlainText(string markdown)
+    {
+        if (string.IsNullOrWhiteSpace(markdown))
+        {
+            return markdown;
+        }
+
+        var result = markdown.Replace("\r\n", "\n").Replace("\r", "\n");
+        result = ConvertImages(result);
+        result = ConvertLinksToPlainText(result);
+        result = HeaderLevel6Regex().Replace(result, "$1");
+        result = HeaderLevel5Regex().Replace(result, "$1");
+        result = HeaderLevel4Regex().Replace(result, "$1");
+        result = HeaderLevel3Regex().Replace(result, "$1");
+        result = HeaderLevel2Regex().Replace(result, "$1");
+        result = HeaderLevel1Regex().Replace(result, "$1");
+        result = BoldDoubleAsterisksRegex().Replace(result, "$1");
+        result = BoldDoubleUnderscoresRegex().Replace(result, "$1");
+        result = ItalicSingleAsteriskRegex().Replace(result, "$1");
+        result = ItalicSingleUnderscoreRegex().Replace(result, "$1");
+        result = StrikethroughRegex().Replace(result, "$1");
+
+        return result;
+    }
+
     private static string ConvertHeaders(string text)
     {
         // Convert ###### Header 6 (most specific first)

--- a/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
@@ -178,6 +178,22 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void WrapMarkdownForConsole_DoesNotWrapTableRows()
+    {
+        var markdown = """
+            | Setting | Environment variable | Purpose |
+            | ---------------------- | ----------------------- | ---------------------------------------------- |
+            | `Azure:SubscriptionId` | `Azure__SubscriptionId` | Target Azure subscription |
+            """;
+
+        var wrapped = Aspire.Cli.Commands.DocsGetCommand.WrapMarkdownForConsole(markdown, width: 40);
+
+        Assert.Contains("| Setting | Environment variable | Purpose |", wrapped);
+        Assert.Contains("| ---------------------- | ----------------------- | ---------------------------------------------- |", wrapped);
+        Assert.Contains("| `Azure:SubscriptionId` | `Azure__SubscriptionId` | Target Azure subscription |", wrapped);
+    }
+
+    [Fact]
     public async Task DocsGetCommand_WithInvalidSlug_ReturnsError()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -182,6 +182,25 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
+    public void DisplayMarkdown_WhenNonInteractive_UsesPlainTextFallback()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var interactionService = CreateInteractionService(console, executionContext, TestHelpers.CreateNonInteractiveHostEnvironment());
+
+        interactionService.DisplayMarkdown("Visit [GitHub](https://github.com) for more info.");
+
+        Assert.Contains("Visit GitHub (https://github.com) for more info.", output.ToString());
+    }
+
+    [Fact]
     public async Task ShowStatusAsync_InDebugMode_DisplaysSubtleMessageInsteadOfSpinner()
     {
         // Arrange

--- a/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
@@ -479,26 +479,36 @@ public class DocsIndexServiceTests
     }
 
     [Fact]
-    public async Task EnsureIndexedAsync_UsesCachedIndexAcrossInstancesWithoutFetching()
+    public async Task EnsureIndexedAsync_RevalidatesCachedIndexAcrossInstances()
     {
         var cache = new MemoryDocsCache();
-        var firstService = CreateService(
-            CreateMockFetcher(
-            """
+        const string content = """
             # Redis Integration
             > Connect to Redis.
 
             Redis content.
-            """),
+            """;
+
+        var firstService = CreateService(
+            CreateMockFetcher(content),
             cache);
 
         await firstService.EnsureIndexedAsync();
 
-        var secondService = CreateService(new ThrowingDocsFetcher(new InvalidOperationException("Should not fetch.")), cache);
+        var fetchCount = 0;
+        var secondService = CreateService(
+            new CountingDocsFetcher(() =>
+            {
+                fetchCount++;
+                return content;
+            }),
+            cache);
+
         var docs = await secondService.ListDocumentsAsync();
 
         var doc = Assert.Single(docs);
         Assert.Equal("Redis Integration", doc.Title);
+        Assert.Equal(1, fetchCount);
     }
 
     [Fact]
@@ -522,7 +532,64 @@ public class DocsIndexServiceTests
 
         var doc = Assert.Single(docs);
         Assert.Equal("Redis Integration", doc.Title);
+    }
 
+    [Fact]
+    public async Task EnsureIndexedAsync_RefreshesCachedIndexWhenSourceContentChanges()
+    {
+        var cache = new MemoryDocsCache();
+        var firstService = CreateService(
+            CreateMockFetcher(
+                """
+                # Redis Integration
+                > Connect to Redis.
+
+                Redis content.
+                """),
+            cache);
+
+        await firstService.EnsureIndexedAsync();
+
+        var secondService = CreateService(
+            CreateMockFetcher(
+                """
+                # PostgreSQL Integration
+                > Connect to PostgreSQL.
+
+                PostgreSQL content.
+                """),
+            cache);
+
+        var docs = await secondService.ListDocumentsAsync();
+
+        var doc = Assert.Single(docs);
+        Assert.Equal("PostgreSQL Integration", doc.Title);
+
+        var thirdService = CreateService(CreateMockFetcher(null), cache);
+        var cachedDocs = await thirdService.ListDocumentsAsync();
+
+        Assert.Equal("PostgreSQL Integration", Assert.Single(cachedDocs).Title);
+    }
+
+    [Fact]
+    public async Task GetDocumentAsync_NormalizesMinifiedInlineTables()
+    {
+        var content = """
+            # Deploy to Azure
+            > Learn how Azure deployment works in Aspire.
+
+            After authentication succeeds, `aspire deploy` still needs a small set of shared Azure settings. | Setting | Environment variable | Purpose | | ---------------------- | ----------------------- | ---------------------------------------------- | | `Azure:SubscriptionId` | `Azure__SubscriptionId` | Target Azure subscription | | `Azure:Location` | `Azure__Location` | Default Azure region for provisioned resources | ### Local settings [Section titled "Local settings"](#local-settings) Continue here.
+            """;
+
+        var service = CreateService(CreateMockFetcher(content));
+
+        var document = await service.GetDocumentAsync("deploy-to-azure");
+        Assert.NotNull(document);
+
+        var normalized = document.Content.Replace("\r\n", "\n", StringComparison.Ordinal);
+        Assert.Contains("\n| Setting | Environment variable | Purpose |\n", normalized);
+        Assert.Contains("\n| `Azure:SubscriptionId` | `Azure__SubscriptionId` | Target Azure subscription |\n", normalized);
+        Assert.Contains("\n### Local settings\n", normalized);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
@@ -125,6 +125,26 @@ public class MarkdownToSpectreConverterTests
     }
 
     [Fact]
+    public void ConvertToPlainText_WithLinksAndImages_ConvertsCorrectly()
+    {
+        var markdown = "Visit [GitHub](https://github.com) and remove ![diagram](https://example.com/diagram.png).";
+
+        var result = MarkdownToSpectreConverter.ConvertToPlainText(markdown);
+
+        Assert.Equal("Visit GitHub (https://github.com) and remove .", result);
+    }
+
+    [Fact]
+    public void ConvertToPlainText_StripsSimpleMarkdownFormatting()
+    {
+        var markdown = "## Heading\nThis is **bold**, *italic*, and ~~deleted~~.";
+
+        var result = MarkdownToSpectreConverter.ConvertToPlainText(markdown);
+
+        Assert.Equal("Heading\nThis is bold, italic, and deleted.", result);
+    }
+
+    [Fact]
     public void ConvertToSpectre_WithComplexMarkdown_ConvertsAllElements()
     {
         // Arrange


### PR DESCRIPTION
## Description

Fixes stale `aspire docs` cache behavior and the broken rendering path in `aspire docs get`.

- Revalidates the cached parsed docs index against the fetched docs source so stale cached indexes are refreshed when `llms-small.txt` changes, while still falling back to cached content if refresh fails.
- Reconstructs minified inline markdown tables, avoids wrapping table rows, and uses a plain-text markdown path for redirected or non-interactive output so links and values like `Azure:SubscriptionId` remain readable.
- Adds regression coverage for stale cache refresh, table normalization, non-interactive markdown output, and table wrapping behavior.

Fixes #16302

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
