### PR TITLE
Use GetRequiredService for DistributedApplicationModel, extract ResolveResourceIds helpers, and improve test coverage

### DIFF
--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -381,7 +381,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
 
     private WaitTargetResolutionResult ResolveWaitTarget(ResourceNotificationService notificationService, string requestedResourceName)
     {
-        var appModel = serviceProvider.GetService<DistributedApplicationModel>();
+        var appModel = serviceProvider.GetRequiredService<DistributedApplicationModel>();
         if (notificationService.TryGetCurrentState(requestedResourceName, out var resourceEvent))
         {
             return WaitTargetResolutionResult.Success(new WaitResourceTarget(
@@ -392,11 +392,6 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
 
         // During startup the resource may not have published its first snapshot yet, so fall back to
         // the app model to resolve the requested logical name or resolved resource id.
-        if (appModel is null)
-        {
-            return WaitTargetResolutionResult.Success(new WaitResourceTarget(requestedResourceName, requestedResourceName, requestedResourceName));
-        }
-
         var matchingResource = appModel.Resources.SingleOrDefault(resource => string.Equals(resource.Name, requestedResourceName, StringComparisons.ResourceName));
         if (matchingResource is not null)
         {
@@ -426,13 +421,8 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         };
     }
 
-    private static string ResolveDisplayName(DistributedApplicationModel? appModel, string requestedResourceName, string resolvedResourceName)
+    private static string ResolveDisplayName(DistributedApplicationModel appModel, string requestedResourceName, string resolvedResourceName)
     {
-        if (appModel is null)
-        {
-            return requestedResourceName;
-        }
-
         var matchingResource = appModel.Resources
             .Select(resource => new { Resource = resource, ResolvedResourceNames = resource.GetResolvedResourceNames() })
             .SingleOrDefault(match => match.ResolvedResourceNames.Any(resourceName => string.Equals(resourceName, resolvedResourceName, StringComparisons.ResourceName)));

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -550,14 +550,9 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
     /// <returns>A list of resource snapshots.</returns>
     public async Task<List<ResourceSnapshot>> GetResourceSnapshotsAsync(CancellationToken cancellationToken = default)
     {
-        var appModel = serviceProvider.GetService<DistributedApplicationModel>();
+        var appModel = serviceProvider.GetRequiredService<DistributedApplicationModel>();
         var notificationService = serviceProvider.GetRequiredService<ResourceNotificationService>();
         var results = new List<ResourceSnapshot>();
-
-        if (appModel is null)
-        {
-            return results;
-        }
 
         // Get current state for each resource directly using TryGetCurrentState
         foreach (var resource in appModel.Resources)
@@ -847,11 +842,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
         ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
 
-        var appModel = serviceProvider.GetService<DistributedApplicationModel>();
-        if (appModel is null)
-        {
-            throw new InvalidOperationException("Application model not found.");
-        }
+        var appModel = serviceProvider.GetRequiredService<DistributedApplicationModel>();
 
         var resource = appModel.Resources
             .OfType<IResourceWithEndpoints>()

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -763,42 +763,14 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         var appModel = serviceProvider.GetRequiredService<DistributedApplicationModel>();
 
         // Step 1: Calculate the resource names
-        var resourcesToLog = new List<string>();
+        var resourcesToLog = resourceName is not null
+            ? ResolveResourceIds(appModel, resourceName)
+            : ResolveAllResourceIds(appModel);
 
-        if (resourceName is not null)
+        if (resourceName is not null && resourcesToLog.Count == 0)
         {
-            // Match by logical name (stream all instances) or resolved instance name like
-            // "apiservice-abc123" (stream just that one) — MCP advertises the resolved form.
-            foreach (var resource in appModel.Resources)
-            {
-                var resolvedNames = resource.GetResolvedResourceNames();
-
-                if (string.Equals(resource.Name, resourceName, StringComparisons.ResourceName))
-                {
-                    resourcesToLog.AddRange(resolvedNames);
-                    break;
-                }
-
-                var matchedInstance = resolvedNames.FirstOrDefault(n => string.Equals(n, resourceName, StringComparisons.ResourceName));
-                if (matchedInstance is not null)
-                {
-                    resourcesToLog.Add(matchedInstance);
-                    break;
-                }
-            }
-
-            if (resourcesToLog.Count == 0)
-            {
-                logger.LogWarning("Resource '{ResourceName}' not found. No logs will be returned.", resourceName);
-                yield break;
-            }
-        }
-        else
-        {
-            foreach (var resource in appModel.Resources)
-            {
-                resourcesToLog.AddRange(resource.GetResolvedResourceNames());
-            }
+            logger.LogWarning("Resource '{ResourceName}' not found. No logs will be returned.", resourceName);
+            yield break;
         }
 
         if (resourcesToLog.Count == 0)
@@ -1071,5 +1043,44 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
 
         // Fall back to double for floating point
         return element.GetDouble();
+    }
+
+    /// <summary>
+    /// Resolves a resource name (logical or resolved instance name) to the list of matching resource IDs.
+    /// Matches by logical name first (returning all instances), then falls back to matching a specific
+    /// resolved instance name like "apiservice-abc123".
+    /// </summary>
+    private static List<string> ResolveResourceIds(DistributedApplicationModel appModel, string resourceName)
+    {
+        foreach (var resource in appModel.Resources)
+        {
+            var resolvedNames = resource.GetResolvedResourceNames();
+
+            if (string.Equals(resource.Name, resourceName, StringComparisons.ResourceName))
+            {
+                return [.. resolvedNames];
+            }
+
+            var matchedInstance = resolvedNames.FirstOrDefault(n => string.Equals(n, resourceName, StringComparisons.ResourceName));
+            if (matchedInstance is not null)
+            {
+                return [matchedInstance];
+            }
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Returns the resolved resource IDs for all resources in the application model.
+    /// </summary>
+    private static List<string> ResolveAllResourceIds(DistributedApplicationModel appModel)
+    {
+        var result = new List<string>();
+        foreach (var resource in appModel.Resources)
+        {
+            result.AddRange(resource.GetResolvedResourceNames());
+        }
+        return result;
     }
 }

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -665,40 +665,6 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task WaitForResourceAsync_ReturnsSuccess_ForLogicalName()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
-        var custom = builder.AddResource(new CustomResource("myresource"));
-
-        using var app = builder.Build();
-        await app.StartAsync().DefaultTimeout();
-
-        var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
-        await notificationService.PublishUpdateAsync(custom.Resource, s => s with
-        {
-            State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
-        }).DefaultTimeout();
-
-        var target = new AuxiliaryBackchannelRpcTarget(
-            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
-            app.Services);
-
-        var result = await target.WaitForResourceAsync(new WaitForResourceRequest
-        {
-            ResourceName = "myresource",
-            Status = "up",
-            TimeoutSeconds = 10
-        }).DefaultTimeout();
-
-        Assert.True(result.Success);
-        Assert.Equal(KnownResourceStates.Running, result.State);
-        Assert.False(result.ResourceNotFound);
-        Assert.False(result.TimedOut);
-
-        await app.StopAsync().DefaultTimeout();
-    }
-
-    [Fact]
     public async Task WaitForResourceAsync_ReturnsNotFound_WhenResourceDoesNotExist()
     {
         using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
@@ -720,44 +686,6 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 
         Assert.False(result.Success);
         Assert.True(result.ResourceNotFound);
-
-        await app.StopAsync().DefaultTimeout();
-    }
-
-    [Fact]
-    public async Task WaitForResourceAsync_ReturnsSuccess_ForResolvedInstanceName()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
-
-        var resourceWithReplicas = builder.AddResource(new CustomResource("myresource"));
-        resourceWithReplicas.WithAnnotation(new DcpInstancesAnnotation([
-            new DcpInstance("myresource-abc123", "abc123", 0),
-            new DcpInstance("myresource-def456", "def456", 1)
-        ]));
-
-        using var app = builder.Build();
-        await app.StartAsync().DefaultTimeout();
-
-        var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
-        await notificationService.PublishUpdateAsync(resourceWithReplicas.Resource, s => s with
-        {
-            State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
-        }).DefaultTimeout();
-
-        var target = new AuxiliaryBackchannelRpcTarget(
-            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
-            app.Services);
-
-        var result = await target.WaitForResourceAsync(new WaitForResourceRequest
-        {
-            ResourceName = "myresource-abc123",
-            Status = "up",
-            TimeoutSeconds = 10
-        }).DefaultTimeout();
-
-        Assert.True(result.Success);
-        Assert.Equal(KnownResourceStates.Running, result.State);
-        Assert.False(result.ResourceNotFound);
 
         await app.StopAsync().DefaultTimeout();
     }

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -680,4 +680,133 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.Equal("http://localhost:18888", result.BaseUrlWithLoginToken);
         Assert.Null(result.CodespacesUrlWithLoginToken);
     }
+
+    [Fact]
+    public async Task WaitForResourceAsync_ReturnsSuccess_ForLogicalName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        var custom = builder.AddResource(new CustomResource("myresource"));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        await notificationService.PublishUpdateAsync(custom.Resource, s => s with
+        {
+            State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
+        }).DefaultTimeout();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services);
+
+        var result = await target.WaitForResourceAsync(new WaitForResourceRequest
+        {
+            ResourceName = "myresource",
+            Status = "up",
+            TimeoutSeconds = 10
+        }).DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal(KnownResourceStates.Running, result.State);
+        Assert.False(result.ResourceNotFound);
+        Assert.False(result.TimedOut);
+
+        await app.StopAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task WaitForResourceAsync_ReturnsNotFound_WhenResourceDoesNotExist()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        builder.AddResource(new CustomResource("myresource"));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services);
+
+        var result = await target.WaitForResourceAsync(new WaitForResourceRequest
+        {
+            ResourceName = "nonexistent",
+            Status = "up",
+            TimeoutSeconds = 10
+        }).DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.True(result.ResourceNotFound);
+
+        await app.StopAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task WaitForResourceAsync_ReturnsSuccess_ForResolvedInstanceName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+
+        var resourceWithReplicas = builder.AddResource(new CustomResource("myresource"));
+        resourceWithReplicas.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myresource-abc123", "abc123", 0),
+            new DcpInstance("myresource-def456", "def456", 1)
+        ]));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        await notificationService.PublishUpdateAsync(resourceWithReplicas.Resource, s => s with
+        {
+            State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
+        }).DefaultTimeout();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services);
+
+        var result = await target.WaitForResourceAsync(new WaitForResourceRequest
+        {
+            ResourceName = "myresource-abc123",
+            Status = "up",
+            TimeoutSeconds = 10
+        }).DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal(KnownResourceStates.Running, result.State);
+        Assert.False(result.ResourceNotFound);
+
+        await app.StopAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task WaitForResourceAsync_ReturnsNotFound_ForBadInstanceName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+
+        var resourceWithReplicas = builder.AddResource(new CustomResource("myresource"));
+        resourceWithReplicas.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myresource-abc123", "abc123", 0),
+            new DcpInstance("myresource-def456", "def456", 1)
+        ]));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services);
+
+        var result = await target.WaitForResourceAsync(new WaitForResourceRequest
+        {
+            ResourceName = "myresource-nonexistent",
+            Status = "up",
+            TimeoutSeconds = 10
+        }).DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.True(result.ResourceNotFound);
+
+        await app.StopAsync().DefaultTimeout();
+    }
 }

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,22 +12,6 @@ namespace Aspire.Hosting.Backchannel;
 [Trait("Partition", "4")]
 public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 {
-    [Fact]
-    public async Task GetResourceSnapshotsAsync_ReturnsEmptyList_WhenAppModelIsNull()
-    {
-        var services = new ServiceCollection();
-        services.AddSingleton(ResourceNotificationServiceTestHelpers.Create());
-        var serviceProvider = services.BuildServiceProvider();
-
-        var target = new AuxiliaryBackchannelRpcTarget(
-            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
-            serviceProvider);
-
-        var result = await target.GetResourceSnapshotsAsync().DefaultTimeout();
-
-        Assert.Empty(result);
-    }
-
     [Fact]
     public async Task GetResourceSnapshotsAsync_EnumeratesResources()
     {

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -24,7 +24,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
             serviceProvider);
 
-        var result = await target.GetResourceSnapshotsAsync();
+        var result = await target.GetResourceSnapshotsAsync().DefaultTimeout();
 
         Assert.Empty(result);
     }
