### PR TITLE
Update GenVmSizes to query all Azure regions for comprehensive VM size list

### DIFF
--- a/docs/specs/aks-support.md
+++ b/docs/specs/aks-support.md
@@ -395,7 +395,7 @@ var aks = builder.AddAzureKubernetesEnvironment("aks")
     .WithSubnet(defaultSubnet);
 
 // Per-pool subnet override
-var gpuPool = aks.AddNodePool("gpu", AksNodeVmSizes.GpuAccelerated.StandardNC6sV3, 0, 5)
+var gpuPool = aks.AddNodePool("gpu", AksNodeVmSizes.StandardNCSv3.StandardNC6sV3, 0, 5)
     .WithSubnet(gpuSubnet);
 ```
 
@@ -557,7 +557,7 @@ var aks = builder.AddAzureKubernetesService("aks")
 - ✅ `AksNodePoolResource` extends base with VM size, scaling, mode config
 - ✅ `AddNodePool()` on both K8s and AKS environments
 - ✅ `WithNodePool()` schedules workloads via `nodeSelector` on pod spec
-- ✅ `AksNodeVmSizes` constants class (GeneralPurpose, ComputeOptimized, MemoryOptimized, GpuAccelerated, StorageOptimized, Burstable, Arm)
+- ✅ `AksNodeVmSizes` constants class (organized by Azure SKU family names)
 - ✅ `GenVmSizes.cs` tool + `update-azure-vm-sizes.yml` monthly workflow
 - ✅ Default "workload" user pool auto-created if none configured
 

--- a/src/Aspire.Hosting.Azure.Kubernetes/AksNodeVmSizes.Generated.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AksNodeVmSizes.Generated.cs
@@ -10,265 +10,7841 @@ namespace Aspire.Hosting.Azure.Kubernetes;
 /// Provides well-known Azure VM size constants for use with AKS node pools.
 /// </summary>
 /// <remarks>
-/// This class is auto-generated. To update, run the GenVmSizes tool:
+/// This class is auto-generated from Azure Resource SKUs across all public Azure regions,
+/// filtered to VM sizes compatible with AKS node pools (minimum 2 vCPUs, 2 GB RAM,
+/// excluding Basic tier VMs).
+/// To update, run the GenVmSizes tool:
 /// <code>dotnet run --project src/Aspire.Hosting.Azure.Kubernetes/tools GenVmSizes.cs</code>
+/// VM size availability varies by region. Not all sizes may be available in every region.
 /// </remarks>
 public static partial class AksNodeVmSizes
 {
     /// <summary>
-    /// General purpose VM sizes optimized for balanced CPU-to-memory ratio.
+    /// VM sizes in the Standard NCASv3_T4 Family.
     /// </summary>
-    public static class GeneralPurpose
+    public static class StandardNCASv3T4
     {
         /// <summary>
-        /// Standard_D2s_v5 — 2 vCPUs, 8 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardD2sV5 = "Standard_D2s_v5";
-
-        /// <summary>
-        /// Standard_D4s_v5 — 4 vCPUs, 16 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardD4sV5 = "Standard_D4s_v5";
-
-        /// <summary>
-        /// Standard_D8s_v5 — 8 vCPUs, 32 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardD8sV5 = "Standard_D8s_v5";
-
-        /// <summary>
-        /// Standard_D16s_v5 — 16 vCPUs, 64 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardD16sV5 = "Standard_D16s_v5";
-
-        /// <summary>
-        /// Standard_D32s_v5 — 32 vCPUs, 128 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardD32sV5 = "Standard_D32s_v5";
-
-        /// <summary>
-        /// Standard_D2s_v6 — 2 vCPUs, 8 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardD2sV6 = "Standard_D2s_v6";
-
-        /// <summary>
-        /// Standard_D4s_v6 — 4 vCPUs, 16 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardD4sV6 = "Standard_D4s_v6";
-
-        /// <summary>
-        /// Standard_D8s_v6 — 8 vCPUs, 32 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardD8sV6 = "Standard_D8s_v6";
-
-        /// <summary>
-        /// Standard_D2as_v5 — 2 vCPUs, 8 GB RAM, Premium SSD, AMD processor.
-        /// </summary>
-        public const string StandardD2asV5 = "Standard_D2as_v5";
-
-        /// <summary>
-        /// Standard_D4as_v5 — 4 vCPUs, 16 GB RAM, Premium SSD, AMD processor.
-        /// </summary>
-        public const string StandardD4asV5 = "Standard_D4as_v5";
-
-        /// <summary>
-        /// Standard_D8as_v5 — 8 vCPUs, 32 GB RAM, Premium SSD, AMD processor.
-        /// </summary>
-        public const string StandardD8asV5 = "Standard_D8as_v5";
-    }
-
-    /// <summary>
-    /// Compute optimized VM sizes with high CPU-to-memory ratio.
-    /// </summary>
-    public static class ComputeOptimized
-    {
-        /// <summary>
-        /// Standard_F2s_v2 — 2 vCPUs, 4 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardF2sV2 = "Standard_F2s_v2";
-
-        /// <summary>
-        /// Standard_F4s_v2 — 4 vCPUs, 8 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardF4sV2 = "Standard_F4s_v2";
-
-        /// <summary>
-        /// Standard_F8s_v2 — 8 vCPUs, 16 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardF8sV2 = "Standard_F8s_v2";
-
-        /// <summary>
-        /// Standard_F16s_v2 — 16 vCPUs, 32 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardF16sV2 = "Standard_F16s_v2";
-    }
-
-    /// <summary>
-    /// Memory optimized VM sizes with high memory-to-CPU ratio.
-    /// </summary>
-    public static class MemoryOptimized
-    {
-        /// <summary>
-        /// Standard_E2s_v5 — 2 vCPUs, 16 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardE2sV5 = "Standard_E2s_v5";
-
-        /// <summary>
-        /// Standard_E4s_v5 — 4 vCPUs, 32 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardE4sV5 = "Standard_E4s_v5";
-
-        /// <summary>
-        /// Standard_E8s_v5 — 8 vCPUs, 64 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardE8sV5 = "Standard_E8s_v5";
-
-        /// <summary>
-        /// Standard_E16s_v5 — 16 vCPUs, 128 GB RAM, Premium SSD.
-        /// </summary>
-        public const string StandardE16sV5 = "Standard_E16s_v5";
-
-        /// <summary>
-        /// Standard_E2as_v5 — 2 vCPUs, 16 GB RAM, Premium SSD, AMD processor.
-        /// </summary>
-        public const string StandardE2asV5 = "Standard_E2as_v5";
-
-        /// <summary>
-        /// Standard_E4as_v5 — 4 vCPUs, 32 GB RAM, Premium SSD, AMD processor.
-        /// </summary>
-        public const string StandardE4asV5 = "Standard_E4as_v5";
-    }
-
-    /// <summary>
-    /// GPU-enabled VM sizes for compute-intensive and ML workloads.
-    /// </summary>
-    public static class GpuAccelerated
-    {
-        /// <summary>
-        /// Standard_NC6s_v3 — 6 vCPUs, 112 GB RAM, 1 GPU (NVIDIA V100).
-        /// </summary>
-        public const string StandardNC6sV3 = "Standard_NC6s_v3";
-
-        /// <summary>
-        /// Standard_NC12s_v3 — 12 vCPUs, 224 GB RAM, 2 GPUs (NVIDIA V100).
-        /// </summary>
-        public const string StandardNC12sV3 = "Standard_NC12s_v3";
-
-        /// <summary>
-        /// Standard_NC24s_v3 — 24 vCPUs, 448 GB RAM, 4 GPUs (NVIDIA V100).
-        /// </summary>
-        public const string StandardNC24sV3 = "Standard_NC24s_v3";
-
-        /// <summary>
-        /// Standard_NC4as_T4_v3 — 4 vCPUs, 28 GB RAM, 1 GPU (NVIDIA T4).
-        /// </summary>
-        public const string StandardNC4asT4V3 = "Standard_NC4as_T4_v3";
-
-        /// <summary>
-        /// Standard_NC8as_T4_v3 — 8 vCPUs, 56 GB RAM, 1 GPU (NVIDIA T4).
-        /// </summary>
-        public const string StandardNC8asT4V3 = "Standard_NC8as_T4_v3";
-
-        /// <summary>
-        /// Standard_NC16as_T4_v3 — 16 vCPUs, 110 GB RAM, 1 GPU (NVIDIA T4).
+        /// Standard_NC16as_T4_v3 — 16 vCPUs — 110 GB RAM — 1 GPU(s) — Premium SSD
         /// </summary>
         public const string StandardNC16asT4V3 = "Standard_NC16as_T4_v3";
 
         /// <summary>
-        /// Standard_NC24ads_A100_v4 — 24 vCPUs, 220 GB RAM, 1 GPU (NVIDIA A100 80GB).
+        /// Standard_NC4as_T4_v3 — 4 vCPUs — 28 GB RAM — 1 GPU(s) — Premium SSD
         /// </summary>
-        public const string StandardNC24adsA100V4 = "Standard_NC24ads_A100_v4";
+        public const string StandardNC4asT4V3 = "Standard_NC4as_T4_v3";
 
         /// <summary>
-        /// Standard_NC48ads_A100_v4 — 48 vCPUs, 440 GB RAM, 2 GPUs (NVIDIA A100 80GB).
+        /// Standard_NC64as_T4_v3 — 64 vCPUs — 440 GB RAM — 4 GPU(s) — Premium SSD
         /// </summary>
-        public const string StandardNC48adsA100V4 = "Standard_NC48ads_A100_v4";
+        public const string StandardNC64asT4V3 = "Standard_NC64as_T4_v3";
+
+        /// <summary>
+        /// Standard_NC8as_T4_v3 — 8 vCPUs — 56 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC8asT4V3 = "Standard_NC8as_T4_v3";
     }
 
     /// <summary>
-    /// Storage optimized VM sizes with high disk throughput and I/O.
+    /// VM sizes in the standard NDAMSv4_A100Family.
     /// </summary>
-    public static class StorageOptimized
+    public static class StandardNDAMSv4A100
     {
         /// <summary>
-        /// Standard_L8s_v3 — 8 vCPUs, 64 GB RAM, Premium SSD, high local NVMe storage.
+        /// Standard_ND96amsr_A100_v4 — 96 vCPUs — 1800 GB RAM — 8 GPU(s) — Premium SSD
         /// </summary>
-        public const string StandardL8sV3 = "Standard_L8s_v3";
-
-        /// <summary>
-        /// Standard_L16s_v3 — 16 vCPUs, 128 GB RAM, Premium SSD, high local NVMe storage.
-        /// </summary>
-        public const string StandardL16sV3 = "Standard_L16s_v3";
-
-        /// <summary>
-        /// Standard_L32s_v3 — 32 vCPUs, 256 GB RAM, Premium SSD, high local NVMe storage.
-        /// </summary>
-        public const string StandardL32sV3 = "Standard_L32s_v3";
+        public const string StandardND96amsrA100V4 = "Standard_ND96amsr_A100_v4";
     }
 
     /// <summary>
-    /// Burstable VM sizes for cost-effective workloads with variable CPU usage.
+    /// VM sizes in the Standard NDASv4_A100 Family.
     /// </summary>
-    public static class Burstable
+    public static class StandardNDASv4A100
     {
         /// <summary>
-        /// Standard_B2s — 2 vCPUs, 4 GB RAM.
+        /// Standard_ND96asr_v4 — 96 vCPUs — 900 GB RAM — 8 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardND96asrV4 = "Standard_ND96asr_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardAv2Family.
+    /// </summary>
+    public static class StandardAv2
+    {
+        /// <summary>
+        /// Standard_A2m_v2 — 2 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardA2mV2 = "Standard_A2m_v2";
+
+        /// <summary>
+        /// Standard_A2_v2 — 2 vCPUs — 4 GB RAM
+        /// </summary>
+        public const string StandardA2V2 = "Standard_A2_v2";
+
+        /// <summary>
+        /// Standard_A4m_v2 — 4 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardA4mV2 = "Standard_A4m_v2";
+
+        /// <summary>
+        /// Standard_A4_v2 — 4 vCPUs — 8 GB RAM
+        /// </summary>
+        public const string StandardA4V2 = "Standard_A4_v2";
+
+        /// <summary>
+        /// Standard_A8m_v2 — 8 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardA8mV2 = "Standard_A8m_v2";
+
+        /// <summary>
+        /// Standard_A8_v2 — 8 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardA8V2 = "Standard_A8_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardBasv2Family.
+    /// </summary>
+    public static class StandardBasv2
+    {
+        /// <summary>
+        /// Standard_B16als_v2 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB16alsV2 = "Standard_B16als_v2";
+
+        /// <summary>
+        /// Standard_B16as_v2 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB16asV2 = "Standard_B16as_v2";
+
+        /// <summary>
+        /// Standard_B2als_v2 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB2alsV2 = "Standard_B2als_v2";
+
+        /// <summary>
+        /// Standard_B2as_v2 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB2asV2 = "Standard_B2as_v2";
+
+        /// <summary>
+        /// Standard_B32als_v2 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB32alsV2 = "Standard_B32als_v2";
+
+        /// <summary>
+        /// Standard_B32as_v2 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB32asV2 = "Standard_B32as_v2";
+
+        /// <summary>
+        /// Standard_B4als_v2 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB4alsV2 = "Standard_B4als_v2";
+
+        /// <summary>
+        /// Standard_B4as_v2 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB4asV2 = "Standard_B4as_v2";
+
+        /// <summary>
+        /// Standard_B8als_v2 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB8alsV2 = "Standard_B8als_v2";
+
+        /// <summary>
+        /// Standard_B8as_v2 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB8asV2 = "Standard_B8as_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardBpsv2Family.
+    /// </summary>
+    public static class StandardBpsv2
+    {
+        /// <summary>
+        /// Standard_B16pls_v2 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB16plsV2 = "Standard_B16pls_v2";
+
+        /// <summary>
+        /// Standard_B16ps_v2 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB16psV2 = "Standard_B16ps_v2";
+
+        /// <summary>
+        /// Standard_B2pls_v2 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB2plsV2 = "Standard_B2pls_v2";
+
+        /// <summary>
+        /// Standard_B2ps_v2 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB2psV2 = "Standard_B2ps_v2";
+
+        /// <summary>
+        /// Standard_B4pls_v2 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB4plsV2 = "Standard_B4pls_v2";
+
+        /// <summary>
+        /// Standard_B4ps_v2 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB4psV2 = "Standard_B4ps_v2";
+
+        /// <summary>
+        /// Standard_B8pls_v2 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB8plsV2 = "Standard_B8pls_v2";
+
+        /// <summary>
+        /// Standard_B8ps_v2 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB8psV2 = "Standard_B8ps_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardBSFamily.
+    /// </summary>
+    public static class StandardBS
+    {
+        /// <summary>
+        /// Standard_B12ms — 12 vCPUs — 48 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB12ms = "Standard_B12ms";
+
+        /// <summary>
+        /// Standard_B16ms — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB16ms = "Standard_B16ms";
+
+        /// <summary>
+        /// Standard_B20ms — 20 vCPUs — 80 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB20ms = "Standard_B20ms";
+
+        /// <summary>
+        /// Standard_B2ms — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB2ms = "Standard_B2ms";
+
+        /// <summary>
+        /// Standard_B2s — 2 vCPUs — 4 GB RAM — Premium SSD
         /// </summary>
         public const string StandardB2s = "Standard_B2s";
 
         /// <summary>
-        /// Standard_B4ms — 4 vCPUs, 16 GB RAM.
+        /// Standard_B4ms — 4 vCPUs — 16 GB RAM — Premium SSD
         /// </summary>
         public const string StandardB4ms = "Standard_B4ms";
 
         /// <summary>
-        /// Standard_B8ms — 8 vCPUs, 32 GB RAM.
+        /// Standard_B8ms — 8 vCPUs — 32 GB RAM — Premium SSD
         /// </summary>
         public const string StandardB8ms = "Standard_B8ms";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardBsv2Family.
+    /// </summary>
+    public static class StandardBsv2
+    {
+        /// <summary>
+        /// Standard_B16ls_v2 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB16lsV2 = "Standard_B16ls_v2";
 
         /// <summary>
-        /// Standard_B2s_v2 — 2 vCPUs, 8 GB RAM.
+        /// Standard_B16s_v2 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB16sV2 = "Standard_B16s_v2";
+
+        /// <summary>
+        /// Standard_B2ls_v2 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB2lsV2 = "Standard_B2ls_v2";
+
+        /// <summary>
+        /// Standard_B2s_v2 — 2 vCPUs — 8 GB RAM — Premium SSD
         /// </summary>
         public const string StandardB2sV2 = "Standard_B2s_v2";
 
         /// <summary>
-        /// Standard_B4s_v2 — 4 vCPUs, 16 GB RAM.
+        /// Standard_B32ls_v2 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB32lsV2 = "Standard_B32ls_v2";
+
+        /// <summary>
+        /// Standard_B32s_v2 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB32sV2 = "Standard_B32s_v2";
+
+        /// <summary>
+        /// Standard_B4ls_v2 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB4lsV2 = "Standard_B4ls_v2";
+
+        /// <summary>
+        /// Standard_B4s_v2 — 4 vCPUs — 16 GB RAM — Premium SSD
         /// </summary>
         public const string StandardB4sV2 = "Standard_B4s_v2";
+
+        /// <summary>
+        /// Standard_B8ls_v2 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB8lsV2 = "Standard_B8ls_v2";
+
+        /// <summary>
+        /// Standard_B8s_v2 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardB8sV2 = "Standard_B8s_v2";
     }
 
     /// <summary>
-    /// Arm-based VM sizes with high energy efficiency and price-performance.
+    /// VM sizes in the standardDADSv5Family.
     /// </summary>
-    public static class Arm
+    public static class StandardDADSv5
     {
         /// <summary>
-        /// Standard_D2pds_v5 — 2 vCPUs, 8 GB RAM, Ampere Altra Arm processor.
+        /// Standard_D16ads_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
         /// </summary>
-        public const string StandardD2pdsV5 = "Standard_D2pds_v5";
+        public const string StandardD16adsV5 = "Standard_D16ads_v5";
 
         /// <summary>
-        /// Standard_D4pds_v5 — 4 vCPUs, 16 GB RAM, Ampere Altra Arm processor.
+        /// Standard_D2ads_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
         /// </summary>
-        public const string StandardD4pdsV5 = "Standard_D4pds_v5";
+        public const string StandardD2adsV5 = "Standard_D2ads_v5";
 
         /// <summary>
-        /// Standard_D8pds_v5 — 8 vCPUs, 32 GB RAM, Ampere Altra Arm processor.
+        /// Standard_D32ads_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
         /// </summary>
-        public const string StandardD8pdsV5 = "Standard_D8pds_v5";
+        public const string StandardD32adsV5 = "Standard_D32ads_v5";
 
         /// <summary>
-        /// Standard_D16pds_v5 — 16 vCPUs, 64 GB RAM, Ampere Altra Arm processor.
+        /// Standard_D48ads_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48adsV5 = "Standard_D48ads_v5";
+
+        /// <summary>
+        /// Standard_D4ads_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4adsV5 = "Standard_D4ads_v5";
+
+        /// <summary>
+        /// Standard_D64ads_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64adsV5 = "Standard_D64ads_v5";
+
+        /// <summary>
+        /// Standard_D8ads_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8adsV5 = "Standard_D8ads_v5";
+
+        /// <summary>
+        /// Standard_D96ads_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96adsV5 = "Standard_D96ads_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDadsv7Family.
+    /// </summary>
+    public static class StandardDadsv7
+    {
+        /// <summary>
+        /// Standard_D128ads_v7 — 128 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD128adsV7 = "Standard_D128ads_v7";
+
+        /// <summary>
+        /// Standard_D160ads_v7 — 160 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD160adsV7 = "Standard_D160ads_v7";
+
+        /// <summary>
+        /// Standard_D16ads_v7 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16adsV7 = "Standard_D16ads_v7";
+
+        /// <summary>
+        /// Standard_D2ads_v7 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2adsV7 = "Standard_D2ads_v7";
+
+        /// <summary>
+        /// Standard_D32ads_v7 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32adsV7 = "Standard_D32ads_v7";
+
+        /// <summary>
+        /// Standard_D48ads_v7 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48adsV7 = "Standard_D48ads_v7";
+
+        /// <summary>
+        /// Standard_D4ads_v7 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4adsV7 = "Standard_D4ads_v7";
+
+        /// <summary>
+        /// Standard_D64ads_v7 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64adsV7 = "Standard_D64ads_v7";
+
+        /// <summary>
+        /// Standard_D8ads_v7 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8adsV7 = "Standard_D8ads_v7";
+
+        /// <summary>
+        /// Standard_D96ads_v7 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96adsV7 = "Standard_D96ads_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDadv6Family.
+    /// </summary>
+    public static class StandardDadv6
+    {
+        /// <summary>
+        /// Standard_D16ads_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16adsV6 = "Standard_D16ads_v6";
+
+        /// <summary>
+        /// Standard_D2ads_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2adsV6 = "Standard_D2ads_v6";
+
+        /// <summary>
+        /// Standard_D32ads_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32adsV6 = "Standard_D32ads_v6";
+
+        /// <summary>
+        /// Standard_D48ads_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48adsV6 = "Standard_D48ads_v6";
+
+        /// <summary>
+        /// Standard_D4ads_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4adsV6 = "Standard_D4ads_v6";
+
+        /// <summary>
+        /// Standard_D64ads_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64adsV6 = "Standard_D64ads_v6";
+
+        /// <summary>
+        /// Standard_D8ads_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8adsV6 = "Standard_D8ads_v6";
+
+        /// <summary>
+        /// Standard_D96ads_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96adsV6 = "Standard_D96ads_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDaldsv7Family.
+    /// </summary>
+    public static class StandardDaldsv7
+    {
+        /// <summary>
+        /// Standard_D128alds_v7 — 128 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD128aldsV7 = "Standard_D128alds_v7";
+
+        /// <summary>
+        /// Standard_D160alds_v7 — 160 vCPUs — 320 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD160aldsV7 = "Standard_D160alds_v7";
+
+        /// <summary>
+        /// Standard_D16alds_v7 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16aldsV7 = "Standard_D16alds_v7";
+
+        /// <summary>
+        /// Standard_D2alds_v7 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2aldsV7 = "Standard_D2alds_v7";
+
+        /// <summary>
+        /// Standard_D32alds_v7 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32aldsV7 = "Standard_D32alds_v7";
+
+        /// <summary>
+        /// Standard_D48alds_v7 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48aldsV7 = "Standard_D48alds_v7";
+
+        /// <summary>
+        /// Standard_D4alds_v7 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4aldsV7 = "Standard_D4alds_v7";
+
+        /// <summary>
+        /// Standard_D64alds_v7 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64aldsV7 = "Standard_D64alds_v7";
+
+        /// <summary>
+        /// Standard_D8alds_v7 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8aldsV7 = "Standard_D8alds_v7";
+
+        /// <summary>
+        /// Standard_D96alds_v7 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96aldsV7 = "Standard_D96alds_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDaldv6Family.
+    /// </summary>
+    public static class StandardDaldv6
+    {
+        /// <summary>
+        /// Standard_D16alds_v6 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16aldsV6 = "Standard_D16alds_v6";
+
+        /// <summary>
+        /// Standard_D2alds_v6 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2aldsV6 = "Standard_D2alds_v6";
+
+        /// <summary>
+        /// Standard_D32alds_v6 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32aldsV6 = "Standard_D32alds_v6";
+
+        /// <summary>
+        /// Standard_D48alds_v6 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48aldsV6 = "Standard_D48alds_v6";
+
+        /// <summary>
+        /// Standard_D4alds_v6 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4aldsV6 = "Standard_D4alds_v6";
+
+        /// <summary>
+        /// Standard_D64alds_v6 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64aldsV6 = "Standard_D64alds_v6";
+
+        /// <summary>
+        /// Standard_D8alds_v6 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8aldsV6 = "Standard_D8alds_v6";
+
+        /// <summary>
+        /// Standard_D96alds_v6 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96aldsV6 = "Standard_D96alds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDalsv7Family.
+    /// </summary>
+    public static class StandardDalsv7
+    {
+        /// <summary>
+        /// Standard_D128als_v7 — 128 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD128alsV7 = "Standard_D128als_v7";
+
+        /// <summary>
+        /// Standard_D160als_v7 — 160 vCPUs — 320 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD160alsV7 = "Standard_D160als_v7";
+
+        /// <summary>
+        /// Standard_D16als_v7 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16alsV7 = "Standard_D16als_v7";
+
+        /// <summary>
+        /// Standard_D2als_v7 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2alsV7 = "Standard_D2als_v7";
+
+        /// <summary>
+        /// Standard_D32als_v7 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32alsV7 = "Standard_D32als_v7";
+
+        /// <summary>
+        /// Standard_D48als_v7 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48alsV7 = "Standard_D48als_v7";
+
+        /// <summary>
+        /// Standard_D4als_v7 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4alsV7 = "Standard_D4als_v7";
+
+        /// <summary>
+        /// Standard_D64als_v7 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64alsV7 = "Standard_D64als_v7";
+
+        /// <summary>
+        /// Standard_D8als_v7 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8alsV7 = "Standard_D8als_v7";
+
+        /// <summary>
+        /// Standard_D96als_v7 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96alsV7 = "Standard_D96als_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDalv6Family.
+    /// </summary>
+    public static class StandardDalv6
+    {
+        /// <summary>
+        /// Standard_D16als_v6 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16alsV6 = "Standard_D16als_v6";
+
+        /// <summary>
+        /// Standard_D2als_v6 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2alsV6 = "Standard_D2als_v6";
+
+        /// <summary>
+        /// Standard_D32als_v6 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32alsV6 = "Standard_D32als_v6";
+
+        /// <summary>
+        /// Standard_D48als_v6 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48alsV6 = "Standard_D48als_v6";
+
+        /// <summary>
+        /// Standard_D4als_v6 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4alsV6 = "Standard_D4als_v6";
+
+        /// <summary>
+        /// Standard_D64als_v6 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64alsV6 = "Standard_D64als_v6";
+
+        /// <summary>
+        /// Standard_D8als_v6 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8alsV6 = "Standard_D8als_v6";
+
+        /// <summary>
+        /// Standard_D96als_v6 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96alsV6 = "Standard_D96als_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDASv4Family.
+    /// </summary>
+    public static class StandardDASv4
+    {
+        /// <summary>
+        /// Standard_D16as_v4 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16asV4 = "Standard_D16as_v4";
+
+        /// <summary>
+        /// Standard_D2as_v4 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2asV4 = "Standard_D2as_v4";
+
+        /// <summary>
+        /// Standard_D32as_v4 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32asV4 = "Standard_D32as_v4";
+
+        /// <summary>
+        /// Standard_D48as_v4 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48asV4 = "Standard_D48as_v4";
+
+        /// <summary>
+        /// Standard_D4as_v4 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4asV4 = "Standard_D4as_v4";
+
+        /// <summary>
+        /// Standard_D64as_v4 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64asV4 = "Standard_D64as_v4";
+
+        /// <summary>
+        /// Standard_D8as_v4 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8asV4 = "Standard_D8as_v4";
+
+        /// <summary>
+        /// Standard_D96as_v4 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96asV4 = "Standard_D96as_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDASv5Family.
+    /// </summary>
+    public static class StandardDASv5
+    {
+        /// <summary>
+        /// Standard_D16as_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16asV5 = "Standard_D16as_v5";
+
+        /// <summary>
+        /// Standard_D2as_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2asV5 = "Standard_D2as_v5";
+
+        /// <summary>
+        /// Standard_D32as_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32asV5 = "Standard_D32as_v5";
+
+        /// <summary>
+        /// Standard_D48as_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48asV5 = "Standard_D48as_v5";
+
+        /// <summary>
+        /// Standard_D4as_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4asV5 = "Standard_D4as_v5";
+
+        /// <summary>
+        /// Standard_D64as_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64asV5 = "Standard_D64as_v5";
+
+        /// <summary>
+        /// Standard_D8as_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8asV5 = "Standard_D8as_v5";
+
+        /// <summary>
+        /// Standard_D96as_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96asV5 = "Standard_D96as_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDasv7Family.
+    /// </summary>
+    public static class StandardDasv7
+    {
+        /// <summary>
+        /// Standard_D128as_v7 — 128 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD128asV7 = "Standard_D128as_v7";
+
+        /// <summary>
+        /// Standard_D160as_v7 — 160 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD160asV7 = "Standard_D160as_v7";
+
+        /// <summary>
+        /// Standard_D16as_v7 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16asV7 = "Standard_D16as_v7";
+
+        /// <summary>
+        /// Standard_D2as_v7 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2asV7 = "Standard_D2as_v7";
+
+        /// <summary>
+        /// Standard_D32as_v7 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32asV7 = "Standard_D32as_v7";
+
+        /// <summary>
+        /// Standard_D48as_v7 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48asV7 = "Standard_D48as_v7";
+
+        /// <summary>
+        /// Standard_D4as_v7 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4asV7 = "Standard_D4as_v7";
+
+        /// <summary>
+        /// Standard_D64as_v7 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64asV7 = "Standard_D64as_v7";
+
+        /// <summary>
+        /// Standard_D8as_v7 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8asV7 = "Standard_D8as_v7";
+
+        /// <summary>
+        /// Standard_D96as_v7 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96asV7 = "Standard_D96as_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDAv4Family.
+    /// </summary>
+    public static class StandardDAv4
+    {
+        /// <summary>
+        /// Standard_D16a_v4 — 16 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardD16aV4 = "Standard_D16a_v4";
+
+        /// <summary>
+        /// Standard_D2a_v4 — 2 vCPUs — 8 GB RAM
+        /// </summary>
+        public const string StandardD2aV4 = "Standard_D2a_v4";
+
+        /// <summary>
+        /// Standard_D32a_v4 — 32 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardD32aV4 = "Standard_D32a_v4";
+
+        /// <summary>
+        /// Standard_D48a_v4 — 48 vCPUs — 192 GB RAM
+        /// </summary>
+        public const string StandardD48aV4 = "Standard_D48a_v4";
+
+        /// <summary>
+        /// Standard_D4a_v4 — 4 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardD4aV4 = "Standard_D4a_v4";
+
+        /// <summary>
+        /// Standard_D64a_v4 — 64 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardD64aV4 = "Standard_D64a_v4";
+
+        /// <summary>
+        /// Standard_D8a_v4 — 8 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardD8aV4 = "Standard_D8a_v4";
+
+        /// <summary>
+        /// Standard_D96a_v4 — 96 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardD96aV4 = "Standard_D96a_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDav6Family.
+    /// </summary>
+    public static class StandardDav6
+    {
+        /// <summary>
+        /// Standard_D16as_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16asV6 = "Standard_D16as_v6";
+
+        /// <summary>
+        /// Standard_D2as_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2asV6 = "Standard_D2as_v6";
+
+        /// <summary>
+        /// Standard_D32as_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32asV6 = "Standard_D32as_v6";
+
+        /// <summary>
+        /// Standard_D48as_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48asV6 = "Standard_D48as_v6";
+
+        /// <summary>
+        /// Standard_D4as_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4asV6 = "Standard_D4as_v6";
+
+        /// <summary>
+        /// Standard_D64as_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64asV6 = "Standard_D64as_v6";
+
+        /// <summary>
+        /// Standard_D8as_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8asV6 = "Standard_D8as_v6";
+
+        /// <summary>
+        /// Standard_D96as_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96asV6 = "Standard_D96as_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCACCV5Family.
+    /// </summary>
+    public static class StandardDCACCV5
+    {
+        /// <summary>
+        /// Standard_DC16as_cc_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16asCcV5 = "Standard_DC16as_cc_v5";
+
+        /// <summary>
+        /// Standard_DC32as_cc_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32asCcV5 = "Standard_DC32as_cc_v5";
+
+        /// <summary>
+        /// Standard_DC48as_cc_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48asCcV5 = "Standard_DC48as_cc_v5";
+
+        /// <summary>
+        /// Standard_DC4as_cc_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4asCcV5 = "Standard_DC4as_cc_v5";
+
+        /// <summary>
+        /// Standard_DC64as_cc_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64asCcV5 = "Standard_DC64as_cc_v5";
+
+        /// <summary>
+        /// Standard_DC8as_cc_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8asCcV5 = "Standard_DC8as_cc_v5";
+
+        /// <summary>
+        /// Standard_DC96as_cc_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96asCcV5 = "Standard_DC96as_cc_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCADCCV5Family.
+    /// </summary>
+    public static class StandardDCADCCV5
+    {
+        /// <summary>
+        /// Standard_DC16ads_cc_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16adsCcV5 = "Standard_DC16ads_cc_v5";
+
+        /// <summary>
+        /// Standard_DC32ads_cc_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32adsCcV5 = "Standard_DC32ads_cc_v5";
+
+        /// <summary>
+        /// Standard_DC48ads_cc_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48adsCcV5 = "Standard_DC48ads_cc_v5";
+
+        /// <summary>
+        /// Standard_DC4ads_cc_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4adsCcV5 = "Standard_DC4ads_cc_v5";
+
+        /// <summary>
+        /// Standard_DC64ads_cc_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64adsCcV5 = "Standard_DC64ads_cc_v5";
+
+        /// <summary>
+        /// Standard_DC8ads_cc_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8adsCcV5 = "Standard_DC8ads_cc_v5";
+
+        /// <summary>
+        /// Standard_DC96ads_cc_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96adsCcV5 = "Standard_DC96ads_cc_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCADSv5Family.
+    /// </summary>
+    public static class StandardDCADSv5
+    {
+        /// <summary>
+        /// Standard_DC16ads_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16adsV5 = "Standard_DC16ads_v5";
+
+        /// <summary>
+        /// Standard_DC2ads_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2adsV5 = "Standard_DC2ads_v5";
+
+        /// <summary>
+        /// Standard_DC32ads_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32adsV5 = "Standard_DC32ads_v5";
+
+        /// <summary>
+        /// Standard_DC48ads_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48adsV5 = "Standard_DC48ads_v5";
+
+        /// <summary>
+        /// Standard_DC4ads_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4adsV5 = "Standard_DC4ads_v5";
+
+        /// <summary>
+        /// Standard_DC64ads_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64adsV5 = "Standard_DC64ads_v5";
+
+        /// <summary>
+        /// Standard_DC8ads_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8adsV5 = "Standard_DC8ads_v5";
+
+        /// <summary>
+        /// Standard_DC96ads_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96adsV5 = "Standard_DC96ads_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCadsv6Family.
+    /// </summary>
+    public static class StandardDCadsv6
+    {
+        /// <summary>
+        /// Standard_DC16ads_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16adsV6 = "Standard_DC16ads_v6";
+
+        /// <summary>
+        /// Standard_DC2ads_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2adsV6 = "Standard_DC2ads_v6";
+
+        /// <summary>
+        /// Standard_DC32ads_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32adsV6 = "Standard_DC32ads_v6";
+
+        /// <summary>
+        /// Standard_DC48ads_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48adsV6 = "Standard_DC48ads_v6";
+
+        /// <summary>
+        /// Standard_DC4ads_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4adsV6 = "Standard_DC4ads_v6";
+
+        /// <summary>
+        /// Standard_DC64ads_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64adsV6 = "Standard_DC64ads_v6";
+
+        /// <summary>
+        /// Standard_DC8ads_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8adsV6 = "Standard_DC8ads_v6";
+
+        /// <summary>
+        /// Standard_DC96ads_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96adsV6 = "Standard_DC96ads_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCASv5Family.
+    /// </summary>
+    public static class StandardDCASv5
+    {
+        /// <summary>
+        /// Standard_DC16as_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16asV5 = "Standard_DC16as_v5";
+
+        /// <summary>
+        /// Standard_DC2as_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2asV5 = "Standard_DC2as_v5";
+
+        /// <summary>
+        /// Standard_DC32as_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32asV5 = "Standard_DC32as_v5";
+
+        /// <summary>
+        /// Standard_DC48as_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48asV5 = "Standard_DC48as_v5";
+
+        /// <summary>
+        /// Standard_DC4as_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4asV5 = "Standard_DC4as_v5";
+
+        /// <summary>
+        /// Standard_DC64as_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64asV5 = "Standard_DC64as_v5";
+
+        /// <summary>
+        /// Standard_DC8as_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8asV5 = "Standard_DC8as_v5";
+
+        /// <summary>
+        /// Standard_DC96as_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96asV5 = "Standard_DC96as_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCasv6Family.
+    /// </summary>
+    public static class StandardDCasv6
+    {
+        /// <summary>
+        /// Standard_DC16as_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16asV6 = "Standard_DC16as_v6";
+
+        /// <summary>
+        /// Standard_DC2as_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2asV6 = "Standard_DC2as_v6";
+
+        /// <summary>
+        /// Standard_DC32as_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32asV6 = "Standard_DC32as_v6";
+
+        /// <summary>
+        /// Standard_DC48as_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48asV6 = "Standard_DC48as_v6";
+
+        /// <summary>
+        /// Standard_DC4as_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4asV6 = "Standard_DC4as_v6";
+
+        /// <summary>
+        /// Standard_DC64as_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64asV6 = "Standard_DC64as_v6";
+
+        /// <summary>
+        /// Standard_DC8as_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8asV6 = "Standard_DC8as_v6";
+
+        /// <summary>
+        /// Standard_DC96as_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96asV6 = "Standard_DC96as_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCEDV5Family.
+    /// </summary>
+    public static class StandardDCEDV5
+    {
+        /// <summary>
+        /// Standard_DC16eds_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16edsV5 = "Standard_DC16eds_v5";
+
+        /// <summary>
+        /// Standard_DC2eds_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2edsV5 = "Standard_DC2eds_v5";
+
+        /// <summary>
+        /// Standard_DC32eds_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32edsV5 = "Standard_DC32eds_v5";
+
+        /// <summary>
+        /// Standard_DC48eds_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48edsV5 = "Standard_DC48eds_v5";
+
+        /// <summary>
+        /// Standard_DC4eds_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4edsV5 = "Standard_DC4eds_v5";
+
+        /// <summary>
+        /// Standard_DC64eds_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64edsV5 = "Standard_DC64eds_v5";
+
+        /// <summary>
+        /// Standard_DC8eds_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8edsV5 = "Standard_DC8eds_v5";
+
+        /// <summary>
+        /// Standard_DC96eds_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96edsV5 = "Standard_DC96eds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCEDV6Family.
+    /// </summary>
+    public static class StandardDCEDV6
+    {
+        /// <summary>
+        /// Standard_DC128eds_v6 — 128 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC128edsV6 = "Standard_DC128eds_v6";
+
+        /// <summary>
+        /// Standard_DC16eds_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16edsV6 = "Standard_DC16eds_v6";
+
+        /// <summary>
+        /// Standard_DC2eds_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2edsV6 = "Standard_DC2eds_v6";
+
+        /// <summary>
+        /// Standard_DC32eds_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32edsV6 = "Standard_DC32eds_v6";
+
+        /// <summary>
+        /// Standard_DC48eds_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48edsV6 = "Standard_DC48eds_v6";
+
+        /// <summary>
+        /// Standard_DC4eds_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4edsV6 = "Standard_DC4eds_v6";
+
+        /// <summary>
+        /// Standard_DC64eds_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64edsV6 = "Standard_DC64eds_v6";
+
+        /// <summary>
+        /// Standard_DC8eds_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8edsV6 = "Standard_DC8eds_v6";
+
+        /// <summary>
+        /// Standard_DC96eds_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96edsV6 = "Standard_DC96eds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCEV5Family.
+    /// </summary>
+    public static class StandardDCEV5
+    {
+        /// <summary>
+        /// Standard_DC16es_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16esV5 = "Standard_DC16es_v5";
+
+        /// <summary>
+        /// Standard_DC2es_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2esV5 = "Standard_DC2es_v5";
+
+        /// <summary>
+        /// Standard_DC32es_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32esV5 = "Standard_DC32es_v5";
+
+        /// <summary>
+        /// Standard_DC48es_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48esV5 = "Standard_DC48es_v5";
+
+        /// <summary>
+        /// Standard_DC4es_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4esV5 = "Standard_DC4es_v5";
+
+        /// <summary>
+        /// Standard_DC64es_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64esV5 = "Standard_DC64es_v5";
+
+        /// <summary>
+        /// Standard_DC8es_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8esV5 = "Standard_DC8es_v5";
+
+        /// <summary>
+        /// Standard_DC96es_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96esV5 = "Standard_DC96es_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCEV6Family.
+    /// </summary>
+    public static class StandardDCEV6
+    {
+        /// <summary>
+        /// Standard_DC128es_v6 — 128 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC128esV6 = "Standard_DC128es_v6";
+
+        /// <summary>
+        /// Standard_DC16es_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16esV6 = "Standard_DC16es_v6";
+
+        /// <summary>
+        /// Standard_DC2es_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2esV6 = "Standard_DC2es_v6";
+
+        /// <summary>
+        /// Standard_DC32es_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32esV6 = "Standard_DC32es_v6";
+
+        /// <summary>
+        /// Standard_DC48es_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48esV6 = "Standard_DC48es_v6";
+
+        /// <summary>
+        /// Standard_DC4es_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4esV6 = "Standard_DC4es_v6";
+
+        /// <summary>
+        /// Standard_DC64es_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC64esV6 = "Standard_DC64es_v6";
+
+        /// <summary>
+        /// Standard_DC8es_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8esV6 = "Standard_DC8es_v6";
+
+        /// <summary>
+        /// Standard_DC96es_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC96esV6 = "Standard_DC96es_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCSv2Family.
+    /// </summary>
+    public static class StandardDCSv2
+    {
+        /// <summary>
+        /// Standard_DC2s_v2 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2sV2 = "Standard_DC2s_v2";
+
+        /// <summary>
+        /// Standard_DC4s_v2 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4sV2 = "Standard_DC4s_v2";
+
+        /// <summary>
+        /// Standard_DC8_v2 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8V2 = "Standard_DC8_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDCSv3Family.
+    /// </summary>
+    public static class StandardDCSv3
+    {
+        /// <summary>
+        /// Standard_DC16s_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16sV3 = "Standard_DC16s_v3";
+
+        /// <summary>
+        /// Standard_DC24s_v3 — 24 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC24sV3 = "Standard_DC24s_v3";
+
+        /// <summary>
+        /// Standard_DC2s_v3 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2sV3 = "Standard_DC2s_v3";
+
+        /// <summary>
+        /// Standard_DC32s_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32sV3 = "Standard_DC32s_v3";
+
+        /// <summary>
+        /// Standard_DC48s_v3 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48sV3 = "Standard_DC48s_v3";
+
+        /// <summary>
+        /// Standard_DC4s_v3 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4sV3 = "Standard_DC4s_v3";
+
+        /// <summary>
+        /// Standard_DC8s_v3 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8sV3 = "Standard_DC8s_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDDCSv3Family.
+    /// </summary>
+    public static class StandardDDCSv3
+    {
+        /// <summary>
+        /// Standard_DC16ds_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC16dsV3 = "Standard_DC16ds_v3";
+
+        /// <summary>
+        /// Standard_DC24ds_v3 — 24 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC24dsV3 = "Standard_DC24ds_v3";
+
+        /// <summary>
+        /// Standard_DC2ds_v3 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC2dsV3 = "Standard_DC2ds_v3";
+
+        /// <summary>
+        /// Standard_DC32ds_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC32dsV3 = "Standard_DC32ds_v3";
+
+        /// <summary>
+        /// Standard_DC48ds_v3 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC48dsV3 = "Standard_DC48ds_v3";
+
+        /// <summary>
+        /// Standard_DC4ds_v3 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC4dsV3 = "Standard_DC4ds_v3";
+
+        /// <summary>
+        /// Standard_DC8ds_v3 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDC8dsV3 = "Standard_DC8ds_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDDSv4Family.
+    /// </summary>
+    public static class StandardDDSv4
+    {
+        /// <summary>
+        /// Standard_D16ds_v4 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16dsV4 = "Standard_D16ds_v4";
+
+        /// <summary>
+        /// Standard_D2ds_v4 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2dsV4 = "Standard_D2ds_v4";
+
+        /// <summary>
+        /// Standard_D32ds_v4 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32dsV4 = "Standard_D32ds_v4";
+
+        /// <summary>
+        /// Standard_D48ds_v4 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48dsV4 = "Standard_D48ds_v4";
+
+        /// <summary>
+        /// Standard_D4ds_v4 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4dsV4 = "Standard_D4ds_v4";
+
+        /// <summary>
+        /// Standard_D64ds_v4 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64dsV4 = "Standard_D64ds_v4";
+
+        /// <summary>
+        /// Standard_D8ds_v4 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8dsV4 = "Standard_D8ds_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDDSv5Family.
+    /// </summary>
+    public static class StandardDDSv5
+    {
+        /// <summary>
+        /// Standard_D16ds_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16dsV5 = "Standard_D16ds_v5";
+
+        /// <summary>
+        /// Standard_D2ds_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2dsV5 = "Standard_D2ds_v5";
+
+        /// <summary>
+        /// Standard_D32ds_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32dsV5 = "Standard_D32ds_v5";
+
+        /// <summary>
+        /// Standard_D48ds_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48dsV5 = "Standard_D48ds_v5";
+
+        /// <summary>
+        /// Standard_D4ds_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4dsV5 = "Standard_D4ds_v5";
+
+        /// <summary>
+        /// Standard_D64ds_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64dsV5 = "Standard_D64ds_v5";
+
+        /// <summary>
+        /// Standard_D8ds_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8dsV5 = "Standard_D8ds_v5";
+
+        /// <summary>
+        /// Standard_D96ds_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96dsV5 = "Standard_D96ds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDdsv6Family.
+    /// </summary>
+    public static class StandardDdsv6
+    {
+        /// <summary>
+        /// Standard_D128ds_v6 — 128 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD128dsV6 = "Standard_D128ds_v6";
+
+        /// <summary>
+        /// Standard_D16ds_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16dsV6 = "Standard_D16ds_v6";
+
+        /// <summary>
+        /// Standard_D192ds_v6 — 192 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD192dsV6 = "Standard_D192ds_v6";
+
+        /// <summary>
+        /// Standard_D2ds_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2dsV6 = "Standard_D2ds_v6";
+
+        /// <summary>
+        /// Standard_D32ds_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32dsV6 = "Standard_D32ds_v6";
+
+        /// <summary>
+        /// Standard_D48ds_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48dsV6 = "Standard_D48ds_v6";
+
+        /// <summary>
+        /// Standard_D4ds_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4dsV6 = "Standard_D4ds_v6";
+
+        /// <summary>
+        /// Standard_D64ds_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64dsV6 = "Standard_D64ds_v6";
+
+        /// <summary>
+        /// Standard_D8ds_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8dsV6 = "Standard_D8ds_v6";
+
+        /// <summary>
+        /// Standard_D96ds_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96dsV6 = "Standard_D96ds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDDv4Family.
+    /// </summary>
+    public static class StandardDDv4
+    {
+        /// <summary>
+        /// Standard_D16d_v4 — 16 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardD16dV4 = "Standard_D16d_v4";
+
+        /// <summary>
+        /// Standard_D2d_v4 — 2 vCPUs — 8 GB RAM
+        /// </summary>
+        public const string StandardD2dV4 = "Standard_D2d_v4";
+
+        /// <summary>
+        /// Standard_D32d_v4 — 32 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardD32dV4 = "Standard_D32d_v4";
+
+        /// <summary>
+        /// Standard_D48d_v4 — 48 vCPUs — 192 GB RAM
+        /// </summary>
+        public const string StandardD48dV4 = "Standard_D48d_v4";
+
+        /// <summary>
+        /// Standard_D4d_v4 — 4 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardD4dV4 = "Standard_D4d_v4";
+
+        /// <summary>
+        /// Standard_D64d_v4 — 64 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardD64dV4 = "Standard_D64d_v4";
+
+        /// <summary>
+        /// Standard_D8d_v4 — 8 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardD8dV4 = "Standard_D8d_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDDv5Family.
+    /// </summary>
+    public static class StandardDDv5
+    {
+        /// <summary>
+        /// Standard_D16d_v5 — 16 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardD16dV5 = "Standard_D16d_v5";
+
+        /// <summary>
+        /// Standard_D2d_v5 — 2 vCPUs — 8 GB RAM
+        /// </summary>
+        public const string StandardD2dV5 = "Standard_D2d_v5";
+
+        /// <summary>
+        /// Standard_D32d_v5 — 32 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardD32dV5 = "Standard_D32d_v5";
+
+        /// <summary>
+        /// Standard_D48d_v5 — 48 vCPUs — 192 GB RAM
+        /// </summary>
+        public const string StandardD48dV5 = "Standard_D48d_v5";
+
+        /// <summary>
+        /// Standard_D4d_v5 — 4 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardD4dV5 = "Standard_D4d_v5";
+
+        /// <summary>
+        /// Standard_D64d_v5 — 64 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardD64dV5 = "Standard_D64d_v5";
+
+        /// <summary>
+        /// Standard_D8d_v5 — 8 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardD8dV5 = "Standard_D8d_v5";
+
+        /// <summary>
+        /// Standard_D96d_v5 — 96 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardD96dV5 = "Standard_D96d_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDFamily.
+    /// </summary>
+    public static class StandardD
+    {
+        /// <summary>
+        /// Standard_D11 — 2 vCPUs — 14 GB RAM
+        /// </summary>
+        public const string StandardD11 = "Standard_D11";
+
+        /// <summary>
+        /// Standard_D12 — 4 vCPUs — 28 GB RAM
+        /// </summary>
+        public const string StandardD12 = "Standard_D12";
+
+        /// <summary>
+        /// Standard_D13 — 8 vCPUs — 56 GB RAM
+        /// </summary>
+        public const string StandardD13 = "Standard_D13";
+
+        /// <summary>
+        /// Standard_D14 — 16 vCPUs — 112 GB RAM
+        /// </summary>
+        public const string StandardD14 = "Standard_D14";
+
+        /// <summary>
+        /// Standard_D2 — 2 vCPUs — 7 GB RAM
+        /// </summary>
+        public const string StandardD2 = "Standard_D2";
+
+        /// <summary>
+        /// Standard_D3 — 4 vCPUs — 14 GB RAM
+        /// </summary>
+        public const string StandardD3 = "Standard_D3";
+
+        /// <summary>
+        /// Standard_D4 — 8 vCPUs — 28 GB RAM
+        /// </summary>
+        public const string StandardD4 = "Standard_D4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDLDSv5Family.
+    /// </summary>
+    public static class StandardDLDSv5
+    {
+        /// <summary>
+        /// Standard_D16lds_v5 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16ldsV5 = "Standard_D16lds_v5";
+
+        /// <summary>
+        /// Standard_D2lds_v5 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2ldsV5 = "Standard_D2lds_v5";
+
+        /// <summary>
+        /// Standard_D32lds_v5 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32ldsV5 = "Standard_D32lds_v5";
+
+        /// <summary>
+        /// Standard_D48lds_v5 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48ldsV5 = "Standard_D48lds_v5";
+
+        /// <summary>
+        /// Standard_D4lds_v5 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4ldsV5 = "Standard_D4lds_v5";
+
+        /// <summary>
+        /// Standard_D64lds_v5 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64ldsV5 = "Standard_D64lds_v5";
+
+        /// <summary>
+        /// Standard_D8lds_v5 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8ldsV5 = "Standard_D8lds_v5";
+
+        /// <summary>
+        /// Standard_D96lds_v5 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96ldsV5 = "Standard_D96lds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDldsv6Family.
+    /// </summary>
+    public static class StandardDldsv6
+    {
+        /// <summary>
+        /// Standard_D128lds_v6 — 128 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD128ldsV6 = "Standard_D128lds_v6";
+
+        /// <summary>
+        /// Standard_D16lds_v6 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16ldsV6 = "Standard_D16lds_v6";
+
+        /// <summary>
+        /// Standard_D2lds_v6 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2ldsV6 = "Standard_D2lds_v6";
+
+        /// <summary>
+        /// Standard_D32lds_v6 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32ldsV6 = "Standard_D32lds_v6";
+
+        /// <summary>
+        /// Standard_D48lds_v6 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48ldsV6 = "Standard_D48lds_v6";
+
+        /// <summary>
+        /// Standard_D4lds_v6 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4ldsV6 = "Standard_D4lds_v6";
+
+        /// <summary>
+        /// Standard_D64lds_v6 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64ldsV6 = "Standard_D64lds_v6";
+
+        /// <summary>
+        /// Standard_D8lds_v6 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8ldsV6 = "Standard_D8lds_v6";
+
+        /// <summary>
+        /// Standard_D96lds_v6 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96ldsV6 = "Standard_D96lds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDLSv5Family.
+    /// </summary>
+    public static class StandardDLSv5
+    {
+        /// <summary>
+        /// Standard_D16ls_v5 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16lsV5 = "Standard_D16ls_v5";
+
+        /// <summary>
+        /// Standard_D2ls_v5 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2lsV5 = "Standard_D2ls_v5";
+
+        /// <summary>
+        /// Standard_D32ls_v5 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32lsV5 = "Standard_D32ls_v5";
+
+        /// <summary>
+        /// Standard_D48ls_v5 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48lsV5 = "Standard_D48ls_v5";
+
+        /// <summary>
+        /// Standard_D4ls_v5 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4lsV5 = "Standard_D4ls_v5";
+
+        /// <summary>
+        /// Standard_D64ls_v5 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64lsV5 = "Standard_D64ls_v5";
+
+        /// <summary>
+        /// Standard_D8ls_v5 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8lsV5 = "Standard_D8ls_v5";
+
+        /// <summary>
+        /// Standard_D96ls_v5 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96lsV5 = "Standard_D96ls_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDlsv6Family.
+    /// </summary>
+    public static class StandardDlsv6
+    {
+        /// <summary>
+        /// Standard_D128ls_v6 — 128 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD128lsV6 = "Standard_D128ls_v6";
+
+        /// <summary>
+        /// Standard_D16ls_v6 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16lsV6 = "Standard_D16ls_v6";
+
+        /// <summary>
+        /// Standard_D2ls_v6 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2lsV6 = "Standard_D2ls_v6";
+
+        /// <summary>
+        /// Standard_D32ls_v6 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32lsV6 = "Standard_D32ls_v6";
+
+        /// <summary>
+        /// Standard_D48ls_v6 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48lsV6 = "Standard_D48ls_v6";
+
+        /// <summary>
+        /// Standard_D4ls_v6 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4lsV6 = "Standard_D4ls_v6";
+
+        /// <summary>
+        /// Standard_D64ls_v6 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64lsV6 = "Standard_D64ls_v6";
+
+        /// <summary>
+        /// Standard_D8ls_v6 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8lsV6 = "Standard_D8ls_v6";
+
+        /// <summary>
+        /// Standard_D96ls_v6 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96lsV6 = "Standard_D96ls_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDPDSv5Family.
+    /// </summary>
+    public static class StandardDPDSv5
+    {
+        /// <summary>
+        /// Standard_D16pds_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
         /// </summary>
         public const string StandardD16pdsV5 = "Standard_D16pds_v5";
 
         /// <summary>
-        /// Standard_E2pds_v5 — 2 vCPUs, 16 GB RAM, Ampere Altra Arm processor.
+        /// Standard_D2pds_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2pdsV5 = "Standard_D2pds_v5";
+
+        /// <summary>
+        /// Standard_D32pds_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32pdsV5 = "Standard_D32pds_v5";
+
+        /// <summary>
+        /// Standard_D48pds_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48pdsV5 = "Standard_D48pds_v5";
+
+        /// <summary>
+        /// Standard_D4pds_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4pdsV5 = "Standard_D4pds_v5";
+
+        /// <summary>
+        /// Standard_D64pds_v5 — 64 vCPUs — 208 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64pdsV5 = "Standard_D64pds_v5";
+
+        /// <summary>
+        /// Standard_D8pds_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8pdsV5 = "Standard_D8pds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDpdsv6Family.
+    /// </summary>
+    public static class StandardDpdsv6
+    {
+        /// <summary>
+        /// Standard_D16pds_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16pdsV6 = "Standard_D16pds_v6";
+
+        /// <summary>
+        /// Standard_D2pds_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2pdsV6 = "Standard_D2pds_v6";
+
+        /// <summary>
+        /// Standard_D32pds_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32pdsV6 = "Standard_D32pds_v6";
+
+        /// <summary>
+        /// Standard_D48pds_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48pdsV6 = "Standard_D48pds_v6";
+
+        /// <summary>
+        /// Standard_D4pds_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4pdsV6 = "Standard_D4pds_v6";
+
+        /// <summary>
+        /// Standard_D64pds_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64pdsV6 = "Standard_D64pds_v6";
+
+        /// <summary>
+        /// Standard_D8pds_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8pdsV6 = "Standard_D8pds_v6";
+
+        /// <summary>
+        /// Standard_D96pds_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96pdsV6 = "Standard_D96pds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDPLDSv5Family.
+    /// </summary>
+    public static class StandardDPLDSv5
+    {
+        /// <summary>
+        /// Standard_D16plds_v5 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16pldsV5 = "Standard_D16plds_v5";
+
+        /// <summary>
+        /// Standard_D2plds_v5 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2pldsV5 = "Standard_D2plds_v5";
+
+        /// <summary>
+        /// Standard_D32plds_v5 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32pldsV5 = "Standard_D32plds_v5";
+
+        /// <summary>
+        /// Standard_D48plds_v5 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48pldsV5 = "Standard_D48plds_v5";
+
+        /// <summary>
+        /// Standard_D4plds_v5 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4pldsV5 = "Standard_D4plds_v5";
+
+        /// <summary>
+        /// Standard_D64plds_v5 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64pldsV5 = "Standard_D64plds_v5";
+
+        /// <summary>
+        /// Standard_D8plds_v5 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8pldsV5 = "Standard_D8plds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDpldsv6Family.
+    /// </summary>
+    public static class StandardDpldsv6
+    {
+        /// <summary>
+        /// Standard_D16plds_v6 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16pldsV6 = "Standard_D16plds_v6";
+
+        /// <summary>
+        /// Standard_D2plds_v6 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2pldsV6 = "Standard_D2plds_v6";
+
+        /// <summary>
+        /// Standard_D32plds_v6 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32pldsV6 = "Standard_D32plds_v6";
+
+        /// <summary>
+        /// Standard_D48plds_v6 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48pldsV6 = "Standard_D48plds_v6";
+
+        /// <summary>
+        /// Standard_D4plds_v6 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4pldsV6 = "Standard_D4plds_v6";
+
+        /// <summary>
+        /// Standard_D64plds_v6 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64pldsV6 = "Standard_D64plds_v6";
+
+        /// <summary>
+        /// Standard_D8plds_v6 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8pldsV6 = "Standard_D8plds_v6";
+
+        /// <summary>
+        /// Standard_D96plds_v6 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96pldsV6 = "Standard_D96plds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDPLSv5Family.
+    /// </summary>
+    public static class StandardDPLSv5
+    {
+        /// <summary>
+        /// Standard_D16pls_v5 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16plsV5 = "Standard_D16pls_v5";
+
+        /// <summary>
+        /// Standard_D2pls_v5 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2plsV5 = "Standard_D2pls_v5";
+
+        /// <summary>
+        /// Standard_D32pls_v5 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32plsV5 = "Standard_D32pls_v5";
+
+        /// <summary>
+        /// Standard_D48pls_v5 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48plsV5 = "Standard_D48pls_v5";
+
+        /// <summary>
+        /// Standard_D4pls_v5 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4plsV5 = "Standard_D4pls_v5";
+
+        /// <summary>
+        /// Standard_D64pls_v5 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64plsV5 = "Standard_D64pls_v5";
+
+        /// <summary>
+        /// Standard_D8pls_v5 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8plsV5 = "Standard_D8pls_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDplsv6Family.
+    /// </summary>
+    public static class StandardDplsv6
+    {
+        /// <summary>
+        /// Standard_D16pls_v6 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16plsV6 = "Standard_D16pls_v6";
+
+        /// <summary>
+        /// Standard_D2pls_v6 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2plsV6 = "Standard_D2pls_v6";
+
+        /// <summary>
+        /// Standard_D32pls_v6 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32plsV6 = "Standard_D32pls_v6";
+
+        /// <summary>
+        /// Standard_D48pls_v6 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48plsV6 = "Standard_D48pls_v6";
+
+        /// <summary>
+        /// Standard_D4pls_v6 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4plsV6 = "Standard_D4pls_v6";
+
+        /// <summary>
+        /// Standard_D64pls_v6 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64plsV6 = "Standard_D64pls_v6";
+
+        /// <summary>
+        /// Standard_D8pls_v6 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8plsV6 = "Standard_D8pls_v6";
+
+        /// <summary>
+        /// Standard_D96pls_v6 — 96 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96plsV6 = "Standard_D96pls_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDPSv5Family.
+    /// </summary>
+    public static class StandardDPSv5
+    {
+        /// <summary>
+        /// Standard_D16ps_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16psV5 = "Standard_D16ps_v5";
+
+        /// <summary>
+        /// Standard_D2ps_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2psV5 = "Standard_D2ps_v5";
+
+        /// <summary>
+        /// Standard_D32ps_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32psV5 = "Standard_D32ps_v5";
+
+        /// <summary>
+        /// Standard_D48ps_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48psV5 = "Standard_D48ps_v5";
+
+        /// <summary>
+        /// Standard_D4ps_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4psV5 = "Standard_D4ps_v5";
+
+        /// <summary>
+        /// Standard_D64ps_v5 — 64 vCPUs — 208 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64psV5 = "Standard_D64ps_v5";
+
+        /// <summary>
+        /// Standard_D8ps_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8psV5 = "Standard_D8ps_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDpsv6Family.
+    /// </summary>
+    public static class StandardDpsv6
+    {
+        /// <summary>
+        /// Standard_D16ps_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16psV6 = "Standard_D16ps_v6";
+
+        /// <summary>
+        /// Standard_D2ps_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2psV6 = "Standard_D2ps_v6";
+
+        /// <summary>
+        /// Standard_D32ps_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32psV6 = "Standard_D32ps_v6";
+
+        /// <summary>
+        /// Standard_D48ps_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48psV6 = "Standard_D48ps_v6";
+
+        /// <summary>
+        /// Standard_D4ps_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4psV6 = "Standard_D4ps_v6";
+
+        /// <summary>
+        /// Standard_D64ps_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64psV6 = "Standard_D64ps_v6";
+
+        /// <summary>
+        /// Standard_D8ps_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8psV6 = "Standard_D8ps_v6";
+
+        /// <summary>
+        /// Standard_D96ps_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96psV6 = "Standard_D96ps_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDSFamily.
+    /// </summary>
+    public static class StandardDS
+    {
+        /// <summary>
+        /// Standard_DS11 — 2 vCPUs — 14 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS11 = "Standard_DS11";
+
+        /// <summary>
+        /// Standard_DS12 — 4 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS12 = "Standard_DS12";
+
+        /// <summary>
+        /// Standard_DS13 — 8 vCPUs — 56 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS13 = "Standard_DS13";
+
+        /// <summary>
+        /// Standard_DS14 — 16 vCPUs — 112 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS14 = "Standard_DS14";
+
+        /// <summary>
+        /// Standard_DS2 — 2 vCPUs — 7 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS2 = "Standard_DS2";
+
+        /// <summary>
+        /// Standard_DS3 — 4 vCPUs — 14 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS3 = "Standard_DS3";
+
+        /// <summary>
+        /// Standard_DS4 — 8 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS4 = "Standard_DS4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDSv2Family.
+    /// </summary>
+    public static class StandardDSv2
+    {
+        /// <summary>
+        /// Standard_DS11-1_v2 — 2 vCPUs — 14 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS111V2 = "Standard_DS11-1_v2";
+
+        /// <summary>
+        /// Standard_DS11_v2 — 2 vCPUs — 14 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS11V2 = "Standard_DS11_v2";
+
+        /// <summary>
+        /// Standard_DS12-1_v2 — 4 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS121V2 = "Standard_DS12-1_v2";
+
+        /// <summary>
+        /// Standard_DS12-2_v2 — 4 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS122V2 = "Standard_DS12-2_v2";
+
+        /// <summary>
+        /// Standard_DS12_v2 — 4 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS12V2 = "Standard_DS12_v2";
+
+        /// <summary>
+        /// Standard_DS13-2_v2 — 8 vCPUs — 56 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS132V2 = "Standard_DS13-2_v2";
+
+        /// <summary>
+        /// Standard_DS13-4_v2 — 8 vCPUs — 56 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS134V2 = "Standard_DS13-4_v2";
+
+        /// <summary>
+        /// Standard_DS13_v2 — 8 vCPUs — 56 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS13V2 = "Standard_DS13_v2";
+
+        /// <summary>
+        /// Standard_DS14-4_v2 — 16 vCPUs — 112 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS144V2 = "Standard_DS14-4_v2";
+
+        /// <summary>
+        /// Standard_DS14-8_v2 — 16 vCPUs — 112 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS148V2 = "Standard_DS14-8_v2";
+
+        /// <summary>
+        /// Standard_DS14_v2 — 16 vCPUs — 112 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS14V2 = "Standard_DS14_v2";
+
+        /// <summary>
+        /// Standard_DS15_v2 — 20 vCPUs — 140 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS15V2 = "Standard_DS15_v2";
+
+        /// <summary>
+        /// Standard_DS2_v2 — 2 vCPUs — 7 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS2V2 = "Standard_DS2_v2";
+
+        /// <summary>
+        /// Standard_DS3_v2 — 4 vCPUs — 14 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS3V2 = "Standard_DS3_v2";
+
+        /// <summary>
+        /// Standard_DS4_v2 — 8 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS4V2 = "Standard_DS4_v2";
+
+        /// <summary>
+        /// Standard_DS5_v2 — 16 vCPUs — 56 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS5V2 = "Standard_DS5_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDSv2PromoFamily.
+    /// </summary>
+    public static class StandardDSv2Promo
+    {
+        /// <summary>
+        /// Standard_DS11_v2_Promo — 2 vCPUs — 14 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS11V2Promo = "Standard_DS11_v2_Promo";
+
+        /// <summary>
+        /// Standard_DS12_v2_Promo — 4 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS12V2Promo = "Standard_DS12_v2_Promo";
+
+        /// <summary>
+        /// Standard_DS13_v2_Promo — 8 vCPUs — 56 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS13V2Promo = "Standard_DS13_v2_Promo";
+
+        /// <summary>
+        /// Standard_DS14_v2_Promo — 16 vCPUs — 112 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS14V2Promo = "Standard_DS14_v2_Promo";
+
+        /// <summary>
+        /// Standard_DS2_v2_Promo — 2 vCPUs — 7 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS2V2Promo = "Standard_DS2_v2_Promo";
+
+        /// <summary>
+        /// Standard_DS3_v2_Promo — 4 vCPUs — 14 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS3V2Promo = "Standard_DS3_v2_Promo";
+
+        /// <summary>
+        /// Standard_DS4_v2_Promo — 8 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS4V2Promo = "Standard_DS4_v2_Promo";
+
+        /// <summary>
+        /// Standard_DS5_v2_Promo — 16 vCPUs — 56 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardDS5V2Promo = "Standard_DS5_v2_Promo";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDSv3Family.
+    /// </summary>
+    public static class StandardDSv3
+    {
+        /// <summary>
+        /// Standard_D16s_v3 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16sV3 = "Standard_D16s_v3";
+
+        /// <summary>
+        /// Standard_D2s_v3 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2sV3 = "Standard_D2s_v3";
+
+        /// <summary>
+        /// Standard_D32s_v3 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32sV3 = "Standard_D32s_v3";
+
+        /// <summary>
+        /// Standard_D48s_v3 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48sV3 = "Standard_D48s_v3";
+
+        /// <summary>
+        /// Standard_D4s_v3 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4sV3 = "Standard_D4s_v3";
+
+        /// <summary>
+        /// Standard_D64s_v3 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64sV3 = "Standard_D64s_v3";
+
+        /// <summary>
+        /// Standard_D8s_v3 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8sV3 = "Standard_D8s_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDSv4Family.
+    /// </summary>
+    public static class StandardDSv4
+    {
+        /// <summary>
+        /// Standard_D16s_v4 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16sV4 = "Standard_D16s_v4";
+
+        /// <summary>
+        /// Standard_D2s_v4 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2sV4 = "Standard_D2s_v4";
+
+        /// <summary>
+        /// Standard_D32s_v4 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32sV4 = "Standard_D32s_v4";
+
+        /// <summary>
+        /// Standard_D48s_v4 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48sV4 = "Standard_D48s_v4";
+
+        /// <summary>
+        /// Standard_D4s_v4 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4sV4 = "Standard_D4s_v4";
+
+        /// <summary>
+        /// Standard_D64s_v4 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64sV4 = "Standard_D64s_v4";
+
+        /// <summary>
+        /// Standard_D8s_v4 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8sV4 = "Standard_D8s_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDSv5Family.
+    /// </summary>
+    public static class StandardDSv5
+    {
+        /// <summary>
+        /// Standard_D16s_v5 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16sV5 = "Standard_D16s_v5";
+
+        /// <summary>
+        /// Standard_D2s_v5 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2sV5 = "Standard_D2s_v5";
+
+        /// <summary>
+        /// Standard_D32s_v5 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32sV5 = "Standard_D32s_v5";
+
+        /// <summary>
+        /// Standard_D48s_v5 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48sV5 = "Standard_D48s_v5";
+
+        /// <summary>
+        /// Standard_D4s_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4sV5 = "Standard_D4s_v5";
+
+        /// <summary>
+        /// Standard_D64s_v5 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64sV5 = "Standard_D64s_v5";
+
+        /// <summary>
+        /// Standard_D8s_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8sV5 = "Standard_D8s_v5";
+
+        /// <summary>
+        /// Standard_D96s_v5 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96sV5 = "Standard_D96s_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardDsv6Family.
+    /// </summary>
+    public static class StandardDsv6
+    {
+        /// <summary>
+        /// Standard_D128s_v6 — 128 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD128sV6 = "Standard_D128s_v6";
+
+        /// <summary>
+        /// Standard_D16s_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD16sV6 = "Standard_D16s_v6";
+
+        /// <summary>
+        /// Standard_D192s_v6 — 192 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD192sV6 = "Standard_D192s_v6";
+
+        /// <summary>
+        /// Standard_D2s_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD2sV6 = "Standard_D2s_v6";
+
+        /// <summary>
+        /// Standard_D32s_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD32sV6 = "Standard_D32s_v6";
+
+        /// <summary>
+        /// Standard_D48s_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD48sV6 = "Standard_D48s_v6";
+
+        /// <summary>
+        /// Standard_D4s_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD4sV6 = "Standard_D4s_v6";
+
+        /// <summary>
+        /// Standard_D64s_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD64sV6 = "Standard_D64s_v6";
+
+        /// <summary>
+        /// Standard_D8s_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD8sV6 = "Standard_D8s_v6";
+
+        /// <summary>
+        /// Standard_D96s_v6 — 96 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardD96sV6 = "Standard_D96s_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDv2Family.
+    /// </summary>
+    public static class StandardDv2
+    {
+        /// <summary>
+        /// Standard_D11_v2 — 2 vCPUs — 14 GB RAM
+        /// </summary>
+        public const string StandardD11V2 = "Standard_D11_v2";
+
+        /// <summary>
+        /// Standard_D12_v2 — 4 vCPUs — 28 GB RAM
+        /// </summary>
+        public const string StandardD12V2 = "Standard_D12_v2";
+
+        /// <summary>
+        /// Standard_D13_v2 — 8 vCPUs — 56 GB RAM
+        /// </summary>
+        public const string StandardD13V2 = "Standard_D13_v2";
+
+        /// <summary>
+        /// Standard_D14_v2 — 16 vCPUs — 112 GB RAM
+        /// </summary>
+        public const string StandardD14V2 = "Standard_D14_v2";
+
+        /// <summary>
+        /// Standard_D15_v2 — 20 vCPUs — 140 GB RAM
+        /// </summary>
+        public const string StandardD15V2 = "Standard_D15_v2";
+
+        /// <summary>
+        /// Standard_D2_v2 — 2 vCPUs — 7 GB RAM
+        /// </summary>
+        public const string StandardD2V2 = "Standard_D2_v2";
+
+        /// <summary>
+        /// Standard_D3_v2 — 4 vCPUs — 14 GB RAM
+        /// </summary>
+        public const string StandardD3V2 = "Standard_D3_v2";
+
+        /// <summary>
+        /// Standard_D4_v2 — 8 vCPUs — 28 GB RAM
+        /// </summary>
+        public const string StandardD4V2 = "Standard_D4_v2";
+
+        /// <summary>
+        /// Standard_D5_v2 — 16 vCPUs — 56 GB RAM
+        /// </summary>
+        public const string StandardD5V2 = "Standard_D5_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDv2PromoFamily.
+    /// </summary>
+    public static class StandardDv2Promo
+    {
+        /// <summary>
+        /// Standard_D11_v2_Promo — 2 vCPUs — 14 GB RAM
+        /// </summary>
+        public const string StandardD11V2Promo = "Standard_D11_v2_Promo";
+
+        /// <summary>
+        /// Standard_D12_v2_Promo — 4 vCPUs — 28 GB RAM
+        /// </summary>
+        public const string StandardD12V2Promo = "Standard_D12_v2_Promo";
+
+        /// <summary>
+        /// Standard_D13_v2_Promo — 8 vCPUs — 56 GB RAM
+        /// </summary>
+        public const string StandardD13V2Promo = "Standard_D13_v2_Promo";
+
+        /// <summary>
+        /// Standard_D14_v2_Promo — 16 vCPUs — 112 GB RAM
+        /// </summary>
+        public const string StandardD14V2Promo = "Standard_D14_v2_Promo";
+
+        /// <summary>
+        /// Standard_D2_v2_Promo — 2 vCPUs — 7 GB RAM
+        /// </summary>
+        public const string StandardD2V2Promo = "Standard_D2_v2_Promo";
+
+        /// <summary>
+        /// Standard_D3_v2_Promo — 4 vCPUs — 14 GB RAM
+        /// </summary>
+        public const string StandardD3V2Promo = "Standard_D3_v2_Promo";
+
+        /// <summary>
+        /// Standard_D4_v2_Promo — 8 vCPUs — 28 GB RAM
+        /// </summary>
+        public const string StandardD4V2Promo = "Standard_D4_v2_Promo";
+
+        /// <summary>
+        /// Standard_D5_v2_Promo — 16 vCPUs — 56 GB RAM
+        /// </summary>
+        public const string StandardD5V2Promo = "Standard_D5_v2_Promo";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDv3Family.
+    /// </summary>
+    public static class StandardDv3
+    {
+        /// <summary>
+        /// Standard_D16_v3 — 16 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardD16V3 = "Standard_D16_v3";
+
+        /// <summary>
+        /// Standard_D2_v3 — 2 vCPUs — 8 GB RAM
+        /// </summary>
+        public const string StandardD2V3 = "Standard_D2_v3";
+
+        /// <summary>
+        /// Standard_D32_v3 — 32 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardD32V3 = "Standard_D32_v3";
+
+        /// <summary>
+        /// Standard_D48_v3 — 48 vCPUs — 192 GB RAM
+        /// </summary>
+        public const string StandardD48V3 = "Standard_D48_v3";
+
+        /// <summary>
+        /// Standard_D4_v3 — 4 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardD4V3 = "Standard_D4_v3";
+
+        /// <summary>
+        /// Standard_D64_v3 — 64 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardD64V3 = "Standard_D64_v3";
+
+        /// <summary>
+        /// Standard_D8_v3 — 8 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardD8V3 = "Standard_D8_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDv4Family.
+    /// </summary>
+    public static class StandardDv4
+    {
+        /// <summary>
+        /// Standard_D16_v4 — 16 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardD16V4 = "Standard_D16_v4";
+
+        /// <summary>
+        /// Standard_D2_v4 — 2 vCPUs — 8 GB RAM
+        /// </summary>
+        public const string StandardD2V4 = "Standard_D2_v4";
+
+        /// <summary>
+        /// Standard_D32_v4 — 32 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardD32V4 = "Standard_D32_v4";
+
+        /// <summary>
+        /// Standard_D48_v4 — 48 vCPUs — 192 GB RAM
+        /// </summary>
+        public const string StandardD48V4 = "Standard_D48_v4";
+
+        /// <summary>
+        /// Standard_D4_v4 — 4 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardD4V4 = "Standard_D4_v4";
+
+        /// <summary>
+        /// Standard_D64_v4 — 64 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardD64V4 = "Standard_D64_v4";
+
+        /// <summary>
+        /// Standard_D8_v4 — 8 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardD8V4 = "Standard_D8_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardDv5Family.
+    /// </summary>
+    public static class StandardDv5
+    {
+        /// <summary>
+        /// Standard_D16_v5 — 16 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardD16V5 = "Standard_D16_v5";
+
+        /// <summary>
+        /// Standard_D2_v5 — 2 vCPUs — 8 GB RAM
+        /// </summary>
+        public const string StandardD2V5 = "Standard_D2_v5";
+
+        /// <summary>
+        /// Standard_D32_v5 — 32 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardD32V5 = "Standard_D32_v5";
+
+        /// <summary>
+        /// Standard_D48_v5 — 48 vCPUs — 192 GB RAM
+        /// </summary>
+        public const string StandardD48V5 = "Standard_D48_v5";
+
+        /// <summary>
+        /// Standard_D4_v5 — 4 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardD4V5 = "Standard_D4_v5";
+
+        /// <summary>
+        /// Standard_D64_v5 — 64 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardD64V5 = "Standard_D64_v5";
+
+        /// <summary>
+        /// Standard_D8_v5 — 8 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardD8V5 = "Standard_D8_v5";
+
+        /// <summary>
+        /// Standard_D96_v5 — 96 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardD96V5 = "Standard_D96_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEADSv5Family.
+    /// </summary>
+    public static class StandardEADSv5
+    {
+        /// <summary>
+        /// Standard_E16-4ads_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164adsV5 = "Standard_E16-4ads_v5";
+
+        /// <summary>
+        /// Standard_E16-8ads_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168adsV5 = "Standard_E16-8ads_v5";
+
+        /// <summary>
+        /// Standard_E16ads_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16adsV5 = "Standard_E16ads_v5";
+
+        /// <summary>
+        /// Standard_E20ads_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20adsV5 = "Standard_E20ads_v5";
+
+        /// <summary>
+        /// Standard_E2ads_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2adsV5 = "Standard_E2ads_v5";
+
+        /// <summary>
+        /// Standard_E32-16ads_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216adsV5 = "Standard_E32-16ads_v5";
+
+        /// <summary>
+        /// Standard_E32-8ads_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328adsV5 = "Standard_E32-8ads_v5";
+
+        /// <summary>
+        /// Standard_E32ads_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32adsV5 = "Standard_E32ads_v5";
+
+        /// <summary>
+        /// Standard_E4-2ads_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42adsV5 = "Standard_E4-2ads_v5";
+
+        /// <summary>
+        /// Standard_E48ads_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48adsV5 = "Standard_E48ads_v5";
+
+        /// <summary>
+        /// Standard_E4ads_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4adsV5 = "Standard_E4ads_v5";
+
+        /// <summary>
+        /// Standard_E64-16ads_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416adsV5 = "Standard_E64-16ads_v5";
+
+        /// <summary>
+        /// Standard_E64-32ads_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432adsV5 = "Standard_E64-32ads_v5";
+
+        /// <summary>
+        /// Standard_E64ads_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64adsV5 = "Standard_E64ads_v5";
+
+        /// <summary>
+        /// Standard_E8-2ads_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82adsV5 = "Standard_E8-2ads_v5";
+
+        /// <summary>
+        /// Standard_E8-4ads_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84adsV5 = "Standard_E8-4ads_v5";
+
+        /// <summary>
+        /// Standard_E8ads_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8adsV5 = "Standard_E8ads_v5";
+
+        /// <summary>
+        /// Standard_E96-24ads_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624adsV5 = "Standard_E96-24ads_v5";
+
+        /// <summary>
+        /// Standard_E96-48ads_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648adsV5 = "Standard_E96-48ads_v5";
+
+        /// <summary>
+        /// Standard_E96ads_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96adsV5 = "Standard_E96ads_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardEadsv7Family.
+    /// </summary>
+    public static class StandardEadsv7
+    {
+        /// <summary>
+        /// Standard_E128-32ads_v7 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE12832adsV7 = "Standard_E128-32ads_v7";
+
+        /// <summary>
+        /// Standard_E128-64ads_v7 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE12864adsV7 = "Standard_E128-64ads_v7";
+
+        /// <summary>
+        /// Standard_E128ads_v7 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE128adsV7 = "Standard_E128ads_v7";
+
+        /// <summary>
+        /// Standard_E16-4ads_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164adsV7 = "Standard_E16-4ads_v7";
+
+        /// <summary>
+        /// Standard_E16-8ads_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168adsV7 = "Standard_E16-8ads_v7";
+
+        /// <summary>
+        /// Standard_E160ads_v7 — 160 vCPUs — 1280 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE160adsV7 = "Standard_E160ads_v7";
+
+        /// <summary>
+        /// Standard_E16ads_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16adsV7 = "Standard_E16ads_v7";
+
+        /// <summary>
+        /// Standard_E2ads_v7 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2adsV7 = "Standard_E2ads_v7";
+
+        /// <summary>
+        /// Standard_E32-16ads_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216adsV7 = "Standard_E32-16ads_v7";
+
+        /// <summary>
+        /// Standard_E32-8ads_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328adsV7 = "Standard_E32-8ads_v7";
+
+        /// <summary>
+        /// Standard_E32ads_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32adsV7 = "Standard_E32ads_v7";
+
+        /// <summary>
+        /// Standard_E4-2ads_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42adsV7 = "Standard_E4-2ads_v7";
+
+        /// <summary>
+        /// Standard_E48ads_v7 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48adsV7 = "Standard_E48ads_v7";
+
+        /// <summary>
+        /// Standard_E4ads_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4adsV7 = "Standard_E4ads_v7";
+
+        /// <summary>
+        /// Standard_E64-16ads_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416adsV7 = "Standard_E64-16ads_v7";
+
+        /// <summary>
+        /// Standard_E64-32ads_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432adsV7 = "Standard_E64-32ads_v7";
+
+        /// <summary>
+        /// Standard_E64ads_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64adsV7 = "Standard_E64ads_v7";
+
+        /// <summary>
+        /// Standard_E8-2ads_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82adsV7 = "Standard_E8-2ads_v7";
+
+        /// <summary>
+        /// Standard_E8-4ads_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84adsV7 = "Standard_E8-4ads_v7";
+
+        /// <summary>
+        /// Standard_E8ads_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8adsV7 = "Standard_E8ads_v7";
+
+        /// <summary>
+        /// Standard_E96-24ads_v7 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624adsV7 = "Standard_E96-24ads_v7";
+
+        /// <summary>
+        /// Standard_E96-48ads_v7 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648adsV7 = "Standard_E96-48ads_v7";
+
+        /// <summary>
+        /// Standard_E96ads_v7 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96adsV7 = "Standard_E96ads_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEadv6Family.
+    /// </summary>
+    public static class StandardEadv6
+    {
+        /// <summary>
+        /// Standard_E16ads_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16adsV6 = "Standard_E16ads_v6";
+
+        /// <summary>
+        /// Standard_E20ads_v6 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20adsV6 = "Standard_E20ads_v6";
+
+        /// <summary>
+        /// Standard_E2ads_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2adsV6 = "Standard_E2ads_v6";
+
+        /// <summary>
+        /// Standard_E32ads_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32adsV6 = "Standard_E32ads_v6";
+
+        /// <summary>
+        /// Standard_E48ads_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48adsV6 = "Standard_E48ads_v6";
+
+        /// <summary>
+        /// Standard_E4ads_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4adsV6 = "Standard_E4ads_v6";
+
+        /// <summary>
+        /// Standard_E64ads_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64adsV6 = "Standard_E64ads_v6";
+
+        /// <summary>
+        /// Standard_E8ads_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8adsV6 = "Standard_E8ads_v6";
+
+        /// <summary>
+        /// Standard_E96-24ads_v6 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624adsV6 = "Standard_E96-24ads_v6";
+
+        /// <summary>
+        /// Standard_E96-48ads_v6 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648adsV6 = "Standard_E96-48ads_v6";
+
+        /// <summary>
+        /// Standard_E96ads_v6 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96adsV6 = "Standard_E96ads_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEASv4Family.
+    /// </summary>
+    public static class StandardEASv4
+    {
+        /// <summary>
+        /// Standard_E16-4as_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164asV4 = "Standard_E16-4as_v4";
+
+        /// <summary>
+        /// Standard_E16-8as_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168asV4 = "Standard_E16-8as_v4";
+
+        /// <summary>
+        /// Standard_E16as_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16asV4 = "Standard_E16as_v4";
+
+        /// <summary>
+        /// Standard_E20as_v4 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20asV4 = "Standard_E20as_v4";
+
+        /// <summary>
+        /// Standard_E2as_v4 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2asV4 = "Standard_E2as_v4";
+
+        /// <summary>
+        /// Standard_E32-16as_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216asV4 = "Standard_E32-16as_v4";
+
+        /// <summary>
+        /// Standard_E32-8as_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328asV4 = "Standard_E32-8as_v4";
+
+        /// <summary>
+        /// Standard_E32as_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32asV4 = "Standard_E32as_v4";
+
+        /// <summary>
+        /// Standard_E4-2as_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42asV4 = "Standard_E4-2as_v4";
+
+        /// <summary>
+        /// Standard_E48as_v4 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48asV4 = "Standard_E48as_v4";
+
+        /// <summary>
+        /// Standard_E4as_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4asV4 = "Standard_E4as_v4";
+
+        /// <summary>
+        /// Standard_E64-16as_v4 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416asV4 = "Standard_E64-16as_v4";
+
+        /// <summary>
+        /// Standard_E64-32as_v4 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432asV4 = "Standard_E64-32as_v4";
+
+        /// <summary>
+        /// Standard_E64as_v4 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64asV4 = "Standard_E64as_v4";
+
+        /// <summary>
+        /// Standard_E8-2as_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82asV4 = "Standard_E8-2as_v4";
+
+        /// <summary>
+        /// Standard_E8-4as_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84asV4 = "Standard_E8-4as_v4";
+
+        /// <summary>
+        /// Standard_E8as_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8asV4 = "Standard_E8as_v4";
+
+        /// <summary>
+        /// Standard_E96-24as_v4 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624asV4 = "Standard_E96-24as_v4";
+
+        /// <summary>
+        /// Standard_E96-48as_v4 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648asV4 = "Standard_E96-48as_v4";
+
+        /// <summary>
+        /// Standard_E96as_v4 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96asV4 = "Standard_E96as_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEASv5Family.
+    /// </summary>
+    public static class StandardEASv5
+    {
+        /// <summary>
+        /// Standard_E16-4as_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164asV5 = "Standard_E16-4as_v5";
+
+        /// <summary>
+        /// Standard_E16-8as_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168asV5 = "Standard_E16-8as_v5";
+
+        /// <summary>
+        /// Standard_E16as_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16asV5 = "Standard_E16as_v5";
+
+        /// <summary>
+        /// Standard_E20as_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20asV5 = "Standard_E20as_v5";
+
+        /// <summary>
+        /// Standard_E2as_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2asV5 = "Standard_E2as_v5";
+
+        /// <summary>
+        /// Standard_E32-16as_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216asV5 = "Standard_E32-16as_v5";
+
+        /// <summary>
+        /// Standard_E32-8as_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328asV5 = "Standard_E32-8as_v5";
+
+        /// <summary>
+        /// Standard_E32as_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32asV5 = "Standard_E32as_v5";
+
+        /// <summary>
+        /// Standard_E4-2as_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42asV5 = "Standard_E4-2as_v5";
+
+        /// <summary>
+        /// Standard_E48as_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48asV5 = "Standard_E48as_v5";
+
+        /// <summary>
+        /// Standard_E4as_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4asV5 = "Standard_E4as_v5";
+
+        /// <summary>
+        /// Standard_E64-16as_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416asV5 = "Standard_E64-16as_v5";
+
+        /// <summary>
+        /// Standard_E64-32as_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432asV5 = "Standard_E64-32as_v5";
+
+        /// <summary>
+        /// Standard_E64as_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64asV5 = "Standard_E64as_v5";
+
+        /// <summary>
+        /// Standard_E8-2as_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82asV5 = "Standard_E8-2as_v5";
+
+        /// <summary>
+        /// Standard_E8-4as_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84asV5 = "Standard_E8-4as_v5";
+
+        /// <summary>
+        /// Standard_E8as_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8asV5 = "Standard_E8as_v5";
+
+        /// <summary>
+        /// Standard_E96-24as_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624asV5 = "Standard_E96-24as_v5";
+
+        /// <summary>
+        /// Standard_E96-48as_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648asV5 = "Standard_E96-48as_v5";
+
+        /// <summary>
+        /// Standard_E96as_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96asV5 = "Standard_E96as_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardEasv7Family.
+    /// </summary>
+    public static class StandardEasv7
+    {
+        /// <summary>
+        /// Standard_E128-32as_v7 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE12832asV7 = "Standard_E128-32as_v7";
+
+        /// <summary>
+        /// Standard_E128-64as_v7 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE12864asV7 = "Standard_E128-64as_v7";
+
+        /// <summary>
+        /// Standard_E128as_v7 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE128asV7 = "Standard_E128as_v7";
+
+        /// <summary>
+        /// Standard_E16-4as_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164asV7 = "Standard_E16-4as_v7";
+
+        /// <summary>
+        /// Standard_E16-8as_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168asV7 = "Standard_E16-8as_v7";
+
+        /// <summary>
+        /// Standard_E160as_v7 — 160 vCPUs — 1280 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE160asV7 = "Standard_E160as_v7";
+
+        /// <summary>
+        /// Standard_E16as_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16asV7 = "Standard_E16as_v7";
+
+        /// <summary>
+        /// Standard_E2as_v7 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2asV7 = "Standard_E2as_v7";
+
+        /// <summary>
+        /// Standard_E32-16as_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216asV7 = "Standard_E32-16as_v7";
+
+        /// <summary>
+        /// Standard_E32-8as_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328asV7 = "Standard_E32-8as_v7";
+
+        /// <summary>
+        /// Standard_E32as_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32asV7 = "Standard_E32as_v7";
+
+        /// <summary>
+        /// Standard_E4-2as_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42asV7 = "Standard_E4-2as_v7";
+
+        /// <summary>
+        /// Standard_E48as_v7 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48asV7 = "Standard_E48as_v7";
+
+        /// <summary>
+        /// Standard_E4as_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4asV7 = "Standard_E4as_v7";
+
+        /// <summary>
+        /// Standard_E64-16as_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416asV7 = "Standard_E64-16as_v7";
+
+        /// <summary>
+        /// Standard_E64-32as_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432asV7 = "Standard_E64-32as_v7";
+
+        /// <summary>
+        /// Standard_E64as_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64asV7 = "Standard_E64as_v7";
+
+        /// <summary>
+        /// Standard_E8-2as_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82asV7 = "Standard_E8-2as_v7";
+
+        /// <summary>
+        /// Standard_E8-4as_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84asV7 = "Standard_E8-4as_v7";
+
+        /// <summary>
+        /// Standard_E8as_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8asV7 = "Standard_E8as_v7";
+
+        /// <summary>
+        /// Standard_E96-24as_v7 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624asV7 = "Standard_E96-24as_v7";
+
+        /// <summary>
+        /// Standard_E96-48as_v7 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648asV7 = "Standard_E96-48as_v7";
+
+        /// <summary>
+        /// Standard_E96as_v7 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96asV7 = "Standard_E96as_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEAv4Family.
+    /// </summary>
+    public static class StandardEAv4
+    {
+        /// <summary>
+        /// Standard_E16a_v4 — 16 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardE16aV4 = "Standard_E16a_v4";
+
+        /// <summary>
+        /// Standard_E20a_v4 — 20 vCPUs — 160 GB RAM
+        /// </summary>
+        public const string StandardE20aV4 = "Standard_E20a_v4";
+
+        /// <summary>
+        /// Standard_E2a_v4 — 2 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardE2aV4 = "Standard_E2a_v4";
+
+        /// <summary>
+        /// Standard_E32a_v4 — 32 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardE32aV4 = "Standard_E32a_v4";
+
+        /// <summary>
+        /// Standard_E48a_v4 — 48 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardE48aV4 = "Standard_E48a_v4";
+
+        /// <summary>
+        /// Standard_E4a_v4 — 4 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardE4aV4 = "Standard_E4a_v4";
+
+        /// <summary>
+        /// Standard_E64a_v4 — 64 vCPUs — 512 GB RAM
+        /// </summary>
+        public const string StandardE64aV4 = "Standard_E64a_v4";
+
+        /// <summary>
+        /// Standard_E8a_v4 — 8 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardE8aV4 = "Standard_E8a_v4";
+
+        /// <summary>
+        /// Standard_E96a_v4 — 96 vCPUs — 672 GB RAM
+        /// </summary>
+        public const string StandardE96aV4 = "Standard_E96a_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEav6Family.
+    /// </summary>
+    public static class StandardEav6
+    {
+        /// <summary>
+        /// Standard_E16as_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16asV6 = "Standard_E16as_v6";
+
+        /// <summary>
+        /// Standard_E20as_v6 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20asV6 = "Standard_E20as_v6";
+
+        /// <summary>
+        /// Standard_E2as_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2asV6 = "Standard_E2as_v6";
+
+        /// <summary>
+        /// Standard_E32as_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32asV6 = "Standard_E32as_v6";
+
+        /// <summary>
+        /// Standard_E48as_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48asV6 = "Standard_E48as_v6";
+
+        /// <summary>
+        /// Standard_E4as_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4asV6 = "Standard_E4as_v6";
+
+        /// <summary>
+        /// Standard_E64as_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64asV6 = "Standard_E64as_v6";
+
+        /// <summary>
+        /// Standard_E8as_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8asV6 = "Standard_E8as_v6";
+
+        /// <summary>
+        /// Standard_E96as_v6 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96asV6 = "Standard_E96as_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEBDSv5Family.
+    /// </summary>
+    public static class StandardEBDSv5
+    {
+        /// <summary>
+        /// Standard_E16bds_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16bdsV5 = "Standard_E16bds_v5";
+
+        /// <summary>
+        /// Standard_E2bds_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2bdsV5 = "Standard_E2bds_v5";
+
+        /// <summary>
+        /// Standard_E32bds_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32bdsV5 = "Standard_E32bds_v5";
+
+        /// <summary>
+        /// Standard_E48bds_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48bdsV5 = "Standard_E48bds_v5";
+
+        /// <summary>
+        /// Standard_E4bds_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4bdsV5 = "Standard_E4bds_v5";
+
+        /// <summary>
+        /// Standard_E64bds_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64bdsV5 = "Standard_E64bds_v5";
+
+        /// <summary>
+        /// Standard_E8bds_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8bdsV5 = "Standard_E8bds_v5";
+
+        /// <summary>
+        /// Standard_E96bds_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96bdsV5 = "Standard_E96bds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEBSv5Family.
+    /// </summary>
+    public static class StandardEBSv5
+    {
+        /// <summary>
+        /// Standard_E16bs_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16bsV5 = "Standard_E16bs_v5";
+
+        /// <summary>
+        /// Standard_E2bs_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2bsV5 = "Standard_E2bs_v5";
+
+        /// <summary>
+        /// Standard_E32bs_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32bsV5 = "Standard_E32bs_v5";
+
+        /// <summary>
+        /// Standard_E48bs_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48bsV5 = "Standard_E48bs_v5";
+
+        /// <summary>
+        /// Standard_E4bs_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4bsV5 = "Standard_E4bs_v5";
+
+        /// <summary>
+        /// Standard_E64bs_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64bsV5 = "Standard_E64bs_v5";
+
+        /// <summary>
+        /// Standard_E8bs_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8bsV5 = "Standard_E8bs_v5";
+
+        /// <summary>
+        /// Standard_E96bs_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96bsV5 = "Standard_E96bs_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECACCV5Family.
+    /// </summary>
+    public static class StandardECACCV5
+    {
+        /// <summary>
+        /// Standard_EC16as_cc_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16asCcV5 = "Standard_EC16as_cc_v5";
+
+        /// <summary>
+        /// Standard_EC20as_cc_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC20asCcV5 = "Standard_EC20as_cc_v5";
+
+        /// <summary>
+        /// Standard_EC32as_cc_v5 — 32 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32asCcV5 = "Standard_EC32as_cc_v5";
+
+        /// <summary>
+        /// Standard_EC48as_cc_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48asCcV5 = "Standard_EC48as_cc_v5";
+
+        /// <summary>
+        /// Standard_EC4as_cc_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4asCcV5 = "Standard_EC4as_cc_v5";
+
+        /// <summary>
+        /// Standard_EC64as_cc_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64asCcV5 = "Standard_EC64as_cc_v5";
+
+        /// <summary>
+        /// Standard_EC8as_cc_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8asCcV5 = "Standard_EC8as_cc_v5";
+
+        /// <summary>
+        /// Standard_EC96as_cc_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC96asCcV5 = "Standard_EC96as_cc_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECADCCV5Family.
+    /// </summary>
+    public static class StandardECADCCV5
+    {
+        /// <summary>
+        /// Standard_EC16ads_cc_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16adsCcV5 = "Standard_EC16ads_cc_v5";
+
+        /// <summary>
+        /// Standard_EC20ads_cc_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC20adsCcV5 = "Standard_EC20ads_cc_v5";
+
+        /// <summary>
+        /// Standard_EC32ads_cc_v5 — 32 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32adsCcV5 = "Standard_EC32ads_cc_v5";
+
+        /// <summary>
+        /// Standard_EC48ads_cc_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48adsCcV5 = "Standard_EC48ads_cc_v5";
+
+        /// <summary>
+        /// Standard_EC4ads_cc_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4adsCcV5 = "Standard_EC4ads_cc_v5";
+
+        /// <summary>
+        /// Standard_EC64ads_cc_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64adsCcV5 = "Standard_EC64ads_cc_v5";
+
+        /// <summary>
+        /// Standard_EC8ads_cc_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8adsCcV5 = "Standard_EC8ads_cc_v5";
+
+        /// <summary>
+        /// Standard_EC96ads_cc_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC96adsCcV5 = "Standard_EC96ads_cc_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECADSv5Family.
+    /// </summary>
+    public static class StandardECADSv5
+    {
+        /// <summary>
+        /// Standard_EC16ads_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16adsV5 = "Standard_EC16ads_v5";
+
+        /// <summary>
+        /// Standard_EC20ads_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC20adsV5 = "Standard_EC20ads_v5";
+
+        /// <summary>
+        /// Standard_EC2ads_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC2adsV5 = "Standard_EC2ads_v5";
+
+        /// <summary>
+        /// Standard_EC32ads_v5 — 32 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32adsV5 = "Standard_EC32ads_v5";
+
+        /// <summary>
+        /// Standard_EC48ads_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48adsV5 = "Standard_EC48ads_v5";
+
+        /// <summary>
+        /// Standard_EC4ads_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4adsV5 = "Standard_EC4ads_v5";
+
+        /// <summary>
+        /// Standard_EC64ads_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64adsV5 = "Standard_EC64ads_v5";
+
+        /// <summary>
+        /// Standard_EC8ads_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8adsV5 = "Standard_EC8ads_v5";
+
+        /// <summary>
+        /// Standard_EC96ads_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC96adsV5 = "Standard_EC96ads_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECadsv6Family.
+    /// </summary>
+    public static class StandardECadsv6
+    {
+        /// <summary>
+        /// Standard_EC16ads_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16adsV6 = "Standard_EC16ads_v6";
+
+        /// <summary>
+        /// Standard_EC2ads_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC2adsV6 = "Standard_EC2ads_v6";
+
+        /// <summary>
+        /// Standard_EC32ads_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32adsV6 = "Standard_EC32ads_v6";
+
+        /// <summary>
+        /// Standard_EC48ads_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48adsV6 = "Standard_EC48ads_v6";
+
+        /// <summary>
+        /// Standard_EC4ads_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4adsV6 = "Standard_EC4ads_v6";
+
+        /// <summary>
+        /// Standard_EC64ads_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64adsV6 = "Standard_EC64ads_v6";
+
+        /// <summary>
+        /// Standard_EC8ads_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8adsV6 = "Standard_EC8ads_v6";
+
+        /// <summary>
+        /// Standard_EC96ads_v6 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC96adsV6 = "Standard_EC96ads_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECASv5Family.
+    /// </summary>
+    public static class StandardECASv5
+    {
+        /// <summary>
+        /// Standard_EC16as_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16asV5 = "Standard_EC16as_v5";
+
+        /// <summary>
+        /// Standard_EC20as_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC20asV5 = "Standard_EC20as_v5";
+
+        /// <summary>
+        /// Standard_EC2as_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC2asV5 = "Standard_EC2as_v5";
+
+        /// <summary>
+        /// Standard_EC32as_v5 — 32 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32asV5 = "Standard_EC32as_v5";
+
+        /// <summary>
+        /// Standard_EC48as_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48asV5 = "Standard_EC48as_v5";
+
+        /// <summary>
+        /// Standard_EC4as_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4asV5 = "Standard_EC4as_v5";
+
+        /// <summary>
+        /// Standard_EC64as_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64asV5 = "Standard_EC64as_v5";
+
+        /// <summary>
+        /// Standard_EC8as_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8asV5 = "Standard_EC8as_v5";
+
+        /// <summary>
+        /// Standard_EC96as_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC96asV5 = "Standard_EC96as_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECasv6Family.
+    /// </summary>
+    public static class StandardECasv6
+    {
+        /// <summary>
+        /// Standard_EC16as_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16asV6 = "Standard_EC16as_v6";
+
+        /// <summary>
+        /// Standard_EC2as_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC2asV6 = "Standard_EC2as_v6";
+
+        /// <summary>
+        /// Standard_EC32as_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32asV6 = "Standard_EC32as_v6";
+
+        /// <summary>
+        /// Standard_EC48as_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48asV6 = "Standard_EC48as_v6";
+
+        /// <summary>
+        /// Standard_EC4as_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4asV6 = "Standard_EC4as_v6";
+
+        /// <summary>
+        /// Standard_EC64as_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64asV6 = "Standard_EC64as_v6";
+
+        /// <summary>
+        /// Standard_EC8as_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8asV6 = "Standard_EC8as_v6";
+
+        /// <summary>
+        /// Standard_EC96as_v6 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC96asV6 = "Standard_EC96as_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECEDV5Family.
+    /// </summary>
+    public static class StandardECEDV5
+    {
+        /// <summary>
+        /// Standard_EC128eds_v5 — 128 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC128edsV5 = "Standard_EC128eds_v5";
+
+        /// <summary>
+        /// Standard_EC16eds_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16edsV5 = "Standard_EC16eds_v5";
+
+        /// <summary>
+        /// Standard_EC2eds_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC2edsV5 = "Standard_EC2eds_v5";
+
+        /// <summary>
+        /// Standard_EC32eds_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32edsV5 = "Standard_EC32eds_v5";
+
+        /// <summary>
+        /// Standard_EC48eds_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48edsV5 = "Standard_EC48eds_v5";
+
+        /// <summary>
+        /// Standard_EC4eds_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4edsV5 = "Standard_EC4eds_v5";
+
+        /// <summary>
+        /// Standard_EC64eds_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64edsV5 = "Standard_EC64eds_v5";
+
+        /// <summary>
+        /// Standard_EC8eds_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8edsV5 = "Standard_EC8eds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardECEDV6Family.
+    /// </summary>
+    public static class StandardECEDV6
+    {
+        /// <summary>
+        /// Standard_EC16eds_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16edsV6 = "Standard_EC16eds_v6";
+
+        /// <summary>
+        /// Standard_EC2eds_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC2edsV6 = "Standard_EC2eds_v6";
+
+        /// <summary>
+        /// Standard_EC32eds_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32edsV6 = "Standard_EC32eds_v6";
+
+        /// <summary>
+        /// Standard_EC48eds_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48edsV6 = "Standard_EC48eds_v6";
+
+        /// <summary>
+        /// Standard_EC4eds_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4edsV6 = "Standard_EC4eds_v6";
+
+        /// <summary>
+        /// Standard_EC64eds_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64edsV6 = "Standard_EC64eds_v6";
+
+        /// <summary>
+        /// Standard_EC8eds_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8edsV6 = "Standard_EC8eds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECEV5Family.
+    /// </summary>
+    public static class StandardECEV5
+    {
+        /// <summary>
+        /// Standard_EC128es_v5 — 128 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC128esV5 = "Standard_EC128es_v5";
+
+        /// <summary>
+        /// Standard_EC16es_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16esV5 = "Standard_EC16es_v5";
+
+        /// <summary>
+        /// Standard_EC2es_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC2esV5 = "Standard_EC2es_v5";
+
+        /// <summary>
+        /// Standard_EC32es_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32esV5 = "Standard_EC32es_v5";
+
+        /// <summary>
+        /// Standard_EC48es_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48esV5 = "Standard_EC48es_v5";
+
+        /// <summary>
+        /// Standard_EC4es_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4esV5 = "Standard_EC4es_v5";
+
+        /// <summary>
+        /// Standard_EC64es_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64esV5 = "Standard_EC64es_v5";
+
+        /// <summary>
+        /// Standard_EC8es_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8esV5 = "Standard_EC8es_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardECEV6Family.
+    /// </summary>
+    public static class StandardECEV6
+    {
+        /// <summary>
+        /// Standard_EC16es_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC16esV6 = "Standard_EC16es_v6";
+
+        /// <summary>
+        /// Standard_EC2es_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC2esV6 = "Standard_EC2es_v6";
+
+        /// <summary>
+        /// Standard_EC32es_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC32esV6 = "Standard_EC32es_v6";
+
+        /// <summary>
+        /// Standard_EC48es_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC48esV6 = "Standard_EC48es_v6";
+
+        /// <summary>
+        /// Standard_EC4es_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC4esV6 = "Standard_EC4es_v6";
+
+        /// <summary>
+        /// Standard_EC64es_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC64esV6 = "Standard_EC64es_v6";
+
+        /// <summary>
+        /// Standard_EC8es_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC8esV6 = "Standard_EC8es_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECIADSv5Family.
+    /// </summary>
+    public static class StandardECIADSv5
+    {
+        /// <summary>
+        /// Standard_EC96iads_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC96iadsV5 = "Standard_EC96iads_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECIASv5Family.
+    /// </summary>
+    public static class StandardECIASv5
+    {
+        /// <summary>
+        /// Standard_EC96ias_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC96iasV5 = "Standard_EC96ias_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECIEDV5Family.
+    /// </summary>
+    public static class StandardECIEDV5
+    {
+        /// <summary>
+        /// Standard_EC128ieds_v5 — 128 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC128iedsV5 = "Standard_EC128ieds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardECIEV5Family.
+    /// </summary>
+    public static class StandardECIEV5
+    {
+        /// <summary>
+        /// Standard_EC128ies_v5 — 128 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardEC128iesV5 = "Standard_EC128ies_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEDSv4Family.
+    /// </summary>
+    public static class StandardEDSv4
+    {
+        /// <summary>
+        /// Standard_E16-4ds_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164dsV4 = "Standard_E16-4ds_v4";
+
+        /// <summary>
+        /// Standard_E16-8ds_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168dsV4 = "Standard_E16-8ds_v4";
+
+        /// <summary>
+        /// Standard_E16ds_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16dsV4 = "Standard_E16ds_v4";
+
+        /// <summary>
+        /// Standard_E20ds_v4 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20dsV4 = "Standard_E20ds_v4";
+
+        /// <summary>
+        /// Standard_E2ds_v4 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2dsV4 = "Standard_E2ds_v4";
+
+        /// <summary>
+        /// Standard_E32-16ds_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216dsV4 = "Standard_E32-16ds_v4";
+
+        /// <summary>
+        /// Standard_E32-8ds_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328dsV4 = "Standard_E32-8ds_v4";
+
+        /// <summary>
+        /// Standard_E32ds_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32dsV4 = "Standard_E32ds_v4";
+
+        /// <summary>
+        /// Standard_E4-2ds_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42dsV4 = "Standard_E4-2ds_v4";
+
+        /// <summary>
+        /// Standard_E48ds_v4 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48dsV4 = "Standard_E48ds_v4";
+
+        /// <summary>
+        /// Standard_E4ds_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4dsV4 = "Standard_E4ds_v4";
+
+        /// <summary>
+        /// Standard_E64-16ds_v4 — 64 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416dsV4 = "Standard_E64-16ds_v4";
+
+        /// <summary>
+        /// Standard_E64-32ds_v4 — 64 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432dsV4 = "Standard_E64-32ds_v4";
+
+        /// <summary>
+        /// Standard_E64ds_v4 — 64 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64dsV4 = "Standard_E64ds_v4";
+
+        /// <summary>
+        /// Standard_E8-2ds_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82dsV4 = "Standard_E8-2ds_v4";
+
+        /// <summary>
+        /// Standard_E8-4ds_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84dsV4 = "Standard_E8-4ds_v4";
+
+        /// <summary>
+        /// Standard_E8ds_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8dsV4 = "Standard_E8ds_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEDSv5Family.
+    /// </summary>
+    public static class StandardEDSv5
+    {
+        /// <summary>
+        /// Standard_E16-4ds_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164dsV5 = "Standard_E16-4ds_v5";
+
+        /// <summary>
+        /// Standard_E16-8ds_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168dsV5 = "Standard_E16-8ds_v5";
+
+        /// <summary>
+        /// Standard_E16ds_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16dsV5 = "Standard_E16ds_v5";
+
+        /// <summary>
+        /// Standard_E20ds_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20dsV5 = "Standard_E20ds_v5";
+
+        /// <summary>
+        /// Standard_E2ds_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2dsV5 = "Standard_E2ds_v5";
+
+        /// <summary>
+        /// Standard_E32-16ds_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216dsV5 = "Standard_E32-16ds_v5";
+
+        /// <summary>
+        /// Standard_E32-8ds_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328dsV5 = "Standard_E32-8ds_v5";
+
+        /// <summary>
+        /// Standard_E32ds_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32dsV5 = "Standard_E32ds_v5";
+
+        /// <summary>
+        /// Standard_E4-2ds_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42dsV5 = "Standard_E4-2ds_v5";
+
+        /// <summary>
+        /// Standard_E48ds_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48dsV5 = "Standard_E48ds_v5";
+
+        /// <summary>
+        /// Standard_E4ds_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4dsV5 = "Standard_E4ds_v5";
+
+        /// <summary>
+        /// Standard_E64-16ds_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416dsV5 = "Standard_E64-16ds_v5";
+
+        /// <summary>
+        /// Standard_E64-32ds_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432dsV5 = "Standard_E64-32ds_v5";
+
+        /// <summary>
+        /// Standard_E64ds_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64dsV5 = "Standard_E64ds_v5";
+
+        /// <summary>
+        /// Standard_E8-2ds_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82dsV5 = "Standard_E8-2ds_v5";
+
+        /// <summary>
+        /// Standard_E8-4ds_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84dsV5 = "Standard_E8-4ds_v5";
+
+        /// <summary>
+        /// Standard_E8ds_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8dsV5 = "Standard_E8ds_v5";
+
+        /// <summary>
+        /// Standard_E96-24ds_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624dsV5 = "Standard_E96-24ds_v5";
+
+        /// <summary>
+        /// Standard_E96-48ds_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648dsV5 = "Standard_E96-48ds_v5";
+
+        /// <summary>
+        /// Standard_E96ds_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96dsV5 = "Standard_E96ds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardEdsv6Family.
+    /// </summary>
+    public static class StandardEdsv6
+    {
+        /// <summary>
+        /// Standard_E128-32ds_v6 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE12832dsV6 = "Standard_E128-32ds_v6";
+
+        /// <summary>
+        /// Standard_E128-64ds_v6 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE12864dsV6 = "Standard_E128-64ds_v6";
+
+        /// <summary>
+        /// Standard_E128ds_v6 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE128dsV6 = "Standard_E128ds_v6";
+
+        /// <summary>
+        /// Standard_E16-4ds_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164dsV6 = "Standard_E16-4ds_v6";
+
+        /// <summary>
+        /// Standard_E16-8ds_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168dsV6 = "Standard_E16-8ds_v6";
+
+        /// <summary>
+        /// Standard_E16ds_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16dsV6 = "Standard_E16ds_v6";
+
+        /// <summary>
+        /// Standard_E192ids_v6 — 192 vCPUs — 1832 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE192idsV6 = "Standard_E192ids_v6";
+
+        /// <summary>
+        /// Standard_E20ds_v6 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20dsV6 = "Standard_E20ds_v6";
+
+        /// <summary>
+        /// Standard_E2ds_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2dsV6 = "Standard_E2ds_v6";
+
+        /// <summary>
+        /// Standard_E32-16ds_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216dsV6 = "Standard_E32-16ds_v6";
+
+        /// <summary>
+        /// Standard_E32-8ds_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328dsV6 = "Standard_E32-8ds_v6";
+
+        /// <summary>
+        /// Standard_E32ds_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32dsV6 = "Standard_E32ds_v6";
+
+        /// <summary>
+        /// Standard_E4-2ds_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42dsV6 = "Standard_E4-2ds_v6";
+
+        /// <summary>
+        /// Standard_E48ds_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48dsV6 = "Standard_E48ds_v6";
+
+        /// <summary>
+        /// Standard_E4ds_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4dsV6 = "Standard_E4ds_v6";
+
+        /// <summary>
+        /// Standard_E64-16ds_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416dsV6 = "Standard_E64-16ds_v6";
+
+        /// <summary>
+        /// Standard_E64-32ds_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432dsV6 = "Standard_E64-32ds_v6";
+
+        /// <summary>
+        /// Standard_E64ds_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64dsV6 = "Standard_E64ds_v6";
+
+        /// <summary>
+        /// Standard_E8-2ds_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82dsV6 = "Standard_E8-2ds_v6";
+
+        /// <summary>
+        /// Standard_E8-4ds_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84dsV6 = "Standard_E8-4ds_v6";
+
+        /// <summary>
+        /// Standard_E8ds_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8dsV6 = "Standard_E8ds_v6";
+
+        /// <summary>
+        /// Standard_E96-24ds_v6 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624dsV6 = "Standard_E96-24ds_v6";
+
+        /// <summary>
+        /// Standard_E96-48ds_v6 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648dsV6 = "Standard_E96-48ds_v6";
+
+        /// <summary>
+        /// Standard_E96ds_v6 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96dsV6 = "Standard_E96ds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEDv4Family.
+    /// </summary>
+    public static class StandardEDv4
+    {
+        /// <summary>
+        /// Standard_E16d_v4 — 16 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardE16dV4 = "Standard_E16d_v4";
+
+        /// <summary>
+        /// Standard_E20d_v4 — 20 vCPUs — 160 GB RAM
+        /// </summary>
+        public const string StandardE20dV4 = "Standard_E20d_v4";
+
+        /// <summary>
+        /// Standard_E2d_v4 — 2 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardE2dV4 = "Standard_E2d_v4";
+
+        /// <summary>
+        /// Standard_E32d_v4 — 32 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardE32dV4 = "Standard_E32d_v4";
+
+        /// <summary>
+        /// Standard_E48d_v4 — 48 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardE48dV4 = "Standard_E48d_v4";
+
+        /// <summary>
+        /// Standard_E4d_v4 — 4 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardE4dV4 = "Standard_E4d_v4";
+
+        /// <summary>
+        /// Standard_E64d_v4 — 64 vCPUs — 504 GB RAM
+        /// </summary>
+        public const string StandardE64dV4 = "Standard_E64d_v4";
+
+        /// <summary>
+        /// Standard_E8d_v4 — 8 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardE8dV4 = "Standard_E8d_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEDv5Family.
+    /// </summary>
+    public static class StandardEDv5
+    {
+        /// <summary>
+        /// Standard_E16d_v5 — 16 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardE16dV5 = "Standard_E16d_v5";
+
+        /// <summary>
+        /// Standard_E20d_v5 — 20 vCPUs — 160 GB RAM
+        /// </summary>
+        public const string StandardE20dV5 = "Standard_E20d_v5";
+
+        /// <summary>
+        /// Standard_E2d_v5 — 2 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardE2dV5 = "Standard_E2d_v5";
+
+        /// <summary>
+        /// Standard_E32d_v5 — 32 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardE32dV5 = "Standard_E32d_v5";
+
+        /// <summary>
+        /// Standard_E48d_v5 — 48 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardE48dV5 = "Standard_E48d_v5";
+
+        /// <summary>
+        /// Standard_E4d_v5 — 4 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardE4dV5 = "Standard_E4d_v5";
+
+        /// <summary>
+        /// Standard_E64d_v5 — 64 vCPUs — 512 GB RAM
+        /// </summary>
+        public const string StandardE64dV5 = "Standard_E64d_v5";
+
+        /// <summary>
+        /// Standard_E8d_v5 — 8 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardE8dV5 = "Standard_E8d_v5";
+
+        /// <summary>
+        /// Standard_E96d_v5 — 96 vCPUs — 672 GB RAM
+        /// </summary>
+        public const string StandardE96dV5 = "Standard_E96d_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIADSv5Family.
+    /// </summary>
+    public static class StandardEIADSv5
+    {
+        /// <summary>
+        /// Standard_E112iads_v5 — 112 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE112iadsV5 = "Standard_E112iads_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIASv4Family.
+    /// </summary>
+    public static class StandardEIASv4
+    {
+        /// <summary>
+        /// Standard_E96ias_v4 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96iasV4 = "Standard_E96ias_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIASv5Family.
+    /// </summary>
+    public static class StandardEIASv5
+    {
+        /// <summary>
+        /// Standard_E112ias_v5 — 112 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE112iasV5 = "Standard_E112ias_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIBDSv5Family.
+    /// </summary>
+    public static class StandardEIBDSv5
+    {
+        /// <summary>
+        /// Standard_E112ibds_v5 — 112 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE112ibdsV5 = "Standard_E112ibds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIBSv5Family.
+    /// </summary>
+    public static class StandardEIBSv5
+    {
+        /// <summary>
+        /// Standard_E112ibs_v5 — 112 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE112ibsV5 = "Standard_E112ibs_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIDSv5Family.
+    /// </summary>
+    public static class StandardEIDSv5
+    {
+        /// <summary>
+        /// Standard_E104ids_v5 — 104 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE104idsV5 = "Standard_E104ids_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIDv5Family.
+    /// </summary>
+    public static class StandardEIDv5
+    {
+        /// <summary>
+        /// Standard_E104id_v5 — 104 vCPUs — 672 GB RAM
+        /// </summary>
+        public const string StandardE104idV5 = "Standard_E104id_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEISv3Family.
+    /// </summary>
+    public static class StandardEISv3
+    {
+        /// <summary>
+        /// Standard_E64is_v3 — 64 vCPUs — 432 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64isV3 = "Standard_E64is_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEISv5Family.
+    /// </summary>
+    public static class StandardEISv5
+    {
+        /// <summary>
+        /// Standard_E104is_v5 — 104 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE104isV5 = "Standard_E104is_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIv3Family.
+    /// </summary>
+    public static class StandardEIv3
+    {
+        /// <summary>
+        /// Standard_E64i_v3 — 64 vCPUs — 432 GB RAM
+        /// </summary>
+        public const string StandardE64iV3 = "Standard_E64i_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEIv5Family.
+    /// </summary>
+    public static class StandardEIv5
+    {
+        /// <summary>
+        /// Standard_E104i_v5 — 104 vCPUs — 672 GB RAM
+        /// </summary>
+        public const string StandardE104iV5 = "Standard_E104i_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEPDSv5Family.
+    /// </summary>
+    public static class StandardEPDSv5
+    {
+        /// <summary>
+        /// Standard_E16pds_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16pdsV5 = "Standard_E16pds_v5";
+
+        /// <summary>
+        /// Standard_E20pds_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20pdsV5 = "Standard_E20pds_v5";
+
+        /// <summary>
+        /// Standard_E2pds_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
         /// </summary>
         public const string StandardE2pdsV5 = "Standard_E2pds_v5";
 
         /// <summary>
-        /// Standard_E4pds_v5 — 4 vCPUs, 32 GB RAM, Ampere Altra Arm processor.
+        /// Standard_E32pds_v5 — 32 vCPUs — 208 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32pdsV5 = "Standard_E32pds_v5";
+
+        /// <summary>
+        /// Standard_E4pds_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
         /// </summary>
         public const string StandardE4pdsV5 = "Standard_E4pds_v5";
+
+        /// <summary>
+        /// Standard_E8pds_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8pdsV5 = "Standard_E8pds_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardEpdsv6Family.
+    /// </summary>
+    public static class StandardEpdsv6
+    {
+        /// <summary>
+        /// Standard_E16pds_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16pdsV6 = "Standard_E16pds_v6";
+
+        /// <summary>
+        /// Standard_E2pds_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2pdsV6 = "Standard_E2pds_v6";
+
+        /// <summary>
+        /// Standard_E32pds_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32pdsV6 = "Standard_E32pds_v6";
+
+        /// <summary>
+        /// Standard_E48pds_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48pdsV6 = "Standard_E48pds_v6";
+
+        /// <summary>
+        /// Standard_E4pds_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4pdsV6 = "Standard_E4pds_v6";
+
+        /// <summary>
+        /// Standard_E64pds_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64pdsV6 = "Standard_E64pds_v6";
+
+        /// <summary>
+        /// Standard_E8pds_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8pdsV6 = "Standard_E8pds_v6";
+
+        /// <summary>
+        /// Standard_E96pds_v6 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96pdsV6 = "Standard_E96pds_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEPSv5Family.
+    /// </summary>
+    public static class StandardEPSv5
+    {
+        /// <summary>
+        /// Standard_E16ps_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16psV5 = "Standard_E16ps_v5";
+
+        /// <summary>
+        /// Standard_E20ps_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20psV5 = "Standard_E20ps_v5";
+
+        /// <summary>
+        /// Standard_E2ps_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2psV5 = "Standard_E2ps_v5";
+
+        /// <summary>
+        /// Standard_E32ps_v5 — 32 vCPUs — 208 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32psV5 = "Standard_E32ps_v5";
+
+        /// <summary>
+        /// Standard_E4ps_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4psV5 = "Standard_E4ps_v5";
+
+        /// <summary>
+        /// Standard_E8ps_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8psV5 = "Standard_E8ps_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardEpsv6Family.
+    /// </summary>
+    public static class StandardEpsv6
+    {
+        /// <summary>
+        /// Standard_E16ps_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16psV6 = "Standard_E16ps_v6";
+
+        /// <summary>
+        /// Standard_E2ps_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2psV6 = "Standard_E2ps_v6";
+
+        /// <summary>
+        /// Standard_E32ps_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32psV6 = "Standard_E32ps_v6";
+
+        /// <summary>
+        /// Standard_E48ps_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48psV6 = "Standard_E48ps_v6";
+
+        /// <summary>
+        /// Standard_E4ps_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4psV6 = "Standard_E4ps_v6";
+
+        /// <summary>
+        /// Standard_E64ps_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64psV6 = "Standard_E64ps_v6";
+
+        /// <summary>
+        /// Standard_E8ps_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8psV6 = "Standard_E8ps_v6";
+
+        /// <summary>
+        /// Standard_E96ps_v6 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96psV6 = "Standard_E96ps_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardESv3Family.
+    /// </summary>
+    public static class StandardESv3
+    {
+        /// <summary>
+        /// Standard_E16-4s_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164sV3 = "Standard_E16-4s_v3";
+
+        /// <summary>
+        /// Standard_E16-8s_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168sV3 = "Standard_E16-8s_v3";
+
+        /// <summary>
+        /// Standard_E16s_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16sV3 = "Standard_E16s_v3";
+
+        /// <summary>
+        /// Standard_E20s_v3 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20sV3 = "Standard_E20s_v3";
+
+        /// <summary>
+        /// Standard_E2s_v3 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2sV3 = "Standard_E2s_v3";
+
+        /// <summary>
+        /// Standard_E32-16s_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216sV3 = "Standard_E32-16s_v3";
+
+        /// <summary>
+        /// Standard_E32-8s_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328sV3 = "Standard_E32-8s_v3";
+
+        /// <summary>
+        /// Standard_E32s_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32sV3 = "Standard_E32s_v3";
+
+        /// <summary>
+        /// Standard_E4-2s_v3 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42sV3 = "Standard_E4-2s_v3";
+
+        /// <summary>
+        /// Standard_E48s_v3 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48sV3 = "Standard_E48s_v3";
+
+        /// <summary>
+        /// Standard_E4s_v3 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4sV3 = "Standard_E4s_v3";
+
+        /// <summary>
+        /// Standard_E64-16s_v3 — 64 vCPUs — 432 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416sV3 = "Standard_E64-16s_v3";
+
+        /// <summary>
+        /// Standard_E64-32s_v3 — 64 vCPUs — 432 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432sV3 = "Standard_E64-32s_v3";
+
+        /// <summary>
+        /// Standard_E64s_v3 — 64 vCPUs — 432 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64sV3 = "Standard_E64s_v3";
+
+        /// <summary>
+        /// Standard_E8-2s_v3 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82sV3 = "Standard_E8-2s_v3";
+
+        /// <summary>
+        /// Standard_E8-4s_v3 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84sV3 = "Standard_E8-4s_v3";
+
+        /// <summary>
+        /// Standard_E8s_v3 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8sV3 = "Standard_E8s_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardESv4Family.
+    /// </summary>
+    public static class StandardESv4
+    {
+        /// <summary>
+        /// Standard_E16-4s_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164sV4 = "Standard_E16-4s_v4";
+
+        /// <summary>
+        /// Standard_E16-8s_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168sV4 = "Standard_E16-8s_v4";
+
+        /// <summary>
+        /// Standard_E16s_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16sV4 = "Standard_E16s_v4";
+
+        /// <summary>
+        /// Standard_E20s_v4 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20sV4 = "Standard_E20s_v4";
+
+        /// <summary>
+        /// Standard_E2s_v4 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2sV4 = "Standard_E2s_v4";
+
+        /// <summary>
+        /// Standard_E32-16s_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216sV4 = "Standard_E32-16s_v4";
+
+        /// <summary>
+        /// Standard_E32-8s_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328sV4 = "Standard_E32-8s_v4";
+
+        /// <summary>
+        /// Standard_E32s_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32sV4 = "Standard_E32s_v4";
+
+        /// <summary>
+        /// Standard_E4-2s_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42sV4 = "Standard_E4-2s_v4";
+
+        /// <summary>
+        /// Standard_E48s_v4 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48sV4 = "Standard_E48s_v4";
+
+        /// <summary>
+        /// Standard_E4s_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4sV4 = "Standard_E4s_v4";
+
+        /// <summary>
+        /// Standard_E64-16s_v4 — 64 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416sV4 = "Standard_E64-16s_v4";
+
+        /// <summary>
+        /// Standard_E64-32s_v4 — 64 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432sV4 = "Standard_E64-32s_v4";
+
+        /// <summary>
+        /// Standard_E64s_v4 — 64 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64sV4 = "Standard_E64s_v4";
+
+        /// <summary>
+        /// Standard_E8-2s_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82sV4 = "Standard_E8-2s_v4";
+
+        /// <summary>
+        /// Standard_E8-4s_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84sV4 = "Standard_E8-4s_v4";
+
+        /// <summary>
+        /// Standard_E8s_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8sV4 = "Standard_E8s_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardESv5Family.
+    /// </summary>
+    public static class StandardESv5
+    {
+        /// <summary>
+        /// Standard_E16-4s_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164sV5 = "Standard_E16-4s_v5";
+
+        /// <summary>
+        /// Standard_E16-8s_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168sV5 = "Standard_E16-8s_v5";
+
+        /// <summary>
+        /// Standard_E16s_v5 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16sV5 = "Standard_E16s_v5";
+
+        /// <summary>
+        /// Standard_E20s_v5 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20sV5 = "Standard_E20s_v5";
+
+        /// <summary>
+        /// Standard_E2s_v5 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2sV5 = "Standard_E2s_v5";
+
+        /// <summary>
+        /// Standard_E32-16s_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216sV5 = "Standard_E32-16s_v5";
+
+        /// <summary>
+        /// Standard_E32-8s_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328sV5 = "Standard_E32-8s_v5";
+
+        /// <summary>
+        /// Standard_E32s_v5 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32sV5 = "Standard_E32s_v5";
+
+        /// <summary>
+        /// Standard_E4-2s_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42sV5 = "Standard_E4-2s_v5";
+
+        /// <summary>
+        /// Standard_E48s_v5 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48sV5 = "Standard_E48s_v5";
+
+        /// <summary>
+        /// Standard_E4s_v5 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4sV5 = "Standard_E4s_v5";
+
+        /// <summary>
+        /// Standard_E64-16s_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416sV5 = "Standard_E64-16s_v5";
+
+        /// <summary>
+        /// Standard_E64-32s_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432sV5 = "Standard_E64-32s_v5";
+
+        /// <summary>
+        /// Standard_E64s_v5 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64sV5 = "Standard_E64s_v5";
+
+        /// <summary>
+        /// Standard_E8-2s_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82sV5 = "Standard_E8-2s_v5";
+
+        /// <summary>
+        /// Standard_E8-4s_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84sV5 = "Standard_E8-4s_v5";
+
+        /// <summary>
+        /// Standard_E8s_v5 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8sV5 = "Standard_E8s_v5";
+
+        /// <summary>
+        /// Standard_E96-24s_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624sV5 = "Standard_E96-24s_v5";
+
+        /// <summary>
+        /// Standard_E96-48s_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648sV5 = "Standard_E96-48s_v5";
+
+        /// <summary>
+        /// Standard_E96s_v5 — 96 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96sV5 = "Standard_E96s_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardEsv6Family.
+    /// </summary>
+    public static class StandardEsv6
+    {
+        /// <summary>
+        /// Standard_E128-32s_v6 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE12832sV6 = "Standard_E128-32s_v6";
+
+        /// <summary>
+        /// Standard_E128-64s_v6 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE12864sV6 = "Standard_E128-64s_v6";
+
+        /// <summary>
+        /// Standard_E128s_v6 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE128sV6 = "Standard_E128s_v6";
+
+        /// <summary>
+        /// Standard_E16-4s_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE164sV6 = "Standard_E16-4s_v6";
+
+        /// <summary>
+        /// Standard_E16-8s_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE168sV6 = "Standard_E16-8s_v6";
+
+        /// <summary>
+        /// Standard_E16s_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE16sV6 = "Standard_E16s_v6";
+
+        /// <summary>
+        /// Standard_E192is_v6 — 192 vCPUs — 1832 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE192isV6 = "Standard_E192is_v6";
+
+        /// <summary>
+        /// Standard_E20s_v6 — 20 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE20sV6 = "Standard_E20s_v6";
+
+        /// <summary>
+        /// Standard_E2s_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE2sV6 = "Standard_E2s_v6";
+
+        /// <summary>
+        /// Standard_E32-16s_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE3216sV6 = "Standard_E32-16s_v6";
+
+        /// <summary>
+        /// Standard_E32-8s_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE328sV6 = "Standard_E32-8s_v6";
+
+        /// <summary>
+        /// Standard_E32s_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE32sV6 = "Standard_E32s_v6";
+
+        /// <summary>
+        /// Standard_E4-2s_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE42sV6 = "Standard_E4-2s_v6";
+
+        /// <summary>
+        /// Standard_E48s_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE48sV6 = "Standard_E48s_v6";
+
+        /// <summary>
+        /// Standard_E4s_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE4sV6 = "Standard_E4s_v6";
+
+        /// <summary>
+        /// Standard_E64-16s_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6416sV6 = "Standard_E64-16s_v6";
+
+        /// <summary>
+        /// Standard_E64-32s_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE6432sV6 = "Standard_E64-32s_v6";
+
+        /// <summary>
+        /// Standard_E64s_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE64sV6 = "Standard_E64s_v6";
+
+        /// <summary>
+        /// Standard_E8-2s_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE82sV6 = "Standard_E8-2s_v6";
+
+        /// <summary>
+        /// Standard_E8-4s_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE84sV6 = "Standard_E8-4s_v6";
+
+        /// <summary>
+        /// Standard_E8s_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE8sV6 = "Standard_E8s_v6";
+
+        /// <summary>
+        /// Standard_E96-24s_v6 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9624sV6 = "Standard_E96-24s_v6";
+
+        /// <summary>
+        /// Standard_E96-48s_v6 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE9648sV6 = "Standard_E96-48s_v6";
+
+        /// <summary>
+        /// Standard_E96s_v6 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE96sV6 = "Standard_E96s_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEv3Family.
+    /// </summary>
+    public static class StandardEv3
+    {
+        /// <summary>
+        /// Standard_E16_v3 — 16 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardE16V3 = "Standard_E16_v3";
+
+        /// <summary>
+        /// Standard_E20_v3 — 20 vCPUs — 160 GB RAM
+        /// </summary>
+        public const string StandardE20V3 = "Standard_E20_v3";
+
+        /// <summary>
+        /// Standard_E2_v3 — 2 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardE2V3 = "Standard_E2_v3";
+
+        /// <summary>
+        /// Standard_E32_v3 — 32 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardE32V3 = "Standard_E32_v3";
+
+        /// <summary>
+        /// Standard_E48_v3 — 48 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardE48V3 = "Standard_E48_v3";
+
+        /// <summary>
+        /// Standard_E4_v3 — 4 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardE4V3 = "Standard_E4_v3";
+
+        /// <summary>
+        /// Standard_E64_v3 — 64 vCPUs — 432 GB RAM
+        /// </summary>
+        public const string StandardE64V3 = "Standard_E64_v3";
+
+        /// <summary>
+        /// Standard_E8_v3 — 8 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardE8V3 = "Standard_E8_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEv4Family.
+    /// </summary>
+    public static class StandardEv4
+    {
+        /// <summary>
+        /// Standard_E16_v4 — 16 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardE16V4 = "Standard_E16_v4";
+
+        /// <summary>
+        /// Standard_E20_v4 — 20 vCPUs — 160 GB RAM
+        /// </summary>
+        public const string StandardE20V4 = "Standard_E20_v4";
+
+        /// <summary>
+        /// Standard_E2_v4 — 2 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardE2V4 = "Standard_E2_v4";
+
+        /// <summary>
+        /// Standard_E32_v4 — 32 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardE32V4 = "Standard_E32_v4";
+
+        /// <summary>
+        /// Standard_E48_v4 — 48 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardE48V4 = "Standard_E48_v4";
+
+        /// <summary>
+        /// Standard_E4_v4 — 4 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardE4V4 = "Standard_E4_v4";
+
+        /// <summary>
+        /// Standard_E64_v4 — 64 vCPUs — 504 GB RAM
+        /// </summary>
+        public const string StandardE64V4 = "Standard_E64_v4";
+
+        /// <summary>
+        /// Standard_E8_v4 — 8 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardE8V4 = "Standard_E8_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardEv5Family.
+    /// </summary>
+    public static class StandardEv5
+    {
+        /// <summary>
+        /// Standard_E16_v5 — 16 vCPUs — 128 GB RAM
+        /// </summary>
+        public const string StandardE16V5 = "Standard_E16_v5";
+
+        /// <summary>
+        /// Standard_E20_v5 — 20 vCPUs — 160 GB RAM
+        /// </summary>
+        public const string StandardE20V5 = "Standard_E20_v5";
+
+        /// <summary>
+        /// Standard_E2_v5 — 2 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardE2V5 = "Standard_E2_v5";
+
+        /// <summary>
+        /// Standard_E32_v5 — 32 vCPUs — 256 GB RAM
+        /// </summary>
+        public const string StandardE32V5 = "Standard_E32_v5";
+
+        /// <summary>
+        /// Standard_E48_v5 — 48 vCPUs — 384 GB RAM
+        /// </summary>
+        public const string StandardE48V5 = "Standard_E48_v5";
+
+        /// <summary>
+        /// Standard_E4_v5 — 4 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardE4V5 = "Standard_E4_v5";
+
+        /// <summary>
+        /// Standard_E64_v5 — 64 vCPUs — 512 GB RAM
+        /// </summary>
+        public const string StandardE64V5 = "Standard_E64_v5";
+
+        /// <summary>
+        /// Standard_E8_v5 — 8 vCPUs — 64 GB RAM
+        /// </summary>
+        public const string StandardE8V5 = "Standard_E8_v5";
+
+        /// <summary>
+        /// Standard_E96_v5 — 96 vCPUs — 672 GB RAM
+        /// </summary>
+        public const string StandardE96V5 = "Standard_E96_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFadsv7Family.
+    /// </summary>
+    public static class StandardFadsv7
+    {
+        /// <summary>
+        /// Standard_F16ads_v7 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16adsV7 = "Standard_F16ads_v7";
+
+        /// <summary>
+        /// Standard_F2ads_v7 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2adsV7 = "Standard_F2ads_v7";
+
+        /// <summary>
+        /// Standard_F32ads_v7 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32adsV7 = "Standard_F32ads_v7";
+
+        /// <summary>
+        /// Standard_F48ads_v7 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48adsV7 = "Standard_F48ads_v7";
+
+        /// <summary>
+        /// Standard_F4ads_v7 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4adsV7 = "Standard_F4ads_v7";
+
+        /// <summary>
+        /// Standard_F64ads_v7 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64adsV7 = "Standard_F64ads_v7";
+
+        /// <summary>
+        /// Standard_F80ads_v7 — 80 vCPUs — 320 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF80adsV7 = "Standard_F80ads_v7";
+
+        /// <summary>
+        /// Standard_F8ads_v7 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8adsV7 = "Standard_F8ads_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFaldsv7Family.
+    /// </summary>
+    public static class StandardFaldsv7
+    {
+        /// <summary>
+        /// Standard_F16alds_v7 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16aldsV7 = "Standard_F16alds_v7";
+
+        /// <summary>
+        /// Standard_F2alds_v7 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2aldsV7 = "Standard_F2alds_v7";
+
+        /// <summary>
+        /// Standard_F32alds_v7 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32aldsV7 = "Standard_F32alds_v7";
+
+        /// <summary>
+        /// Standard_F48alds_v7 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48aldsV7 = "Standard_F48alds_v7";
+
+        /// <summary>
+        /// Standard_F4alds_v7 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4aldsV7 = "Standard_F4alds_v7";
+
+        /// <summary>
+        /// Standard_F64alds_v7 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64aldsV7 = "Standard_F64alds_v7";
+
+        /// <summary>
+        /// Standard_F80alds_v7 — 80 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF80aldsV7 = "Standard_F80alds_v7";
+
+        /// <summary>
+        /// Standard_F8alds_v7 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8aldsV7 = "Standard_F8alds_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFalsv6Family.
+    /// </summary>
+    public static class StandardFalsv6
+    {
+        /// <summary>
+        /// Standard_F16als_v6 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16alsV6 = "Standard_F16als_v6";
+
+        /// <summary>
+        /// Standard_F2als_v6 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2alsV6 = "Standard_F2als_v6";
+
+        /// <summary>
+        /// Standard_F32als_v6 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32alsV6 = "Standard_F32als_v6";
+
+        /// <summary>
+        /// Standard_F48als_v6 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48alsV6 = "Standard_F48als_v6";
+
+        /// <summary>
+        /// Standard_F4als_v6 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4alsV6 = "Standard_F4als_v6";
+
+        /// <summary>
+        /// Standard_F64als_v6 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64alsV6 = "Standard_F64als_v6";
+
+        /// <summary>
+        /// Standard_F8als_v6 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8alsV6 = "Standard_F8als_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFalsv7Family.
+    /// </summary>
+    public static class StandardFalsv7
+    {
+        /// <summary>
+        /// Standard_F16als_v7 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16alsV7 = "Standard_F16als_v7";
+
+        /// <summary>
+        /// Standard_F2als_v7 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2alsV7 = "Standard_F2als_v7";
+
+        /// <summary>
+        /// Standard_F32als_v7 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32alsV7 = "Standard_F32als_v7";
+
+        /// <summary>
+        /// Standard_F48als_v7 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48alsV7 = "Standard_F48als_v7";
+
+        /// <summary>
+        /// Standard_F4als_v7 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4alsV7 = "Standard_F4als_v7";
+
+        /// <summary>
+        /// Standard_F64als_v7 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64alsV7 = "Standard_F64als_v7";
+
+        /// <summary>
+        /// Standard_F80als_v7 — 80 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF80alsV7 = "Standard_F80als_v7";
+
+        /// <summary>
+        /// Standard_F8als_v7 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8alsV7 = "Standard_F8als_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFamdsv7Family.
+    /// </summary>
+    public static class StandardFamdsv7
+    {
+        /// <summary>
+        /// Standard_F16-4amds_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF164amdsV7 = "Standard_F16-4amds_v7";
+
+        /// <summary>
+        /// Standard_F16-8amds_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF168amdsV7 = "Standard_F16-8amds_v7";
+
+        /// <summary>
+        /// Standard_F16amds_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16amdsV7 = "Standard_F16amds_v7";
+
+        /// <summary>
+        /// Standard_F2-1amds_v7 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF21amdsV7 = "Standard_F2-1amds_v7";
+
+        /// <summary>
+        /// Standard_F2amds_v7 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2amdsV7 = "Standard_F2amds_v7";
+
+        /// <summary>
+        /// Standard_F32-16amds_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF3216amdsV7 = "Standard_F32-16amds_v7";
+
+        /// <summary>
+        /// Standard_F32-8amds_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF328amdsV7 = "Standard_F32-8amds_v7";
+
+        /// <summary>
+        /// Standard_F32amds_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32amdsV7 = "Standard_F32amds_v7";
+
+        /// <summary>
+        /// Standard_F4-1amds_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF41amdsV7 = "Standard_F4-1amds_v7";
+
+        /// <summary>
+        /// Standard_F4-2amds_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF42amdsV7 = "Standard_F4-2amds_v7";
+
+        /// <summary>
+        /// Standard_F48amds_v7 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48amdsV7 = "Standard_F48amds_v7";
+
+        /// <summary>
+        /// Standard_F4amds_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4amdsV7 = "Standard_F4amds_v7";
+
+        /// <summary>
+        /// Standard_F64-16amds_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF6416amdsV7 = "Standard_F64-16amds_v7";
+
+        /// <summary>
+        /// Standard_F64-32amds_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF6432amdsV7 = "Standard_F64-32amds_v7";
+
+        /// <summary>
+        /// Standard_F64amds_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64amdsV7 = "Standard_F64amds_v7";
+
+        /// <summary>
+        /// Standard_F8-2amds_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF82amdsV7 = "Standard_F8-2amds_v7";
+
+        /// <summary>
+        /// Standard_F8-4amds_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF84amdsV7 = "Standard_F8-4amds_v7";
+
+        /// <summary>
+        /// Standard_F80amds_v7 — 80 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF80amdsV7 = "Standard_F80amds_v7";
+
+        /// <summary>
+        /// Standard_F8amds_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8amdsV7 = "Standard_F8amds_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFamsv6Family.
+    /// </summary>
+    public static class StandardFamsv6
+    {
+        /// <summary>
+        /// Standard_F16ams_v6 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16amsV6 = "Standard_F16ams_v6";
+
+        /// <summary>
+        /// Standard_F2ams_v6 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2amsV6 = "Standard_F2ams_v6";
+
+        /// <summary>
+        /// Standard_F32ams_v6 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32amsV6 = "Standard_F32ams_v6";
+
+        /// <summary>
+        /// Standard_F48ams_v6 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48amsV6 = "Standard_F48ams_v6";
+
+        /// <summary>
+        /// Standard_F4ams_v6 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4amsV6 = "Standard_F4ams_v6";
+
+        /// <summary>
+        /// Standard_F64ams_v6 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64amsV6 = "Standard_F64ams_v6";
+
+        /// <summary>
+        /// Standard_F8ams_v6 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8amsV6 = "Standard_F8ams_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFamsv7Family.
+    /// </summary>
+    public static class StandardFamsv7
+    {
+        /// <summary>
+        /// Standard_F16-4ams_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF164amsV7 = "Standard_F16-4ams_v7";
+
+        /// <summary>
+        /// Standard_F16-8ams_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF168amsV7 = "Standard_F16-8ams_v7";
+
+        /// <summary>
+        /// Standard_F16ams_v7 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16amsV7 = "Standard_F16ams_v7";
+
+        /// <summary>
+        /// Standard_F2-1ams_v7 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF21amsV7 = "Standard_F2-1ams_v7";
+
+        /// <summary>
+        /// Standard_F2ams_v7 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2amsV7 = "Standard_F2ams_v7";
+
+        /// <summary>
+        /// Standard_F32-16ams_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF3216amsV7 = "Standard_F32-16ams_v7";
+
+        /// <summary>
+        /// Standard_F32-8ams_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF328amsV7 = "Standard_F32-8ams_v7";
+
+        /// <summary>
+        /// Standard_F32ams_v7 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32amsV7 = "Standard_F32ams_v7";
+
+        /// <summary>
+        /// Standard_F4-1ams_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF41amsV7 = "Standard_F4-1ams_v7";
+
+        /// <summary>
+        /// Standard_F4-2ams_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF42amsV7 = "Standard_F4-2ams_v7";
+
+        /// <summary>
+        /// Standard_F48ams_v7 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48amsV7 = "Standard_F48ams_v7";
+
+        /// <summary>
+        /// Standard_F4ams_v7 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4amsV7 = "Standard_F4ams_v7";
+
+        /// <summary>
+        /// Standard_F64-16ams_v7 — 80 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF6416amsV7 = "Standard_F64-16ams_v7";
+
+        /// <summary>
+        /// Standard_F64-32ams_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF6432amsV7 = "Standard_F64-32ams_v7";
+
+        /// <summary>
+        /// Standard_F64ams_v7 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64amsV7 = "Standard_F64ams_v7";
+
+        /// <summary>
+        /// Standard_F8-2ams_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF82amsV7 = "Standard_F8-2ams_v7";
+
+        /// <summary>
+        /// Standard_F8-4ams_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF84amsV7 = "Standard_F8-4ams_v7";
+
+        /// <summary>
+        /// Standard_F80ams_v7 — 80 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF80amsV7 = "Standard_F80ams_v7";
+
+        /// <summary>
+        /// Standard_F8ams_v7 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8amsV7 = "Standard_F8ams_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFasv6Family.
+    /// </summary>
+    public static class StandardFasv6
+    {
+        /// <summary>
+        /// Standard_F16as_v6 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16asV6 = "Standard_F16as_v6";
+
+        /// <summary>
+        /// Standard_F2as_v6 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2asV6 = "Standard_F2as_v6";
+
+        /// <summary>
+        /// Standard_F32as_v6 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32asV6 = "Standard_F32as_v6";
+
+        /// <summary>
+        /// Standard_F48as_v6 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48asV6 = "Standard_F48as_v6";
+
+        /// <summary>
+        /// Standard_F4as_v6 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4asV6 = "Standard_F4as_v6";
+
+        /// <summary>
+        /// Standard_F64as_v6 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64asV6 = "Standard_F64as_v6";
+
+        /// <summary>
+        /// Standard_F8as_v6 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8asV6 = "Standard_F8as_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFasv7Family.
+    /// </summary>
+    public static class StandardFasv7
+    {
+        /// <summary>
+        /// Standard_F16as_v7 — 16 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16asV7 = "Standard_F16as_v7";
+
+        /// <summary>
+        /// Standard_F2as_v7 — 2 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2asV7 = "Standard_F2as_v7";
+
+        /// <summary>
+        /// Standard_F32as_v7 — 32 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32asV7 = "Standard_F32as_v7";
+
+        /// <summary>
+        /// Standard_F48as_v7 — 48 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48asV7 = "Standard_F48as_v7";
+
+        /// <summary>
+        /// Standard_F4as_v7 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4asV7 = "Standard_F4as_v7";
+
+        /// <summary>
+        /// Standard_F64as_v7 — 64 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64asV7 = "Standard_F64as_v7";
+
+        /// <summary>
+        /// Standard_F80as_v7 — 80 vCPUs — 320 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF80asV7 = "Standard_F80as_v7";
+
+        /// <summary>
+        /// Standard_F8as_v7 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8asV7 = "Standard_F8as_v7";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardFFamily.
+    /// </summary>
+    public static class StandardF
+    {
+        /// <summary>
+        /// Standard_F16 — 16 vCPUs — 32 GB RAM
+        /// </summary>
+        public const string StandardF16 = "Standard_F16";
+
+        /// <summary>
+        /// Standard_F2 — 2 vCPUs — 4 GB RAM
+        /// </summary>
+        public const string StandardF2 = "Standard_F2";
+
+        /// <summary>
+        /// Standard_F4 — 4 vCPUs — 8 GB RAM
+        /// </summary>
+        public const string StandardF4 = "Standard_F4";
+
+        /// <summary>
+        /// Standard_F8 — 8 vCPUs — 16 GB RAM
+        /// </summary>
+        public const string StandardF8 = "Standard_F8";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardFSFamily.
+    /// </summary>
+    public static class StandardFS
+    {
+        /// <summary>
+        /// Standard_F16s — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16s = "Standard_F16s";
+
+        /// <summary>
+        /// Standard_F2s — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2s = "Standard_F2s";
+
+        /// <summary>
+        /// Standard_F4s — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4s = "Standard_F4s";
+
+        /// <summary>
+        /// Standard_F8s — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8s = "Standard_F8s";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardFSv2Family.
+    /// </summary>
+    public static class StandardFSv2
+    {
+        /// <summary>
+        /// Standard_F16s_v2 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF16sV2 = "Standard_F16s_v2";
+
+        /// <summary>
+        /// Standard_F2s_v2 — 2 vCPUs — 4 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF2sV2 = "Standard_F2s_v2";
+
+        /// <summary>
+        /// Standard_F32s_v2 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF32sV2 = "Standard_F32s_v2";
+
+        /// <summary>
+        /// Standard_F48s_v2 — 48 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF48sV2 = "Standard_F48s_v2";
+
+        /// <summary>
+        /// Standard_F4s_v2 — 4 vCPUs — 8 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF4sV2 = "Standard_F4s_v2";
+
+        /// <summary>
+        /// Standard_F64s_v2 — 64 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF64sV2 = "Standard_F64s_v2";
+
+        /// <summary>
+        /// Standard_F72s_v2 — 72 vCPUs — 144 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF72sV2 = "Standard_F72s_v2";
+
+        /// <summary>
+        /// Standard_F8s_v2 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardF8sV2 = "Standard_F8s_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFXmdsv2Family.
+    /// </summary>
+    public static class StandardFXmdsv2
+    {
+        /// <summary>
+        /// Standard_FX12-6mds_v2 — 12 vCPUs — 252 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX126mdsV2 = "Standard_FX12-6mds_v2";
+
+        /// <summary>
+        /// Standard_FX12mds_v2 — 12 vCPUs — 252 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX12mdsV2 = "Standard_FX12mds_v2";
+
+        /// <summary>
+        /// Standard_FX16-4mds_v2 — 16 vCPUs — 336 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX164mdsV2 = "Standard_FX16-4mds_v2";
+
+        /// <summary>
+        /// Standard_FX16-8mds_v2 — 16 vCPUs — 336 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX168mdsV2 = "Standard_FX16-8mds_v2";
+
+        /// <summary>
+        /// Standard_FX16mds_v2 — 16 vCPUs — 336 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX16mdsV2 = "Standard_FX16mds_v2";
+
+        /// <summary>
+        /// Standard_FX24-12mds_v2 — 24 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX2412mdsV2 = "Standard_FX24-12mds_v2";
+
+        /// <summary>
+        /// Standard_FX24-6mds_v2 — 24 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX246mdsV2 = "Standard_FX24-6mds_v2";
+
+        /// <summary>
+        /// Standard_FX24mds_v2 — 24 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX24mdsV2 = "Standard_FX24mds_v2";
+
+        /// <summary>
+        /// Standard_FX2mds_v2 — 2 vCPUs — 42 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX2mdsV2 = "Standard_FX2mds_v2";
+
+        /// <summary>
+        /// Standard_FX32-16mds_v2 — 32 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX3216mdsV2 = "Standard_FX32-16mds_v2";
+
+        /// <summary>
+        /// Standard_FX32-8mds_v2 — 32 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX328mdsV2 = "Standard_FX32-8mds_v2";
+
+        /// <summary>
+        /// Standard_FX32mds_v2 — 32 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX32mdsV2 = "Standard_FX32mds_v2";
+
+        /// <summary>
+        /// Standard_FX4-2mds_v2 — 4 vCPUs — 84 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX42mdsV2 = "Standard_FX4-2mds_v2";
+
+        /// <summary>
+        /// Standard_FX48-12mds_v2 — 48 vCPUs — 1008 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX4812mdsV2 = "Standard_FX48-12mds_v2";
+
+        /// <summary>
+        /// Standard_FX48-24mds_v2 — 48 vCPUs — 1008 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX4824mdsV2 = "Standard_FX48-24mds_v2";
+
+        /// <summary>
+        /// Standard_FX48mds_v2 — 48 vCPUs — 1008 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX48mdsV2 = "Standard_FX48mds_v2";
+
+        /// <summary>
+        /// Standard_FX4mds_v2 — 4 vCPUs — 84 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX4mdsV2 = "Standard_FX4mds_v2";
+
+        /// <summary>
+        /// Standard_FX64-16mds_v2 — 64 vCPUs — 1344 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX6416mdsV2 = "Standard_FX64-16mds_v2";
+
+        /// <summary>
+        /// Standard_FX64-32mds_v2 — 64 vCPUs — 1344 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX6432mdsV2 = "Standard_FX64-32mds_v2";
+
+        /// <summary>
+        /// Standard_FX64mds_v2 — 64 vCPUs — 1344 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX64mdsV2 = "Standard_FX64mds_v2";
+
+        /// <summary>
+        /// Standard_FX8-2mds_v2 — 8 vCPUs — 168 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX82mdsV2 = "Standard_FX8-2mds_v2";
+
+        /// <summary>
+        /// Standard_FX8-4mds_v2 — 8 vCPUs — 168 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX84mdsV2 = "Standard_FX8-4mds_v2";
+
+        /// <summary>
+        /// Standard_FX8mds_v2 — 8 vCPUs — 168 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX8mdsV2 = "Standard_FX8mds_v2";
+
+        /// <summary>
+        /// Standard_FX96-24mds_v2 — 96 vCPUs — 1832 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX9624mdsV2 = "Standard_FX96-24mds_v2";
+
+        /// <summary>
+        /// Standard_FX96-48mds_v2 — 96 vCPUs — 1832 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX9648mdsV2 = "Standard_FX96-48mds_v2";
+
+        /// <summary>
+        /// Standard_FX96mds_v2 — 96 vCPUs — 1832 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX96mdsV2 = "Standard_FX96mds_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardFXMDVSFamily.
+    /// </summary>
+    public static class StandardFXMDVS
+    {
+        /// <summary>
+        /// Standard_FX12mds — 12 vCPUs — 252 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX12mds = "Standard_FX12mds";
+
+        /// <summary>
+        /// Standard_FX24mds — 24 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX24mds = "Standard_FX24mds";
+
+        /// <summary>
+        /// Standard_FX36mds — 36 vCPUs — 756 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX36mds = "Standard_FX36mds";
+
+        /// <summary>
+        /// Standard_FX48mds — 48 vCPUs — 1008 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX48mds = "Standard_FX48mds";
+
+        /// <summary>
+        /// Standard_FX4mds — 4 vCPUs — 84 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX4mds = "Standard_FX4mds";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardFXmsv2Family.
+    /// </summary>
+    public static class StandardFXmsv2
+    {
+        /// <summary>
+        /// Standard_FX12-6ms_v2 — 12 vCPUs — 252 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX126msV2 = "Standard_FX12-6ms_v2";
+
+        /// <summary>
+        /// Standard_FX12ms_v2 — 12 vCPUs — 252 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX12msV2 = "Standard_FX12ms_v2";
+
+        /// <summary>
+        /// Standard_FX16-4ms_v2 — 16 vCPUs — 336 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX164msV2 = "Standard_FX16-4ms_v2";
+
+        /// <summary>
+        /// Standard_FX16-8ms_v2 — 16 vCPUs — 336 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX168msV2 = "Standard_FX16-8ms_v2";
+
+        /// <summary>
+        /// Standard_FX16ms_v2 — 16 vCPUs — 336 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX16msV2 = "Standard_FX16ms_v2";
+
+        /// <summary>
+        /// Standard_FX24-12ms_v2 — 24 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX2412msV2 = "Standard_FX24-12ms_v2";
+
+        /// <summary>
+        /// Standard_FX24-6ms_v2 — 24 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX246msV2 = "Standard_FX24-6ms_v2";
+
+        /// <summary>
+        /// Standard_FX24ms_v2 — 24 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX24msV2 = "Standard_FX24ms_v2";
+
+        /// <summary>
+        /// Standard_FX2ms_v2 — 2 vCPUs — 42 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX2msV2 = "Standard_FX2ms_v2";
+
+        /// <summary>
+        /// Standard_FX32-16ms_v2 — 32 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX3216msV2 = "Standard_FX32-16ms_v2";
+
+        /// <summary>
+        /// Standard_FX32-8ms_v2 — 32 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX328msV2 = "Standard_FX32-8ms_v2";
+
+        /// <summary>
+        /// Standard_FX32ms_v2 — 32 vCPUs — 672 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX32msV2 = "Standard_FX32ms_v2";
+
+        /// <summary>
+        /// Standard_FX4-2ms_v2 — 4 vCPUs — 84 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX42msV2 = "Standard_FX4-2ms_v2";
+
+        /// <summary>
+        /// Standard_FX48-12ms_v2 — 48 vCPUs — 1008 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX4812msV2 = "Standard_FX48-12ms_v2";
+
+        /// <summary>
+        /// Standard_FX48-24ms_v2 — 48 vCPUs — 1008 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX4824msV2 = "Standard_FX48-24ms_v2";
+
+        /// <summary>
+        /// Standard_FX48ms_v2 — 48 vCPUs — 1008 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX48msV2 = "Standard_FX48ms_v2";
+
+        /// <summary>
+        /// Standard_FX4ms_v2 — 4 vCPUs — 84 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX4msV2 = "Standard_FX4ms_v2";
+
+        /// <summary>
+        /// Standard_FX64-16ms_v2 — 64 vCPUs — 1344 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX6416msV2 = "Standard_FX64-16ms_v2";
+
+        /// <summary>
+        /// Standard_FX64-32ms_v2 — 64 vCPUs — 1344 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX6432msV2 = "Standard_FX64-32ms_v2";
+
+        /// <summary>
+        /// Standard_FX64ms_v2 — 64 vCPUs — 1344 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX64msV2 = "Standard_FX64ms_v2";
+
+        /// <summary>
+        /// Standard_FX8-2ms_v2 — 8 vCPUs — 168 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX82msV2 = "Standard_FX8-2ms_v2";
+
+        /// <summary>
+        /// Standard_FX8-4ms_v2 — 8 vCPUs — 168 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX84msV2 = "Standard_FX8-4ms_v2";
+
+        /// <summary>
+        /// Standard_FX8ms_v2 — 8 vCPUs — 168 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX8msV2 = "Standard_FX8ms_v2";
+
+        /// <summary>
+        /// Standard_FX96-24ms_v2 — 96 vCPUs — 1832 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX9624msV2 = "Standard_FX96-24ms_v2";
+
+        /// <summary>
+        /// Standard_FX96-48ms_v2 — 96 vCPUs — 1832 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX9648msV2 = "Standard_FX96-48ms_v2";
+
+        /// <summary>
+        /// Standard_FX96ms_v2 — 96 vCPUs — 1832 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardFX96msV2 = "Standard_FX96ms_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardGFamily.
+    /// </summary>
+    public static class StandardG
+    {
+        /// <summary>
+        /// Standard_G1 — 2 vCPUs — 28 GB RAM
+        /// </summary>
+        public const string StandardG1 = "Standard_G1";
+
+        /// <summary>
+        /// Standard_G2 — 4 vCPUs — 56 GB RAM
+        /// </summary>
+        public const string StandardG2 = "Standard_G2";
+
+        /// <summary>
+        /// Standard_G3 — 8 vCPUs — 112 GB RAM
+        /// </summary>
+        public const string StandardG3 = "Standard_G3";
+
+        /// <summary>
+        /// Standard_G4 — 16 vCPUs — 224 GB RAM
+        /// </summary>
+        public const string StandardG4 = "Standard_G4";
+
+        /// <summary>
+        /// Standard_G5 — 32 vCPUs — 448 GB RAM
+        /// </summary>
+        public const string StandardG5 = "Standard_G5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardGSFamily.
+    /// </summary>
+    public static class StandardGS
+    {
+        /// <summary>
+        /// Standard_GS1 — 2 vCPUs — 28 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS1 = "Standard_GS1";
+
+        /// <summary>
+        /// Standard_GS2 — 4 vCPUs — 56 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS2 = "Standard_GS2";
+
+        /// <summary>
+        /// Standard_GS3 — 8 vCPUs — 112 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS3 = "Standard_GS3";
+
+        /// <summary>
+        /// Standard_GS4 — 16 vCPUs — 224 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS4 = "Standard_GS4";
+
+        /// <summary>
+        /// Standard_GS4-4 — 16 vCPUs — 224 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS44 = "Standard_GS4-4";
+
+        /// <summary>
+        /// Standard_GS4-8 — 16 vCPUs — 224 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS48 = "Standard_GS4-8";
+
+        /// <summary>
+        /// Standard_GS5 — 32 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS5 = "Standard_GS5";
+
+        /// <summary>
+        /// Standard_GS5-16 — 32 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS516 = "Standard_GS5-16";
+
+        /// <summary>
+        /// Standard_GS5-8 — 32 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardGS58 = "Standard_GS5-8";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardHBrsv2Family.
+    /// </summary>
+    public static class StandardHBrsv2
+    {
+        /// <summary>
+        /// Standard_HB120-16rs_v2 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB12016rsV2 = "Standard_HB120-16rs_v2";
+
+        /// <summary>
+        /// Standard_HB120-32rs_v2 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB12032rsV2 = "Standard_HB120-32rs_v2";
+
+        /// <summary>
+        /// Standard_HB120-64rs_v2 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB12064rsV2 = "Standard_HB120-64rs_v2";
+
+        /// <summary>
+        /// Standard_HB120-96rs_v2 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB12096rsV2 = "Standard_HB120-96rs_v2";
+
+        /// <summary>
+        /// Standard_HB120rs_v2 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB120rsV2 = "Standard_HB120rs_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardHBv3Family.
+    /// </summary>
+    public static class StandardHBv3
+    {
+        /// <summary>
+        /// Standard_HB120-16rs_v3 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB12016rsV3 = "Standard_HB120-16rs_v3";
+
+        /// <summary>
+        /// Standard_HB120-32rs_v3 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB12032rsV3 = "Standard_HB120-32rs_v3";
+
+        /// <summary>
+        /// Standard_HB120-64rs_v3 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB12064rsV3 = "Standard_HB120-64rs_v3";
+
+        /// <summary>
+        /// Standard_HB120-96rs_v3 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB12096rsV3 = "Standard_HB120-96rs_v3";
+
+        /// <summary>
+        /// Standard_HB120rs_v3 — 120 vCPUs — 456 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB120rsV3 = "Standard_HB120rs_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardHBv4Family.
+    /// </summary>
+    public static class StandardHBv4
+    {
+        /// <summary>
+        /// Standard_HB176-144rs_v4 — 176 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB176144rsV4 = "Standard_HB176-144rs_v4";
+
+        /// <summary>
+        /// Standard_HB176-24rs_v4 — 176 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB17624rsV4 = "Standard_HB176-24rs_v4";
+
+        /// <summary>
+        /// Standard_HB176-48rs_v4 — 176 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB17648rsV4 = "Standard_HB176-48rs_v4";
+
+        /// <summary>
+        /// Standard_HB176-96rs_v4 — 176 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB17696rsV4 = "Standard_HB176-96rs_v4";
+
+        /// <summary>
+        /// Standard_HB176rs_v4 — 176 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB176rsV4 = "Standard_HB176rs_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardHBv5Family.
+    /// </summary>
+    public static class StandardHBv5
+    {
+        /// <summary>
+        /// Standard_HB368-144rs_v5 — 368 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB368144rsV5 = "Standard_HB368-144rs_v5";
+
+        /// <summary>
+        /// Standard_HB368-192rs_v5 — 368 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB368192rsV5 = "Standard_HB368-192rs_v5";
+
+        /// <summary>
+        /// Standard_HB368-240rs_v5 — 368 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB368240rsV5 = "Standard_HB368-240rs_v5";
+
+        /// <summary>
+        /// Standard_HB368-288rs_v5 — 368 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB368288rsV5 = "Standard_HB368-288rs_v5";
+
+        /// <summary>
+        /// Standard_HB368-336rs_v5 — 368 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB368336rsV5 = "Standard_HB368-336rs_v5";
+
+        /// <summary>
+        /// Standard_HB368-48rs_v5 — 368 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB36848rsV5 = "Standard_HB368-48rs_v5";
+
+        /// <summary>
+        /// Standard_HB368-96rs_v5 — 368 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB36896rsV5 = "Standard_HB368-96rs_v5";
+
+        /// <summary>
+        /// Standard_HB368rs_v5 — 368 vCPUs — 448 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHB368rsV5 = "Standard_HB368rs_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardHCSFamily.
+    /// </summary>
+    public static class StandardHCS
+    {
+        /// <summary>
+        /// Standard_HC44-16rs — 44 vCPUs — 352 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHC4416rs = "Standard_HC44-16rs";
+
+        /// <summary>
+        /// Standard_HC44-32rs — 44 vCPUs — 352 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHC4432rs = "Standard_HC44-32rs";
+
+        /// <summary>
+        /// Standard_HC44rs — 44 vCPUs — 352 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHC44rs = "Standard_HC44rs";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardHXFamily.
+    /// </summary>
+    public static class StandardHX
+    {
+        /// <summary>
+        /// Standard_HX176-144rs — 176 vCPUs — 1408 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHX176144rs = "Standard_HX176-144rs";
+
+        /// <summary>
+        /// Standard_HX176-24rs — 176 vCPUs — 1408 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHX17624rs = "Standard_HX176-24rs";
+
+        /// <summary>
+        /// Standard_HX176-48rs — 176 vCPUs — 1408 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHX17648rs = "Standard_HX176-48rs";
+
+        /// <summary>
+        /// Standard_HX176-96rs — 176 vCPUs — 1408 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHX17696rs = "Standard_HX176-96rs";
+
+        /// <summary>
+        /// Standard_HX176rs — 176 vCPUs — 1408 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardHX176rs = "Standard_HX176rs";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardLaosv4Family.
+    /// </summary>
+    public static class StandardLaosv4
+    {
+        /// <summary>
+        /// Standard_L12aos_v4 — 12 vCPUs — 96 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL12aosV4 = "Standard_L12aos_v4";
+
+        /// <summary>
+        /// Standard_L16aos_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL16aosV4 = "Standard_L16aos_v4";
+
+        /// <summary>
+        /// Standard_L24aos_v4 — 24 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL24aosV4 = "Standard_L24aos_v4";
+
+        /// <summary>
+        /// Standard_L2aos_v4 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL2aosV4 = "Standard_L2aos_v4";
+
+        /// <summary>
+        /// Standard_L32aos_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL32aosV4 = "Standard_L32aos_v4";
+
+        /// <summary>
+        /// Standard_L4aos_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL4aosV4 = "Standard_L4aos_v4";
+
+        /// <summary>
+        /// Standard_L8aos_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL8aosV4 = "Standard_L8aos_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardLASv3Family.
+    /// </summary>
+    public static class StandardLASv3
+    {
+        /// <summary>
+        /// Standard_L16as_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL16asV3 = "Standard_L16as_v3";
+
+        /// <summary>
+        /// Standard_L32as_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL32asV3 = "Standard_L32as_v3";
+
+        /// <summary>
+        /// Standard_L48as_v3 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL48asV3 = "Standard_L48as_v3";
+
+        /// <summary>
+        /// Standard_L64as_v3 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL64asV3 = "Standard_L64as_v3";
+
+        /// <summary>
+        /// Standard_L80as_v3 — 80 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL80asV3 = "Standard_L80as_v3";
+
+        /// <summary>
+        /// Standard_L8as_v3 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL8asV3 = "Standard_L8as_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardLasv4Family.
+    /// </summary>
+    public static class StandardLasv4
+    {
+        /// <summary>
+        /// Standard_L16as_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL16asV4 = "Standard_L16as_v4";
+
+        /// <summary>
+        /// Standard_L2as_v4 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL2asV4 = "Standard_L2as_v4";
+
+        /// <summary>
+        /// Standard_L32as_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL32asV4 = "Standard_L32as_v4";
+
+        /// <summary>
+        /// Standard_L48as_v4 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL48asV4 = "Standard_L48as_v4";
+
+        /// <summary>
+        /// Standard_L4as_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL4asV4 = "Standard_L4as_v4";
+
+        /// <summary>
+        /// Standard_L64as_v4 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL64asV4 = "Standard_L64as_v4";
+
+        /// <summary>
+        /// Standard_L80as_v4 — 80 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL80asV4 = "Standard_L80as_v4";
+
+        /// <summary>
+        /// Standard_L8as_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL8asV4 = "Standard_L8as_v4";
+
+        /// <summary>
+        /// Standard_L96as_v4 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL96asV4 = "Standard_L96as_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardLSFamily.
+    /// </summary>
+    public static class StandardLS
+    {
+        /// <summary>
+        /// Standard_L16s — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL16s = "Standard_L16s";
+
+        /// <summary>
+        /// Standard_L32s — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL32s = "Standard_L32s";
+
+        /// <summary>
+        /// Standard_L4s — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL4s = "Standard_L4s";
+
+        /// <summary>
+        /// Standard_L8s — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL8s = "Standard_L8s";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardLSv2Family.
+    /// </summary>
+    public static class StandardLSv2
+    {
+        /// <summary>
+        /// Standard_L16s_v2 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL16sV2 = "Standard_L16s_v2";
+
+        /// <summary>
+        /// Standard_L32s_v2 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL32sV2 = "Standard_L32s_v2";
+
+        /// <summary>
+        /// Standard_L48s_v2 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL48sV2 = "Standard_L48s_v2";
+
+        /// <summary>
+        /// Standard_L64s_v2 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL64sV2 = "Standard_L64s_v2";
+
+        /// <summary>
+        /// Standard_L80s_v2 — 80 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL80sV2 = "Standard_L80s_v2";
+
+        /// <summary>
+        /// Standard_L8s_v2 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL8sV2 = "Standard_L8s_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardLSv3Family.
+    /// </summary>
+    public static class StandardLSv3
+    {
+        /// <summary>
+        /// Standard_L16s_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL16sV3 = "Standard_L16s_v3";
+
+        /// <summary>
+        /// Standard_L32s_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL32sV3 = "Standard_L32s_v3";
+
+        /// <summary>
+        /// Standard_L48s_v3 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL48sV3 = "Standard_L48s_v3";
+
+        /// <summary>
+        /// Standard_L64s_v3 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL64sV3 = "Standard_L64s_v3";
+
+        /// <summary>
+        /// Standard_L80s_v3 — 80 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL80sV3 = "Standard_L80s_v3";
+
+        /// <summary>
+        /// Standard_L8s_v3 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL8sV3 = "Standard_L8s_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardLsv4Family.
+    /// </summary>
+    public static class StandardLsv4
+    {
+        /// <summary>
+        /// Standard_L16s_v4 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL16sV4 = "Standard_L16s_v4";
+
+        /// <summary>
+        /// Standard_L2s_v4 — 2 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL2sV4 = "Standard_L2s_v4";
+
+        /// <summary>
+        /// Standard_L32s_v4 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL32sV4 = "Standard_L32s_v4";
+
+        /// <summary>
+        /// Standard_L48s_v4 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL48sV4 = "Standard_L48s_v4";
+
+        /// <summary>
+        /// Standard_L4s_v4 — 4 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL4sV4 = "Standard_L4s_v4";
+
+        /// <summary>
+        /// Standard_L64s_v4 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL64sV4 = "Standard_L64s_v4";
+
+        /// <summary>
+        /// Standard_L80s_v4 — 80 vCPUs — 640 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL80sV4 = "Standard_L80s_v4";
+
+        /// <summary>
+        /// Standard_L8s_v4 — 8 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL8sV4 = "Standard_L8s_v4";
+
+        /// <summary>
+        /// Standard_L96s_v4 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardL96sV4 = "Standard_L96s_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardMBDSMediumMemoryv3Family.
+    /// </summary>
+    public static class StandardMBDSMediumMemoryv3
+    {
+        /// <summary>
+        /// Standard_M128-64bds_3_v3 — 128 vCPUs — 2794 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM12864bds3V3 = "Standard_M128-64bds_3_v3";
+
+        /// <summary>
+        /// Standard_M128-64bds_v3 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM12864bdsV3 = "Standard_M128-64bds_v3";
+
+        /// <summary>
+        /// Standard_M128bds_3_v3 — 128 vCPUs — 2794 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128bds3V3 = "Standard_M128bds_3_v3";
+
+        /// <summary>
+        /// Standard_M128bds_v3 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128bdsV3 = "Standard_M128bds_v3";
+
+        /// <summary>
+        /// Standard_M16bds_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM16bdsV3 = "Standard_M16bds_v3";
+
+        /// <summary>
+        /// Standard_M176-88bds_4_v3 — 176 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM17688bds4V3 = "Standard_M176-88bds_4_v3";
+
+        /// <summary>
+        /// Standard_M176-88bds_v3 — 176 vCPUs — 1536 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM17688bdsV3 = "Standard_M176-88bds_v3";
+
+        /// <summary>
+        /// Standard_M176bds_4_v3 — 176 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM176bds4V3 = "Standard_M176bds_4_v3";
+
+        /// <summary>
+        /// Standard_M176bds_v3 — 176 vCPUs — 1536 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM176bdsV3 = "Standard_M176bds_v3";
+
+        /// <summary>
+        /// Standard_M32bds_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM32bdsV3 = "Standard_M32bds_v3";
+
+        /// <summary>
+        /// Standard_M48bds_v3 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM48bdsV3 = "Standard_M48bds_v3";
+
+        /// <summary>
+        /// Standard_M64-32bds_1_v3 — 64 vCPUs — 1397 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM6432bds1V3 = "Standard_M64-32bds_1_v3";
+
+        /// <summary>
+        /// Standard_M64bds_1_v3 — 64 vCPUs — 1397 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64bds1V3 = "Standard_M64bds_1_v3";
+
+        /// <summary>
+        /// Standard_M64bds_v3 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64bdsV3 = "Standard_M64bds_v3";
+
+        /// <summary>
+        /// Standard_M96-48bds_2_v3 — 96 vCPUs — 1946 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM9648bds2V3 = "Standard_M96-48bds_2_v3";
+
+        /// <summary>
+        /// Standard_M96bds_2_v3 — 96 vCPUs — 1946 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM96bds2V3 = "Standard_M96bds_2_v3";
+
+        /// <summary>
+        /// Standard_M96bds_v3 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM96bdsV3 = "Standard_M96bds_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardMBSMediumMemoryv3Family.
+    /// </summary>
+    public static class StandardMBSMediumMemoryv3
+    {
+        /// <summary>
+        /// Standard_M128-64bs_v3 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM12864bsV3 = "Standard_M128-64bs_v3";
+
+        /// <summary>
+        /// Standard_M128bs_v3 — 128 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128bsV3 = "Standard_M128bs_v3";
+
+        /// <summary>
+        /// Standard_M16bs_v3 — 16 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM16bsV3 = "Standard_M16bs_v3";
+
+        /// <summary>
+        /// Standard_M176-88bs_v3 — 176 vCPUs — 1536 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM17688bsV3 = "Standard_M176-88bs_v3";
+
+        /// <summary>
+        /// Standard_M176bs_v3 — 176 vCPUs — 1536 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM176bsV3 = "Standard_M176bs_v3";
+
+        /// <summary>
+        /// Standard_M32bs_v3 — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM32bsV3 = "Standard_M32bs_v3";
+
+        /// <summary>
+        /// Standard_M416bs_v3 — 416 vCPUs — 3800 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416bsV3 = "Standard_M416bs_v3";
+
+        /// <summary>
+        /// Standard_M48bs_v3 — 48 vCPUs — 384 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM48bsV3 = "Standard_M48bs_v3";
+
+        /// <summary>
+        /// Standard_M64bs_v3 — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64bsV3 = "Standard_M64bs_v3";
+
+        /// <summary>
+        /// Standard_M96bs_v3 — 96 vCPUs — 768 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM96bsV3 = "Standard_M96bs_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMDSHighMemoryv3Family.
+    /// </summary>
+    public static class StandardMDSHighMemoryv3
+    {
+        /// <summary>
+        /// Standard_M416ds_6_v3 — 416 vCPUs — 5696 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416ds6V3 = "Standard_M416ds_6_v3";
+
+        /// <summary>
+        /// Standard_M416ds_8_v3 — 416 vCPUs — 7600 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416ds8V3 = "Standard_M416ds_8_v3";
+
+        /// <summary>
+        /// Standard_M624ds_12_v3 — 624 vCPUs — 11400 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM624ds12V3 = "Standard_M624ds_12_v3";
+
+        /// <summary>
+        /// Standard_M832ds_12_v3 — 832 vCPUs — 11400 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM832ds12V3 = "Standard_M832ds_12_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMDSMediumMemoryv2Family.
+    /// </summary>
+    public static class StandardMDSMediumMemoryv2
+    {
+        /// <summary>
+        /// Standard_M128dms_v2 — 128 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128dmsV2 = "Standard_M128dms_v2";
+
+        /// <summary>
+        /// Standard_M128ds_v2 — 128 vCPUs — 2048 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128dsV2 = "Standard_M128ds_v2";
+
+        /// <summary>
+        /// Standard_M32dms_v2 — 32 vCPUs — 875 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM32dmsV2 = "Standard_M32dms_v2";
+
+        /// <summary>
+        /// Standard_M64dms_v2 — 64 vCPUs — 1792 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64dmsV2 = "Standard_M64dms_v2";
+
+        /// <summary>
+        /// Standard_M64ds_v2 — 64 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64dsV2 = "Standard_M64ds_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMDSMediumMemoryv3Family.
+    /// </summary>
+    public static class StandardMDSMediumMemoryv3
+    {
+        /// <summary>
+        /// Standard_M12ds_v3 — 12 vCPUs — 240 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM12dsV3 = "Standard_M12ds_v3";
+
+        /// <summary>
+        /// Standard_M176ds_3_v3 — 176 vCPUs — 2794 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM176ds3V3 = "Standard_M176ds_3_v3";
+
+        /// <summary>
+        /// Standard_M176ds_4_v3 — 176 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM176ds4V3 = "Standard_M176ds_4_v3";
+
+        /// <summary>
+        /// Standard_M24ds_v3 — 24 vCPUs — 480 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM24dsV3 = "Standard_M24ds_v3";
+
+        /// <summary>
+        /// Standard_M48ds_1_v3 — 48 vCPUs — 974 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM48ds1V3 = "Standard_M48ds_1_v3";
+
+        /// <summary>
+        /// Standard_M96ds_1_v3 — 96 vCPUs — 974 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM96ds1V3 = "Standard_M96ds_1_v3";
+
+        /// <summary>
+        /// Standard_M96ds_2_v3 — 96 vCPUs — 1946 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM96ds2V3 = "Standard_M96ds_2_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMIDSHighMemoryv3Family.
+    /// </summary>
+    public static class StandardMIDSHighMemoryv3
+    {
+        /// <summary>
+        /// Standard_M832ids_16_v3 — 832 vCPUs — 15200 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM832ids16V3 = "Standard_M832ids_16_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMIDSMediumMemoryv2Family.
+    /// </summary>
+    public static class StandardMIDSMediumMemoryv2
+    {
+        /// <summary>
+        /// Standard_M192idms_v2 — 192 vCPUs — 4096 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM192idmsV2 = "Standard_M192idms_v2";
+
+        /// <summary>
+        /// Standard_M192ids_v2 — 192 vCPUs — 2048 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM192idsV2 = "Standard_M192ids_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMISHighMemoryv3Family.
+    /// </summary>
+    public static class StandardMISHighMemoryv3
+    {
+        /// <summary>
+        /// Standard_M832is_16_v3 — 832 vCPUs — 15200 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM832is16V3 = "Standard_M832is_16_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMISMediumMemoryv2Family.
+    /// </summary>
+    public static class StandardMISMediumMemoryv2
+    {
+        /// <summary>
+        /// Standard_M192ims_v2 — 192 vCPUs — 4096 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM192imsV2 = "Standard_M192ims_v2";
+
+        /// <summary>
+        /// Standard_M192is_v2 — 192 vCPUs — 2048 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM192isV2 = "Standard_M192is_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMSFamily.
+    /// </summary>
+    public static class StandardMS
+    {
+        /// <summary>
+        /// Standard_M128 — 128 vCPUs — 2048 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128 = "Standard_M128";
+
+        /// <summary>
+        /// Standard_M128-32ms — 128 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM12832ms = "Standard_M128-32ms";
+
+        /// <summary>
+        /// Standard_M128-64ms — 128 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM12864ms = "Standard_M128-64ms";
+
+        /// <summary>
+        /// Standard_M128m — 128 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128m = "Standard_M128m";
+
+        /// <summary>
+        /// Standard_M128ms — 128 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128ms = "Standard_M128ms";
+
+        /// <summary>
+        /// Standard_M128s — 128 vCPUs — 2048 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128s = "Standard_M128s";
+
+        /// <summary>
+        /// Standard_M16-4ms — 16 vCPUs — 437.5 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM164ms = "Standard_M16-4ms";
+
+        /// <summary>
+        /// Standard_M16-8ms — 16 vCPUs — 437.5 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM168ms = "Standard_M16-8ms";
+
+        /// <summary>
+        /// Standard_M16ms — 16 vCPUs — 437.5 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM16ms = "Standard_M16ms";
+
+        /// <summary>
+        /// Standard_M32-16ms — 32 vCPUs — 875 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM3216ms = "Standard_M32-16ms";
+
+        /// <summary>
+        /// Standard_M32-8ms — 32 vCPUs — 875 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM328ms = "Standard_M32-8ms";
+
+        /// <summary>
+        /// Standard_M32ls — 32 vCPUs — 256 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM32ls = "Standard_M32ls";
+
+        /// <summary>
+        /// Standard_M32ms — 32 vCPUs — 875 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM32ms = "Standard_M32ms";
+
+        /// <summary>
+        /// Standard_M32ts — 32 vCPUs — 192 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM32ts = "Standard_M32ts";
+
+        /// <summary>
+        /// Standard_M64 — 64 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64 = "Standard_M64";
+
+        /// <summary>
+        /// Standard_M64-16ms — 64 vCPUs — 1792 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM6416ms = "Standard_M64-16ms";
+
+        /// <summary>
+        /// Standard_M64-32ms — 64 vCPUs — 1792 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM6432ms = "Standard_M64-32ms";
+
+        /// <summary>
+        /// Standard_M64ls — 64 vCPUs — 512 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64ls = "Standard_M64ls";
+
+        /// <summary>
+        /// Standard_M64m — 64 vCPUs — 1792 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64m = "Standard_M64m";
+
+        /// <summary>
+        /// Standard_M64ms — 64 vCPUs — 1792 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64ms = "Standard_M64ms";
+
+        /// <summary>
+        /// Standard_M64s — 64 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64s = "Standard_M64s";
+
+        /// <summary>
+        /// Standard_M8-2ms — 8 vCPUs — 218.75 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM82ms = "Standard_M8-2ms";
+
+        /// <summary>
+        /// Standard_M8-4ms — 8 vCPUs — 218.75 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM84ms = "Standard_M8-4ms";
+
+        /// <summary>
+        /// Standard_M8ms — 8 vCPUs — 218.75 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM8ms = "Standard_M8ms";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMSHighMemoryv3Family.
+    /// </summary>
+    public static class StandardMSHighMemoryv3
+    {
+        /// <summary>
+        /// Standard_M416s_6_v3 — 416 vCPUs — 5696 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416s6V3 = "Standard_M416s_6_v3";
+
+        /// <summary>
+        /// Standard_M416s_8_v3 — 416 vCPUs — 7600 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416s8V3 = "Standard_M416s_8_v3";
+
+        /// <summary>
+        /// Standard_M624s_12_v3 — 624 vCPUs — 11400 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM624s12V3 = "Standard_M624s_12_v3";
+
+        /// <summary>
+        /// Standard_M832s_12_v3 — 832 vCPUs — 11400 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM832s12V3 = "Standard_M832s_12_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMSMediumMemoryv2Family.
+    /// </summary>
+    public static class StandardMSMediumMemoryv2
+    {
+        /// <summary>
+        /// Standard_M128ms_v2 — 128 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128msV2 = "Standard_M128ms_v2";
+
+        /// <summary>
+        /// Standard_M128s_v2 — 128 vCPUs — 2048 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM128sV2 = "Standard_M128s_v2";
+
+        /// <summary>
+        /// Standard_M32ms_v2 — 32 vCPUs — 875 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM32msV2 = "Standard_M32ms_v2";
+
+        /// <summary>
+        /// Standard_M64ms_v2 — 64 vCPUs — 1792 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64msV2 = "Standard_M64ms_v2";
+
+        /// <summary>
+        /// Standard_M64s_v2 — 64 vCPUs — 1024 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM64sV2 = "Standard_M64s_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMSMediumMemoryv3Family.
+    /// </summary>
+    public static class StandardMSMediumMemoryv3
+    {
+        /// <summary>
+        /// Standard_M12s_v3 — 12 vCPUs — 240 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM12sV3 = "Standard_M12s_v3";
+
+        /// <summary>
+        /// Standard_M176s_3_v3 — 176 vCPUs — 2794 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM176s3V3 = "Standard_M176s_3_v3";
+
+        /// <summary>
+        /// Standard_M176s_4_v3 — 176 vCPUs — 3892 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM176s4V3 = "Standard_M176s_4_v3";
+
+        /// <summary>
+        /// Standard_M24s_v3 — 24 vCPUs — 480 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM24sV3 = "Standard_M24s_v3";
+
+        /// <summary>
+        /// Standard_M48s_1_v3 — 48 vCPUs — 974 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM48s1V3 = "Standard_M48s_1_v3";
+
+        /// <summary>
+        /// Standard_M96s_1_v3 — 96 vCPUs — 974 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM96s1V3 = "Standard_M96s_1_v3";
+
+        /// <summary>
+        /// Standard_M96s_2_v3 — 96 vCPUs — 1946 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM96s2V3 = "Standard_M96s_2_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardMSv2Family.
+    /// </summary>
+    public static class StandardMSv2
+    {
+        /// <summary>
+        /// Standard_M208ms_v2 — 208 vCPUs — 5700 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM208msV2 = "Standard_M208ms_v2";
+
+        /// <summary>
+        /// Standard_M208s_v2 — 208 vCPUs — 2850 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM208sV2 = "Standard_M208s_v2";
+
+        /// <summary>
+        /// Standard_M416-208ms_v2 — 416 vCPUs — 11400 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416208msV2 = "Standard_M416-208ms_v2";
+
+        /// <summary>
+        /// Standard_M416-208s_v2 — 416 vCPUs — 5700 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416208sV2 = "Standard_M416-208s_v2";
+
+        /// <summary>
+        /// Standard_M416ms_v2 — 416 vCPUs — 11400 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416msV2 = "Standard_M416ms_v2";
+
+        /// <summary>
+        /// Standard_M416s_10_v2 — 416 vCPUs — 9496 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416s10V2 = "Standard_M416s_10_v2";
+
+        /// <summary>
+        /// Standard_M416s_8_v2 — 416 vCPUs — 7600 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416s8V2 = "Standard_M416s_8_v2";
+
+        /// <summary>
+        /// Standard_M416s_9_v2 — 416 vCPUs — 8568 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416s9V2 = "Standard_M416s_9_v2";
+
+        /// <summary>
+        /// Standard_M416s_v2 — 416 vCPUs — 5700 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardM416sV2 = "Standard_M416s_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardNCADSA100v4Family.
+    /// </summary>
+    public static class StandardNCADSA100v4
+    {
+        /// <summary>
+        /// Standard_NC24ads_A100_v4 — 24 vCPUs — 220 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC24adsA100V4 = "Standard_NC24ads_A100_v4";
+
+        /// <summary>
+        /// Standard_NC48ads_A100_v4 — 48 vCPUs — 440 GB RAM — 2 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC48adsA100V4 = "Standard_NC48ads_A100_v4";
+
+        /// <summary>
+        /// Standard_NC96ads_A100_v4 — 96 vCPUs — 880 GB RAM — 4 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC96adsA100V4 = "Standard_NC96ads_A100_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardNCADSA10v4Family.
+    /// </summary>
+    public static class StandardNCADSA10v4
+    {
+        /// <summary>
+        /// Standard_NC16ads_A10_v4 — 16 vCPUs — 200 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC16adsA10V4 = "Standard_NC16ads_A10_v4";
+
+        /// <summary>
+        /// Standard_NC32ads_A10_v4 — 32 vCPUs — 400 GB RAM — 2 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC32adsA10V4 = "Standard_NC32ads_A10_v4";
+
+        /// <summary>
+        /// Standard_NC8ads_A10_v4 — 8 vCPUs — 100 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC8adsA10V4 = "Standard_NC8ads_A10_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardNCadsH100v5Family.
+    /// </summary>
+    public static class StandardNCadsH100v5
+    {
+        /// <summary>
+        /// Standard_NC40ads_H100_v5 — 40 vCPUs — 320 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC40adsH100V5 = "Standard_NC40ads_H100_v5";
+
+        /// <summary>
+        /// Standard_NC80adis_H100_v5 — 80 vCPUs — 640 GB RAM — 2 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC80adisH100V5 = "Standard_NC80adis_H100_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardNCCads2023Family.
+    /// </summary>
+    public static class StandardNCCads2023
+    {
+        /// <summary>
+        /// Standard_NCC40ads_H100_v5 — 40 vCPUs — 320 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNCC40adsH100V5 = "Standard_NCC40ads_H100_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNCSv3Family.
+    /// </summary>
+    public static class StandardNCSv3
+    {
+        /// <summary>
+        /// Standard_NC12s_v3 — 12 vCPUs — 224 GB RAM — 2 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC12sV3 = "Standard_NC12s_v3";
+
+        /// <summary>
+        /// Standard_NC24rs_v3 — 24 vCPUs — 448 GB RAM — 4 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC24rsV3 = "Standard_NC24rs_v3";
+
+        /// <summary>
+        /// Standard_NC24s_v3 — 24 vCPUs — 448 GB RAM — 4 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC24sV3 = "Standard_NC24s_v3";
+
+        /// <summary>
+        /// Standard_NC6s_v3 — 6 vCPUs — 112 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNC6sV3 = "Standard_NC6s_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNDISRGB200V6NDRFamily.
+    /// </summary>
+    public static class StandardNDISRGB200V6NDR
+    {
+        /// <summary>
+        /// Standard_ND128isr_NDR_GB200_v6 — 128 vCPUs — 864 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardND128isrNDRGB200V6 = "Standard_ND128isr_NDR_GB200_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNDISRGB300V6Family.
+    /// </summary>
+    public static class StandardNDISRGB300V6
+    {
+        /// <summary>
+        /// Standard_ND128isr_GB300_v6 — 128 vCPUs — 864 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardND128isrGB300V6 = "Standard_ND128isr_GB300_v6";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNDISRH200V5Family.
+    /// </summary>
+    public static class StandardNDISRH200V5
+    {
+        /// <summary>
+        /// Standard_ND96isr_H200_v5 — 96 vCPUs — 1850 GB RAM — 8 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardND96isrH200V5 = "Standard_ND96isr_H200_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNDISv5MI300XFamily.
+    /// </summary>
+    public static class StandardNDISv5MI300X
+    {
+        /// <summary>
+        /// Standard_ND96isr_MI300X_v5 — 96 vCPUs — 1850 GB RAM — 8 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardND96isrMI300XV5 = "Standard_ND96isr_MI300X_v5";
+
+        /// <summary>
+        /// Standard_ND96is_MI300X_v5 — 96 vCPUs — 1850 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardND96isMI300XV5 = "Standard_ND96is_MI300X_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNDSH100v5Family.
+    /// </summary>
+    public static class StandardNDSH100v5
+    {
+        /// <summary>
+        /// Standard_ND96isr_H100_v5 — 96 vCPUs — 1900 GB RAM — 8 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardND96isrH100V5 = "Standard_ND96isr_H100_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNDSv2Family.
+    /// </summary>
+    public static class StandardNDSv2
+    {
+        /// <summary>
+        /// Standard_ND40rs_v2 — 40 vCPUs — 672 GB RAM — 8 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardND40rsV2 = "Standard_ND40rs_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardNGADSV620v1Family.
+    /// </summary>
+    public static class StandardNGADSV620v1
+    {
+        /// <summary>
+        /// Standard_NG16ads_V620_v1 — 16 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNG16adsV620V1 = "Standard_NG16ads_V620_v1";
+
+        /// <summary>
+        /// Standard_NG32adms_V620_v1 — 32 vCPUs — 176 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNG32admsV620V1 = "Standard_NG32adms_V620_v1";
+
+        /// <summary>
+        /// Standard_NG32ads_V620_v1 — 32 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNG32adsV620V1 = "Standard_NG32ads_V620_v1";
+
+        /// <summary>
+        /// Standard_NG8ads_V620_v1 — 8 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNG8adsV620V1 = "Standard_NG8ads_V620_v1";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNPSFamily.
+    /// </summary>
+    public static class StandardNPS
+    {
+        /// <summary>
+        /// Standard_NP10s — 10 vCPUs — 168 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNP10s = "Standard_NP10s";
+
+        /// <summary>
+        /// Standard_NP20s — 20 vCPUs — 336 GB RAM — 2 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNP20s = "Standard_NP20s";
+
+        /// <summary>
+        /// Standard_NP40s — 40 vCPUs — 672 GB RAM — 4 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNP40s = "Standard_NP40s";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardNVADSA10v5Family.
+    /// </summary>
+    public static class StandardNVADSA10v5
+    {
+        /// <summary>
+        /// Standard_NV12ads_A10_v5 — 12 vCPUs — 110 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV12adsA10V5 = "Standard_NV12ads_A10_v5";
+
+        /// <summary>
+        /// Standard_NV18ads_A10_v5 — 18 vCPUs — 220 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV18adsA10V5 = "Standard_NV18ads_A10_v5";
+
+        /// <summary>
+        /// Standard_NV36adms_A10_v5 — 36 vCPUs — 880 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV36admsA10V5 = "Standard_NV36adms_A10_v5";
+
+        /// <summary>
+        /// Standard_NV36ads_A10_v5 — 36 vCPUs — 440 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV36adsA10V5 = "Standard_NV36ads_A10_v5";
+
+        /// <summary>
+        /// Standard_NV6ads_A10_v5 — 6 vCPUs — 55 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV6adsA10V5 = "Standard_NV6ads_A10_v5";
+
+        /// <summary>
+        /// Standard_NV72ads_A10_v5 — 72 vCPUs — 880 GB RAM — 2 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV72adsA10V5 = "Standard_NV72ads_A10_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the StandardNVadsV710v5Family.
+    /// </summary>
+    public static class StandardNVadsV710v5
+    {
+        /// <summary>
+        /// Standard_NV12ads_V710_v5 — 12 vCPUs — 64 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNV12adsV710V5 = "Standard_NV12ads_V710_v5";
+
+        /// <summary>
+        /// Standard_NV24ads_V710_v5 — 24 vCPUs — 128 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNV24adsV710V5 = "Standard_NV24ads_V710_v5";
+
+        /// <summary>
+        /// Standard_NV28adms_V710_v5 — 28 vCPUs — 160 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNV28admsV710V5 = "Standard_NV28adms_V710_v5";
+
+        /// <summary>
+        /// Standard_NV4ads_V710_v5 — 4 vCPUs — 16 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNV4adsV710V5 = "Standard_NV4ads_V710_v5";
+
+        /// <summary>
+        /// Standard_NV8ads_V710_v5 — 8 vCPUs — 32 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardNV8adsV710V5 = "Standard_NV8ads_V710_v5";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNVSv2Family.
+    /// </summary>
+    public static class StandardNVSv2
+    {
+        /// <summary>
+        /// Standard_NV12s_v2 — 12 vCPUs — 224 GB RAM — 2 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV12sV2 = "Standard_NV12s_v2";
+
+        /// <summary>
+        /// Standard_NV24s_v2 — 24 vCPUs — 448 GB RAM — 4 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV24sV2 = "Standard_NV24s_v2";
+
+        /// <summary>
+        /// Standard_NV6s_v2 — 6 vCPUs — 112 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV6sV2 = "Standard_NV6s_v2";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNVSv3Family.
+    /// </summary>
+    public static class StandardNVSv3
+    {
+        /// <summary>
+        /// Standard_NV12s_v3 — 12 vCPUs — 112 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV12sV3 = "Standard_NV12s_v3";
+
+        /// <summary>
+        /// Standard_NV24s_v3 — 24 vCPUs — 224 GB RAM — 2 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV24sV3 = "Standard_NV24s_v3";
+
+        /// <summary>
+        /// Standard_NV48s_v3 — 48 vCPUs — 448 GB RAM — 4 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV48sV3 = "Standard_NV48s_v3";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardNVSv4Family.
+    /// </summary>
+    public static class StandardNVSv4
+    {
+        /// <summary>
+        /// Standard_NV16as_v4 — 16 vCPUs — 56 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV16asV4 = "Standard_NV16as_v4";
+
+        /// <summary>
+        /// Standard_NV32as_v4 — 32 vCPUs — 112 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV32asV4 = "Standard_NV32as_v4";
+
+        /// <summary>
+        /// Standard_NV4as_v4 — 4 vCPUs — 14 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV4asV4 = "Standard_NV4as_v4";
+
+        /// <summary>
+        /// Standard_NV8as_v4 — 8 vCPUs — 28 GB RAM — 1 GPU(s) — Premium SSD
+        /// </summary>
+        public const string StandardNV8asV4 = "Standard_NV8as_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardPBSFamily.
+    /// </summary>
+    public static class StandardPBS
+    {
+        /// <summary>
+        /// Standard_PB6s — 6 vCPUs — 112 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardPB6s = "Standard_PB6s";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardXEIDSv4Family.
+    /// </summary>
+    public static class StandardXEIDSv4
+    {
+        /// <summary>
+        /// Standard_E80ids_v4 — 80 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE80idsV4 = "Standard_E80ids_v4";
+    }
+
+    /// <summary>
+    /// VM sizes in the standardXEISv4Family.
+    /// </summary>
+    public static class StandardXEISv4
+    {
+        /// <summary>
+        /// Standard_E80is_v4 — 80 vCPUs — 504 GB RAM — Premium SSD
+        /// </summary>
+        public const string StandardE80isV4 = "Standard_E80is_v4";
     }
 }

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
@@ -232,7 +232,7 @@ public static class AzureKubernetesEnvironmentExtensions
     /// var aks = builder.AddAzureKubernetesEnvironment("aks")
     ///     .WithSubnet(defaultSubnet);
     ///
-    /// var gpuPool = aks.AddNodePool("gpu", AksNodeVmSizes.GpuAccelerated.StandardNC6sV3, 0, 5)
+    /// var gpuPool = aks.AddNodePool("gpu", AksNodeVmSizes.StandardNCSv3.StandardNC6sV3, 0, 5)
     ///     .WithSubnet(gpuSubnet);
     /// </code>
     /// </example>

--- a/src/Aspire.Hosting.Azure.Kubernetes/tools/GenVmSizes.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/tools/GenVmSizes.cs
@@ -1,15 +1,85 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #:property PublishAot=false
+#:property NoWarn=CS1591
 
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 
-// Fetch VM sizes from Azure REST API using the 'az' CLI
+// =============================================================================
+// GenVmSizes — AKS Node Pool VM Size Code Generator
+// =============================================================================
+//
+// PURPOSE
+// -------
+// This tool generates AksNodeVmSizes.Generated.cs, which contains string
+// constants for Azure VM sizes that can be used with AKS node pools. These
+// constants provide IntelliSense discoverability and compile-time safety when
+// configuring AKS node pool VM sizes in Aspire hosting code.
+//
+// HOW IT WORKS
+// ------------
+// 1. Queries the Microsoft.Compute/skus REST API without a location filter.
+//    This single paginated call returns every VM SKU across every Azure region
+//    in the subscription, giving us a comprehensive union of all available sizes.
+//
+// 2. Deduplicates by VM name (many entries exist — one per region per SKU) and
+//    keeps the first entry alphabetically by location for stable capability
+//    metadata (vCPUs, RAM, GPU count, etc.) across runs.
+//
+// 3. Applies AKS compatibility filters based on the documented restrictions at:
+//    https://learn.microsoft.com/azure/aks/quotas-skus-regions#restricted-vm-sizes
+//
+//    - Excludes VM sizes with fewer than 2 vCPUs
+//    - Excludes VM sizes with fewer than 2 GB RAM
+//    - Excludes Basic tier VMs
+//
+// 4. Groups the filtered VM sizes by their Azure SKU family name and generates
+//    a C# file with nested static classes containing string constants.
+//
+// LIMITATIONS AND CAVEATS
+// -----------------------
+// There is NO dedicated Azure API that returns "only VM sizes valid for AKS
+// node pools." The closest option is `az aks nodepool list-available-sizes`,
+// but that requires an existing AKS cluster and only returns sizes for the
+// cluster's region — it cannot be used standalone or globally.
+//
+// As a result, the filtering applied here is HEURISTIC-BASED. It removes
+// sizes that are documented as incompatible with AKS, but it does not
+// guarantee that every remaining size will be accepted by AKS when creating
+// a node pool. AKS may silently reject certain sizes for reasons not exposed
+// in the Compute SKUs API (e.g., sizes blocked by AKS for compatibility
+// testing, sizes in preview requiring feature flags, or region-specific
+// restrictions).
+//
+// In practice, the generated list is a superset of what AKS actually accepts.
+// This is acceptable for providing IntelliSense suggestions — users will get
+// a validation error from AKS at deployment time if they pick an unsupported
+// size, but they won't miss valid sizes due to overly aggressive filtering.
+//
+// If Azure ever exposes a standalone API for AKS-compatible VM sizes, this
+// tool should be updated to use it instead of the heuristic approach.
+//
+// REQUIREMENTS
+// ------------
+// - Azure CLI (`az`) must be installed and in PATH
+// - Must be logged in (`az login`) with access to a subscription
+// - Must be targeting the public Azure cloud (AzureCloud)
+// - Set AZURE_SUBSCRIPTION_ID env var, or the default subscription is used
+//
+// USAGE
+// -----
+// From the repository root:
+//   dotnet run --project src/Aspire.Hosting.Azure.Kubernetes/tools GenVmSizes.cs
+//
+// =============================================================================
+
+// Fetch VM sizes from Azure REST API using the 'az' CLI.
+// Uses the unfiltered Compute SKUs endpoint which returns all SKUs across
+// all regions in a single paginated response, ensuring comprehensive coverage.
 var subscriptionId = Environment.GetEnvironmentVariable("AZURE_SUBSCRIPTION_ID");
 if (string.IsNullOrWhiteSpace(subscriptionId))
 {
@@ -24,52 +94,82 @@ if (string.IsNullOrWhiteSpace(subscriptionId))
     return 1;
 }
 
+// Verify we're targeting the public Azure cloud
+var cloudName = await RunAzCommand("cloud show --query name -o tsv").ConfigureAwait(false);
+cloudName = cloudName?.Trim();
+if (string.IsNullOrWhiteSpace(cloudName))
+{
+    Console.Error.WriteLine("Error: Failed to determine the active Azure cloud. Ensure the Azure CLI is installed and that you are logged in with 'az login'.");
+    return 1;
+}
+if (!string.Equals(cloudName, "AzureCloud", StringComparison.OrdinalIgnoreCase))
+{
+    Console.Error.WriteLine($"Error: This tool is intended for the public Azure cloud (AzureCloud), but the active cloud is '{cloudName}'.");
+    Console.Error.WriteLine("Switch to AzureCloud with: az cloud set --name AzureCloud");
+    return 1;
+}
+
 Console.WriteLine($"Using subscription: {subscriptionId}");
 
-// Query all US regions for VM SKUs to build a comprehensive unified list.
-// Different regions offer different VM sizes, so querying multiple regions
-// ensures we capture the full set available across the US.
-string[] usRegions = [
-    "eastus", "eastus2", "centralus", "northcentralus", "southcentralus",
-    "westus", "westus2", "westus3", "westcentralus"
-];
-
+// Query all VM SKUs across all regions in a single paginated call.
+// This returns the full union of VM sizes available anywhere in the subscription,
+// eliminating the need to enumerate individual regions.
 var allSkus = new List<ResourceSku>();
-foreach (var region in usRegions)
+string? nextUrl = $"https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Compute/skus?api-version=2021-07-01";
+var pageCount = 0;
+
+while (nextUrl is not null)
 {
-    Console.WriteLine($"Querying VM SKUs for {region}...");
-    var url = $"https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Compute/skus?api-version=2021-07-01&$filter=location eq '{region}'";
-    var json = await RunAzCommand($"rest --method get --url \"{url}\"").ConfigureAwait(false);
+    pageCount++;
+    Console.WriteLine($"Fetching VM SKUs (page {pageCount})...");
+
+    var json = await RunAzCommand($"rest --method get --url \"{nextUrl}\"").ConfigureAwait(false);
 
     if (string.IsNullOrWhiteSpace(json))
     {
-        Console.Error.WriteLine($"Warning: Failed to fetch VM SKUs for {region}, skipping.");
-        continue;
+        Console.Error.WriteLine($"Error: Failed to fetch VM SKUs (page {pageCount}).");
+        return 1;
     }
 
     var skuResponse = JsonSerializer.Deserialize<SkuResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
     if (skuResponse?.Value is not null)
     {
         allSkus.AddRange(skuResponse.Value);
-        Console.WriteLine($"  Found {skuResponse.Value.Count} SKUs in {region}");
+        Console.WriteLine($"  Received {skuResponse.Value.Count} SKUs (total so far: {allSkus.Count})");
     }
+
+    nextUrl = skuResponse?.NextLink;
 }
 
 if (allSkus.Count == 0)
 {
-    Console.Error.WriteLine("Error: Failed to fetch VM SKUs from any US region.");
+    Console.Error.WriteLine("Error: No VM SKUs returned from Azure.");
     return 1;
 }
 
-// Filter to virtualMachines, deduplicate by name (keep first occurrence for capability data)
+// Filter to virtualMachines, apply AKS node pool compatibility filters, and
+// deduplicate by name deterministically.
+//
+// AKS restrictions (https://learn.microsoft.com/azure/aks/quotas-skus-regions#restricted-vm-sizes):
+// - VM sizes with fewer than 2 vCPUs are restricted
+// - VM sizes with fewer than 2 GB RAM are restricted for user node pools
+// - Basic tier VMs are not supported
+// - Av1 series VMs are not recommended (deprecated)
+//
+// The unfiltered API returns one entry per (SKU, location) pair, so there are
+// many duplicates by name. We sort by location before grouping to ensure stable
+// capability data regardless of API response ordering.
 var vmSkus = allSkus
     .Where(s => s.ResourceType == "virtualMachines" && !string.IsNullOrEmpty(s.Name))
-    .GroupBy(s => s.Name)
+    .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+    .ThenBy(s => s.Locations?.FirstOrDefault() ?? "", StringComparer.OrdinalIgnoreCase)
+    .GroupBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
     .Select(g => g.First())
     .Select(s => new VmSizeInfo
     {
         Name = s.Name!,
         Family = s.Family ?? "Other",
+        Tier = s.Tier ?? "",
         VCpus = s.GetCapabilityValue("vCPUs"),
         MemoryGB = s.GetCapabilityValue("MemoryGB"),
         MaxDataDiskCount = s.GetCapabilityValue("MaxDataDiskCount"),
@@ -77,12 +177,12 @@ var vmSkus = allSkus
         AcceleratedNetworking = s.GetCapabilityBool("AcceleratedNetworkingEnabled"),
         GpuCount = s.GetCapabilityValue("GPUs"),
     })
-    .DistinctBy(s => s.Name)
+    .Where(IsAksCompatible)
     .OrderBy(s => s.Family, StringComparer.OrdinalIgnoreCase)
     .ThenBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
     .ToList();
 
-Console.WriteLine($"Found {vmSkus.Count} VM sizes");
+Console.WriteLine($"Found {vmSkus.Count} AKS-compatible VM sizes");
 
 var code = VmSizeClassGenerator.GenerateCode("Aspire.Hosting.Azure.Kubernetes", vmSkus);
 File.WriteAllText(Path.Combine("..", "AksNodeVmSizes.Generated.cs"), code);
@@ -90,11 +190,50 @@ Console.WriteLine($"Generated AksNodeVmSizes.Generated.cs with {vmSkus.Count} VM
 
 return 0;
 
+static bool IsAksCompatible(VmSizeInfo vm)
+{
+    // AKS requires at least 2 vCPUs
+    if (double.TryParse(vm.VCpus, CultureInfo.InvariantCulture, out var vcpus) && vcpus < 2)
+    {
+        return false;
+    }
+
+    // AKS requires at least 2 GB RAM for user node pools
+    if (double.TryParse(vm.MemoryGB, CultureInfo.InvariantCulture, out var memGb) && memGb < 2)
+    {
+        return false;
+    }
+
+    // Basic tier VMs are not supported
+    if (vm.Tier.Equals("Basic", StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    // Basic_* SKUs (naming convention) are not supported
+    if (vm.Name.StartsWith("Basic_", StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    return true;
+}
+
 static async Task<string?> RunAzCommand(string arguments)
 {
+    // Resolve 'az' CLI path. On Windows, az is a .cmd batch file so we need
+    // to resolve it explicitly since Process.Start may not find .cmd files
+    // in PATH when UseShellExecute=false.
+    var azPath = FindAzCli();
+    if (azPath is null)
+    {
+        Console.Error.WriteLine("Error: 'az' CLI not found. Ensure Azure CLI is installed and in PATH.");
+        return null;
+    }
+
     var psi = new ProcessStartInfo
     {
-        FileName = "az",
+        FileName = azPath,
         Arguments = arguments,
         RedirectStandardOutput = true,
         RedirectStandardError = true,
@@ -126,10 +265,49 @@ static async Task<string?> RunAzCommand(string arguments)
     return process.ExitCode == 0 ? output : null;
 }
 
+static string? FindAzCli()
+{
+    const string commandName = "az";
+
+    var pathDirs = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    string[] candidates;
+    if (OperatingSystem.IsWindows())
+    {
+        // Use PATHEXT to discover valid executable extensions (e.g., .cmd, .bat, .exe)
+        var pathExt = (Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD")
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        candidates = [.. pathExt.Select(ext => commandName + ext)];
+    }
+    else
+    {
+        candidates = [commandName];
+    }
+
+    foreach (var dir in pathDirs)
+    {
+        foreach (var candidate in candidates)
+        {
+            var fullPath = Path.Combine(dir, candidate);
+            if (File.Exists(fullPath))
+            {
+                return fullPath;
+            }
+        }
+    }
+
+    return null;
+}
+
 public sealed class SkuResponse
 {
     [JsonPropertyName("value")]
     public List<ResourceSku>? Value { get; set; }
+
+    [JsonPropertyName("nextLink")]
+    public string? NextLink { get; set; }
 }
 
 public sealed class ResourceSku
@@ -148,6 +326,9 @@ public sealed class ResourceSku
 
     [JsonPropertyName("family")]
     public string? Family { get; set; }
+
+    [JsonPropertyName("locations")]
+    public List<string>? Locations { get; set; }
 
     [JsonPropertyName("capabilities")]
     public List<SkuCapability>? Capabilities { get; set; }
@@ -177,6 +358,7 @@ public sealed class VmSizeInfo
 {
     public string Name { get; set; } = "";
     public string Family { get; set; } = "";
+    public string Tier { get; set; } = "";
     public string? VCpus { get; set; }
     public string? MemoryGB { get; set; }
     public string? MaxDataDiskCount { get; set; }
@@ -202,12 +384,12 @@ internal static partial class VmSizeClassGenerator
         sb.AppendLine("/// Provides well-known Azure VM size constants for use with AKS node pools.");
         sb.AppendLine("/// </summary>");
         sb.AppendLine("/// <remarks>");
-        sb.AppendLine("/// This class is auto-generated from Azure Resource SKUs across all US regions.");
+        sb.AppendLine("/// This class is auto-generated from Azure Resource SKUs across all public Azure regions,");
+        sb.AppendLine("/// filtered to VM sizes compatible with AKS node pools (minimum 2 vCPUs, 2 GB RAM,");
+        sb.AppendLine("/// excluding Basic tier VMs).");
         sb.AppendLine("/// To update, run the GenVmSizes tool:");
         sb.AppendLine("/// <code>dotnet run --project src/Aspire.Hosting.Azure.Kubernetes/tools GenVmSizes.cs</code>");
-        sb.AppendLine("/// VM size availability varies by region. This list is a union of sizes available");
-        sb.AppendLine("/// across eastus, eastus2, centralus, northcentralus, southcentralus, westus, westus2,");
-        sb.AppendLine("/// westus3, and westcentralus. Not all sizes may be available in every region.");
+        sb.AppendLine("/// VM size availability varies by region. Not all sizes may be available in every region.");
         sb.AppendLine("/// </remarks>");
         sb.AppendLine("public static partial class AksNodeVmSizes");
         sb.AppendLine("{");
@@ -225,9 +407,12 @@ internal static partial class VmSizeClassGenerator
             firstClass = false;
 
             var className = FamilyToClassName(group.Key);
+            var familyDisplayName = group.Key.EndsWith("Family", StringComparison.OrdinalIgnoreCase)
+                ? group.Key
+                : group.Key + " family";
 
             sb.AppendLine("    /// <summary>");
-            sb.AppendLine(CultureInfo.InvariantCulture, $"    /// VM sizes in the {EscapeXml(group.Key)} family.");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"    /// VM sizes in the {EscapeXml(familyDisplayName)}.");
             sb.AppendLine("    /// </summary>");
             sb.AppendLine(CultureInfo.InvariantCulture, $"    public static class {className}");
             sb.AppendLine("    {");

--- a/src/Aspire.Hosting.Azure.Kubernetes/tools/GenVmSizes.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/tools/GenVmSizes.cs
@@ -154,7 +154,9 @@ if (allSkus.Count == 0)
 // - VM sizes with fewer than 2 vCPUs are restricted
 // - VM sizes with fewer than 2 GB RAM are restricted for user node pools
 // - Basic tier VMs are not supported
-// - Av1 series VMs are not recommended (deprecated)
+//
+// Note: Av1 series VMs are "not recommended" by AKS docs but are not explicitly
+// restricted, so they are included in the generated output.
 //
 // The unfiltered API returns one entry per (SKU, location) pair, so there are
 // many duplicates by name. We sort by location before grouping to ensure stable


### PR DESCRIPTION
## Description

The `GenVmSizes.cs` tool previously only queried 9 US regions for VM SKUs, resulting in the `AksNodeVmSizes.Generated.cs` file missing many VM sizes that are available exclusively in non-US regions.

### Changes

**Tool (`GenVmSizes.cs`):**
- Replaced hardcoded US region list with the unfiltered `Microsoft.Compute/skus` API endpoint, which returns all SKUs across all Azure regions in a single paginated response
- Added `nextLink` pagination support for the SKU API response
- Added AzureCloud verification to prevent accidental use with government/sovereign clouds
- Added deterministic deduplication (sort by name + location before grouping for stable output across runs)
- Fixed `az` CLI path resolution for cross-platform compatibility (Windows `.cmd` files weren't found by `Process.Start`)
- Removed unused `using` directive and suppressed CS1591 for the tool-only types

**Generated output (`AksNodeVmSizes.Generated.cs`):**
- Regenerated from ~50 hand-curated entries to **1,373 VM sizes**
- Categories now use Azure SKU family names from the API (e.g., `StandardDSv5`, `StandardFSv2`) instead of hand-curated names

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
