### PR TITLE
Fix FluentSelect/FluentCombobox value binding when options change

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -14,370 +14,370 @@ internal static class InteractionCommands
     {
         resource
             .WithCommand("confirmation-interaction", "Confirmation interactions", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-               var resultTask1 = interactionService.PromptConfirmationAsync("Command confirmation", "Are you sure?", cancellationToken: commandContext.CancellationToken);
-               var resultTask2 = interactionService.PromptMessageBoxAsync("Command confirmation", "Are you really sure?", new MessageBoxInteractionOptions { Intent = MessageIntent.Warning, ShowSecondaryButton = true }, cancellationToken: commandContext.CancellationToken);
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                var resultTask1 = interactionService.PromptConfirmationAsync("Command confirmation", "Are you sure?", cancellationToken: commandContext.CancellationToken);
+                var resultTask2 = interactionService.PromptMessageBoxAsync("Command confirmation", "Are you really sure?", new MessageBoxInteractionOptions { Intent = MessageIntent.Warning, ShowSecondaryButton = true }, cancellationToken: commandContext.CancellationToken);
 
-               await Task.WhenAll(resultTask1, resultTask2);
+                await Task.WhenAll(resultTask1, resultTask2);
 
-               if (resultTask1.Result.Data != true || resultTask2.Result.Data != true)
-               {
-                   return CommandResults.Failure("Canceled");
-               }
+                if (resultTask1.Result.Data != true || resultTask2.Result.Data != true)
+                {
+                    return CommandResults.Failure("Canceled");
+                }
 
-               _ = interactionService.PromptMessageBoxAsync("Command executed", "The command successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, PrimaryButtonText = "Yeah!" });
-               return CommandResults.Success();
-           })
-           .WithCommand("messagebar-interaction", "Messagebar interactions", executeCommand: async commandContext =>
-           {
-               await Task.Yield();
+                _ = interactionService.PromptMessageBoxAsync("Command executed", "The command successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, PrimaryButtonText = "Yeah!" });
+                return CommandResults.Success();
+            })
+            .WithCommand("messagebar-interaction", "Messagebar interactions", executeCommand: async commandContext =>
+            {
+                await Task.Yield();
 
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-               _ = interactionService.PromptNotificationAsync("Success bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Success });
-               _ = interactionService.PromptNotificationAsync("Information bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Information });
-               _ = interactionService.PromptNotificationAsync("Warning bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Warning });
-               _ = interactionService.PromptNotificationAsync("Error bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Error, LinkText = "Click here for more information", LinkUrl = "https://www.microsoft.com" });
-               _ = interactionService.PromptNotificationAsync("Confirmation bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Confirmation });
-               _ = interactionService.PromptNotificationAsync("No dismiss", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Information, ShowDismiss = false });
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                _ = interactionService.PromptNotificationAsync("Success bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Success });
+                _ = interactionService.PromptNotificationAsync("Information bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Information });
+                _ = interactionService.PromptNotificationAsync("Warning bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Warning });
+                _ = interactionService.PromptNotificationAsync("Error bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Error, LinkText = "Click here for more information", LinkUrl = "https://www.microsoft.com" });
+                _ = interactionService.PromptNotificationAsync("Confirmation bar", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Confirmation });
+                _ = interactionService.PromptNotificationAsync("No dismiss", "The command successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Information, ShowDismiss = false });
 
-               return CommandResults.Success();
-           })
-           .WithCommand("html-interaction", "HTML interactions", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                return CommandResults.Success();
+            })
+            .WithCommand("html-interaction", "HTML interactions", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
 
-               _ = interactionService.PromptNotificationAsync("Success <strong>bar</strong>", "The **command** successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Success });
-               _ = interactionService.PromptNotificationAsync("Success <strong>bar</strong>", "The **command** successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Success, EnableMessageMarkdown = true });
-               _ = interactionService.PromptNotificationAsync("Success <strong>bar</strong>", "Multiline 1\r\n\r\nMultiline 2", new NotificationInteractionOptions { Intent = MessageIntent.Success, EnableMessageMarkdown = true });
+                _ = interactionService.PromptNotificationAsync("Success <strong>bar</strong>", "The **command** successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Success });
+                _ = interactionService.PromptNotificationAsync("Success <strong>bar</strong>", "The **command** successfully executed.", new NotificationInteractionOptions { Intent = MessageIntent.Success, EnableMessageMarkdown = true });
+                _ = interactionService.PromptNotificationAsync("Success <strong>bar</strong>", "Multiline 1\r\n\r\nMultiline 2", new NotificationInteractionOptions { Intent = MessageIntent.Success, EnableMessageMarkdown = true });
 
-               _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The **command** successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success });
-               _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The **command** successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, EnableMessageMarkdown = true });
-               _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "Multiline 1\r\n\r\nMultiline 2", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, EnableMessageMarkdown = true });
+                _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The **command** successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success });
+                _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The **command** successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, EnableMessageMarkdown = true });
+                _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "Multiline 1\r\n\r\nMultiline 2", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, EnableMessageMarkdown = true });
 
-               var inputNoMarkdown = new InteractionInput { Name = "Name", Label = "<strong>Name</strong>", InputType = InputType.Text, Placeholder = "Enter <strong>your</strong> name.", Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.\r\n\r\nFor more information about the `IInteractionService`, see https://learn.microsoft.com." };
-               var inputHasMarkdown = new InteractionInput { Name = "Name", Label = "<strong>Name</strong>", InputType = InputType.Text, Placeholder = "Enter <strong>your</strong> name.", Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.\r\n\r\nFor more information about the `IInteractionService`, see https://learn.microsoft.com.", EnableDescriptionMarkdown = true };
+                var inputNoMarkdown = new InteractionInput { Name = "Name", Label = "<strong>Name</strong>", InputType = InputType.Text, Placeholder = "Enter <strong>your</strong> name.", Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.\r\n\r\nFor more information about the `IInteractionService`, see https://learn.microsoft.com." };
+                var inputHasMarkdown = new InteractionInput { Name = "Name", Label = "<strong>Name</strong>", InputType = InputType.Text, Placeholder = "Enter <strong>your</strong> name.", Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.\r\n\r\nFor more information about the `IInteractionService`, see https://learn.microsoft.com.", EnableDescriptionMarkdown = true };
 
-               _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide **your** name. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui. For more information about the `IInteractionService`, see https://learn.microsoft.com.", inputNoMarkdown);
-               _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide **your** name. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui. For more information about the `IInteractionService`, see https://learn.microsoft.com.", inputHasMarkdown, new InputsDialogInteractionOptions { EnableMessageMarkdown = true });
-               _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide **your** name.\r\n\r\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.\r\n\r\nFor more information about the `IInteractionService`, see https://learn.microsoft.com.", inputHasMarkdown, new InputsDialogInteractionOptions { EnableMessageMarkdown = true });
+                _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide **your** name. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui. For more information about the `IInteractionService`, see https://learn.microsoft.com.", inputNoMarkdown);
+                _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide **your** name. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui. For more information about the `IInteractionService`, see https://learn.microsoft.com.", inputHasMarkdown, new InputsDialogInteractionOptions { EnableMessageMarkdown = true });
+                _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide **your** name.\r\n\r\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.\r\n\r\nFor more information about the `IInteractionService`, see https://learn.microsoft.com.", inputHasMarkdown, new InputsDialogInteractionOptions { EnableMessageMarkdown = true });
 
-               return CommandResults.Success();
-           })
-           .WithCommand("long-content-interaction", "Long content interactions", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                return CommandResults.Success();
+            })
+            .WithCommand("long-content-interaction", "Long content interactions", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
 
-               var inputHasMarkdown = new InteractionInput { Name = "Name", Label = "<strong>Name</strong>", InputType = InputType.Text, Placeholder = "Enter <strong>your</strong> name.", Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.", EnableDescriptionMarkdown = true };
-               var choiceWithLongContent = new InteractionInput
-               {
-                   Name = "Choice",
-                   InputType = InputType.Choice,
-                   Label = "Choice with long content",
-                   Placeholder = "Select a value. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.",
-                   Options = [
-                       KeyValuePair.Create("option1", "Option 1 - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui."),
-                       KeyValuePair.Create("option2", "Option 2 - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.")
-                   ]
-               };
-               var choiceCustomOptionsWithLongContent = new InteractionInput
-               {
-                   Name = "Combobox",
-                   InputType = InputType.Choice,
-                   Label = "Choice with long content",
-                   AllowCustomChoice = true,
-                   Placeholder = "Select a value. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.",
-                   Options = [
-                       KeyValuePair.Create("option1", "Option 1 - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui."),
-                       KeyValuePair.Create("option2", "Option 2 - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.")
-                   ]
-               };
+                var inputHasMarkdown = new InteractionInput { Name = "Name", Label = "<strong>Name</strong>", InputType = InputType.Text, Placeholder = "Enter <strong>your</strong> name.", Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.", EnableDescriptionMarkdown = true };
+                var choiceWithLongContent = new InteractionInput
+                {
+                    Name = "Choice",
+                    InputType = InputType.Choice,
+                    Label = "Choice with long content",
+                    Placeholder = "Select a value. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.",
+                    Options = [
+                        KeyValuePair.Create("option1", "Option 1 - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui."),
+                        KeyValuePair.Create("option2", "Option 2 - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.")
+                    ]
+                };
+                var choiceCustomOptionsWithLongContent = new InteractionInput
+                {
+                    Name = "Combobox",
+                    InputType = InputType.Choice,
+                    Label = "Choice with long content",
+                    AllowCustomChoice = true,
+                    Placeholder = "Select a value. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.",
+                    Options = [
+                        KeyValuePair.Create("option1", "Option 1 - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui."),
+                        KeyValuePair.Create("option2", "Option 2 - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, **neque id** efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui.")
+                    ]
+                };
 
-               _ = await interactionService.PromptInputsAsync(
-                   "Text <strong>request</strong>",
-                   "Provide **your** name. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui. For more information about the `IInteractionService`, see https://learn.microsoft.com.",
-                   [inputHasMarkdown, choiceWithLongContent, choiceCustomOptionsWithLongContent],
-                   new InputsDialogInteractionOptions { EnableMessageMarkdown = true });
+                _ = await interactionService.PromptInputsAsync(
+                    "Text <strong>request</strong>",
+                    "Provide **your** name. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id massa arcu. Morbi ac risus eget augue venenatis hendrerit. Morbi posuere, neque id efficitur ultrices, velit augue suscipit ante, vitae lacinia elit risus nec dui. For more information about the `IInteractionService`, see https://learn.microsoft.com.",
+                    [inputHasMarkdown, choiceWithLongContent, choiceCustomOptionsWithLongContent],
+                    new InputsDialogInteractionOptions { EnableMessageMarkdown = true });
 
-               return CommandResults.Success();
-           })
-           .WithCommand("value-interaction", "Value interactions", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-               var result = await interactionService.PromptInputAsync(
-                   title: "Text request",
-                   message: "Provide your name",
-                   inputLabel: "Name",
-                   placeHolder: "Enter your name",
-                   options: new InputsDialogInteractionOptions
-                   {
-                       ValidationCallback = context =>
-                       {
-                           var input = context.Inputs[0];
-                           if (!string.IsNullOrEmpty(input.Value) && input.Value.Length < 3)
-                           {
-                               context.AddValidationError(input, "Name must be at least 3 characters long.");
-                           }
-                           return Task.CompletedTask;
-                       }
-                   },
-                   cancellationToken: commandContext.CancellationToken);
+                return CommandResults.Success();
+            })
+            .WithCommand("value-interaction", "Value interactions", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                var result = await interactionService.PromptInputAsync(
+                    title: "Text request",
+                    message: "Provide your name",
+                    inputLabel: "Name",
+                    placeHolder: "Enter your name",
+                    options: new InputsDialogInteractionOptions
+                    {
+                        ValidationCallback = context =>
+                        {
+                            var input = context.Inputs[0];
+                            if (!string.IsNullOrEmpty(input.Value) && input.Value.Length < 3)
+                            {
+                                context.AddValidationError(input, "Name must be at least 3 characters long.");
+                            }
+                            return Task.CompletedTask;
+                        }
+                    },
+                    cancellationToken: commandContext.CancellationToken);
 
-               if (result.Canceled)
-               {
-                   return CommandResults.Failure("Canceled");
-               }
+                if (result.Canceled)
+                {
+                    return CommandResults.Failure("Canceled");
+                }
 
-               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+                var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
 
-               var input = result.Data;
-               logger.LogInformation("Input: {Name} = {Value}", input.Name, input.Value);
+                var input = result.Data;
+                logger.LogInformation("Input: {Name} = {Value}", input.Name, input.Value);
 
-               return CommandResults.Success();
-           })
-           .WithCommand("choice-no-placeholder", "Choice with no placeholder", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-               var dinnerInput = new InteractionInput
-               {
-                   Name = "Dinner",
-                   InputType = InputType.Choice,
-                   Label = "Dinner",
-                   Required = true,
-                   Options =
-                   [
-                       KeyValuePair.Create("pizza", "Pizza"),
-                       KeyValuePair.Create("fried-chicken", "Fried chicken"),
-                       KeyValuePair.Create("burger", "Burger")
-                   ]
-               };
-               var requirementsInput = new InteractionInput
-               {
-                   Name = "Requirements",
-                   InputType = InputType.Choice,
-                   Label = "Requirements",
-                   AllowCustomChoice = true,
-                   Options =
-                   [
-                       KeyValuePair.Create("vegetarian", "Vegetarian"),
-                       KeyValuePair.Create("vegan", "Vegan")
-                   ]
-               };
-               var result = await interactionService.PromptInputsAsync(
-                   title: "Text request",
-                   message: "Provide your name",
-                   inputs: [
-                       dinnerInput,
+                return CommandResults.Success();
+            })
+            .WithCommand("choice-no-placeholder", "Choice with no placeholder", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                var dinnerInput = new InteractionInput
+                {
+                    Name = "Dinner",
+                    InputType = InputType.Choice,
+                    Label = "Dinner",
+                    Required = true,
+                    Options =
+                    [
+                        KeyValuePair.Create("pizza", "Pizza"),
+                        KeyValuePair.Create("fried-chicken", "Fried chicken"),
+                        KeyValuePair.Create("burger", "Burger")
+                    ]
+                };
+                var requirementsInput = new InteractionInput
+                {
+                    Name = "Requirements",
+                    InputType = InputType.Choice,
+                    Label = "Requirements",
+                    AllowCustomChoice = true,
+                    Options =
+                    [
+                        KeyValuePair.Create("vegetarian", "Vegetarian"),
+                        KeyValuePair.Create("vegan", "Vegan")
+                    ]
+                };
+                var result = await interactionService.PromptInputsAsync(
+                    title: "Text request",
+                    message: "Provide your name",
+                    inputs: [
+                        dinnerInput,
                        requirementsInput
-                   ],
-                   cancellationToken: commandContext.CancellationToken);
+                    ],
+                    cancellationToken: commandContext.CancellationToken);
 
-               if (result.Canceled)
-               {
-                   return CommandResults.Failure("Canceled");
-               }
+                if (result.Canceled)
+                {
+                    return CommandResults.Failure("Canceled");
+                }
 
-               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+                var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
 
-               foreach (var updatedInput in result.Data)
-               {
-                   logger.LogInformation("Input: {Label} = {Value}", updatedInput.Label, updatedInput.Value);
-               }
+                foreach (var updatedInput in result.Data)
+                {
+                    logger.LogInformation("Input: {Label} = {Value}", updatedInput.Label, updatedInput.Value);
+                }
 
-               return CommandResults.Success();
-           })
-           .WithCommand("input-interaction", "Input interactions", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-               var dinnerInput = new InteractionInput
-               {
-                   Name = "Dinner",
-                   InputType = InputType.Choice,
-                   Label = "Dinner",
-                   Placeholder = "Select dinner",
-                   Required = true,
-                   Options =
-                   [
-                       KeyValuePair.Create("pizza", "Pizza"),
-                       KeyValuePair.Create("fried-chicken", "Fried chicken"),
-                       KeyValuePair.Create("burger", "Burger"),
-                       KeyValuePair.Create("salmon", "Salmon"),
-                       KeyValuePair.Create("chicken-pie", "Chicken pie"),
-                       KeyValuePair.Create("sushi", "Sushi"),
-                       KeyValuePair.Create("tacos", "Tacos"),
-                       KeyValuePair.Create("pasta", "Pasta"),
-                       KeyValuePair.Create("salad", "Salad"),
-                       KeyValuePair.Create("steak", "Steak"),
-                       KeyValuePair.Create("vegetarian", "Vegetarian"),
-                       KeyValuePair.Create("sausage", "Sausage"),
-                       KeyValuePair.Create("lasagne", "Lasagne"),
-                       KeyValuePair.Create("fish-pie", "Fish pie"),
-                       KeyValuePair.Create("soup", "Soup"),
-                       KeyValuePair.Create("beef-stew", "Beef stew"),
-                       KeyValuePair.Create("welsh-pie", "Llanfair­pwllgwyngyll­gogery­chwyrn­drobwll­llan­tysilio­gogo­goch pie"),
-                   ]
-               };
-               var requirementsInput = new InteractionInput
-               {
-                   Name = "Requirements",
-                   InputType = InputType.Choice,
-                   Label = "Requirements",
-                   Placeholder = "Select requirements",
-                   AllowCustomChoice = true,
-                   Options =
-                   [
-                       KeyValuePair.Create("vegetarian", "Vegetarian"),
-                       KeyValuePair.Create("vegan", "Vegan")
-                   ]
-               };
-               var numberOfPeopleInput = new InteractionInput { Name = "NumberOfPeople", InputType = InputType.Number, Label = "Number of people", Placeholder = "Enter number of people", Value = "2", Required = true };
-               var inputs = new List<InteractionInput>
-               {
-                   new InteractionInput { Name = "Name", InputType = InputType.Text, Label = "Name", Placeholder = "Enter name", Required = true, MaxLength = 50 },
-                   new InteractionInput { Name = "Password", InputType = InputType.SecretText, Label = "Password", Placeholder = "Enter password", Required = true, MaxLength = 20 },
-                   dinnerInput,
-                   numberOfPeopleInput,
-                   requirementsInput,
-                   new InteractionInput { Name = "RememberMe", InputType = InputType.Boolean, Label = "Remember me", Placeholder = "What does this do?", Required = true },
-               };
-               var result = await interactionService.PromptInputsAsync(
-                   "Input request",
-                   "Provide your name",
-                   inputs,
-                   options: new InputsDialogInteractionOptions
-                   {
-                       ValidationCallback = context =>
-                       {
-                           if (dinnerInput.Value == "steak" && int.TryParse(numberOfPeopleInput.Value, CultureInfo.InvariantCulture, out var i) && i > 4)
-                           {
-                               context.AddValidationError(numberOfPeopleInput, "Number of people can't be greater than 4 when eating steak.");
-                           }
-                           return Task.CompletedTask;
-                       }
-                   },
-                   cancellationToken: commandContext.CancellationToken);
+                return CommandResults.Success();
+            })
+            .WithCommand("input-interaction", "Input interactions", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                var dinnerInput = new InteractionInput
+                {
+                    Name = "Dinner",
+                    InputType = InputType.Choice,
+                    Label = "Dinner",
+                    Placeholder = "Select dinner",
+                    Required = true,
+                    Options =
+                    [
+                        KeyValuePair.Create("pizza", "Pizza"),
+                        KeyValuePair.Create("fried-chicken", "Fried chicken"),
+                        KeyValuePair.Create("burger", "Burger"),
+                        KeyValuePair.Create("salmon", "Salmon"),
+                        KeyValuePair.Create("chicken-pie", "Chicken pie"),
+                        KeyValuePair.Create("sushi", "Sushi"),
+                        KeyValuePair.Create("tacos", "Tacos"),
+                        KeyValuePair.Create("pasta", "Pasta"),
+                        KeyValuePair.Create("salad", "Salad"),
+                        KeyValuePair.Create("steak", "Steak"),
+                        KeyValuePair.Create("vegetarian", "Vegetarian"),
+                        KeyValuePair.Create("sausage", "Sausage"),
+                        KeyValuePair.Create("lasagne", "Lasagne"),
+                        KeyValuePair.Create("fish-pie", "Fish pie"),
+                        KeyValuePair.Create("soup", "Soup"),
+                        KeyValuePair.Create("beef-stew", "Beef stew"),
+                        KeyValuePair.Create("welsh-pie", "Llanfair­pwllgwyngyll­gogery­chwyrn­drobwll­llan­tysilio­gogo­goch pie"),
+                    ]
+                };
+                var requirementsInput = new InteractionInput
+                {
+                    Name = "Requirements",
+                    InputType = InputType.Choice,
+                    Label = "Requirements",
+                    Placeholder = "Select requirements",
+                    AllowCustomChoice = true,
+                    Options =
+                    [
+                        KeyValuePair.Create("vegetarian", "Vegetarian"),
+                        KeyValuePair.Create("vegan", "Vegan")
+                    ]
+                };
+                var numberOfPeopleInput = new InteractionInput { Name = "NumberOfPeople", InputType = InputType.Number, Label = "Number of people", Placeholder = "Enter number of people", Value = "2", Required = true };
+                var inputs = new List<InteractionInput>
+                {
+                    new InteractionInput { Name = "Name", InputType = InputType.Text, Label = "Name", Placeholder = "Enter name", Required = true, MaxLength = 50 },
+                    new InteractionInput { Name = "Password", InputType = InputType.SecretText, Label = "Password", Placeholder = "Enter password", Required = true, MaxLength = 20 },
+                    dinnerInput,
+                    numberOfPeopleInput,
+                    requirementsInput,
+                    new InteractionInput { Name = "RememberMe", InputType = InputType.Boolean, Label = "Remember me", Placeholder = "What does this do?", Required = true },
+                };
+                var result = await interactionService.PromptInputsAsync(
+                    "Input request",
+                    "Provide your name",
+                    inputs,
+                    options: new InputsDialogInteractionOptions
+                    {
+                        ValidationCallback = context =>
+                        {
+                            if (dinnerInput.Value == "steak" && int.TryParse(numberOfPeopleInput.Value, CultureInfo.InvariantCulture, out var i) && i > 4)
+                            {
+                                context.AddValidationError(numberOfPeopleInput, "Number of people can't be greater than 4 when eating steak.");
+                            }
+                            return Task.CompletedTask;
+                        }
+                    },
+                    cancellationToken: commandContext.CancellationToken);
 
-               if (result.Canceled)
-               {
-                   return CommandResults.Failure("Canceled");
-               }
+                if (result.Canceled)
+                {
+                    return CommandResults.Failure("Canceled");
+                }
 
-               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+                var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
 
-               foreach (var updatedInput in result.Data)
-               {
-                   logger.LogInformation("Input: {Name} = {Value}", updatedInput.Name, updatedInput.Value);
-               }
+                foreach (var updatedInput in result.Data)
+                {
+                    logger.LogInformation("Input: {Name} = {Value}", updatedInput.Name, updatedInput.Value);
+                }
 
-               return CommandResults.Success();
-           })
-           .WithCommand("choice-interaction", "Choice interactions", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-               var predefinedOptionsInput = new InteractionInput
-               {
-                   Name = "PredefinedOptions",
-                   InputType = InputType.Choice,
-                   Placeholder = "Placeholder!",
-                   Required = true,
-                   Options = [
-                       KeyValuePair.Create("option1", "Option 1"),
-                       KeyValuePair.Create("option2", "Option 2"),
-                       KeyValuePair.Create("option3", "Option 3")
-                   ]
-               };
-               var customChoiceInput = new InteractionInput
-               {
-                   Name = "CustomChoice",
-                   InputType = InputType.Choice,
-                   Label = "Custom choice",
-                   Placeholder = "Placeholder!",
-                   AllowCustomChoice = true,
-                   Required = true,
-                   DynamicLoading = new InputLoadOptions
-                   {
-                       LoadCallback = async (context) =>
-                       {
-                           await Task.Delay(5000, context.CancellationToken);
+                return CommandResults.Success();
+            })
+            .WithCommand("choice-interaction", "Choice interactions", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                var predefinedOptionsInput = new InteractionInput
+                {
+                    Name = "PredefinedOptions",
+                    InputType = InputType.Choice,
+                    Placeholder = "Placeholder!",
+                    Required = true,
+                    Options = [
+                        KeyValuePair.Create("option1", "Option 1"),
+                        KeyValuePair.Create("option2", "Option 2"),
+                        KeyValuePair.Create("option3", "Option 3")
+                    ]
+                };
+                var customChoiceInput = new InteractionInput
+                {
+                    Name = "CustomChoice",
+                    InputType = InputType.Choice,
+                    Label = "Custom choice",
+                    Placeholder = "Placeholder!",
+                    AllowCustomChoice = true,
+                    Required = true,
+                    DynamicLoading = new InputLoadOptions
+                    {
+                        LoadCallback = async (context) =>
+                        {
+                            await Task.Delay(5000, context.CancellationToken);
 
-                           // Simulate loading options from a database or web service.
-                           context.Input.Options = [
-                               KeyValuePair.Create("option1", "Option 1"),
-                               KeyValuePair.Create("option2", "Option 2"),
-                               KeyValuePair.Create("option3", "Option 3")
-                           ];
-                       }
-                   }
-               };
-               var sharedDynamicOptions = new InputLoadOptions
-               {
-                   LoadCallback = async (context) =>
-                   {
-                       var dependsOnInput = context.AllInputs["PredefinedOptions"];
+                            // Simulate loading options from a database or web service.
+                            context.Input.Options = [
+                                KeyValuePair.Create("option1", "Option 1"),
+                                KeyValuePair.Create("option2", "Option 2"),
+                                KeyValuePair.Create("option3", "Option 3")
+                            ];
+                        }
+                    }
+                };
+                var sharedDynamicOptions = new InputLoadOptions
+                {
+                    LoadCallback = async (context) =>
+                    {
+                        var dependsOnInput = context.AllInputs["PredefinedOptions"];
 
-                       if (!string.IsNullOrEmpty(dependsOnInput.Value))
-                       {
-                           await Task.Delay(5000, context.CancellationToken);
-                           var list = new List<KeyValuePair<string, string>>();
-                           for (var i = 0; i < 3; i++)
-                           {
-                               list.Add(KeyValuePair.Create($"option{i}-{dependsOnInput.Value}", $"Option {i} - {dependsOnInput.Value}"));
-                           }
+                        if (!string.IsNullOrEmpty(dependsOnInput.Value))
+                        {
+                            await Task.Delay(5000, context.CancellationToken);
+                            var list = new List<KeyValuePair<string, string>>();
+                            for (var i = 0; i < 3; i++)
+                            {
+                                list.Add(KeyValuePair.Create($"option{i}-{dependsOnInput.Value}", $"Option {i} - {dependsOnInput.Value}"));
+                            }
 
-                           context.Input.Disabled = false;
-                           context.Input.Options = list;
-                       }
-                       else
-                       {
-                           context.Input.Disabled = true;
-                       }
-                   },
-                   DependsOnInputs = ["PredefinedOptions"]
-               };
-               var dynamicInput = new InteractionInput
-               {
-                   Name = "Dynamic",
-                   InputType = InputType.Choice,
-                   Label = "Dynamic",
-                   Placeholder = "Select dynamic value",
-                   Required = true,
-                   Disabled = true,
-                   DynamicLoading = sharedDynamicOptions
-               };
-               var dynamicCustomChoiceInput = new InteractionInput
-               {
-                   Name = "DynamicCustomChoice",
-                   InputType = InputType.Choice,
-                   Label = "Dynamic custom choice",
-                   Placeholder = "Select dynamic value",
-                   AllowCustomChoice = true,
-                   Required = true,
-                   Disabled = true,
-                   DynamicLoading = sharedDynamicOptions
-               };
-               var dynamicTextInput = new InteractionInput
-               {
-                   Name = "DynamicTextInput",
-                   InputType = InputType.Text,
-                   Placeholder = "Placeholder!",
-                   Required = true,
-                   Disabled = true,
-                   DynamicLoading = new InputLoadOptions
-                   {
-                       DependsOnInputs = ["Dynamic"],
-                       LoadCallback = async (context) =>
-                       {
-                           await Task.Delay(5000, context.CancellationToken);
-                           var dependsOnInput = context.AllInputs["Dynamic"];
-                           context.Input.Value = dependsOnInput.Value;
-                       }
-                   }
-               };
+                            context.Input.Disabled = false;
+                            context.Input.Options = list;
+                        }
+                        else
+                        {
+                            context.Input.Disabled = true;
+                        }
+                    },
+                    DependsOnInputs = ["PredefinedOptions"]
+                };
+                var dynamicInput = new InteractionInput
+                {
+                    Name = "Dynamic",
+                    InputType = InputType.Choice,
+                    Label = "Dynamic",
+                    Placeholder = "Select dynamic value",
+                    Required = true,
+                    Disabled = true,
+                    DynamicLoading = sharedDynamicOptions
+                };
+                var dynamicCustomChoiceInput = new InteractionInput
+                {
+                    Name = "DynamicCustomChoice",
+                    InputType = InputType.Choice,
+                    Label = "Dynamic custom choice",
+                    Placeholder = "Select dynamic value",
+                    AllowCustomChoice = true,
+                    Required = true,
+                    Disabled = true,
+                    DynamicLoading = sharedDynamicOptions
+                };
+                var dynamicTextInput = new InteractionInput
+                {
+                    Name = "DynamicTextInput",
+                    InputType = InputType.Text,
+                    Placeholder = "Placeholder!",
+                    Required = true,
+                    Disabled = true,
+                    DynamicLoading = new InputLoadOptions
+                    {
+                        DependsOnInputs = ["Dynamic"],
+                        LoadCallback = async (context) =>
+                        {
+                            await Task.Delay(5000, context.CancellationToken);
+                            var dependsOnInput = context.AllInputs["Dynamic"];
+                            context.Input.Value = dependsOnInput.Value;
+                        }
+                    }
+                };
 