@@ -44,23 +44,23 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         ]));
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
         await notificationService.PublishUpdateAsync(resourceWithReplicas.Resource, "myresource-abc123", s => s with
         {
             State = new ResourceStateSnapshot("Running", KnownResourceStateStyles.Success)
-        });
+        }).DefaultTimeout();
         await notificationService.PublishUpdateAsync(resourceWithReplicas.Resource, "myresource-def456", s => s with
         {
             State = new ResourceStateSnapshot("Running", KnownResourceStateStyles.Success)
-        });
+        }).DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
             app.Services);
 
-        var result = await target.GetResourceSnapshotsAsync();
+        var result = await target.GetResourceSnapshotsAsync().DefaultTimeout();
 
         // Dashboard resource should now be included
         Assert.Contains(result, r => r.Name == KnownResourceNames.AspireDashboard);
@@ -75,7 +75,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.Contains(result, r => r.Name == "myresource-def456");
         Assert.All(result.Where(r => r.Name.StartsWith("myresource-")), r => Assert.Equal("myresource", r.DisplayName));
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var custom = builder.AddResource(new CustomResource("myresource"));
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var createdAt = DateTime.UtcNow.AddMinutes(-5);
         var startedAt = DateTime.UtcNow.AddMinutes(-4);
@@ -127,13 +127,13 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
                 new ResourcePropertySnapshot(CustomResourceKnownProperties.Source, "normal-value"),
                 new ResourcePropertySnapshot("ConnectionString", "secret-value") { IsSensitive = true }
             ]
