### PR TITLE
Add shared test service guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ kill <pid>
 * Copy existing style in nearby files for test method names and capitalization.
 * Do not leave newly-added tests commented out. All added tests should be building and passing.
 * Do not use Directory.SetCurrentDirectory in tests as it can cause side effects when tests execute concurrently.
+* Prefer using shared test service implementations (e.g., project-level `TestServices/` or `Helpers/` directories, or the cross-project `tests/Shared/` folder) rather than creating private implementation classes within individual test files. Reusing existing test fakes and helpers keeps tests consistent, reduces duplication, and makes maintenance easier. Do not create private test classes when a shared one already exists or can be extended.
 
 ## Running tests
 


### PR DESCRIPTION
## Description

Add shared test service guidance to AGENTS.md so that AI agents (and contributors) are directed to reuse existing test fakes and helpers from project-level `TestServices/`/`Helpers/` directories or the cross-project `tests/Shared/` folder, rather than creating duplicate private implementations in individual test files.

This mirrors the existing guidance in `.github/instructions/test-review-guidelines.instructions.md` (Shared Test Dependencies section) which pattern-based instructions surface for `tests/**/*.cs` files, but was missing from the top-level AGENTS.md that agents always consult.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