-               var inputs = new List<InteractionInput>
+                var inputs = new List<InteractionInput>
                {
                    customChoiceInput,
                    predefinedOptionsInput,
@@ -385,209 +385,405 @@ internal static class InteractionCommands
                    dynamicCustomChoiceInput,
                    dynamicTextInput
                };
-               var result = await interactionService.PromptInputsAsync(
-                   "Choice inputs",
-                   "Range of choice inputs",
-                   inputs,
-                   options: new InputsDialogInteractionOptions
-                   {
-                       ValidationCallback = context =>
-                       {
-                           return Task.CompletedTask;
-                       }
-                   },
-                   cancellationToken: commandContext.CancellationToken);
+                var result = await interactionService.PromptInputsAsync(
+                    "Choice inputs",
+                    "Range of choice inputs",
+                    inputs,
+                    options: new InputsDialogInteractionOptions
+                    {
+                        ValidationCallback = context =>
+                        {
+                            return Task.CompletedTask;
+                        }
+                    },
+                    cancellationToken: commandContext.CancellationToken);
 
-               if (result.Canceled)
-               {
-                   return CommandResults.Failure("Canceled");
-               }
+                if (result.Canceled)
+                {
+                    return CommandResults.Failure("Canceled");
+                }
 
-               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+                var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
 