-        });
+        }).DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
             app.Services);
 
-        var result = await target.GetResourceSnapshotsAsync();
+        var result = await target.GetResourceSnapshotsAsync().DefaultTimeout();
 
         var snapshot = Assert.Single(result);
 
@@ -194,7 +194,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.True(snapshot.Properties.TryGetValue("ConnectionString", out var sensitiveValue));
         Assert.Null(sensitiveValue);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -392,7 +392,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
         resourceLoggerService.TimeProvider = new FixedTimeProvider();
 
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var logger = resourceLoggerService.GetLogger("myresource");
         logger.LogInformation("Hello from myresource");
@@ -414,7 +414,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, log.LineNumber);
         Assert.False(log.IsError);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -424,7 +424,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         builder.AddResource(new CustomResource("myresource"));
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
@@ -438,7 +438,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 
         Assert.Empty(logs);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -455,7 +455,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
         resourceLoggerService.TimeProvider = new FixedTimeProvider();
 
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var logger1 = resourceLoggerService.GetLogger("resource1");
         logger1.LogInformation("Log from resource1");
@@ -483,7 +483,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var log2 = Assert.Single(logs, l => l.ResourceName == "resource2");
         Assert.Equal($"{TestTimestamp} Log from resource2", log2.Content);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -497,12 +497,17 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
             new DcpInstance("myresource-def456", "def456", 1)
         ]));
 
