### PR TITLE
Add Foundry portal link to deployment summary

### DIFF
--- a/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
@@ -62,7 +62,8 @@ public class AzureCognitiveServicesProjectResource :
                     }
 
                     var encodedSubscriptionId = EncodeSubscriptionId(subscriptionId);
-                    var portalUrl = $"https://ai.azure.com/nextgen/r/{encodedSubscriptionId},{resourceGroupName},,{Parent.Name},{Name}/home";
+                    // Commas are percent-encoded so terminal link detection doesn't truncate the URL.
+                    var portalUrl = $"https://ai.azure.com/nextgen/r/{encodedSubscriptionId}%2C{Uri.EscapeDataString(resourceGroupName)}%2C%2C{Uri.EscapeDataString(Parent.Name)}%2C{Uri.EscapeDataString(Name)}/home";
 
                     await context.ReportingStep.CompleteAsync(portalUrl).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
@@ -63,6 +63,7 @@ public class AzureCognitiveServicesProjectResource :
                     context.Summary.Add(Name, new MarkdownString($"[{portalUrl}]({portalUrl})"));
                 },
                 Resource = this,
+                Tags = ["print-summary"],
                 DependsOnSteps = [AzureEnvironmentResource.ProvisionInfrastructureStepName],
                 RequiredBySteps = [WellKnownPipelineSteps.Deploy]
             };

--- a/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
@@ -56,9 +56,11 @@ public class AzureCognitiveServicesProjectResource :
                         return;
                     }
                     var encodedSubscriptionId = EncodeSubscriptionId(subscriptionId);
-                    // Print dashboard URL
-                    await context.ReportingStep.CompleteAsync(
-                        $"https://ai.azure.com/nextgen/r/{encodedSubscriptionId},{resourceGroupName},,{Parent.Name},{Name}/home").ConfigureAwait(false);
+                    var portalUrl = $"https://ai.azure.com/nextgen/r/{encodedSubscriptionId},{resourceGroupName},,{Parent.Name},{Name}/home";
+
+                    await context.ReportingStep.CompleteAsync(portalUrl).ConfigureAwait(false);
+
+                    context.Summary.Add(Name, new MarkdownString($"[{portalUrl}]({portalUrl})"));
                 },
                 Resource = this,
                 DependsOnSteps = [AzureEnvironmentResource.ProvisionInfrastructureStepName],

--- a/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
@@ -6,10 +6,9 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Pipelines;
+using Azure.Core;
 using Azure.Provisioning;
 using Azure.Provisioning.CognitiveServices;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Foundry;
 
@@ -48,13 +47,20 @@ public class AzureCognitiveServicesProjectResource :
                 Name = $"compute-endpoints-{name}",
                 Action = async (context) =>
                 {
-                    var configuration = context.Services.GetRequiredService<IConfiguration>();
-                    var subscriptionId = configuration["Azure:SubscriptionId"];
-                    var resourceGroupName = configuration["Azure:ResourceGroup"];
+                    var parentId = await Parent.Id.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+                    if (string.IsNullOrEmpty(parentId))
+                    {
+                        return;
+                    }
+
+                    var resourceId = new ResourceIdentifier(parentId);
+                    var subscriptionId = resourceId.SubscriptionId;
+                    var resourceGroupName = resourceId.ResourceGroupName;
                     if (string.IsNullOrEmpty(subscriptionId) || string.IsNullOrEmpty(resourceGroupName))
                     {
                         return;
                     }
+
                     var encodedSubscriptionId = EncodeSubscriptionId(subscriptionId);
                     var portalUrl = $"https://ai.azure.com/nextgen/r/{encodedSubscriptionId},{resourceGroupName},,{Parent.Name},{Name}/home";
 


### PR DESCRIPTION
## Description

When deploying an app to Azure AI Foundry, the pipeline summary (the "✓ PIPELINE SUCCEEDED" output) shows general Azure information (target, resource group, subscription, location) but does not include a link to the Foundry portal for the deployed project.

This change adds the Foundry portal URL to `ctx.Summary` in the existing `compute-endpoints` pipeline step, following the same pattern used by Azure Container Apps and App Service. The portal URL was already being constructed and reported via `ReportingStep.CompleteAsync()` — it just wasn't being added to the final summary.

After this change the deployment summary will include a clickable link to the project in the Foundry portal (e.g. `https://ai.azure.com/nextgen/r/.../home`).

Fixes #15970

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