-               foreach (var updatedInput in result.Data)
-               {
-                   logger.LogInformation("Input: {Name} = {Value}", updatedInput.Name, updatedInput.Value);
-               }
+                foreach (var updatedInput in result.Data)
+                {
+                    logger.LogInformation("Input: {Name} = {Value}", updatedInput.Name, updatedInput.Value);
+                }
 
-               return CommandResults.Success();
-           })
-           .WithCommand("dynamic-error", "Dynamic error", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-               var predefinedOptionsInput = new InteractionInput
-               {
-                   Name = "PredefinedOptions",
-                   InputType = InputType.Choice,
-                   Placeholder = "Placeholder!",
-                   Required = true,
-                   Options = [
-                       KeyValuePair.Create("option1", "Option 1"),
-                       KeyValuePair.Create("option2", "Option 2"),
-                       KeyValuePair.Create("option3", "Option 3")
-                   ]
-               };
-               var customChoiceInput = new InteractionInput
-               {
-                   Name = "CustomChoice",
-                   InputType = InputType.Choice,
-                   Label = "Custom choice",
-                   Placeholder = "Placeholder!",
-                   AllowCustomChoice = true,
-                   Required = true,
-                   DynamicLoading = new InputLoadOptions
-                   {
-                       LoadCallback = async (context) =>
-                       {
-                           await Task.Delay(1000, context.CancellationToken);
+                return CommandResults.Success();
+            })
+            .WithCommand("dynamic-error", "Dynamic error", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                var predefinedOptionsInput = new InteractionInput
+                {
+                    Name = "PredefinedOptions",
+                    InputType = InputType.Choice,
+                    Placeholder = "Placeholder!",
+                    Required = true,
+                    Options = [
+                        KeyValuePair.Create("option1", "Option 1"),
+                        KeyValuePair.Create("option2", "Option 2"),
+                        KeyValuePair.Create("option3", "Option 3")
+                    ]
+                };
+                var customChoiceInput = new InteractionInput
+                {
+                    Name = "CustomChoice",
+                    InputType = InputType.Choice,
+                    Label = "Custom choice",
+                    Placeholder = "Placeholder!",
+                    AllowCustomChoice = true,
+                    Required = true,
+                    DynamicLoading = new InputLoadOptions
+                    {
+                        LoadCallback = async (context) =>
+                        {
+                            await Task.Delay(1000, context.CancellationToken);
 
-                           throw new InvalidOperationException("Error!");
-                       }
-                   }
-               };
-               var dynamicInput = new InteractionInput
-               {
-                   Name = "Dynamic",
-                   InputType = InputType.Choice,
-                   Label = "Dynamic",
-                   Placeholder = "Select dynamic value",
-                   Required = true,
-                   DynamicLoading = new InputLoadOptions
-                   {
-                       LoadCallback = async (context) =>
-                       {
-                           await Task.Delay(1000, context.CancellationToken);
+                            throw new InvalidOperationException("Error!");
+                        }
+                    }
+                };
+                var dynamicInput = new InteractionInput
+                {
+                    Name = "Dynamic",
+                    InputType = InputType.Choice,
+                    Label = "Dynamic",
+                    Placeholder = "Select dynamic value",
+                    Required = true,
+                    DynamicLoading = new InputLoadOptions
+                    {
+                        LoadCallback = async (context) =>
+                        {
+                            await Task.Delay(1000, context.CancellationToken);
 
-                           var dependsOnInput = context.AllInputs["PredefinedOptions"];
+                            var dependsOnInput = context.AllInputs["PredefinedOptions"];
 
-                           if (dependsOnInput.Value == "option1")
-                           {
-                               throw new InvalidOperationException("Error!");
-                           }
+                            if (dependsOnInput.Value == "option1")
+                            {
+                                throw new InvalidOperationException("Error!");
+                            }
 
-                           var list = new List<KeyValuePair<string, string>>();
-                           for (var i = 0; i < 3; i++)
-                           {
-                               list.Add(KeyValuePair.Create($"option{i}-{dependsOnInput.Value}", $"Option {i} - {dependsOnInput.Value}"));
-                           }
+                            var list = new List<KeyValuePair<string, string>>();
+                            for (var i = 0; i < 3; i++)
+                            {
+                                list.Add(KeyValuePair.Create($"option{i}-{dependsOnInput.Value}", $"Option {i} - {dependsOnInput.Value}"));
+                            }
 
-                           context.Input.Options = list;
-                       },
-                       DependsOnInputs = ["PredefinedOptions"]
-                   }
-               };
+                            context.Input.Options = list;
+                        },
+                        DependsOnInputs = ["PredefinedOptions"]
+                    }
+                };
 