+        var otherResource = builder.AddResource(new CustomResource("otherresource"));
+        otherResource.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("otherresource-xyz789", "xyz789", 0)
+        ]));
+
         using var app = builder.Build();
 
         var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
         resourceLoggerService.TimeProvider = new FixedTimeProvider();
 
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var logger1 = resourceLoggerService.GetLogger("myresource-abc123");
         logger1.LogInformation("Log from replica 1");
@@ -511,6 +516,10 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var logger2 = resourceLoggerService.GetLogger("myresource-def456");
         logger2.LogInformation("Log from replica 2");
         resourceLoggerService.Complete("myresource-def456");
+
+        var otherLogger = resourceLoggerService.GetLogger("otherresource-xyz789");
+        otherLogger.LogInformation("Log from other resource");
+        resourceLoggerService.Complete("otherresource-xyz789");
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
@@ -530,7 +539,9 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var replica2 = Assert.Single(logs, l => l.ResourceName == "myresource-def456");
         Assert.Equal($"{TestTimestamp} Log from replica 2", replica2.Content);
 
-        await app.StopAsync();
+        Assert.DoesNotContain(logs, l => l.ResourceName == "otherresource-xyz789");
+
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -549,7 +560,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
         resourceLoggerService.TimeProvider = new FixedTimeProvider();
 
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var logger1 = resourceLoggerService.GetLogger("myresource-abc123");
         logger1.LogInformation("Log from replica 1");
@@ -573,7 +584,15 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.Equal("myresource-def456", log.ResourceName);
         Assert.Equal($"{TestTimestamp} Log from replica 2", log.Content);
 
-        await app.StopAsync();
+        var badLogs = new List<ResourceLogLine>();
+        await foreach (var logLine in target.GetResourceLogsAsync("myresource-nonexistent", follow: false))
+        {
+            badLogs.Add(logLine);
+        }
+
+        Assert.Empty(badLogs);
+
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -587,7 +606,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
         resourceLoggerService.TimeProvider = new FixedTimeProvider();
 
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
@@ -613,7 +632,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         logger.LogInformation("First log");
         logger.LogInformation("Second log");
 