-               var inputs = new List<InteractionInput>
+                var inputs = new List<InteractionInput>
                {
                    predefinedOptionsInput,
                    customChoiceInput,
                    dynamicInput
                };
-               var result = await interactionService.PromptInputsAsync(
-                   "Choice inputs",
-                   "Range of choice inputs",
-                   inputs,
-                   options: new InputsDialogInteractionOptions
-                   {
-                       ValidationCallback = context =>
-                       {
-                           return Task.CompletedTask;
-                       }
-                   },
-                   cancellationToken: commandContext.CancellationToken);
+                var result = await interactionService.PromptInputsAsync(
+                    "Choice inputs",
+                    "Range of choice inputs",
+                    inputs,
+                    options: new InputsDialogInteractionOptions
+                    {
+                        ValidationCallback = context =>
+                        {
+                            return Task.CompletedTask;
+                        }
+                    },
+                    cancellationToken: commandContext.CancellationToken);
 
-               if (result.Canceled)
-               {
-                   return CommandResults.Failure("Canceled");
-               }
+                if (result.Canceled)
+                {
+                    return CommandResults.Failure("Canceled");
+                }
 
-               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+                var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
 
-               foreach (var updatedInput in result.Data)
-               {
-                   logger.LogInformation("Input: {Name} = {Value}", updatedInput.Name, updatedInput.Value);
-               }
+                foreach (var updatedInput in result.Data)
+                {
+                    logger.LogInformation("Input: {Name} = {Value}", updatedInput.Name, updatedInput.Value);
+                }
 
-               return CommandResults.Success();
-           })
-           .WithCommand("dismiss-interaction", "Dismiss interaction tests", executeCommand: commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                return CommandResults.Success();
+            })
+            .WithCommand("dismiss-interaction", "Dismiss interaction tests", executeCommand: commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
 
-               RunInteractionWithDismissValues(nameof(IInteractionService.PromptNotificationAsync), (showDismiss, title) =>
-               {
-                   return interactionService.PromptNotificationAsync(
-                       title: title,
-                       message: string.Empty,
-                       options: new NotificationInteractionOptions { ShowDismiss = showDismiss },
-                       cancellationToken: commandContext.CancellationToken);
-               });
-               RunInteractionWithDismissValues(nameof(IInteractionService.PromptConfirmationAsync), (showDismiss, title) =>
-               {
-                   return interactionService.PromptConfirmationAsync(
-                       title: title,
-                       message: string.Empty,
-                       options: new MessageBoxInteractionOptions { ShowDismiss = showDismiss },
-                       cancellationToken: commandContext.CancellationToken);
-               });
-               RunInteractionWithDismissValues(nameof(IInteractionService.PromptMessageBoxAsync), (showDismiss, title) =>
-               {
-                   return interactionService.PromptMessageBoxAsync(
-                       title: title,
-                       message: string.Empty,
-                       options: new MessageBoxInteractionOptions { ShowDismiss = showDismiss },
-                       cancellationToken: commandContext.CancellationToken);
-               });
-               RunInteractionWithDismissValues(nameof(IInteractionService.PromptInputAsync), (showDismiss, title) =>
-               {
-                   return interactionService.PromptInputAsync(
-                       title: title,
-                       message: string.Empty,
-                       inputLabel: "Input",
-                       placeHolder: "Enter input",
-                       options: new InputsDialogInteractionOptions { ShowDismiss = showDismiss },
-                       cancellationToken: commandContext.CancellationToken);
-               });
+                RunInteractionWithDismissValues(nameof(IInteractionService.PromptNotificationAsync), (showDismiss, title) =>
+                {
+                    return interactionService.PromptNotificationAsync(
+                        title: title,
+                        message: string.Empty,
+                        options: new NotificationInteractionOptions { ShowDismiss = showDismiss },
+                        cancellationToken: commandContext.CancellationToken);
+                });
+                RunInteractionWithDismissValues(nameof(IInteractionService.PromptConfirmationAsync), (showDismiss, title) =>
+                {
+                    return interactionService.PromptConfirmationAsync(
+                        title: title,
+                        message: string.Empty,
+                        options: new MessageBoxInteractionOptions { ShowDismiss = showDismiss },
+                        cancellationToken: commandContext.CancellationToken);
+                });
+                RunInteractionWithDismissValues(nameof(IInteractionService.PromptMessageBoxAsync), (showDismiss, title) =>
+                {
+                    return interactionService.PromptMessageBoxAsync(
+                        title: title,
+                        message: string.Empty,
+                        options: new MessageBoxInteractionOptions { ShowDismiss = showDismiss },
+                        cancellationToken: commandContext.CancellationToken);
+                });
+                RunInteractionWithDismissValues(nameof(IInteractionService.PromptInputAsync), (showDismiss, title) =>
+                {
+                    return interactionService.PromptInputAsync(
+                        title: title,
+                        message: string.Empty,
+                        inputLabel: "Input",
+                        placeHolder: "Enter input",
+                        options: new InputsDialogInteractionOptions { ShowDismiss = showDismiss },
+                        cancellationToken: commandContext.CancellationToken);
+                });
 
-               return Task.FromResult(CommandResults.Success());
-           })
-           .WithCommand("many-values", "Many values", executeCommand: async commandContext =>
-           {
-               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-               var inputs = new List<InteractionInput>();
-               for (var i = 0; i < 50; i++)
-               {
-                   inputs.Add(new InteractionInput
-                   {
-                       Name = $"Input{i + 1}",
-                       InputType = InputType.Text,
-                       Label = $"Input {i + 1}",
-                       Placeholder = $"Enter input {i + 1}"
-                   });
-               }
-               var result = await interactionService.PromptInputsAsync(
-                   title: "Text request",
-                   message: "Provide your name",
-                   inputs: inputs,
-                   cancellationToken: commandContext.CancellationToken);
+                return Task.FromResult(CommandResults.Success());
+            })
+            .WithCommand("many-values", "Many values", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+                var inputs = new List<InteractionInput>();
+                for (var i = 0; i < 50; i++)
+                {
+                    inputs.Add(new InteractionInput
+                    {
+                        Name = $"Input{i + 1}",
+                        InputType = InputType.Text,
+                        Label = $"Input {i + 1}",
+                        Placeholder = $"Enter input {i + 1}"
+                    });
+                }
+                var result = await interactionService.PromptInputsAsync(
+                    title: "Text request",
+                    message: "Provide your name",
+                    inputs: inputs,
+                    cancellationToken: commandContext.CancellationToken);
 
-               if (result.Canceled)
-               {
-                   return CommandResults.Failure("Canceled");
-               }
+                if (result.Canceled)
+                {
+                    return CommandResults.Failure("Canceled");
+                }
 
-               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+                var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
 
-               foreach (var input in result.Data)
-               {
-                   logger.LogInformation("Input: {Name} = {Value}", input.Name, input.Value);
-               }
+                foreach (var input in result.Data)
+                {
+                    logger.LogInformation("Input: {Name} = {Value}", input.Name, input.Value);
+                }
 
-               return CommandResults.Success();
-           });
+                return CommandResults.Success();
+            })
+            .WithCommand("azure-provisioning-simulation", "Azure provisioning simulation", executeCommand: async commandContext =>
+            {
+                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+
+                var tenantInput = new InteractionInput
+                {
+                    Name = "Tenant",
+                    InputType = InputType.Choice,
+                    Label = "Tenant ID",
+                    Required = true,
+                    AllowCustomChoice = true,
+                    Placeholder = "Select tenant ID",
+                    DynamicLoading = new InputLoadOptions
+                    {
+                        LoadCallback = async (context) =>
+                        {
+                            // Simulate fetching tenants from Azure.
+                            await Task.Delay(1500, context.CancellationToken);
+                            context.Input.Options = [
+                                KeyValuePair.Create("11111111-1111-1111-1111-111111111111", "Contoso Corp (11111111-1111-1111-1111-111111111111)"),
+                                KeyValuePair.Create("22222222-2222-2222-2222-222222222222", "Fabrikam Inc (22222222-2222-2222-2222-222222222222)"),
+                                KeyValuePair.Create("33333333-3333-3333-3333-333333333333", "Northwind Traders (33333333-3333-3333-3333-333333333333)")
+                            ];
+                        }
+                    }
+                };
+
+                var subscriptionInput = new InteractionInput
+                {
+                    Name = "SubscriptionId",
+                    InputType = InputType.Choice,
+                    Label = "Subscription ID",
+                    Required = true,
+                    AllowCustomChoice = true,
+                    Placeholder = "Select subscription ID",
+                    Disabled = true,
+                    DynamicLoading = new InputLoadOptions
+                    {
+                        LoadCallback = async (context) =>
+                        {
+                            // Simulate fetching subscriptions for the selected tenant.
+                            await Task.Delay(2000, context.CancellationToken);
+
+                            var tenantId = context.AllInputs["Tenant"].Value ?? string.Empty;
+                            context.Input.Disabled = false;
+
+                            if (tenantId.StartsWith("1", StringComparison.Ordinal))
+                            {
+                                context.Input.Options = [
+                                    KeyValuePair.Create("aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Dev/Test Subscription (aaaa1111)"),
+                                    KeyValuePair.Create("bbbb2222-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "Production Subscription (bbbb2222)")
+                                ];
+                            }
+                            else
+                            {
+                                context.Input.Options = [
+                                    KeyValuePair.Create("cccc3333-cccc-cccc-cccc-cccccccccccc", "Sandbox Subscription (cccc3333)"),
+                                    KeyValuePair.Create("dddd4444-dddd-dddd-dddd-dddddddddddd", "Staging Subscription (dddd4444)"),
+                                    KeyValuePair.Create("eeee5555-eeee-eeee-eeee-eeeeeeeeeeee", "Production Subscription (eeee5555)")
+                                ];
+                            }
+                        },
+                        DependsOnInputs = ["Tenant"]
+                    }
+                };
+
+                var resourceGroupInput = new InteractionInput
+                {
+                    Name = "ResourceGroup",
+                    InputType = InputType.Choice,
+                    Label = "Resource group",
+                    Placeholder = "Select or enter resource group",
+                    AllowCustomChoice = true,
+                    Disabled = true,
+                    DynamicLoading = new InputLoadOptions
+                    {
+                        LoadCallback = async (context) =>
+                        {
+                            // Simulate fetching resource groups for the selected subscription.
+                            await Task.Delay(1000, context.CancellationToken);
+
+                            context.Input.Options = [
+                                KeyValuePair.Create("rg-aspire-dev", "rg-aspire-dev"),
+                               KeyValuePair.Create("rg-myapp-prod", "rg-myapp-prod"),
+                               KeyValuePair.Create("rg-shared-services", "rg-shared-services")
+                            ];
+                            context.Input.Disabled = false;
+
+                            if (string.IsNullOrEmpty(context.Input.Value))
+                            {
+                                context.Input.Value = "rg-aspire-stress";
+                            }
+                        },
+                        DependsOnInputs = ["SubscriptionId"]
+                    }
+                };
+
+                var locationInput = new InteractionInput
+                {
+                    Name = "Location",
+                    InputType = InputType.Choice,
+                    Label = "Location",
+                    Placeholder = "Select location",
+                    Required = true,
+                    Disabled = true,
+                    DynamicLoading = new InputLoadOptions
+                    {
+                        LoadCallback = async (context) =>
+                        {
+                            var resourceGroupName = context.AllInputs["ResourceGroup"].Value ?? string.Empty;
+
+                            // If an existing resource group is selected, lock the location.
+                            if (resourceGroupName is "rg-aspire-dev" or "rg-myapp-prod" or "rg-shared-services")
+                            {
+                                await Task.Delay(6000, context.CancellationToken);
+                                var existingLocation = resourceGroupName switch
+                                {
+                                    "rg-aspire-dev" => "westus2-rg",
+                                    "rg-myapp-prod" => "eastus-rg",
+                                    "rg-shared-services" => "centralus-rg",
+                                    _ => "westus2-rg"
+                                };
+                                context.Input.Options = [KeyValuePair.Create(existingLocation, existingLocation)];
+                                context.Input.Value = existingLocation;
+                                //context.Input.Disabled = true;
+                                return;
+                            }
+
+                            // For new resource groups, simulate loading all available locations.
+                            await Task.Delay(3000, context.CancellationToken);
+                            context.Input.Options = [
+                                KeyValuePair.Create("eastus", "East US"),
+                                KeyValuePair.Create("eastus2", "East US 2"),
+                                KeyValuePair.Create("westus2", "West US 2"),
+                                KeyValuePair.Create("westus3", "West US 3"),
+                                KeyValuePair.Create("centralus", "Central US"),
+                                KeyValuePair.Create("northeurope", "North Europe"),
+                                KeyValuePair.Create("westeurope", "West Europe"),
+                                KeyValuePair.Create("southeastasia", "Southeast Asia"),
+                                KeyValuePair.Create("australiaeast", "Australia East"),
+                                KeyValuePair.Create("japaneast", "Japan East")
+                            ];
+                            context.Input.Disabled = false;
+                        },
+                        DependsOnInputs = ["SubscriptionId", "ResourceGroup"]
+                    }
+                };
+
+                var inputs = new List<InteractionInput> { tenantInput, subscriptionInput, resourceGroupInput, locationInput };
+
+                var result = await interactionService.PromptInputsAsync(
+                    "Azure provisioning",
+                    "The model contains Azure resources that require an Azure Subscription.\n\nTo learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).",
+                    inputs,
+                    new InputsDialogInteractionOptions
+                    {
+                        EnableMessageMarkdown = true,
+                        ValidationCallback = (validationContext) =>
+                        {
+                            var tenant = validationContext.Inputs["Tenant"];
+                            if (!string.IsNullOrWhiteSpace(tenant.Value) && !Guid.TryParse(tenant.Value, out _))
+                            {
+                                validationContext.AddValidationError(tenant, "Tenant ID must be a valid GUID.");
+                            }
+
+                            var subscription = validationContext.Inputs["SubscriptionId"];
+                            if (!string.IsNullOrWhiteSpace(subscription.Value) && !Guid.TryParse(subscription.Value, out _))
+                            {
+                                validationContext.AddValidationError(subscription, "Subscription ID must be a valid GUID.");
+                            }
+
+                            return Task.CompletedTask;
+                        }
+                    },
+                    commandContext.CancellationToken);
+
+                if (result.Canceled)
+                {
+                    return CommandResults.Canceled();
+                }
+
+                var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+
+                foreach (var input in result.Data)
+                {
+                    logger.LogInformation("Azure provisioning: {Name} = {Value}", input.Name, input.Value);
+                }
+
+                return CommandResults.Success();
+            }, new CommandOptions
+            {
+                Description = "Simulates the Azure provisioning interaction inputs prompt with pretend data.",
+                IconName = "CloudArrowUp",
+                IconVariant = IconVariant.Filled
+            });
 
         return resource;
     }