-        await collectTask.WaitAsync(TimeSpan.FromSeconds(10));
+        await collectTask.DefaultTimeout();
 
         Assert.Equal(2, logs.Count);
 
@@ -623,7 +642,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.Equal("myresource", logs[1].ResourceName);
         Assert.Equal($"{TestTimestamp} Second log", logs[1].Content);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -649,7 +668,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         {
             State = KnownResourceStates.Running,
             ResourceReadyEvent = new EventSnapshot(Task.CompletedTask)
-        });
+        }).DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -191,7 +191,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         ]));
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
@@ -208,13 +208,13 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         await notificationService.PublishUpdateAsync(resourceWithReplicas.Resource, "myresource-abc123", s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
-        });
+        }).DefaultTimeout();
 
-        var response = await waitTask.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        var response = await waitTask.DefaultTimeout();
 
         Assert.True(response.Success);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -228,7 +228,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         ]));
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
@@ -245,13 +245,13 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         await notificationService.PublishUpdateAsync(resourceWithReplicas.Resource, "myresource-abc123", s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
-        });
+        }).DefaultTimeout();
 
-        var response = await waitTask.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        var response = await waitTask.DefaultTimeout();
 
         Assert.True(response.Success);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         ]));
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
@@ -283,7 +283,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("Resource 'myresource' failed to become healthy before the operation was cancelled.", exception.Message);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -298,7 +298,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         ]));
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
@@ -316,7 +316,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("Resource 'myresource-abc123' failed to become healthy before the operation was cancelled.", exception.Message);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -331,7 +331,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         ]));
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         var target = new AuxiliaryBackchannelRpcTarget(
             NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
@@ -342,13 +342,13 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
             ResourceName = "myresource",
             Status = "up",
             TimeoutSeconds = 5
-        });
+        }).DefaultTimeout();
 
         Assert.False(response.Success);
         Assert.False(response.ResourceNotFound);
         Assert.Equal("Resource 'myresource' is ambiguous because it has multiple replicas. Specify the exact instance name.", response.ErrorMessage);
 
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
     }
 
     private sealed class CustomResource(string name) : Resource(name)


### PR DESCRIPTION
## Description

Cleans up `AuxiliaryBackchannelRpcTarget` and improves its test coverage.

### Use `GetRequiredService` for `DistributedApplicationModel`

`DistributedApplicationModel` is always registered by the hosting infrastructure. Several methods used `GetService` with defensive null checks that silently degraded behavior (e.g., returning empty results or falling back to unresolved names). Replaced all `GetService<DistributedApplicationModel>()` calls with `GetRequiredService<DistributedApplicationModel>()` and removed the dead null-handling code in:

- `ResolveWaitTarget` — removed null fallback that returned an unresolved `WaitResourceTarget`
- `ResolveDisplayName` — changed parameter from `DistributedApplicationModel?` to `DistributedApplicationModel`, removed null guard
- `GetResourceSnapshotsAsync` — removed early empty return
- `CallResourceMcpToolAsync` — removed manual null check + `InvalidOperationException`

### Extract `ResolveResourceIds` and `ResolveAllResourceIds` helpers

Extracted the inline resource-name resolution logic from `GetResourceLogsAsync` into two reusable `private static` methods:

- `ResolveResourceIds(appModel, resourceName)` — resolves a logical name or instance name to matching resource IDs
- `ResolveAllResourceIds(appModel)` — returns all resolved resource IDs

### Improve test coverage

- Removed `GetResourceSnapshotsAsync_ReturnsEmptyList_WhenAppModelIsNull` (no longer applicable)
- Added `DefaultTimeout()` to all `await` calls across all tests
- Added `WaitForResourceAsync_ReturnsNotFound_WhenResourceDoesNotExist` — verifies not-found for unknown resource
- Added `WaitForResourceAsync_ReturnsNotFound_ForBadInstanceName` — verifies not-found for a non-existent instance name
- Expanded `GetResourceLogsAsync_ReturnsLogsFromReplicas` to verify logs from unrelated resources are excluded
- Expanded `GetResourceLogsAsync_ReturnsLogsForSingleReplica_WhenResolvedInstanceNameIsPassed` to verify bad instance names return empty results

Fixes #16246

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No