--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -712,7 +712,7 @@ internal static class InteractionCommands
                                 };
                                 context.Input.Options = [KeyValuePair.Create(existingLocation, existingLocation)];
                                 context.Input.Value = existingLocation;
-                                //context.Input.Disabled = true;
+                                context.Input.Disabled = true;
                                 return;
                             }
 

--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -671,8 +671,8 @@ internal static class InteractionCommands
 
                             context.Input.Options = [
                                 KeyValuePair.Create("rg-aspire-dev", "rg-aspire-dev"),
-                               KeyValuePair.Create("rg-myapp-prod", "rg-myapp-prod"),
-                               KeyValuePair.Create("rg-shared-services", "rg-shared-services")
+                                KeyValuePair.Create("rg-myapp-prod", "rg-myapp-prod"),
+                                KeyValuePair.Create("rg-shared-services", "rg-shared-services")
                             ];
                             context.Input.Disabled = false;
 

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -90,7 +90,7 @@
                                 *@
                                 @if (!localItem.Input.AllowCustomChoice)
                                 {
-                                    <FluentSelect @key="input.ViewModel.ChoiceVersion"
+                                    <FluentSelect @key="input.ViewModel.InputKey"
                                                   TOption="SelectViewModel<string>"
                                                   @ref="@_elementRefs[input.ViewModel]"
                                                   @bind-Value="input.ViewModel.Value"
@@ -108,7 +108,7 @@
                                 }
                                 else
                                 {
-                                    <FluentCombobox @key="input.ViewModel.ChoiceVersion"
+                                    <FluentCombobox @key="input.ViewModel.InputKey"
                                                     TOption="SelectViewModel<string>"
                                                     @ref="@_elementRefs[input.ViewModel]"
                                                     @bind-Value="input.ViewModel.Value"

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -90,7 +90,8 @@
                                 *@
                                 @if (!localItem.Input.AllowCustomChoice)
                                 {
-                                    <FluentSelect TOption="SelectViewModel<string>"
+                                    <FluentSelect @key="input.ViewModel.ChoiceVersion"
+                                                  TOption="SelectViewModel<string>"
                                                   @ref="@_elementRefs[input.ViewModel]"
                                                   @bind-Value="input.ViewModel.Value"
                                                   Placeholder="@input.ViewModel.Input.Placeholder"
@@ -107,7 +108,8 @@
                                 }
                                 else
                                 {
-                                    <FluentCombobox TOption="SelectViewModel<string>"
+                                    <FluentCombobox @key="input.ViewModel.ChoiceVersion"
+                                                    TOption="SelectViewModel<string>"
                                                     @ref="@_elementRefs[input.ViewModel]"
                                                     @bind-Value="input.ViewModel.Value"
                                                     Placeholder="@input.ViewModel.Input.Placeholder"

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -211,7 +211,7 @@ public partial class InteractionsInputDialog : IAsyncDisposable
     private static Icon GetSecretTextIcon(InputViewModel inputModel)
     {
         return inputModel.IsSecretTextVisible
-            ? new Icons.Regular.Size16.EyeOff() 
+            ? new Icons.Regular.Size16.EyeOff()
             : new Icons.Regular.Size16.Eye();
     }
 

--- a/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
@@ -63,11 +63,17 @@ public sealed class InputViewModel
     public List<SelectViewModel<string>> SelectOptions { get; private set; } = [];
 
     /// <summary>
-    /// Incremented each time <see cref="SelectOptions"/> is rebuilt. Used as a <c>@key</c>
-    /// on FluentSelect so Blazor recreates the component when options change, avoiding a
-    /// race where the web component clears the bound value during an options refresh.
+    /// Incremented each time <see cref="SelectOptions"/> is rebuilt so Blazor
+    /// recreates the choice input component when options change, avoiding a race
+    /// where the web component clears the bound value during an options refresh.
     /// </summary>
     public int ChoiceVersion { get; private set; }
+
+    /// <summary>
+    /// A key unique per input that changes when <see cref="ChoiceVersion"/> changes.
+    /// Used as a Blazor <c>@key</c> on FluentSelect / FluentCombobox.
+    /// </summary>
+    public string InputKey => $"{Input.Name}_{ChoiceVersion}";
 
     public IEnumerable<SelectViewModel<string>> FilteredOptions()
     {

--- a/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
@@ -49,13 +49,13 @@ public sealed class InputViewModel
             {
                 SelectOptions = optionsVM;
                 ChoiceVersion++;
+            }
 
-                // Default to the first option if no placeholder is set, the value is empty, and custom choice is disabled.
-                // This is done so the input model value matches frontend behavior (FluentSelect defaults to the first option)
-                if (string.IsNullOrEmpty(input.Placeholder) && string.IsNullOrEmpty(input.Value) && optionsVM.Count > 0 && !input.AllowCustomChoice)
-                {
-                    input.Value = optionsVM[0].Id;
-                }
+            // Default to the first option if no placeholder is set, the value is empty, and custom choice is disabled.
+            // This is done so the input model value matches frontend behavior (FluentSelect defaults to the first option)
+            if (string.IsNullOrEmpty(input.Placeholder) && string.IsNullOrEmpty(input.Value) && optionsVM.Count > 0 && !input.AllowCustomChoice)
+            {
+                input.Value = optionsVM[0].Id;
             }
         }
     }

--- a/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
@@ -44,18 +44,30 @@ public sealed class InputViewModel
                 .Select(option => new SelectViewModel<string> { Id = option.Key, Name = option.Value, })
                 .ToList();
 
-            SelectOptions = optionsVM;
-
-            // Default to the first option if no placeholder is set, the value is empty, and custom choice is disabled.
-            // This is done so the input model value matches frontend behavior (FluentSelect defaults to the first option)
-            if (string.IsNullOrEmpty(input.Placeholder) && string.IsNullOrEmpty(input.Value) && optionsVM.Count > 0 && !input.AllowCustomChoice)
+            // Only update the options if they have changed to avoid unnecessarily recreating the FluentSelect component.
+            if (!OptionsEqual(SelectOptions, optionsVM))
             {
-                input.Value = optionsVM[0].Id;
+                SelectOptions = optionsVM;
+                ChoiceVersion++;
+
+                // Default to the first option if no placeholder is set, the value is empty, and custom choice is disabled.
+                // This is done so the input model value matches frontend behavior (FluentSelect defaults to the first option)
+                if (string.IsNullOrEmpty(input.Placeholder) && string.IsNullOrEmpty(input.Value) && optionsVM.Count > 0 && !input.AllowCustomChoice)
+                {
+                    input.Value = optionsVM[0].Id;
+                }
             }
         }
     }
 
     public List<SelectViewModel<string>> SelectOptions { get; private set; } = [];
+
+    /// <summary>
+    /// Incremented each time <see cref="SelectOptions"/> is rebuilt. Used as a <c>@key</c>
+    /// on FluentSelect so Blazor recreates the component when options change, avoiding a
+    /// race where the web component clears the bound value during an options refresh.
+    /// </summary>
+    public int ChoiceVersion { get; private set; }
 
     public IEnumerable<SelectViewModel<string>> FilteredOptions()
     {
@@ -101,4 +113,22 @@ public sealed class InputViewModel
 
     // Used to track secret text visibility state
     public bool IsSecretTextVisible { get; set; }
+
+    private static bool OptionsEqual(List<SelectViewModel<string>> existing, List<SelectViewModel<string>> incoming)
+    {
+        if (existing.Count != incoming.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < existing.Count; i++)
+        {
+            if (existing[i].Id != incoming[i].Id || existing[i].Name != incoming[i].Name)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -104,10 +104,26 @@ internal sealed class RunModeProvisioningContextProvider(
     {
         // Caches for dynamic loading callbacks to avoid redundant Azure API calls.
         // Keyed by the relevant parameter (tenant ID, subscription ID) so they invalidate when the dependency changes.
-        Task<(List<KeyValuePair<string, string>>? tenantOptions, bool fetchSucceeded)>? tenantsTask = null;
         var subscriptionsCache = new ConcurrentDictionary<string, Task<(List<KeyValuePair<string, string>>? subscriptionOptions, bool fetchSucceeded)>>();
         var resourceGroupsCache = new ConcurrentDictionary<string, Task<(List<(string Name, string Location)>? resourceGroupOptions, bool fetchSucceeded)>>();
         var locationsCache = new ConcurrentDictionary<string, Task<(List<KeyValuePair<string, string>> locationOptions, bool fetchSucceeded)>>();
+
+        // Helper to cache only successful results. Failed tasks are evicted so the next callback retries.
+        static async Task<(T options, bool fetchSucceeded)> GetOrAddAsync<T>(
+            ConcurrentDictionary<string, Task<(T options, bool fetchSucceeded)>> cache,
+            string key,
+            Func<string, Task<(T options, bool fetchSucceeded)>> valueFactory)
+        {
+            var cachedTask = cache.GetOrAdd(key, valueFactory);
+            var result = await cachedTask.ConfigureAwait(false);
+
+            if (!result.fetchSucceeded)
+            {
+                cache.TryRemove(new KeyValuePair<string, Task<(T options, bool fetchSucceeded)>>(key, cachedTask));
+            }
+
+            return result;
+        }
 
         while (_options.Location == null || _options.SubscriptionId == null)
         {
@@ -149,7 +165,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             LoadCallback = async (context) =>
                             {
                                 var (tenantOptions, fetchSucceeded) =
-                                    await (tenantsTask ??= TryGetTenantsAsync(cancellationToken)).ConfigureAwait(false);
+                                    await TryGetTenantsAsync(cancellationToken).ConfigureAwait(false);
 
                                 context.Input.Options = fetchSucceeded
                                     ? tenantOptions!
@@ -176,7 +192,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             var tenantId = context.AllInputs[TenantName].Value ?? string.Empty;
 
                             var (subscriptionOptions, fetchSucceeded) =
-                                await subscriptionsCache.GetOrAdd(tenantId, key => TryGetSubscriptionsAsync(key, cancellationToken)).ConfigureAwait(false);
+                                await GetOrAddAsync(subscriptionsCache, tenantId, key => TryGetSubscriptionsAsync(key, cancellationToken)).ConfigureAwait(false);
 
                             context.Input.Options = fetchSucceeded
                                 ? subscriptionOptions!
@@ -215,7 +231,7 @@ internal sealed class RunModeProvisioningContextProvider(
                         {
                             var subscriptionId = context.AllInputs[SubscriptionIdName].Value ?? string.Empty;
 
-                            var (resourceGroupOptions, fetchSucceeded) = await resourceGroupsCache.GetOrAdd(subscriptionId, key => TryGetResourceGroupsWithLocationAsync(key, cancellationToken)).ConfigureAwait(false);
+                            var (resourceGroupOptions, fetchSucceeded) = await GetOrAddAsync(resourceGroupsCache, subscriptionId, key => TryGetResourceGroupsWithLocationAsync(key, cancellationToken)).ConfigureAwait(false);
 
                             if (fetchSucceeded && resourceGroupOptions is not null)
                             {
@@ -254,7 +270,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             var resourceGroupName = context.AllInputs[ResourceGroupName].Value ?? string.Empty;
 
                             // Check if the selected resource group is an existing one
-                            var (resourceGroupOptions, fetchSucceeded) = await resourceGroupsCache.GetOrAdd(subscriptionId, key => TryGetResourceGroupsWithLocationAsync(key, cancellationToken)).ConfigureAwait(false);
+                            var (resourceGroupOptions, fetchSucceeded) = await GetOrAddAsync(resourceGroupsCache, subscriptionId, key => TryGetResourceGroupsWithLocationAsync(key, cancellationToken)).ConfigureAwait(false);
 
                             if (fetchSucceeded && resourceGroupOptions is not null)
                             {
@@ -270,7 +286,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             }
 
                             // For new resource groups, load all locations
-                            var (locationOptions, _) = await locationsCache.GetOrAdd(subscriptionId, key => TryGetLocationsAsync(key, cancellationToken)).ConfigureAwait(false);
+                            var (locationOptions, _) = await GetOrAddAsync(locationsCache, subscriptionId, key => TryGetLocationsAsync(key, cancellationToken)).ConfigureAwait(false);
                             context.Input.Options = locationOptions;
                             context.Input.Disabled = false;
                         },

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -4,6 +4,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using Aspire.Hosting.Azure.Resources;
 using Aspire.Hosting.Azure.Utils;
@@ -101,6 +102,13 @@ internal sealed class RunModeProvisioningContextProvider(
 
     private async Task RetrieveAzureProvisioningOptions(CancellationToken cancellationToken = default)
     {
+        // Caches for dynamic loading callbacks to avoid redundant Azure API calls.
+        // Keyed by the relevant parameter (tenant ID, subscription ID) so they invalidate when the dependency changes.
+        Task<(List<KeyValuePair<string, string>>? tenantOptions, bool fetchSucceeded)>? tenantsTask = null;
+        var subscriptionsCache = new ConcurrentDictionary<string, Task<(List<KeyValuePair<string, string>>? subscriptionOptions, bool fetchSucceeded)>>();
+        var resourceGroupsCache = new ConcurrentDictionary<string, Task<(List<(string Name, string Location)>? resourceGroupOptions, bool fetchSucceeded)>>();
+        var locationsCache = new ConcurrentDictionary<string, Task<(List<KeyValuePair<string, string>> locationOptions, bool fetchSucceeded)>>();
+
         while (_options.Location == null || _options.SubscriptionId == null)
         {
             var messageBarResult = await _interactionService.PromptNotificationAsync(
@@ -141,7 +149,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             LoadCallback = async (context) =>
                             {
                                 var (tenantOptions, fetchSucceeded) =
-                                    await TryGetTenantsAsync(cancellationToken).ConfigureAwait(false);
+                                    await (tenantsTask ??= TryGetTenantsAsync(cancellationToken)).ConfigureAwait(false);
 
                                 context.Input.Options = fetchSucceeded
                                     ? tenantOptions!
@@ -168,7 +176,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             var tenantId = context.AllInputs[TenantName].Value ?? string.Empty;
 
                             var (subscriptionOptions, fetchSucceeded) =
-                                await TryGetSubscriptionsAsync(tenantId, cancellationToken).ConfigureAwait(false);
+                                await subscriptionsCache.GetOrAdd(tenantId, key => TryGetSubscriptionsAsync(key, cancellationToken)).ConfigureAwait(false);
 
                             context.Input.Options = fetchSucceeded
                                 ? subscriptionOptions!
@@ -207,7 +215,7 @@ internal sealed class RunModeProvisioningContextProvider(
                         {
                             var subscriptionId = context.AllInputs[SubscriptionIdName].Value ?? string.Empty;
 
-                            var (resourceGroupOptions, fetchSucceeded) = await TryGetResourceGroupsWithLocationAsync(subscriptionId, cancellationToken).ConfigureAwait(false);
+                            var (resourceGroupOptions, fetchSucceeded) = await resourceGroupsCache.GetOrAdd(subscriptionId, key => TryGetResourceGroupsWithLocationAsync(key, cancellationToken)).ConfigureAwait(false);
 
                             if (fetchSucceeded && resourceGroupOptions is not null)
                             {
@@ -246,7 +254,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             var resourceGroupName = context.AllInputs[ResourceGroupName].Value ?? string.Empty;
 
                             // Check if the selected resource group is an existing one
-                            var (resourceGroupOptions, fetchSucceeded) = await TryGetResourceGroupsWithLocationAsync(subscriptionId, cancellationToken).ConfigureAwait(false);
+                            var (resourceGroupOptions, fetchSucceeded) = await resourceGroupsCache.GetOrAdd(subscriptionId, key => TryGetResourceGroupsWithLocationAsync(key, cancellationToken)).ConfigureAwait(false);
 
                             if (fetchSucceeded && resourceGroupOptions is not null)
                             {
@@ -262,7 +270,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             }
 
                             // For new resource groups, load all locations
-                            var (locationOptions, _) = await TryGetLocationsAsync(subscriptionId, cancellationToken).ConfigureAwait(false);
+                            var (locationOptions, _) = await locationsCache.GetOrAdd(subscriptionId, key => TryGetLocationsAsync(key, cancellationToken)).ConfigureAwait(false);
                             context.Input.Options = locationOptions;
                             context.Input.Disabled = false;
                         },

--- a/tests/Aspire.Dashboard.Components.Tests/Model/InputViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Model/InputViewModelTests.cs
@@ -178,4 +178,85 @@ public class InputViewModelTests
         // Assert - When AllowCustomChoice is true, value should not default
         Assert.True(string.IsNullOrEmpty(viewModel.Value));
     }
+
+    [Fact]
+    public void OptionsVersion_IncrementedWhenOptionsChange()
+    {
+        var input = new InteractionInput
+        {
+            Label = "Choose",
+            InputType = InputType.Choice,
+            Placeholder = "Select"
+        };
+        input.Options.Add("a", "A");
+
+        var viewModel = new InputViewModel(input);
+        var initialVersion = viewModel.ChoiceVersion;
+
+        var updatedInput = new InteractionInput
+        {
+            Label = "Choose",
+            InputType = InputType.Choice,
+            Placeholder = "Select"
+        };
+        updatedInput.Options.Add("b", "B");
+        updatedInput.Options.Add("c", "C");
+
+        viewModel.SetInput(updatedInput);
+
+        Assert.Equal(initialVersion + 1, viewModel.ChoiceVersion);
+    }
+
+    [Fact]
+    public void OptionsVersion_NotIncrementedForNonChoiceInput()
+    {
+        var input = new InteractionInput
+        {
+            Label = "Name",
+            InputType = InputType.Text
+        };
+
+        var viewModel = new InputViewModel(input);
+        var initialVersion = viewModel.ChoiceVersion;
+
+        var updatedInput = new InteractionInput
+        {
+            Label = "Name",
+            InputType = InputType.Text,
+            Value = "test"
+        };
+
+        viewModel.SetInput(updatedInput);
+
+        Assert.Equal(initialVersion, viewModel.ChoiceVersion);
+    }
+
+    [Fact]
+    public void ChoiceVersion_NotIncrementedWhenOptionsUnchanged()
+    {
+        var input = new InteractionInput
+        {
+            Label = "Choose",
+            InputType = InputType.Choice,
+            Placeholder = "Select"
+        };
+        input.Options.Add("a", "A");
+        input.Options.Add("b", "B");
+
+        var viewModel = new InputViewModel(input);
+        var initialVersion = viewModel.ChoiceVersion;
+
+        var sameInput = new InteractionInput
+        {
+            Label = "Choose",
+            InputType = InputType.Choice,
+            Placeholder = "Select"
+        };
+        sameInput.Options.Add("a", "A");
+        sameInput.Options.Add("b", "B");
+
+        viewModel.SetInput(sameInput);
+
+        Assert.Equal(initialVersion, viewModel.ChoiceVersion);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/InputViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/InputViewModelTests.cs
@@ -5,7 +5,7 @@ using Aspire.Dashboard.Model.Interaction;
 using Aspire.DashboardService.Proto.V1;
 using Xunit;
 
-namespace Aspire.Dashboard.Components.Tests.Model;
+namespace Aspire.Dashboard.Tests.Model;
 
 public class InputViewModelTests
 {

--- a/tests/Aspire.Dashboard.Tests/Model/InputViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/InputViewModelTests.cs
@@ -180,7 +180,7 @@ public class InputViewModelTests
     }
 
     [Fact]
-    public void OptionsVersion_IncrementedWhenOptionsChange()
+    public void ChoiceVersion_IncrementedWhenOptionsChange()
     {
         var input = new InteractionInput
         {
@@ -208,7 +208,7 @@ public class InputViewModelTests
     }
 
     [Fact]
-    public void OptionsVersion_NotIncrementedForNonChoiceInput()
+    public void ChoiceVersion_NotIncrementedForNonChoiceInput()
     {
         var input = new InteractionInput
         {


### PR DESCRIPTION
## Description

Fix an issue where `FluentSelect` and `FluentCombobox` inputs in `InteractionsInputDialog` sometimes lose their bound value when the list of options and value change at the same time. The underlying web component can emit an internal change event during an options rebuild, clearing the bound value before the new one takes effect.

**Changes:**

1. **`InputViewModel.ChoiceVersion`** — Added a counter that increments only when `SelectOptions` actually change. Used as a `@key` on `FluentSelect` and `FluentCombobox` in the dialog so Blazor destroys and recreates the component when options change, initializing it fresh with the correct options and value together. Skips increment when the new options match the existing ones.

2. **Azure provisioning API call caching** — `RunModeProvisioningContextProvider` dynamic loading callbacks now cache results using `ConcurrentDictionary<string, Task<T>>` (keyed by tenant/subscription ID) to avoid redundant Azure API calls. The biggest win is the Location callback, which previously re-fetched resource groups and locations on every resource group change.

3. **Stress playground** — Added an "Azure provisioning simulation" command to the Stress AppHost that exercises the full cascading dynamic inputs pattern (Tenant → Subscription → ResourceGroup → Location) with pretend data, for manual testing of the interaction dialog.

Fixes https://youtu.be/0s64lPsr6oM?t=13143

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
