### PR TITLE
Enable dashboard telemetry API by default with ApiKey auth and login token exchange

### DIFF
--- a/localhive.ps1
+++ b/localhive.ps1
@@ -308,6 +308,13 @@ if (-not $SkipBundle) {
   $bundleProjPath = Join-Path $RepoRoot "eng" "Bundle.proj"
   $skipNativeArg = if ($NativeAot) { '' } else { '/p:SkipNativeBuild=true' }
 
+  # Clean stale managed publish output so dotnet publish doesn't skip due to incremental builds
+  $staleManagedDir = Join-Path $RepoRoot "artifacts" "bundle" $bundleRid "managed"
+  if (Test-Path -LiteralPath $staleManagedDir) {
+    Write-Log "Cleaning stale managed publish output at $staleManagedDir"
+    Remove-Item -LiteralPath $staleManagedDir -Force -Recurse
+  }
+
   Write-Log "Building bundle (aspire-managed + DCP$(if ($NativeAot) { ' + native AOT CLI' }))..."
   $buildArgs = @($bundleProjPath, '-c', $effectiveConfig, "/p:VersionSuffix=$VersionSuffix", "/p:TargetRid=$bundleRid")
   if (-not $NativeAot) {

--- a/localhive.sh
+++ b/localhive.sh
@@ -315,6 +315,13 @@ fi
 if [[ $SKIP_BUNDLE -eq 0 ]]; then
   BUNDLE_PROJ="$REPO_ROOT/eng/Bundle.proj"
 
+  # Clean stale managed publish output so dotnet publish doesn't skip due to incremental builds
+  STALE_MANAGED_DIR="$REPO_ROOT/artifacts/bundle/$BUNDLE_RID/managed"
+  if [[ -d "$STALE_MANAGED_DIR" ]]; then
+    log "Cleaning stale managed publish output at $STALE_MANAGED_DIR"
+    rm -rf "$STALE_MANAGED_DIR"
+  fi
+
   if [[ $NATIVE_AOT -eq 1 ]]; then
     log "Building bundle (aspire-managed + DCP + native AOT CLI)..."
     dotnet build "$BUNDLE_PROJ" -c "$EFFECTIVE_CONFIG" "/p:VersionSuffix=$VERSION_SUFFIX" "/p:TargetRid=$BUNDLE_RID"

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -120,6 +120,7 @@
     <Compile Include="$(SharedDir)Otlp\Serialization\OtlpJsonSerializerContext.cs" Link="Otlp\OtlpJsonSerializerContext.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\TelemetryApiResponse.cs" Link="Otlp\TelemetryApiResponse.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\ResourceInfoJson.cs" Link="Otlp\ResourceInfoJson.cs" />
+    <Compile Include="$(SharedDir)Model\Serialization\TelemetryValidateTokenJson.cs" Link="Otlp\TelemetryValidateTokenJson.cs" />
     <Compile Include="$(SharedDir)Export\ExportArchive.cs" Link="Export\ExportArchive.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\AnsiParser.cs" Link="ConsoleLogs\AnsiParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\LogEntries.cs" Link="ConsoleLogs\LogEntries.cs" />

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -77,6 +77,7 @@
     <Compile Include="$(SharedDir)BundleDiscovery.cs" Link="Layout\BundleDiscovery.cs" />
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
+    <Compile Include="$(SharedDir)DashboardConfigNames.cs" Link="Utils\DashboardConfigNames.cs" />
     <Compile Include="$(SharedDir)ContainerRuntimeDetector.cs" Link="Utils\ContainerRuntimeDetector.cs" />
     <Compile Include="$(SharedDir)DashboardExitCodes.cs" Link="Utils\DashboardExitCodes.cs" />
     <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" Link="Utils\KnownOtelConfigNames.cs" />

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -125,7 +125,11 @@ internal sealed class DashboardRunCommand : BaseCommand
             {
                 var apiKey = TokenGenerator.GenerateToken();
                 environmentVariables[DashboardConfigNames.DashboardApiPrimaryApiKeyName.EnvVarName] = apiKey;
-                environmentVariables[DashboardConfigNames.DashboardApiAuthModeName.EnvVarName] = "ApiKey";
+
+                if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, DashboardConfigNames.DashboardApiAuthModeName.EnvVarName))
+                {
+                    environmentVariables[DashboardConfigNames.DashboardApiAuthModeName.EnvVarName] = "ApiKey";
+                }
             }
         }
 

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -148,8 +148,10 @@ internal sealed class DashboardRunCommand : BaseCommand
         AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpHttpUrlOption, KnownConfigNames.DashboardOtlpHttpEndpointUrl, defaultValue: "http://localhost:4318");
         AddBoolOptionArg(parseResult, args, unmatchedTokens, executionContext, s_allowAnonymousOption, KnownConfigNames.DashboardUnsecuredAllowAnonymous);
 
-        // Always enable the telemetry API so CLI commands (e.g. aspire otel) can query the dashboard.
-        if (!ConfigSettingHasValue(unmatchedTokens, executionContext, KnownConfigNames.DashboardApiEnabled))
+        // Always enable the telemetry API so CLI commands (e.g. aspire otel) can query the dashboard,
+        // unless the user has explicitly configured either the enabled or disabled setting.
+        if (!ConfigSettingHasValue(unmatchedTokens, executionContext, KnownConfigNames.DashboardApiEnabled) &&
+            !ConfigSettingHasValue(unmatchedTokens, executionContext, KnownConfigNames.DashboardApiDisabled))
         {
             args.Add($"--{KnownConfigNames.DashboardApiEnabled}=true");
         }

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -107,19 +107,25 @@ internal sealed class DashboardRunCommand : BaseCommand
         AddOptionArgs(parseResult, dashboardArgs, unmatchedTokens, ExecutionContext);
 
         // Set a browser token for frontend auth unless anonymous access is enabled.
-        // The token is passed via environment variable (not command-line arg) to
-        // avoid exposing it in process listings (e.g. ps, Task Manager).
+        // Tokens and keys are passed via environment variables (not command-line args)
+        // to avoid exposing them in process listings (e.g. ps, Task Manager).
         string? browserToken = null;
-        Dictionary<string, string>? environmentVariables = null;
+        var environmentVariables = new Dictionary<string, string>();
         if (!allowAnonymous && !ConfigSettingHasValue(unmatchedTokens, ExecutionContext, "ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS"))
         {
             if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, "DASHBOARD__FRONTEND__BROWSERTOKEN"))
             {
                 browserToken = TokenGenerator.GenerateToken();
-                environmentVariables = new Dictionary<string, string>
-                {
-                    ["DASHBOARD__FRONTEND__BROWSERTOKEN"] = browserToken
-                };
+                environmentVariables["DASHBOARD__FRONTEND__BROWSERTOKEN"] = browserToken;
+            }
+
+            // Enable API key authentication for the telemetry API so that only
+            // callers who possess the key (or the browser token) can query it.
+            if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, "DASHBOARD__API__PRIMARYAPIKEY"))
+            {
+                var apiKey = TokenGenerator.GenerateToken();
+                environmentVariables["DASHBOARD__API__PRIMARYAPIKEY"] = apiKey;
+                environmentVariables["DASHBOARD__API__AUTHMODE"] = "ApiKey";
             }
         }
 

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -111,21 +111,21 @@ internal sealed class DashboardRunCommand : BaseCommand
         // to avoid exposing them in process listings (e.g. ps, Task Manager).
         string? browserToken = null;
         var environmentVariables = new Dictionary<string, string>();
-        if (!allowAnonymous && !ConfigSettingHasValue(unmatchedTokens, ExecutionContext, "ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS"))
+        if (!allowAnonymous && !ConfigSettingHasValue(unmatchedTokens, ExecutionContext, KnownConfigNames.DashboardUnsecuredAllowAnonymous))
         {
-            if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, "DASHBOARD__FRONTEND__BROWSERTOKEN"))
+            if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, DashboardConfigNames.DashboardFrontendBrowserTokenName.EnvVarName))
             {
                 browserToken = TokenGenerator.GenerateToken();
-                environmentVariables["DASHBOARD__FRONTEND__BROWSERTOKEN"] = browserToken;
+                environmentVariables[DashboardConfigNames.DashboardFrontendBrowserTokenName.EnvVarName] = browserToken;
             }
 
             // Enable API key authentication for the telemetry API so that only
             // callers who possess the key (or the browser token) can query it.
-            if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, "DASHBOARD__API__PRIMARYAPIKEY"))
+            if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, DashboardConfigNames.DashboardApiPrimaryApiKeyName.EnvVarName))
             {
                 var apiKey = TokenGenerator.GenerateToken();
-                environmentVariables["DASHBOARD__API__PRIMARYAPIKEY"] = apiKey;
-                environmentVariables["DASHBOARD__API__AUTHMODE"] = "ApiKey";
+                environmentVariables[DashboardConfigNames.DashboardApiPrimaryApiKeyName.EnvVarName] = apiKey;
+                environmentVariables[DashboardConfigNames.DashboardApiAuthModeName.EnvVarName] = "ApiKey";
             }
         }
 
@@ -139,18 +139,18 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     private static void AddOptionArgs(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens, CliExecutionContext executionContext)
     {
-        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_frontendUrlOption, "ASPNETCORE_URLS", defaultValue: "http://localhost:18888");
-        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpGrpcUrlOption, "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL", defaultValue: "http://localhost:4317");
-        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpHttpUrlOption, "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL", defaultValue: "http://localhost:4318");
-        AddBoolOptionArg(parseResult, args, unmatchedTokens, executionContext, s_allowAnonymousOption, "ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS");
+        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_frontendUrlOption, KnownConfigNames.AspNetCoreUrls, defaultValue: "http://localhost:18888");
+        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpGrpcUrlOption, KnownConfigNames.DashboardOtlpGrpcEndpointUrl, defaultValue: "http://localhost:4317");
+        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpHttpUrlOption, KnownConfigNames.DashboardOtlpHttpEndpointUrl, defaultValue: "http://localhost:4318");
+        AddBoolOptionArg(parseResult, args, unmatchedTokens, executionContext, s_allowAnonymousOption, KnownConfigNames.DashboardUnsecuredAllowAnonymous);
 
         // Always enable the telemetry API so CLI commands (e.g. aspire otel) can query the dashboard.
-        if (!ConfigSettingHasValue(unmatchedTokens, executionContext, "ASPIRE_DASHBOARD_API_ENABLED"))
+        if (!ConfigSettingHasValue(unmatchedTokens, executionContext, KnownConfigNames.DashboardApiEnabled))
         {
-            args.Add("--ASPIRE_DASHBOARD_API_ENABLED=true");
+            args.Add($"--{KnownConfigNames.DashboardApiEnabled}=true");
         }
 
-        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_configFilePathOption, "ASPIRE_DASHBOARD_CONFIG_FILE_PATH", defaultValue: null);
+        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_configFilePathOption, KnownConfigNames.DashboardConfigFilePath, defaultValue: null);
     }
 
     private static void AddStringOptionArg(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens,
@@ -229,9 +229,9 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     internal static DashboardInfo ResolveDashboardInfo(List<string> dashboardArgs, IReadOnlyList<string> unmatchedTokens, CliExecutionContext executionContext, string? browserToken)
     {
-        var frontendUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, "ASPNETCORE_URLS") ?? "http://localhost:18888";
-        var otlpGrpcUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL") ?? "http://localhost:4317";
-        var otlpHttpUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL") ?? "http://localhost:4318";
+        var frontendUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, KnownConfigNames.AspNetCoreUrls) ?? "http://localhost:18888";
+        var otlpGrpcUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, KnownConfigNames.DashboardOtlpGrpcEndpointUrl) ?? "http://localhost:4317";
+        var otlpHttpUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, KnownConfigNames.DashboardOtlpHttpEndpointUrl) ?? "http://localhost:4318";
 
         // Take the first URL if multiple are specified (semicolon-separated).
         var parts = frontendUrl.Split(';', StringSplitOptions.RemoveEmptyEntries);

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -51,11 +51,6 @@ internal sealed class DashboardRunCommand : BaseCommand
         Description = DashboardCommandStrings.AllowAnonymousOptionDescription
     };
 
-    private static readonly Option<bool> s_enableApiOption = new("--enable-api")
-    {
-        Description = DashboardCommandStrings.EnableApiOptionDescription
-    };
-
     private static readonly Option<string?> s_configFilePathOption = new("--config-file-path")
     {
         Description = DashboardCommandStrings.ConfigFilePathOptionDescription
@@ -83,7 +78,6 @@ internal sealed class DashboardRunCommand : BaseCommand
         Options.Add(s_otlpGrpcUrlOption);
         Options.Add(s_otlpHttpUrlOption);
         Options.Add(s_allowAnonymousOption);
-        Options.Add(s_enableApiOption);
         Options.Add(s_configFilePathOption);
         TreatUnmatchedTokensAsErrors = false;
     }
@@ -143,7 +137,13 @@ internal sealed class DashboardRunCommand : BaseCommand
         AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpGrpcUrlOption, "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL", defaultValue: "http://localhost:4317");
         AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpHttpUrlOption, "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL", defaultValue: "http://localhost:4318");
         AddBoolOptionArg(parseResult, args, unmatchedTokens, executionContext, s_allowAnonymousOption, "ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS");
-        AddBoolOptionArg(parseResult, args, unmatchedTokens, executionContext, s_enableApiOption, "ASPIRE_DASHBOARD_API_ENABLED");
+
+        // Always enable the telemetry API so CLI commands (e.g. aspire otel) can query the dashboard.
+        if (!ConfigSettingHasValue(unmatchedTokens, executionContext, "ASPIRE_DASHBOARD_API_ENABLED"))
+        {
+            args.Add("--ASPIRE_DASHBOARD_API_ENABLED=true");
+        }
+
         AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_configFilePathOption, "ASPIRE_DASHBOARD_CONFIG_FILE_PATH", defaultValue: null);
     }
 
@@ -166,7 +166,7 @@ internal sealed class DashboardRunCommand : BaseCommand
     }
 
     private static void AddBoolOptionArg(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens,
-        CliExecutionContext executionContext, Option<bool> option, string envVarName)
+        CliExecutionContext executionContext, Option<bool> option, string envVarName, bool? defaultValue = null)
     {
         if (ConfigSettingHasValue(unmatchedTokens, executionContext, envVarName))
         {
@@ -175,14 +175,18 @@ internal sealed class DashboardRunCommand : BaseCommand
 
         var result = parseResult.GetResult(option);
 
-        // Skip when the result comes from the option's default value rather than
-        // explicit user input. Without the Implicit check, Option<bool> defaults
-        // (e.g. false) would always emit "--ALLOW_ANONYMOUS=false" even when the
-        // user never specified --allow-anonymous.
+        // When the user explicitly specified the option, use their value.
+        // When a defaultValue is provided and the user did not specify the option, use the default.
+        // Without a defaultValue, skip when the result comes from the option's default value rather
+        // than explicit user input, to avoid always emitting e.g. "--ALLOW_ANONYMOUS=false".
         if (result is not null && !result.Implicit)
         {
             var value = parseResult.GetValue(option);
             args.Add($"--{envVarName}={value.ToString().ToLowerInvariant()}");
+        }
+        else if (defaultValue is not null)
+        {
+            args.Add($"--{envVarName}={defaultValue.Value.ToString().ToLowerInvariant()}");
         }
     }
 

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -111,7 +111,7 @@ internal sealed class ExportCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: false, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: false, ExecutionContext.LogFilePath, cancellationToken);
 
         if (!dashboardApi.Success)
         {
@@ -130,8 +130,8 @@ internal sealed class ExportCommand : BaseCommand
         catch (HttpRequestException ex) when (dashboardUrl is not null)
         {
             _logger.LogError(ex, "Failed to export telemetry data from dashboard");
-            var errorMessage = await TelemetryCommandHelpers.FormatTelemetryErrorMessageAsync(ex, dashboardApi.BaseUrl!, true, _httpClientFactory, _logger, cancellationToken);
-            _interactionService.DisplayError(errorMessage);
+            var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, true, _httpClientFactory, _logger, cancellationToken);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo, ExecutionContext.LogFilePath);
             return ExitCodeConstants.DashboardFailure;
         }
         catch (Exception ex)

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -111,7 +111,7 @@ internal sealed class ExportCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: false, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: false, cancellationToken);
 
         if (!dashboardApi.Success)
         {

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -226,14 +226,19 @@ internal static class TelemetryCommandHelpers
 
                 if (!exchangeResult.Success)
                 {
-                    var errorInfo = exchangeResult.ConnectionFailed
-                        ? new TelemetryErrorInfo(
+                    var errorInfo = exchangeResult.FailureKind switch
+                    {
+                        TokenExchangeFailureKind.ConnectionError => new TelemetryErrorInfo(
                             string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, dashboardUrl),
-                            TelemetryCommandStrings.DashboardConnectionFailedHint)
-                        : new TelemetryErrorInfo(
+                            TelemetryCommandStrings.DashboardConnectionFailedHint),
+                        TokenExchangeFailureKind.ApiNotEnabled => new TelemetryErrorInfo(
+                            string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, dashboardUrl),
+                            TelemetryCommandStrings.DashboardApiNotEnabledHint),
+                        _ => new TelemetryErrorInfo(
                             TelemetryCommandStrings.DashboardLoginTokenFailed,
                             TelemetryCommandStrings.DashboardLoginTokenFailedHint,
-                            TelemetryCommandStrings.DashboardLoginTokenFailedAnonymousHint);
+                            TelemetryCommandStrings.DashboardLoginTokenFailedAnonymousHint),
+                    };
                     DisplayTelemetryError(interactionService, errorInfo, logFilePath);
                     return DashboardApiResult.Failure(ExitCodeConstants.DashboardFailure);
                 }
@@ -435,7 +440,7 @@ internal static class TelemetryCommandHelpers
             if (!response.IsSuccessStatusCode)
             {
                 logger.LogDebug("Login token exchange failed with status {StatusCode}", response.StatusCode);
-                return TokenExchangeResult.Failed;
+                return TokenExchangeResult.FromStatusCode(response.StatusCode);
             }
 
             var result = await response.Content.ReadFromJsonAsync(OtlpJsonSerializerContext.Default.TelemetryValidateTokenResponse, cancellationToken).ConfigureAwait(false);
@@ -674,22 +679,49 @@ internal sealed record DashboardApiResult(
 }
 
 /// <summary>
+/// Describes the kind of failure that occurred during a login token exchange.
+/// </summary>
+internal enum TokenExchangeFailureKind
+{
+    /// <summary>No failure (exchange succeeded).</summary>
+    None,
+    /// <summary>The token was invalid or rejected by the dashboard (401).</summary>
+    TokenRejected,
+    /// <summary>The telemetry API is not enabled on the dashboard (404).</summary>
+    ApiNotEnabled,
+    /// <summary>The dashboard was not reachable (connection error).</summary>
+    ConnectionError,
+    /// <summary>An unexpected HTTP status code was returned.</summary>
+    Other,
+}
+
+/// <summary>
 /// Result of exchanging a frontend login token for an API key via the dashboard.
 /// </summary>
 /// <param name="Success">Whether the exchange succeeded. When <c>false</c>, the token was invalid or the endpoint was unreachable.</param>
 /// <param name="ApiKey">The API key returned by the dashboard, or <c>null</c> if the dashboard API is unsecured.</param>
-/// <param name="ConnectionFailed">When <c>true</c>, the failure was due to a connection error (dashboard not reachable) rather than a bad token.</param>
-internal sealed record TokenExchangeResult(bool Success, string? ApiKey, bool ConnectionFailed = false)
+/// <param name="FailureKind">The kind of failure when <paramref name="Success"/> is <c>false</c>.</param>
+internal sealed record TokenExchangeResult(bool Success, string? ApiKey, TokenExchangeFailureKind FailureKind = TokenExchangeFailureKind.None)
 {
     /// <summary>
     /// A failed token exchange result due to an invalid or rejected token.
     /// </summary>
-    public static readonly TokenExchangeResult Failed = new(false, null);
+    public static readonly TokenExchangeResult Failed = new(false, null, TokenExchangeFailureKind.TokenRejected);
 
     /// <summary>
     /// A failed token exchange result due to a connection error.
     /// </summary>
-    public static readonly TokenExchangeResult ConnectionError = new(false, null, ConnectionFailed: true);
+    public static readonly TokenExchangeResult ConnectionError = new(false, null, TokenExchangeFailureKind.ConnectionError);
+
+    /// <summary>
+    /// Creates a failed result from an HTTP status code.
+    /// </summary>
+    public static TokenExchangeResult FromStatusCode(HttpStatusCode statusCode) => statusCode switch
+    {
+        HttpStatusCode.NotFound => new(false, null, TokenExchangeFailureKind.ApiNotEnabled),
+        HttpStatusCode.Unauthorized => new(false, null, TokenExchangeFailureKind.TokenRejected),
+        _ => new(false, null, TokenExchangeFailureKind.Other),
+    };
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Mcp.Tools;
@@ -167,6 +168,8 @@ internal static class TelemetryCommandHelpers
     /// </summary>
     /// <param name="connectionResolver">The connection resolver for AppHost discovery.</param>
     /// <param name="interactionService">The interaction service for displaying messages.</param>
+    /// <param name="httpClientFactory">The HTTP client factory for making API calls.</param>
+    /// <param name="logger">The logger for diagnostic messages.</param>
     /// <param name="projectFile">The optional AppHost project file.</param>
     /// <param name="dashboardUrl">The optional direct dashboard URL (mutually exclusive with <paramref name="projectFile"/>).</param>
     /// <param name="apiKey">The optional API key for dashboard authentication.</param>
@@ -179,6 +182,8 @@ internal static class TelemetryCommandHelpers
     public static async Task<DashboardApiResult> GetDashboardApiAsync(
         AppHostConnectionResolver connectionResolver,
         IInteractionService interactionService,
+        IHttpClientFactory httpClientFactory,
+        ILogger logger,
         FileInfo? projectFile,
         string? dashboardUrl,
         string? apiKey,
@@ -195,6 +200,9 @@ internal static class TelemetryCommandHelpers
         // Direct dashboard URL mode — bypass AppHost discovery
         if (dashboardUrl is not null)
         {
+            // Extract login token before normalizing the URL
+            var loginToken = McpToolHelpers.ExtractLoginToken(dashboardUrl);
+
             // Normalize login URLs (e.g., http://localhost:18888/login?t=abc) to base URL
             dashboardUrl = McpToolHelpers.StripLoginPath(dashboardUrl) ?? dashboardUrl;
 
@@ -202,6 +210,13 @@ internal static class TelemetryCommandHelpers
             {
                 interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl));
                 return DashboardApiResult.Failure(ExitCodeConstants.InvalidCommand);
+            }
+
+            // If no explicit --api-key was provided but a login token was found in the URL,
+            // exchange the login token for an API key via the dashboard.
+            if (apiKey is null && loginToken is not null)
+            {
+                apiKey = await ExchangeLoginTokenForApiKeyAsync(httpClientFactory, dashboardUrl, loginToken, logger, cancellationToken).ConfigureAwait(false);
             }
 
             var token = apiKey ?? string.Empty;
@@ -327,6 +342,47 @@ internal static class TelemetryCommandHelpers
         }
 
         return string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.FailedToFetchTelemetry, ex.Message);
+    }
+
+    /// <summary>
+    /// Exchanges a frontend login token for an API key by calling the dashboard's
+    /// <c>POST /api/telemetry/validateToken</c> endpoint.
+    /// </summary>
+    /// <returns>The API key, or <c>null</c> if the exchange failed or the API is unsecured.</returns>
+    internal static async Task<string?> ExchangeLoginTokenForApiKeyAsync(
+        IHttpClientFactory httpClientFactory,
+        string dashboardBaseUrl,
+        string loginToken,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = httpClientFactory.CreateClient();
+            var url = DashboardUrls.TelemetryApiKeyUrl(dashboardBaseUrl);
+
+            var content = new StringContent(
+                JsonValue.Create(loginToken).ToJsonString(),
+                System.Text.Encoding.UTF8,
+                "application/json");
+
+            var response = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogDebug("Login token exchange failed with status {StatusCode}", response.StatusCode);
+                return null;
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var node = JsonNode.Parse(json);
+            return node?["apiKey"]?.GetValue<string>();
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to exchange login token for API key at {Url}", dashboardBaseUrl);
+            return null;
+        }
     }
 
     public static bool TryResolveResourceNames(

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -195,6 +195,9 @@ internal static class TelemetryCommandHelpers
         // Direct dashboard URL mode — bypass AppHost discovery
         if (dashboardUrl is not null)
         {
+            // Normalize login URLs (e.g., http://localhost:18888/login?t=abc) to base URL
+            dashboardUrl = McpToolHelpers.StripLoginPath(dashboardUrl) ?? dashboardUrl;
+
             if (!UrlHelper.IsHttpUrl(dashboardUrl))
             {
                 interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl));

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -5,7 +5,6 @@ using System.CommandLine;
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Mcp.Tools;
@@ -177,6 +176,7 @@ internal static class TelemetryCommandHelpers
     /// When <c>true</c>, a missing Dashboard API is a hard error.
     /// When <c>false</c>, a missing Dashboard API is non-fatal and the method returns success with <c>null</c> base URL and token.
     /// </param>
+    /// <param name="logFilePath">The path to the current session's log file, displayed alongside errors.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="DashboardApiResult"/> with the resolved connection and dashboard API info.</returns>
     public static async Task<DashboardApiResult> GetDashboardApiAsync(
@@ -188,6 +188,7 @@ internal static class TelemetryCommandHelpers
         string? dashboardUrl,
         string? apiKey,
         bool requireDashboard,
+        string logFilePath,
         CancellationToken cancellationToken)
     {
         // Validate mutual exclusivity of --apphost and --dashboard-url
@@ -208,7 +209,12 @@ internal static class TelemetryCommandHelpers
 
             if (!UrlHelper.IsHttpUrl(dashboardUrl))
             {
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl));
+                DisplayTelemetryError(
+                    interactionService,
+                    new TelemetryErrorInfo(
+                        string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl),
+                        TelemetryCommandStrings.DashboardUrlInvalidHint),
+                    logFilePath);
                 return DashboardApiResult.Failure(ExitCodeConstants.InvalidCommand);
             }
 
@@ -216,7 +222,23 @@ internal static class TelemetryCommandHelpers
             // exchange the login token for an API key via the dashboard.
             if (apiKey is null && loginToken is not null)
             {
-                apiKey = await ExchangeLoginTokenForApiKeyAsync(httpClientFactory, dashboardUrl, loginToken, logger, cancellationToken).ConfigureAwait(false);
+                var exchangeResult = await ExchangeLoginTokenForApiKeyAsync(httpClientFactory, dashboardUrl, loginToken, logger, cancellationToken).ConfigureAwait(false);
+
+                if (!exchangeResult.Success)
+                {
+                    var errorInfo = exchangeResult.ConnectionFailed
+                        ? new TelemetryErrorInfo(
+                            string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, dashboardUrl),
+                            TelemetryCommandStrings.DashboardConnectionFailedHint)
+                        : new TelemetryErrorInfo(
+                            TelemetryCommandStrings.DashboardLoginTokenFailed,
+                            TelemetryCommandStrings.DashboardLoginTokenFailedHint,
+                            TelemetryCommandStrings.DashboardLoginTokenFailedAnonymousHint);
+                    DisplayTelemetryError(interactionService, errorInfo, logFilePath);
+                    return DashboardApiResult.Failure(ExitCodeConstants.DashboardFailure);
+                }
+
+                apiKey = exchangeResult.ApiKey;
             }
 
             var token = apiKey ?? string.Empty;
@@ -242,7 +264,12 @@ internal static class TelemetryCommandHelpers
         {
             if (requireDashboard)
             {
-                interactionService.DisplayError(TelemetryCommandStrings.DashboardApiNotAvailable);
+                DisplayTelemetryError(
+                    interactionService,
+                    new TelemetryErrorInfo(
+                        TelemetryCommandStrings.DashboardNotAvailable,
+                        TelemetryCommandStrings.DashboardNotAvailableHint),
+                    logFilePath);
                 return DashboardApiResult.Failure(ExitCodeConstants.DashboardFailure);
             }
 
@@ -278,10 +305,28 @@ internal static class TelemetryCommandHelpers
     }
 
     /// <summary>
+    /// Displays a telemetry error with a structured format: error message, optional hint, and log file path.
+    /// </summary>
+    public static void DisplayTelemetryError(
+        IInteractionService interactionService,
+        TelemetryErrorInfo errorInfo,
+        string logFilePath)
+    {
+        interactionService.DisplayError(errorInfo.Error);
+
+        foreach (var hint in errorInfo.Hints)
+        {
+            interactionService.DisplayMessage(KnownEmojis.Information, hint);
+        }
+
+        interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, logFilePath));
+    }
+
+    /// <summary>
     /// Formats an error message for a telemetry HTTP failure, using dashboard-specific diagnostics
     /// when a direct dashboard URL was provided, or a generic message otherwise.
     /// </summary>
-    public static async Task<string> FormatTelemetryErrorMessageAsync(
+    public static async Task<TelemetryErrorInfo> FormatTelemetryErrorAsync(
         HttpRequestException ex,
         string baseUrl,
         bool dashboardOnly,
@@ -291,16 +336,16 @@ internal static class TelemetryCommandHelpers
     {
         if (dashboardOnly)
         {
-            return await GetDashboardApiErrorMessageAsync(ex, baseUrl, httpClientFactory, logger, cancellationToken);
+            return await GetDashboardApiErrorAsync(ex, baseUrl, httpClientFactory, logger, cancellationToken);
         }
 
-        return string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.FailedToFetchTelemetry, ex.Message);
+        return new TelemetryErrorInfo(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.FailedToFetchTelemetry, ex.Message));
     }
 
     /// <summary>
-    /// Produces a user-friendly error message for dashboard API failures when using --dashboard-url.
+    /// Produces a user-friendly error for dashboard API failures when using --dashboard-url.
     /// </summary>
-    public static async Task<string> GetDashboardApiErrorMessageAsync(
+    public static async Task<TelemetryErrorInfo> GetDashboardApiErrorAsync(
         HttpRequestException ex,
         string dashboardBaseUrl,
         IHttpClientFactory httpClientFactory,
@@ -309,7 +354,7 @@ internal static class TelemetryCommandHelpers
     {
         if (ex.StatusCode == HttpStatusCode.Unauthorized)
         {
-            return TelemetryCommandStrings.DashboardAuthFailed;
+            return new TelemetryErrorInfo(TelemetryCommandStrings.DashboardAuthFailed, TelemetryCommandStrings.DashboardAuthFailedHint, TelemetryCommandStrings.DashboardAuthFailedAnonymousHint);
         }
 
         if (ex.StatusCode == HttpStatusCode.NotFound)
@@ -322,8 +367,10 @@ internal static class TelemetryCommandHelpers
 
                 if (probeResponse.IsSuccessStatusCode)
                 {
-                    // Dashboard is reachable but the API endpoint returned 404 — API not enabled
-                    return string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, dashboardBaseUrl);
+                    // API is not enabled
+                    return new TelemetryErrorInfo(
+                        string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, dashboardBaseUrl),
+                        TelemetryCommandStrings.DashboardApiNotEnabledHint);
                 }
             }
             catch (Exception probeEx)
@@ -332,24 +379,45 @@ internal static class TelemetryCommandHelpers
             }
 
             // Dashboard base URL is also not reachable — wrong URL
-            return string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlNotReachable, dashboardBaseUrl);
+            return new TelemetryErrorInfo(
+                string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlNotReachable, dashboardBaseUrl),
+                TelemetryCommandStrings.DashboardUrlNotReachableHint);
         }
 
         if (ex.StatusCode is null)
         {
             // No HTTP status — connection refused or network error
-            return string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, dashboardBaseUrl);
+            return new TelemetryErrorInfo(
+                string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, dashboardBaseUrl),
+                TelemetryCommandStrings.DashboardConnectionFailedHint);
         }
 
-        return string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.FailedToFetchTelemetry, ex.Message);
+        return new TelemetryErrorInfo(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.FailedToFetchTelemetry, ex.Message));
+    }
+
+    /// <summary>
+    /// Returns a combined error message string for dashboard API failures.
+    /// Used by MCP tools that return error text rather than using interactive display.
+    /// </summary>
+    public static async Task<string> GetDashboardApiErrorMessageAsync(
+        HttpRequestException ex,
+        string dashboardBaseUrl,
+        IHttpClientFactory httpClientFactory,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var errorInfo = await GetDashboardApiErrorAsync(ex, dashboardBaseUrl, httpClientFactory, logger, cancellationToken);
+        return errorInfo.Hints.Length > 0
+            ? $"{errorInfo.Error} {string.Join(" ", errorInfo.Hints)}"
+            : errorInfo.Error;
     }
 
     /// <summary>
     /// Exchanges a frontend login token for an API key by calling the dashboard's
     /// <c>POST /api/telemetry/validateToken</c> endpoint.
     /// </summary>
-    /// <returns>The API key, or <c>null</c> if the exchange failed or the API is unsecured.</returns>
-    internal static async Task<string?> ExchangeLoginTokenForApiKeyAsync(
+    /// <returns>A <see cref="TokenExchangeResult"/> indicating success or failure, with the API key when available.</returns>
+    internal static async Task<TokenExchangeResult> ExchangeLoginTokenForApiKeyAsync(
         IHttpClientFactory httpClientFactory,
         string dashboardBaseUrl,
         string loginToken,
@@ -361,27 +429,27 @@ internal static class TelemetryCommandHelpers
             using var client = httpClientFactory.CreateClient();
             var url = DashboardUrls.TelemetryApiKeyUrl(dashboardBaseUrl);
 
-            var content = new StringContent(
-                JsonValue.Create(loginToken).ToJsonString(),
-                System.Text.Encoding.UTF8,
-                "application/json");
-
-            var response = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
+            var request = new TelemetryValidateTokenRequest(loginToken);
+            var response = await client.PostAsJsonAsync(url, request, OtlpJsonSerializerContext.Default.TelemetryValidateTokenRequest, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
                 logger.LogDebug("Login token exchange failed with status {StatusCode}", response.StatusCode);
-                return null;
+                return TokenExchangeResult.Failed;
             }
 
-            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            var node = JsonNode.Parse(json);
-            return node?["apiKey"]?.GetValue<string>();
+            var result = await response.Content.ReadFromJsonAsync(OtlpJsonSerializerContext.Default.TelemetryValidateTokenResponse, cancellationToken).ConfigureAwait(false);
+            return new TokenExchangeResult(true, result?.ApiKey);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogDebug(ex, "Failed to exchange login token for API key at {Url}", dashboardBaseUrl);
+            return TokenExchangeResult.ConnectionError;
         }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Failed to exchange login token for API key at {Url}", dashboardBaseUrl);
-            return null;
+            return TokenExchangeResult.Failed;
         }
     }
 
@@ -604,3 +672,29 @@ internal sealed record DashboardApiResult(
     public static DashboardApiResult Failure(int exitCode)
         => new(false, null, null, null, null, exitCode);
 }
+
+/// <summary>
+/// Result of exchanging a frontend login token for an API key via the dashboard.
+/// </summary>
+/// <param name="Success">Whether the exchange succeeded. When <c>false</c>, the token was invalid or the endpoint was unreachable.</param>
+/// <param name="ApiKey">The API key returned by the dashboard, or <c>null</c> if the dashboard API is unsecured.</param>
+/// <param name="ConnectionFailed">When <c>true</c>, the failure was due to a connection error (dashboard not reachable) rather than a bad token.</param>
+internal sealed record TokenExchangeResult(bool Success, string? ApiKey, bool ConnectionFailed = false)
+{
+    /// <summary>
+    /// A failed token exchange result due to an invalid or rejected token.
+    /// </summary>
+    public static readonly TokenExchangeResult Failed = new(false, null);
+
+    /// <summary>
+    /// A failed token exchange result due to a connection error.
+    /// </summary>
+    public static readonly TokenExchangeResult ConnectionError = new(false, null, ConnectionFailed: true);
+}
+
+/// <summary>
+/// Structured error information for telemetry commands, containing the error message and optional remediation hints.
+/// </summary>
+/// <param name="Error">The error message describing what went wrong.</param>
+/// <param name="Hints">Optional hints describing how to fix the problem. Each hint is displayed on a separate line.</param>
+internal sealed record TelemetryErrorInfo(string Error, params string[] Hints);

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -101,7 +101,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, ExecutionContext.LogFilePath, cancellationToken);
 
         if (!dashboardApi.Success)
         {
@@ -158,8 +158,8 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Failed to fetch logs from Dashboard API");
-            var errorMessage = await TelemetryCommandHelpers.FormatTelemetryErrorMessageAsync(ex, baseUrl, dashboardOnly, _httpClientFactory, _logger, cancellationToken);
-            _interactionService.DisplayError(errorMessage);
+            var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, baseUrl, dashboardOnly, _httpClientFactory, _logger, cancellationToken);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo, ExecutionContext.LogFilePath);
             return ExitCodeConstants.DashboardFailure;
         }
     }

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -101,7 +101,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
 
         if (!dashboardApi.Success)
         {

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -123,29 +123,29 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         bool dashboardOnly,
         CancellationToken cancellationToken)
     {
-        using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
-
-        // Resolve resource name to specific instances (handles replicas)
-        var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
-        var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
-
-        // Pre-resolve colors so assignment is deterministic regardless of data order
-        TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
-
-        // If a resource was specified but not found, return error
-        if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
-        {
-            _interactionService.DisplayError($"Resource '{resource}' not found.");
-            return ExitCodeConstants.InvalidCommand;
-        }
-
-        // Build URL with query parameters
-        int? effectiveLimit = (limit.HasValue && !follow) ? limit.Value : null;
-
-        var url = DashboardUrls.TelemetryLogsApiUrl(baseUrl, resolvedResources, traceId: traceId, severity: severity, limit: effectiveLimit, follow: follow ? true : null);
-
         try
         {
+            using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
+
+            // Resolve resource name to specific instances (handles replicas)
+            var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
+            var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
+
+            // Pre-resolve colors so assignment is deterministic regardless of data order
+            TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
+
+            // If a resource was specified but not found, return error
+            if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
+            {
+                _interactionService.DisplayError($"Resource '{resource}' not found.");
+                return ExitCodeConstants.InvalidCommand;
+            }
+
+            // Build URL with query parameters
+            int? effectiveLimit = (limit.HasValue && !follow) ? limit.Value : null;
+
+            var url = DashboardUrls.TelemetryLogsApiUrl(baseUrl, resolvedResources, traceId: traceId, severity: severity, limit: effectiveLimit, follow: follow ? true : null);
+
             if (follow)
             {
                 return await StreamLogsAsync(client, url, format, allOtlpResources, cancellationToken);

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -93,7 +93,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, ExecutionContext.LogFilePath, cancellationToken);
 
         if (!dashboardApi.Success)
         {
@@ -153,8 +153,8 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Failed to fetch spans from Dashboard API");
-            var errorMessage = await TelemetryCommandHelpers.FormatTelemetryErrorMessageAsync(ex, baseUrl, dashboardOnly, _httpClientFactory, _logger, cancellationToken);
-            _interactionService.DisplayError(errorMessage);
+            var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, baseUrl, dashboardOnly, _httpClientFactory, _logger, cancellationToken);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo, ExecutionContext.LogFilePath);
             return ExitCodeConstants.DashboardFailure;
         }
     }

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -116,31 +116,31 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         string dashboardUrl,
         CancellationToken cancellationToken)
     {
-        using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
-
-        // Resolve resource name to specific instances (handles replicas)
-        var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
-        var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
-
-        // Pre-resolve colors so assignment is deterministic regardless of data order
-        TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
-
-        // If a resource was specified but not found, return error
-        if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
-        {
-            _interactionService.DisplayError($"Resource '{resource}' not found.");
-            return ExitCodeConstants.InvalidCommand;
-        }
-
-        // Build URL with query parameters
-        int? effectiveLimit = (limit.HasValue && !follow) ? limit.Value : null;
-
-        var url = DashboardUrls.TelemetrySpansApiUrl(baseUrl, resolvedResources, traceId: traceId, hasError: hasError, limit: effectiveLimit, follow: follow ? true : null);
-
-        _logger.LogDebug("Fetching spans from {Url}", url);
-
         try
         {
+            using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
+
+            // Resolve resource name to specific instances (handles replicas)
+            var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
+            var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
+
+            // Pre-resolve colors so assignment is deterministic regardless of data order
+            TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
+
+            // If a resource was specified but not found, return error
+            if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
+            {
+                _interactionService.DisplayError($"Resource '{resource}' not found.");
+                return ExitCodeConstants.InvalidCommand;
+            }
+
+            // Build URL with query parameters
+            int? effectiveLimit = (limit.HasValue && !follow) ? limit.Value : null;
+
+            var url = DashboardUrls.TelemetrySpansApiUrl(baseUrl, resolvedResources, traceId: traceId, hasError: hasError, limit: effectiveLimit, follow: follow ? true : null);
+
+            _logger.LogDebug("Fetching spans from {Url}", url);
+
             if (follow)
             {
                 return await StreamSpansAsync(client, url, format, allOtlpResources, dashboardUrl, cancellationToken);

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -93,7 +93,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
 
         if (!dashboardApi.Success)
         {

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -91,7 +91,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
 
         if (!dashboardApi.Success)
         {

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -91,7 +91,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, ExecutionContext.LogFilePath, cancellationToken);
 
         if (!dashboardApi.Success)
         {
@@ -112,8 +112,8 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Failed to fetch traces from Dashboard API");
-            var errorMessage = await TelemetryCommandHelpers.FormatTelemetryErrorMessageAsync(ex, dashboardApi.BaseUrl!, dashboardUrl is not null, _httpClientFactory, _logger, cancellationToken);
-            _interactionService.DisplayError(errorMessage);
+            var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, dashboardUrl is not null, _httpClientFactory, _logger, cancellationToken);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo, ExecutionContext.LogFilePath);
             return ExitCodeConstants.DashboardFailure;
         }
     }

--- a/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
+++ b/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
@@ -73,16 +73,12 @@ internal static class McpToolHelpers
         if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
             uri.AbsolutePath.EndsWith("/login", StringComparison.OrdinalIgnoreCase))
         {
-            var query = uri.Query;
-            if (query.Length > 0)
+            // Parse query string to find 't' parameter
+            var queryParams = HttpUtility.ParseQueryString(uri.Query);
+            var token = queryParams["t"];
+            if (!string.IsNullOrEmpty(token))
             {
-                // Parse query string to find 't' parameter
-                var queryParams = HttpUtility.ParseQueryString(query);
-                var token = queryParams["t"];
-                if (!string.IsNullOrEmpty(token))
-                {
-                    return token;
-                }
+                return token;
             }
         }
 

--- a/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
+++ b/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Web;
 using Aspire.Cli.Backchannel;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
@@ -56,5 +57,35 @@ internal static class McpToolHelpers
         }
 
         return url;
+    }
+
+    /// <summary>
+    /// Extracts the browser token (<c>t</c> query parameter) from a dashboard login URL.
+    /// Returns <c>null</c> if the URL does not contain a login token.
+    /// </summary>
+    internal static string? ExtractLoginToken(string? url)
+    {
+        if (url is null)
+        {
+            return null;
+        }
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+            uri.AbsolutePath.EndsWith("/login", StringComparison.OrdinalIgnoreCase))
+        {
+            var query = uri.Query;
+            if (query.Length > 0)
+            {
+                // Parse query string to find 't' parameter
+                var queryParams = HttpUtility.ParseQueryString(query);
+                var token = queryParams["t"];
+                if (!string.IsNullOrEmpty(token))
+                {
+                    return token;
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Aspire.Cli/Resources/DashboardCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DashboardCommandStrings.Designer.cs
@@ -123,12 +123,6 @@ namespace Aspire.Cli.Resources {
             }
         }
 
-        public static string EnableApiOptionDescription {
-            get {
-                return ResourceManager.GetString("EnableApiOptionDescription", resourceCulture);
-            }
-        }
-
         public static string ConfigFilePathOptionDescription {
             get {
                 return ResourceManager.GetString("ConfigFilePathOptionDescription", resourceCulture);

--- a/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
@@ -156,9 +156,6 @@
   <data name="AllowAnonymousOptionDescription" xml:space="preserve">
     <value>Allow anonymous access to the dashboard</value>
   </data>
-  <data name="EnableApiOptionDescription" xml:space="preserve">
-    <value>Enable the telemetry API endpoint on the dashboard</value>
-  </data>
   <data name="ConfigFilePathOptionDescription" xml:space="preserve">
     <value>The path for a JSON configuration file</value>
   </data>

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
@@ -180,9 +180,9 @@ namespace Aspire.Cli.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Dashboard API is not available. Ensure the apphost is running with Dashboard enabled..
         /// </summary>
-        internal static string DashboardApiNotAvailable {
+        internal static string DashboardNotAvailable {
             get {
-                return ResourceManager.GetString("DashboardApiNotAvailable", resourceCulture);
+                return ResourceManager.GetString("DashboardNotAvailable", resourceCulture);
             }
         }
         
@@ -291,9 +291,69 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        internal static string DashboardConnectionFailedHint {
+            get {
+                return ResourceManager.GetString("DashboardConnectionFailedHint", resourceCulture);
+            }
+        }
+
         internal static string DashboardUrlInvalid {
             get {
                 return ResourceManager.GetString("DashboardUrlInvalid", resourceCulture);
+            }
+        }
+
+        internal static string DashboardUrlInvalidHint {
+            get {
+                return ResourceManager.GetString("DashboardUrlInvalidHint", resourceCulture);
+            }
+        }
+
+        internal static string DashboardLoginTokenFailed {
+            get {
+                return ResourceManager.GetString("DashboardLoginTokenFailed", resourceCulture);
+            }
+        }
+
+        internal static string DashboardLoginTokenFailedHint {
+            get {
+                return ResourceManager.GetString("DashboardLoginTokenFailedHint", resourceCulture);
+            }
+        }
+
+        internal static string DashboardLoginTokenFailedAnonymousHint {
+            get {
+                return ResourceManager.GetString("DashboardLoginTokenFailedAnonymousHint", resourceCulture);
+            }
+        }
+
+        internal static string DashboardNotAvailableHint {
+            get {
+                return ResourceManager.GetString("DashboardNotAvailableHint", resourceCulture);
+            }
+        }
+
+        internal static string DashboardAuthFailedHint {
+            get {
+                return ResourceManager.GetString("DashboardAuthFailedHint", resourceCulture);
+            }
+        }
+
+        internal static string DashboardAuthFailedAnonymousHint {
+            get {
+                return ResourceManager.GetString("DashboardAuthFailedAnonymousHint", resourceCulture);
+            }
+        }
+
+        internal static string DashboardUrlNotReachableHint {
+            get {
+                return ResourceManager.GetString("DashboardUrlNotReachableHint", resourceCulture);
+            }
+        }
+
+        internal static string DashboardApiNotEnabledHint {
+            get {
+                return ResourceManager.GetString("DashboardApiNotEnabledHint", resourceCulture);
             }
         }
     }

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
@@ -156,8 +156,11 @@
   <data name="LimitMustBePositive" xml:space="preserve">
     <value>The --limit value must be a positive number.</value>
   </data>
-  <data name="DashboardApiNotAvailable" xml:space="preserve">
-    <value>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</value>
+  <data name="DashboardNotAvailable" xml:space="preserve">
+    <value>Could not fetch telemetry data from the dashboard. The dashboard is not available.</value>
+  </data>
+  <data name="DashboardNotAvailableHint" xml:space="preserve">
+    <value>Ensure the AppHost is running with the dashboard enabled.</value>
   </data>
   <data name="FailedToFetchTelemetry" xml:space="preserve">
     <value>Failed to fetch telemetry: {0}</value>
@@ -196,18 +199,45 @@
     <value>The --dashboard-url and --apphost options cannot be used together. Specify one or the other.</value>
   </data>
   <data name="DashboardAuthFailed" xml:space="preserve">
-    <value>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</value>
+    <value>Could not fetch telemetry data from the dashboard. Authentication was denied.</value>
+  </data>
+  <data name="DashboardAuthFailedHint" xml:space="preserve">
+    <value>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</value>
+  </data>
+  <data name="DashboardAuthFailedAnonymousHint" xml:space="preserve">
+    <value>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</value>
   </data>
   <data name="DashboardUrlNotReachable" xml:space="preserve">
-    <value>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</value>
+    <value>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</value>
+  </data>
+  <data name="DashboardUrlNotReachableHint" xml:space="preserve">
+    <value>Verify the URL is correct.</value>
   </data>
   <data name="DashboardApiNotEnabled" xml:space="preserve">
-    <value>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</value>
+    <value>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</value>
+  </data>
+  <data name="DashboardApiNotEnabledHint" xml:space="preserve">
+    <value>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</value>
   </data>
   <data name="DashboardConnectionFailed" xml:space="preserve">
-    <value>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</value>
+    <value>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</value>
+  </data>
+  <data name="DashboardConnectionFailedHint" xml:space="preserve">
+    <value>Verify the dashboard is running and the URL is correct.</value>
   </data>
   <data name="DashboardUrlInvalid" xml:space="preserve">
-    <value>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</value>
+    <value>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</value>
+  </data>
+  <data name="DashboardUrlInvalidHint" xml:space="preserve">
+    <value>Specify an absolute URL like 'http://localhost:18888'.</value>
+  </data>
+  <data name="DashboardLoginTokenFailed" xml:space="preserve">
+    <value>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</value>
+  </data>
+  <data name="DashboardLoginTokenFailedHint" xml:space="preserve">
+    <value>Ensure you are using the login URL from the currently running dashboard instance.</value>
+  </data>
+  <data name="DashboardLoginTokenFailedAnonymousHint" xml:space="preserve">
+    <value>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
@@ -187,7 +187,7 @@
     <value>Status</value>
   </data>
   <data name="DashboardUrlOptionDescription" xml:space="preserve">
-    <value>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</value>
+    <value>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</value>
   </data>
   <data name="ApiKeyOptionDescription" xml:space="preserve">
     <value>API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</value>
@@ -202,7 +202,7 @@
     <value>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</value>
   </data>
   <data name="DashboardApiNotEnabled" xml:space="preserve">
-    <value>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</value>
+    <value>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</value>
   </data>
   <data name="DashboardConnectionFailed" xml:space="preserve">
     <value>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</value>

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
@@ -190,7 +190,7 @@
     <value>Status</value>
   </data>
   <data name="DashboardUrlOptionDescription" xml:space="preserve">
-    <value>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</value>
+    <value>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</value>
   </data>
   <data name="ApiKeyOptionDescription" xml:space="preserve">
     <value>API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</value>
@@ -199,10 +199,10 @@
     <value>The --dashboard-url and --apphost options cannot be used together. Specify one or the other.</value>
   </data>
   <data name="DashboardAuthFailed" xml:space="preserve">
-    <value>Could not fetch telemetry data from the dashboard. Authentication was denied.</value>
+    <value>Could not fetch telemetry data from the dashboard. Authentication failed.</value>
   </data>
   <data name="DashboardAuthFailedHint" xml:space="preserve">
-    <value>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</value>
+    <value>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</value>
   </data>
   <data name="DashboardAuthFailedAnonymousHint" xml:space="preserve">
     <value>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</value>

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
@@ -202,7 +202,7 @@
     <value>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</value>
   </data>
   <data name="DashboardApiNotEnabled" xml:space="preserve">
-    <value>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</value>
+    <value>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</value>
   </data>
   <data name="DashboardConnectionFailed" xml:space="preserve">
     <value>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</value>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
@@ -67,11 +67,6 @@
         <target state="new">Manage the Aspire dashboard</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnableApiOptionDescription">
-        <source>Enable the telemetry API endpoint on the dashboard</source>
-        <target state="new">Enable the telemetry API endpoint on the dashboard</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">Rozhraní API řídicího panelu není k dispozici. Ujistěte se, že hostitel aplikací běží s povoleným řídicím panelem.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">Die Dashboard-API ist nicht verfügbar. Stellen Sie sicher, dass der AppHost mit aktiviertem Dashboard ausgeführt wird.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">La API de panel no está disponible. Asegúrese de que AppHost se esté ejecutando con Panel habilitado.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">Désolé, l’API du tableau de bord n’est pas disponible. Vérifiez que AppHost fonctionne avec le tableau de bord activé.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">L'API del dashboard non è disponibile. Verificare che AppHost sia in esecuzione con il dashboard abilitato.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">ダッシュボード API は利用できません。ダッシュボードが有効になっている状態で AppHost が実行されていることを確認します。</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">대시보드 API를 사용할 수 없습니다. AppHost가 대시보드를 활성화한 상태로 실행 중인지 확인하세요.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">Interfejs API pulpitu nawigacyjnego jest niedostępny. Upewnij się, że host aplikacji działa z włączonym pulpitem nawigacyjnym.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">A API do painel não está disponível. Verifique se o AppHost está em execução com o Painel habilitado.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">API панели мониторинга недоступен. Убедитесь, что AppHost запущен с включенной панелью мониторинга.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">Pano API'si kullanılamıyor. AppHost'un Pano özelliği etkin olarak çalıştığından emin olun.</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">仪表板 API 不可用。请确保 AppHost 在运行时启用了仪表板。</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Configure the dashboard with Dashboard:Api:Enabled set to true.</target>
+        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run --enable-api' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</source>
-        <target state="new">URL of a standalone Aspire Dashboard to connect to directly (bypasses AppHost discovery)</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -7,24 +7,64 @@
         <target state="new">API key for authenticating with the dashboard (optional, for dashboards with API key authentication)</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotAvailable">
-        <source>Dashboard API is not available. Ensure the AppHost is running with Dashboard enabled.</source>
-        <target state="needs-review-translation">儀表板 API 無法使用。確保 AppHost 執行中且儀表板功能已啟用。</target>
+      <trans-unit id="DashboardApiNotEnabled">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard at '{0}' does not have the telemetry API enabled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DashboardApiNotEnabled">
-        <source>The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
-        <target state="new">The dashboard at '{0}' does not have the telemetry API enabled. Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
+      <trans-unit id="DashboardApiNotEnabledHint">
+        <source>Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</source>
+        <target state="new">Start the dashboard with 'aspire dashboard run' or set Dashboard:Api:Enabled to true.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</source>
-        <target state="new">Authentication denied by the dashboard. Use --api-key to specify a valid API key that matches the dashboard's configured API key (Dashboard:Api:PrimaryApiKey).</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardAuthFailedHint">
+        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
-        <source>Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</source>
-        <target state="new">Could not connect to the dashboard at '{0}'. Verify the dashboard is running and the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Unable to connect to '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardConnectionFailedHint">
+        <source>Verify the dashboard is running and the URL is correct.</source>
+        <target state="new">Verify the dashboard is running and the URL is correct.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailed">
+        <source>Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The login token in the URL is invalid or expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedAnonymousHint">
+        <source>Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</source>
+        <target state="new">Alternatively, allow anonymous access with 'aspire dashboard run --allow-anonymous' or by setting the ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS environment variable to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardLoginTokenFailedHint">
+        <source>Ensure you are using the login URL from the currently running dashboard instance.</source>
+        <target state="new">Ensure you are using the login URL from the currently running dashboard instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailable">
+        <source>Could not fetch telemetry data from the dashboard. The dashboard is not available.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The dashboard is not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardNotAvailableHint">
+        <source>Ensure the AppHost is running with the dashboard enabled.</source>
+        <target state="new">Ensure the AppHost is running with the dashboard enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlAndAppHostExclusive">
@@ -33,13 +73,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlInvalid">
-        <source>The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</source>
-        <target state="new">The value '{0}' is not a valid URL. Specify an absolute URL like 'http://localhost:18888'.</target>
+        <source>Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The value '{0}' is not a valid URL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlInvalidHint">
+        <source>Specify an absolute URL like 'http://localhost:18888'.</source>
+        <target state="new">Specify an absolute URL like 'http://localhost:18888'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlNotReachable">
-        <source>The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</source>
-        <target state="new">The specified --dashboard-url '{0}' does not appear to be a valid Aspire Dashboard. Verify the URL is correct.</target>
+        <source>Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. The specified URL '{0}' does not appear to be a valid dashboard address.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardUrlNotReachableHint">
+        <source>Verify the URL is correct.</source>
+        <target state="new">Verify the URL is correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailed">
-        <source>Could not fetch telemetry data from the dashboard. Authentication was denied.</source>
-        <target state="new">Could not fetch telemetry data from the dashboard. Authentication was denied.</target>
+        <source>Could not fetch telemetry data from the dashboard. Authentication failed.</source>
+        <target state="new">Could not fetch telemetry data from the dashboard. Authentication failed.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedAnonymousHint">
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardAuthFailedHint">
-        <source>Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</source>
-        <target state="new">Authenticate with the dashboard using a --dashboard-url value that includes a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or specify --api-key with a key matching the dashboard's configured API key.</target>
+        <source>Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</source>
+        <target state="new">Authenticate with the dashboard either with a --dashboard-url including a valid login token (e.g. http://localhost:18888/login?t=TOKEN), or with an --api-key matching the dashboard's configured API key.</target>
         <note />
       </trans-unit>
       <trans-unit id="DashboardConnectionFailed">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardUrlOptionDescription">
-        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</source>
-        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized</target>
+        <source>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</source>
+        <target state="new">Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Dashboard/Api/ApiAuthenticationHandler.cs
+++ b/src/Aspire.Dashboard/Api/ApiAuthenticationHandler.cs
@@ -3,7 +3,6 @@
 
 using System.Security.Claims;
 using System.Text.Encodings.Web;
-using Aspire.Dashboard.Authentication;
 using Aspire.Dashboard.Configuration;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
@@ -86,51 +85,13 @@ public sealed class ApiAuthenticationHandler(
 
                 return AuthenticateResult.Fail("Authentication failed.");
             }
-
-            // API key header not provided - fall through to frontend auth for browser access
-        }
-
-        // Try frontend authentication (for browser-based access)
-        var frontendResult = await Context.AuthenticateAsync(FrontendCompositeAuthenticationDefaults.AuthenticationScheme).ConfigureAwait(false);
-        if (frontendResult.Succeeded)
-        {
-            return frontendResult;
-        }
-
-        // Return frontend failure if present
-        if (frontendResult.Failure is not null)
-        {
-            return frontendResult;
+            else
+            {
+                return AuthenticateResult.Fail($"API key from '{ApiKeyHeaderName}' header is missing.");
+            }
         }
 
         return AuthenticateResult.NoResult();
-    }
-
-    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
-    {
-        // If an API key was provided (but was wrong), return 401 instead of redirecting
-        if (Context.Request.Headers.ContainsKey(ApiKeyHeaderName))
-        {
-            Context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-            return Task.CompletedTask;
-        }
-
-        // For browser-based access without API key, redirect to login
-        var frontendAuthMode = dashboardOptions.CurrentValue.Frontend.AuthMode;
-        var scheme = frontendAuthMode switch
-        {
-            FrontendAuthMode.OpenIdConnect => FrontendAuthenticationDefaults.AuthenticationSchemeOpenIdConnect,
-            FrontendAuthMode.BrowserToken => FrontendAuthenticationDefaults.AuthenticationSchemeBrowserToken,
-            _ => null
-        };
-
-        if (scheme != null)
-        {
-            return Context.ChallengeAsync(scheme);
-        }
-
-        Context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-        return Task.CompletedTask;
     }
 
     public const string AuthenticationScheme = "Api";

--- a/src/Aspire.Dashboard/Api/ApiAuthenticationHandler.cs
+++ b/src/Aspire.Dashboard/Api/ApiAuthenticationHandler.cs
@@ -28,7 +28,7 @@ public sealed class ApiAuthenticationHandler(
     /// </summary>
     public const string ApiKeyHeaderName = "x-api-key";
 
-    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         var currentOptions = dashboardOptions.CurrentValue;
         var apiAuthMode = currentOptions.Api.AuthMode;
@@ -37,7 +37,7 @@ public sealed class ApiAuthenticationHandler(
         if (apiAuthMode is ApiAuthMode.Unsecured)
         {
             var id = new ClaimsIdentity([new Claim(ClaimName, bool.TrueString)], AuthenticationScheme);
-            return AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(id), Scheme.Name));
+            return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(id), Scheme.Name)));
         }
 
         // If API auth requires API key
@@ -46,10 +46,9 @@ public sealed class ApiAuthenticationHandler(
             var apiKeyBytes = currentOptions.Api.GetPrimaryApiKeyBytesOrNull();
 
             // If ApiKey mode is set but no key is configured, fail authentication
-            // rather than silently falling through to frontend auth
             if (apiKeyBytes is null)
             {
-                return AuthenticateResult.Fail("API key authentication is enabled but no API key is configured.");
+                return Task.FromResult(AuthenticateResult.Fail("API key authentication is enabled but no API key is configured."));
             }
 
             if (Context.Request.Headers.TryGetValue(ApiKeyHeaderName, out var apiKeyHeader))
@@ -57,20 +56,20 @@ public sealed class ApiAuthenticationHandler(
                 // There must be exactly one header with the API key.
                 if (apiKeyHeader.Count != 1)
                 {
-                    return AuthenticateResult.Fail("Invalid API key header.");
+                    return Task.FromResult(AuthenticateResult.Fail("Invalid API key header."));
                 }
 
                 var providedApiKey = apiKeyHeader.ToString();
                 if (string.IsNullOrEmpty(providedApiKey))
                 {
-                    return AuthenticateResult.Fail("Invalid API key header.");
+                    return Task.FromResult(AuthenticateResult.Fail("Invalid API key header."));
                 }
 
                 // Check primary key
                 if (CompareHelpers.CompareKey(apiKeyBytes, providedApiKey))
                 {
                     var id = new ClaimsIdentity([new Claim(ClaimName, bool.TrueString)], AuthenticationScheme);
-                    return AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(id), Scheme.Name));
+                    return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(id), Scheme.Name)));
                 }
 
                 // Check secondary key (for key rotation)
@@ -78,18 +77,18 @@ public sealed class ApiAuthenticationHandler(
                     CompareHelpers.CompareKey(secondaryBytes, providedApiKey))
                 {
                     var id = new ClaimsIdentity([new Claim(ClaimName, bool.TrueString)], AuthenticationScheme);
-                    return AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(id), Scheme.Name));
+                    return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(id), Scheme.Name)));
                 }
 
-                return AuthenticateResult.Fail("Authentication failed.");
+                return Task.FromResult(AuthenticateResult.Fail("Authentication failed."));
             }
             else
             {
-                return AuthenticateResult.Fail($"API key from '{ApiKeyHeaderName}' header is missing.");
+                return Task.FromResult(AuthenticateResult.Fail($"API key from '{ApiKeyHeaderName}' header is missing."));
             }
         }
 
-        return AuthenticateResult.NoResult();
+        return Task.FromResult(AuthenticateResult.NoResult());
     }
 
     public const string AuthenticationScheme = "Api";

--- a/src/Aspire.Dashboard/Api/ApiAuthenticationHandler.cs
+++ b/src/Aspire.Dashboard/Api/ApiAuthenticationHandler.cs
@@ -10,12 +10,10 @@ using Microsoft.Extensions.Options;
 namespace Aspire.Dashboard.Api;
 
 /// <summary>
-/// Authentication handler for the Dashboard API that supports API key auth
-/// and falls back to frontend auth (browser token, OIDC, or unsecured based on configuration).
+/// Authentication handler for the Dashboard API that supports API key authentication.
 /// </summary>
 /// <remarks>
-/// When Api.AuthMode is ApiKey, the API key is required for programmatic access.
-/// Browser-based access can still use frontend auth (browser token, OIDC).
+/// When Api.AuthMode is ApiKey, all requests must include a valid API key via the x-api-key header.
 /// When Api.AuthMode is Unsecured, no authentication is required.
 /// </remarks>
 public sealed class ApiAuthenticationHandler(

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -327,6 +327,7 @@
     <Compile Include="$(SharedDir)Otlp\Serialization\OtlpJsonSerializerContext.cs" Link="Otlp\Model\Serialization\OtlpJsonSerializerContext.Shared.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\TelemetryApiResponse.cs" Link="Otlp\Model\Serialization\TelemetryApiResponse.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\ResourceInfoJson.cs" Link="Otlp\Model\Serialization\ResourceInfoJson.cs" />
+    <Compile Include="$(SharedDir)Model\Serialization\TelemetryValidateTokenJson.cs" Link="Otlp\Model\Serialization\TelemetryValidateTokenJson.cs" />
     <Compile Include="$(SharedDir)Export\ExportArchive.cs" Link="Export\ExportArchive.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\LogEntrySerializer.cs" Link="ConsoleLogs\LogEntrySerializer.cs" />
   </ItemGroup>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -187,7 +187,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     private bool ShouldShowUnsecuredApiMessage()
     {
         // Only show warning if API is enabled and unsecured
-        return Options.CurrentValue.Api.Enabled.GetValueOrDefault() &&
+        return !Options.CurrentValue.Api.Disabled.GetValueOrDefault() &&
                Options.CurrentValue.Api.AuthMode == ApiAuthMode.Unsecured;
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Login.razor.js
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor.js
@@ -1,7 +1,10 @@
 export async function validateToken(token) {
     try {
-        var url = `/api/validatetoken?token=${encodeURIComponent(token)}`;
-        var response = await fetch(url, { method: 'POST' });
+        var response = await fetch('/api/validatetoken', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token: token })
+        });
         return response.text();
     } catch (ex) {
         return `Error validating token: ${ex}`;

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -145,13 +145,30 @@ public sealed class ApiOptions
 {
     private byte[]? _primaryApiKeyBytes;
     private byte[]? _secondaryApiKeyBytes;
+    private bool? _disabled;
 
     /// <summary>
     /// Gets or sets whether the Telemetry HTTP API is enabled.
     /// When false, the /api/telemetry/* endpoints are not registered.
+    /// Defaults to true.
+    /// </summary>
+    [Obsolete("Use Disabled instead.")]
+    public bool? Enabled
+    {
+        get => _disabled is null ? null : !_disabled;
+        set => _disabled = value is null ? null : !value;
+    }
+
+    /// <summary>
+    /// Gets or sets whether the Telemetry HTTP API is disabled.
+    /// When true, the /api/telemetry/* endpoints are not registered.
     /// Defaults to false.
     /// </summary>
-    public bool? Enabled { get; set; }
+    public bool? Disabled
+    {
+        get => _disabled;
+        set => _disabled = value;
+    }
 
     /// <summary>
     /// Gets or sets the authentication mode for API endpoints.

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -62,8 +62,7 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
         {
             options.Frontend.AuthMode ??= FrontendAuthMode.BrowserToken;
             options.Otlp.AuthMode ??= OtlpAuthMode.Unsecured;
-
-            options.Api.AuthMode ??= string.IsNullOrEmpty(options.Api.PrimaryApiKey) ? ApiAuthMode.Unsecured : ApiAuthMode.ApiKey;
+            options.Api.AuthMode ??= ApiAuthMode.ApiKey;
         }
 
         if (options.Frontend.AuthMode == FrontendAuthMode.BrowserToken && string.IsNullOrEmpty(options.Frontend.BrowserToken))
@@ -76,9 +75,31 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
             options.Frontend.BrowserToken = token;
         }
 
+        if (options.Api.AuthMode == ApiAuthMode.ApiKey && string.IsNullOrEmpty(options.Api.PrimaryApiKey))
+        {
+            var apiKey = TokenGenerator.GenerateToken();
+
+            // Set the generated API key in configuration. This is required because options could be created multiple times
+            // (at startup, after CI is created, after options change). Setting the key in configuration makes it consistent.
+            _configuration[DashboardConfigNames.DashboardApiPrimaryApiKeyName.ConfigKey] = apiKey;
+            options.Api.PrimaryApiKey = apiKey;
+        }
+
         options.AI.Disabled = _configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey);
 
-        options.Api.Enabled ??= _configuration.GetBool(DashboardConfigNames.DashboardAspireApiEnabledName.ConfigKey);
+        // DashboardAspireApiDisabledName takes precedence over DashboardAspireApiEnabledName.
+        if (_configuration.GetBool(DashboardConfigNames.DashboardAspireApiDisabledName.ConfigKey) is { } apiDisabled)
+        {
+            options.Api.Disabled ??= apiDisabled;
+        }
+        else if (_configuration.GetBool(DashboardConfigNames.DashboardAspireApiEnabledName.ConfigKey) is { } apiEnabled)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            options.Api.Enabled ??= apiEnabled;
+#pragma warning restore CS0618
+        }
+
+        options.Api.Disabled ??= false;
 
         if (_configuration.GetBool(DashboardConfigNames.Legacy.DashboardOtlpSuppressUnsecuredTelemetryMessageName.ConfigKey) is { } suppressUnsecuredTelemetryMessage)
         {

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -108,9 +108,9 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
 
         if (effectiveApiAuthMode is ApiAuthMode.ApiKey)
         {
-            // Check if any API key is configured
-            var hasApiKey = !string.IsNullOrEmpty(options.Api.PrimaryApiKey);
-            if (!hasApiKey)
+            // PrimaryApiKey should always be present when AuthMode is ApiKey because
+            // PostConfigureDashboardOptions generates a key when one isn't specified.
+            if (string.IsNullOrEmpty(options.Api.PrimaryApiKey))
             {
                 errorMessages.Add($"PrimaryApiKey is required when API authentication mode is ApiKey. Specify Dashboard:Api:PrimaryApiKey.");
             }

--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using Aspire.Dashboard.Api;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
@@ -27,9 +26,9 @@ public static class DashboardEndpointsBuilder
         IEndpointConventionBuilder builder;
         if (dashboardOptions.Frontend.AuthMode == FrontendAuthMode.BrowserToken)
         {
-            builder = endpoints.MapPost("/api/validatetoken", async (string token, HttpContext httpContext, IOptionsMonitor<DashboardOptions> dashboardOptions) =>
+            builder = endpoints.MapPost("/api/validatetoken", async ([FromBody] ValidateTokenRequest request, HttpContext httpContext, IOptionsMonitor<DashboardOptions> dashboardOptions) =>
             {
-                return await ValidateTokenMiddleware.TryAuthenticateAsync(token, httpContext, dashboardOptions).ConfigureAwait(false);
+                return await ValidateTokenMiddleware.TryAuthenticateAsync(request.Token, httpContext, dashboardOptions).ConfigureAwait(false);
             });
 
 #if DEBUG
@@ -110,7 +109,7 @@ public static class DashboardEndpointsBuilder
         // POST /api/telemetry/validateToken - Exchange a browser token for the telemetry API key.
         // Returns the API key if the token is valid and the API uses key-based auth, or null if unsecured.
         // Returns 401 if the token is invalid, 404 if the telemetry API is not enabled.
-        group.MapPost("/validateToken", (string token, IOptionsMonitor<DashboardOptions> optionsMonitor) =>
+        group.MapPost("/validateToken", ([FromBody] TelemetryValidateTokenRequest request, IOptionsMonitor<DashboardOptions> optionsMonitor) =>
         {
             var currentOptions = optionsMonitor.CurrentValue;
 
@@ -121,7 +120,7 @@ public static class DashboardEndpointsBuilder
             }
 
             var expectedBrowserTokenBytes = currentOptions.Frontend.GetBrowserTokenBytes();
-            if (expectedBrowserTokenBytes is null || !CompareHelpers.CompareKey(expectedBrowserTokenBytes, token))
+            if (expectedBrowserTokenBytes is null || !CompareHelpers.CompareKey(expectedBrowserTokenBytes, request.Token))
             {
                 return Results.Unauthorized();
             }
@@ -131,7 +130,7 @@ public static class DashboardEndpointsBuilder
                 ? currentOptions.Api.PrimaryApiKey
                 : null;
 
-            return Results.Json(new TelemetryApiKeyResponse(apiKey), TelemetryApiKeyJsonContext.Default.TelemetryApiKeyResponse);
+            return Results.Json(new TelemetryValidateTokenResponse(apiKey), OtlpJsonSerializerContext.Default.TelemetryValidateTokenResponse);
         }).AllowAnonymous();
 
         // GET /api/telemetry/resources - List resources that have telemetry data
@@ -269,12 +268,5 @@ public static class DashboardEndpointsBuilder
     }
 }
 
-/// <summary>
-/// Response from the <c>POST /api/telemetry/validateToken</c> endpoint.
-/// </summary>
-/// <param name="ApiKey">The API key to use for telemetry API access, or <c>null</c> when the API is unsecured.</param>
-internal sealed record TelemetryApiKeyResponse(string? ApiKey);
-
-[JsonSerializable(typeof(TelemetryApiKeyResponse))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
-internal sealed partial class TelemetryApiKeyJsonContext : JsonSerializerContext;
+/// <param name="Token">The browser token to validate.</param>
+internal sealed record ValidateTokenRequest(string Token);

--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -94,8 +94,8 @@ public static class DashboardEndpointsBuilder
 
     public static void MapTelemetryApi(this IEndpointRouteBuilder endpoints, DashboardOptions dashboardOptions)
     {
-        // Check if API is enabled (defaults to disabled if not specified)
-        if (!dashboardOptions.Api.Enabled.GetValueOrDefault())
+        // Check if API is disabled
+        if (dashboardOptions.Api.Disabled.GetValueOrDefault())
         {
             endpoints.MapGetNotFound("/api/telemetry/{*path}").SkipStatusCodePages();
             endpoints.MapPostNotFound("/api/telemetry/{*path}").SkipStatusCodePages();

--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Aspire.Dashboard.Api;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
@@ -89,6 +90,7 @@ public static class DashboardEndpointsBuilder
 
             return Results.LocalRedirect(redirectUrl);
         }).SkipStatusCodePages();
+
     }
 
     public static void MapTelemetryApi(this IEndpointRouteBuilder endpoints, DashboardOptions dashboardOptions)
@@ -97,12 +99,40 @@ public static class DashboardEndpointsBuilder
         if (!dashboardOptions.Api.Enabled.GetValueOrDefault())
         {
             endpoints.MapGetNotFound("/api/telemetry/{*path}").SkipStatusCodePages();
+            endpoints.MapPostNotFound("/api/telemetry/{*path}").SkipStatusCodePages();
             return;
         }
 
         var group = endpoints.MapGroup("/api/telemetry")
             .RequireAuthorization(ApiAuthenticationHandler.PolicyName)
             .SkipStatusCodePages();
+
+        // POST /api/telemetry/validateToken - Exchange a browser token for the telemetry API key.
+        // Returns the API key if the token is valid and the API uses key-based auth, or null if unsecured.
+        // Returns 401 if the token is invalid, 404 if the telemetry API is not enabled.
+        group.MapPost("/validateToken", (string token, IOptionsMonitor<DashboardOptions> optionsMonitor) =>
+        {
+            var currentOptions = optionsMonitor.CurrentValue;
+
+            // Validate the browser token
+            if (currentOptions.Frontend.AuthMode != FrontendAuthMode.BrowserToken)
+            {
+                return Results.Unauthorized();
+            }
+
+            var expectedBrowserTokenBytes = currentOptions.Frontend.GetBrowserTokenBytes();
+            if (expectedBrowserTokenBytes is null || !CompareHelpers.CompareKey(expectedBrowserTokenBytes, token))
+            {
+                return Results.Unauthorized();
+            }
+
+            // Token is valid — return the API key (null if unsecured)
+            var apiKey = currentOptions.Api.AuthMode == ApiAuthMode.ApiKey
+                ? currentOptions.Api.PrimaryApiKey
+                : null;
+
+            return Results.Json(new TelemetryApiKeyResponse(apiKey), TelemetryApiKeyJsonContext.Default.TelemetryApiKeyResponse);
+        }).AllowAnonymous();
 
         // GET /api/telemetry/resources - List resources that have telemetry data
         group.MapGet("/resources", (TelemetryApiService service) =>
@@ -238,3 +268,13 @@ public static class DashboardEndpointsBuilder
         }
     }
 }
+
+/// <summary>
+/// Response from the <c>POST /api/telemetry/validateToken</c> endpoint.
+/// </summary>
+/// <param name="ApiKey">The API key to use for telemetry API access, or <c>null</c> when the API is unsecured.</param>
+internal sealed record TelemetryApiKeyResponse(string? ApiKey);
+
+[JsonSerializable(typeof(TelemetryApiKeyResponse))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class TelemetryApiKeyJsonContext : JsonSerializerContext;

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -401,6 +401,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 _logger.LogWarning("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030");
             }
 
+            _logger.LogDebug("Dashboard API enabled: {ApiEnabled}", _dashboardOptionsMonitor.CurrentValue.Api.Enabled.GetValueOrDefault());
+
             // Only show API security warning if API is enabled and unsecured
             // API runs on the frontend endpoint (no separate accessor needed)
             if (_dashboardOptionsMonitor.CurrentValue.Api.Enabled.GetValueOrDefault() &&

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -401,11 +401,11 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 _logger.LogWarning("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030");
             }
 
-            _logger.LogDebug("Dashboard API enabled: {ApiEnabled}", _dashboardOptionsMonitor.CurrentValue.Api.Enabled.GetValueOrDefault());
+            _logger.LogDebug("Dashboard API disabled: {ApiDisabled}", _dashboardOptionsMonitor.CurrentValue.Api.Disabled.GetValueOrDefault());
 
             // Only show API security warning if API is enabled and unsecured
             // API runs on the frontend endpoint (no separate accessor needed)
-            if (_dashboardOptionsMonitor.CurrentValue.Api.Enabled.GetValueOrDefault() &&
+            if (!_dashboardOptionsMonitor.CurrentValue.Api.Disabled.GetValueOrDefault() &&
                 _dashboardOptionsMonitor.CurrentValue.Api.AuthMode == ApiAuthMode.Unsecured)
             {
                 _logger.LogWarning("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.");

--- a/src/Aspire.Dashboard/Model/Assistant/ChatClientFactory.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/ChatClientFactory.cs
@@ -175,7 +175,7 @@ public sealed class ChatClientFactory
             // An debug session connection isn't needed in this case.
             if (UseOpenAI())
             {
-                _logger.LogInformation("AI is enabled via OpenAI.");
+                _logger.LogDebug("AI is enabled via OpenAI.");
                 return true;
             }
 #endif
@@ -183,7 +183,7 @@ public sealed class ChatClientFactory
             // No debug session configured. Expected when the app host is started from CLI.
             if (!DebugSessionHelpers.HasDebugSession(_dashboardOptions.CurrentValue.DebugSession, out _, out _, out _))
             {
-                _logger.LogInformation("AI is disabled because there isn't a debug session.");
+                _logger.LogDebug("AI is disabled because there isn't a debug session.");
                 return false;
             }
 

--- a/src/Aspire.Dashboard/Properties/launchSettings.json
+++ b/src/Aspire.Dashboard/Properties/launchSettings.json
@@ -17,6 +17,19 @@
         "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:4318"
       },
       "applicationUrl": "http://localhost:15889"
+    },
+    "http (browser + api)": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:4317",
+        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:4318",
+        "ASPIRE_DASHBOARD_API_ENABLED": "true",
+        "DASHBOARD__API__PRIMARYAPIKEY": "12345678",
+        "DASHBOARD__API__AUTHMODE": "ApiKey"
+      },
+      "applicationUrl": "http://localhost:15889"
     }
   }
 }

--- a/src/Aspire.Dashboard/Telemetry/DashboardTelemetrySender.cs
+++ b/src/Aspire.Dashboard/Telemetry/DashboardTelemetrySender.cs
@@ -123,7 +123,7 @@ public sealed class DashboardTelemetrySender : IDashboardTelemetrySender
             }
         }
 
-        _logger.LogInformation("Telemetry is not configured.");
+        _logger.LogDebug("Telemetry is not configured.");
         client = null;
         return false;
     }

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -14,6 +14,7 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardFileConfigDirectoryName = new(KnownConfigNames.DashboardFileConfigDirectory);
     public static readonly ConfigName DashboardAIDisabledName = new(KnownConfigNames.DashboardAIDisabled);
     public static readonly ConfigName DashboardAspireApiEnabledName = new(KnownConfigNames.DashboardApiEnabled);
+    public static readonly ConfigName DashboardAspireApiDisabledName = new(KnownConfigNames.DashboardApiDisabled);
     public static readonly ConfigName ResourceServiceUrlName = new(KnownConfigNames.ResourceServiceEndpointUrl);
     public static readonly ConfigName ForwardedHeaders = new(KnownConfigNames.DashboardForwardedHeadersEnabled);
 
@@ -23,6 +24,7 @@ internal static class DashboardConfigNames
 
     // Dashboard API Authentication - used for Telemetry API
     public static readonly ConfigName DashboardApiEnabledName = new("Dashboard:Api:Enabled", "DASHBOARD__API__ENABLED");
+    public static readonly ConfigName DashboardApiDisabledName = new("Dashboard:Api:Disabled", "DASHBOARD__API__DISABLED");
     public static readonly ConfigName DashboardApiAuthModeName = new("Dashboard:Api:AuthMode", "DASHBOARD__API__AUTHMODE");
     public static readonly ConfigName DashboardApiPrimaryApiKeyName = new("Dashboard:Api:PrimaryApiKey", "DASHBOARD__API__PRIMARYAPIKEY");
     public static readonly ConfigName DashboardApiSecondaryApiKeyName = new("Dashboard:Api:SecondaryApiKey", "DASHBOARD__API__SECONDARYAPIKEY");

--- a/src/Shared/DashboardUrls.cs
+++ b/src/Shared/DashboardUrls.cs
@@ -305,6 +305,16 @@ internal static class DashboardUrls
     }
 
     /// <summary>
+    /// Builds the URL for the telemetry API key exchange endpoint.
+    /// </summary>
+    /// <param name="baseUrl">The dashboard base URL.</param>
+    /// <returns>The full API URL.</returns>
+    public static string TelemetryApiKeyUrl(string baseUrl)
+    {
+        return CombineUrl(baseUrl, "/api/telemetry/validateToken");
+    }
+
+    /// <summary>
     /// Appends multiple resource query parameters to a URL.
     /// </summary>
     private static string AddResourceParams(string url, List<string>? resources)

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -18,6 +18,7 @@ internal static class KnownConfigNames
     public const string DashboardFileConfigDirectory = "ASPIRE_DASHBOARD_FILE_CONFIG_DIRECTORY";
     public const string DashboardAIDisabled = "ASPIRE_DASHBOARD_AI_DISABLED";
     public const string DashboardApiEnabled = "ASPIRE_DASHBOARD_API_ENABLED";
+    public const string DashboardApiDisabled = "ASPIRE_DASHBOARD_API_DISABLED";
     public const string DashboardForwardedHeadersEnabled = "ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED";
 
     public const string ShowDashboardResources = "ASPIRE_SHOW_DASHBOARD_RESOURCES";

--- a/src/Shared/Model/Serialization/TelemetryValidateTokenJson.cs
+++ b/src/Shared/Model/Serialization/TelemetryValidateTokenJson.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Otlp.Serialization;
+
+/// <summary>
+/// Request to the <c>POST /api/telemetry/validateToken</c> endpoint.
+/// Shared between Dashboard and CLI.
+/// </summary>
+/// <param name="Token">The browser token to validate.</param>
+internal sealed record TelemetryValidateTokenRequest(string Token);
+
+/// <summary>
+/// Response from the <c>POST /api/telemetry/validateToken</c> endpoint.
+/// Shared between Dashboard and CLI.
+/// </summary>
+/// <param name="ApiKey">The API key to use for telemetry API access, or <c>null</c> when the API is unsecured.</param>
+internal sealed record TelemetryValidateTokenResponse(string? ApiKey);

--- a/src/Shared/Otlp/Serialization/OtlpJsonSerializerContext.cs
+++ b/src/Shared/Otlp/Serialization/OtlpJsonSerializerContext.cs
@@ -64,6 +64,8 @@ namespace Aspire.Otlp.Serialization;
 [JsonSerializable(typeof(ResourceJson))]
 // Telemetry API types
 [JsonSerializable(typeof(TelemetryApiResponse))]
+[JsonSerializable(typeof(TelemetryValidateTokenRequest))]
+[JsonSerializable(typeof(TelemetryValidateTokenResponse))]
 [JsonSerializable(typeof(ResourceInfoJson))]
 [JsonSerializable(typeof(ResourceInfoJson[]))]
 #if !CLI

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -217,6 +217,9 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(capturedEnv);
         Assert.True(capturedEnv.ContainsKey("DASHBOARD__FRONTEND__BROWSERTOKEN"));
         Assert.False(string.IsNullOrEmpty(capturedEnv["DASHBOARD__FRONTEND__BROWSERTOKEN"]));
+        Assert.True(capturedEnv.ContainsKey("DASHBOARD__API__PRIMARYAPIKEY"));
+        Assert.False(string.IsNullOrEmpty(capturedEnv["DASHBOARD__API__PRIMARYAPIKEY"]));
+        Assert.Equal("ApiKey", capturedEnv["DASHBOARD__API__AUTHMODE"]);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -59,7 +59,6 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [InlineData("--otlp-grpc-url http://localhost:4317")]
     [InlineData("--otlp-http-url http://localhost:4318")]
     [InlineData("--allow-anonymous")]
-    [InlineData("--enable-api")]
     [InlineData("--config-file-path /path/to/config.json")]
     public void DashboardRunCommand_ParsesOptionsWithoutErrors(string args)
     {
@@ -170,7 +169,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
             arg => Assert.Equal("dashboard", arg),
             arg => Assert.Equal("--ASPNETCORE_URLS=http://localhost:18888", arg),
             arg => Assert.Equal("--ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:4317", arg),
-            arg => Assert.Equal("--ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://localhost:4318", arg));
+            arg => Assert.Equal("--ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://localhost:4318", arg),
+            arg => Assert.Equal("--ASPIRE_DASHBOARD_API_ENABLED=true", arg));
     }
 
     [Theory]
@@ -178,7 +178,6 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [InlineData("--otlp-grpc-url http://localhost:9317", "--ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:9317")]
     [InlineData("--otlp-http-url http://localhost:9318", "--ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://localhost:9318")]
     [InlineData("--allow-anonymous", "--ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true")]
-    [InlineData("--enable-api", "--ASPIRE_DASHBOARD_API_ENABLED=true")]
     [InlineData("--config-file-path /path/to/config.json", "--ASPIRE_DASHBOARD_CONFIG_FILE_PATH=/path/to/config.json")]
     public async Task DashboardRunCommand_IndividualOption_PassesCorrectArgToProcess(string cliArgs, string expectedArg)
     {
@@ -242,6 +241,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
             arg => Assert.Equal("--ASPNETCORE_URLS=http://localhost:18888", arg),
             arg => Assert.Equal("--ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:4317", arg),
             arg => Assert.Equal("--ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://localhost:4318", arg),
+            arg => Assert.Equal("--ASPIRE_DASHBOARD_API_ENABLED=true", arg),
             arg => Assert.Equal("--CUSTOM_SETTING=myvalue", arg));
     }
 
@@ -256,7 +256,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("dashboard run --frontend-url http://localhost:5000 --otlp-grpc-url http://localhost:9317 --otlp-http-url http://localhost:9318 --allow-anonymous --enable-api --config-file-path /my/config.json");
+        var result = command.Parse("dashboard run --frontend-url http://localhost:5000 --otlp-grpc-url http://localhost:9317 --otlp-http-url http://localhost:9318 --allow-anonymous --config-file-path /my/config.json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -265,6 +265,12 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
                     Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
                 };
             }
+            // The validateToken probe (POST) is used to distinguish "API not enabled" from "auth required".
+            // Return 404 to indicate the API is not enabled.
+            if (url.Contains("/api/telemetry/validateToken"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
             if (url.Contains("/api/telemetry/"))
             {
                 if (statusCode is null)
@@ -321,11 +327,12 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
             factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
 
-        Assert.Equal("test-api-key-123", result);
+        Assert.True(result.Success);
+        Assert.Equal("test-api-key-123", result.ApiKey);
     }
 
     [Fact]
-    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNull_WhenApiKeyIsNull()
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNullApiKey_WhenApiKeyIsNull()
     {
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -337,11 +344,12 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
             factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
 
-        Assert.Null(result);
+        Assert.True(result.Success);
+        Assert.Null(result.ApiKey);
     }
 
     [Fact]
-    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNull_WhenUnauthorized()
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsFailed_WhenUnauthorized()
     {
         var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
         using var handler = new MockHttpMessageHandler(response);
@@ -350,11 +358,11 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
             factory, "http://localhost:18888", "wrong-token", NullLogger.Instance, CancellationToken.None);
 
-        Assert.Null(result);
+        Assert.False(result.Success);
     }
 
     [Fact]
-    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNull_WhenNotFound()
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsFailed_WhenNotFound()
     {
         var response = new HttpResponseMessage(HttpStatusCode.NotFound);
         using var handler = new MockHttpMessageHandler(response);
@@ -363,11 +371,11 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
             factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
 
-        Assert.Null(result);
+        Assert.False(result.Success);
     }
 
     [Fact]
-    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNull_WhenConnectionFails()
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsConnectionError_WhenConnectionFails()
     {
         using var handler = new MockHttpMessageHandler(new HttpRequestException("Connection refused"));
         var factory = new MockHttpClientFactory(handler);
@@ -375,7 +383,8 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
             factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
 
-        Assert.Null(result);
+        Assert.False(result.Success);
+        Assert.True(result.ConnectionFailed);
     }
 
     [Fact]
@@ -395,7 +404,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
             factory, "http://localhost:18888", "my-token", NullLogger.Instance, CancellationToken.None);
 
-        Assert.Equal("\"my-token\"", capturedBody);
+        Assert.Equal("""{"token":"my-token"}""", capturedBody);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -390,6 +390,20 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsOther_WhenUnexpectedStatusCode()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        using var handler = new MockHttpMessageHandler(response);
+        var factory = new MockHttpClientFactory(handler);
+
+        var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
+            factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(TokenExchangeFailureKind.Other, result.FailureKind);
+    }
+
+    [Fact]
     public async Task ExchangeLoginTokenForApiKeyAsync_SendsTokenAsJsonBody()
     {
         string? capturedBody = null;

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -13,6 +13,7 @@ using Aspire.Otlp.Serialization;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -305,5 +306,115 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
             attrs.Add(new() { Key = "service.instance.id", Value = new OtlpAnyValueJson { StringValue = instanceId } });
         }
         return new OtlpResourceJson { Attributes = [.. attrs] };
+    }
+
+    [Fact]
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsApiKey_WhenResponseContainsKey()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"apiKey":"test-api-key-123"}""", System.Text.Encoding.UTF8, "application/json")
+        };
+        using var handler = new MockHttpMessageHandler(response);
+        var factory = new MockHttpClientFactory(handler);
+
+        var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
+            factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
+
+        Assert.Equal("test-api-key-123", result);
+    }
+
+    [Fact]
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNull_WhenApiKeyIsNull()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"apiKey":null}""", System.Text.Encoding.UTF8, "application/json")
+        };
+        using var handler = new MockHttpMessageHandler(response);
+        var factory = new MockHttpClientFactory(handler);
+
+        var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
+            factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNull_WhenUnauthorized()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        using var handler = new MockHttpMessageHandler(response);
+        var factory = new MockHttpClientFactory(handler);
+
+        var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
+            factory, "http://localhost:18888", "wrong-token", NullLogger.Instance, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNull_WhenNotFound()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound);
+        using var handler = new MockHttpMessageHandler(response);
+        var factory = new MockHttpClientFactory(handler);
+
+        var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
+            factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ExchangeLoginTokenForApiKeyAsync_ReturnsNull_WhenConnectionFails()
+    {
+        using var handler = new MockHttpMessageHandler(new HttpRequestException("Connection refused"));
+        var factory = new MockHttpClientFactory(handler);
+
+        var result = await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
+            factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ExchangeLoginTokenForApiKeyAsync_SendsTokenAsJsonBody()
+    {
+        string? capturedBody = null;
+        using var handler = new MockHttpMessageHandler(request =>
+        {
+            capturedBody = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"apiKey":"key"}""", System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var factory = new MockHttpClientFactory(handler);
+
+        await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
+            factory, "http://localhost:18888", "my-token", NullLogger.Instance, CancellationToken.None);
+
+        Assert.Equal("\"my-token\"", capturedBody);
+    }
+
+    [Fact]
+    public async Task ExchangeLoginTokenForApiKeyAsync_CallsCorrectUrl()
+    {
+        string? capturedUrl = null;
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"apiKey":"key"}""", System.Text.Encoding.UTF8, "application/json")
+        };
+        using var handler = new MockHttpMessageHandler(response, request =>
+        {
+            capturedUrl = request.RequestUri?.ToString();
+        });
+        var factory = new MockHttpClientFactory(handler);
+
+        await TelemetryCommandHelpers.ExchangeLoginTokenForApiKeyAsync(
+            factory, "http://localhost:18888", "my-token", NullLogger.Instance, CancellationToken.None);
+
+        Assert.Equal("http://localhost:18888/api/telemetry/validateToken", capturedUrl);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -359,6 +359,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
             factory, "http://localhost:18888", "wrong-token", NullLogger.Instance, CancellationToken.None);
 
         Assert.False(result.Success);
+        Assert.Equal(TokenExchangeFailureKind.TokenRejected, result.FailureKind);
     }
 
     [Fact]
@@ -372,6 +373,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
             factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
 
         Assert.False(result.Success);
+        Assert.Equal(TokenExchangeFailureKind.ApiNotEnabled, result.FailureKind);
     }
 
     [Fact]
@@ -384,7 +386,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
             factory, "http://localhost:18888", "browser-token", NullLogger.Instance, CancellationToken.None);
 
         Assert.False(result.Success);
-        Assert.True(result.ConnectionFailed);
+        Assert.Equal(TokenExchangeFailureKind.ConnectionError, result.FailureKind);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -441,4 +441,94 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, "http://localhost:18888"), errorMessage);
     }
+
+    [Fact]
+    public async Task TelemetryLogsCommand_WithDashboardUrl_ResourcesEndpoint404_DisplaysApiNotEnabledMessage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var testInteractionService = new TestInteractionService();
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/"))
+            {
+                // All telemetry API endpoints return 404 when API is not enabled
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+            // Base URL probe returns OK (dashboard is running, just no API)
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<html></html>", System.Text.Encoding.UTF8, "text/html")
+            };
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel logs --dashboard-url http://localhost:18888");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, "http://localhost:18888"), errorMessage);
+    }
+
+    [Fact]
+    public async Task TelemetryLogsCommand_WithLoginUrl_NormalizesToBaseUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        string? capturedBaseUrl = null;
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            capturedBaseUrl ??= request.RequestUri!.GetLeftPart(UriPartial.Authority);
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            if (url.Contains("/api/telemetry/logs"))
+            {
+                var json = BuildLogsJson(("redis", null, 9, "Information", "Ready", s_testTime));
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        // Pass a login URL — should be normalized to base URL
+        var result = command.Parse("otel logs --dashboard-url http://localhost:18888/login?t=abc123");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        // Verify the request went to the base URL (without /login path)
+        Assert.NotNull(capturedBaseUrl);
+        Assert.DoesNotContain("/login", capturedBaseUrl);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -443,6 +443,36 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task TelemetryLogsCommand_WithLoginUrl_ConnectionRefused_DisplaysConnectionFailedMessage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var testInteractionService = new TestInteractionService();
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            throw new HttpRequestException("Connection refused");
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel logs --dashboard-url http://localhost:18888/login?t=sometoken");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, "http://localhost:18888"), errorMessage);
+    }
+
+    [Fact]
     public async Task TelemetryLogsCommand_WithDashboardUrl_ResourcesEndpoint404_DisplaysApiNotEnabledMessage()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -493,6 +523,13 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         {
             capturedBaseUrl ??= request.RequestUri!.GetLeftPart(UriPartial.Authority);
             var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/validateToken"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""{"apiKey":"test-key"}""", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
             if (url.Contains("/api/telemetry/resources"))
             {
                 return new HttpResponseMessage(HttpStatusCode.OK)

--- a/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
@@ -259,4 +259,44 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(TelemetryCommandStrings.DashboardAuthFailed, errorMessage);
     }
+
+    [Fact]
+    public async Task TelemetrySpansCommand_WithDashboardUrl_ResourcesEndpoint404_DisplaysApiNotEnabledMessage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var testInteractionService = new TestInteractionService();
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/"))
+            {
+                // All telemetry API endpoints return 404 when API is not enabled
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+            // Base URL probe returns OK (dashboard is running, just no API)
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<html></html>", System.Text.Encoding.UTF8, "text/html")
+            };
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel spans --dashboard-url http://localhost:18888");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
+        Assert.Equal(string.Format(System.Globalization.CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, "http://localhost:18888"), errorMessage);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Mcp/ListStructuredLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListStructuredLogsToolTests.cs
@@ -33,7 +33,7 @@ public class ListStructuredLogsToolTests
     }
 
     [Fact]
-    public async Task ListStructuredLogsTool_ThrowsException_WhenDashboardApiNotAvailable()
+    public async Task ListStructuredLogsTool_ThrowsException_WhenDashboardNotAvailable()
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -47,7 +47,7 @@ public class ListStructuredLogsToolTests
         var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
             () => tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).AsTask()).DefaultTimeout();
 
-        Assert.Contains("Dashboard is not available", exception.Message);
+        Assert.Contains(McpErrorMessages.DashboardNotAvailable, exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Mcp/McpToolHelpersTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/McpToolHelpersTests.cs
@@ -25,4 +25,22 @@ public class McpToolHelpersTests
         var result = McpToolHelpers.StripLoginPath(input);
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("http://localhost:18888", null)]
+    [InlineData("http://localhost:18888/login", null)] // No query string
+    [InlineData("http://localhost:18888/login?t=authtoken123", "authtoken123")]
+    [InlineData("https://localhost:16319/login?t=d8d8255df4c79aebcb5b7325828ccb20", "d8d8255df4c79aebcb5b7325828ccb20")]
+    [InlineData("http://localhost/base/login?t=token123", "token123")]
+    [InlineData("https://example.com:8080/app/deep/login?t=abc", "abc")]
+    [InlineData("http://localhost:18888/login?other=value", null)] // No 't' parameter
+    [InlineData("http://localhost:18888/login?t=", null)] // Empty token
+    [InlineData("http://localhost:18888/notlogin?t=abc", null)] // Path doesn't end with /login
+    [InlineData("invalid-url", null)]
+    public void ExtractLoginToken_ExtractsTokenFromLoginUrl(string? input, string? expected)
+    {
+        var result = McpToolHelpers.ExtractLoginToken(input);
+        Assert.Equal(expected, result);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -141,7 +141,7 @@ public class FrontendBrowserTokenAuthTests
         using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
-        var response = await client.PostAsync("/api/validatetoken?token=" + requestToken, content: null).DefaultTimeout();
+        var response = await client.PostAsJsonAsync("/api/validatetoken", new { Token = requestToken }).DefaultTimeout();
 
         // Assert
         Assert.Equal(statusCode, response.StatusCode);

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -64,6 +64,7 @@ public static class IntegrationTestHelpers
             [DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = nameof(OtlpAuthMode.Unsecured),
             [DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.Unsecured),
             [DashboardConfigNames.DashboardApiEnabledName.ConfigKey] = "true",
+            [DashboardConfigNames.DashboardApiAuthModeName.ConfigKey] = nameof(ApiAuthMode.Unsecured),
             // Allow the requirement of HTTPS communication with the OpenIdConnect authority to be relaxed during tests.
             ["Authentication:Schemes:OpenIdConnect:RequireHttpsMetadata"] = "false"
         };

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -487,12 +487,16 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             {
                 data.Remove(DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey);
                 data.Remove(DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey);
+                data.Remove(DashboardConfigNames.DashboardApiAuthModeName.ConfigKey);
+                data.Remove(DashboardConfigNames.DashboardApiPrimaryApiKeyName.ConfigKey);
             });
 
         // Assert
         Assert.Equal(FrontendAuthMode.BrowserToken, app.DashboardOptionsMonitor.CurrentValue.Frontend.AuthMode);
         Assert.Equal(16, Convert.FromHexString(app.DashboardOptionsMonitor.CurrentValue.Frontend.BrowserToken!).Length);
         Assert.Equal(OtlpAuthMode.Unsecured, app.DashboardOptionsMonitor.CurrentValue.Otlp.AuthMode);
+        Assert.Equal(ApiAuthMode.ApiKey, app.DashboardOptionsMonitor.CurrentValue.Api.AuthMode);
+        Assert.False(string.IsNullOrEmpty(app.DashboardOptionsMonitor.CurrentValue.Api.PrimaryApiKey), "A primary API key should be auto-generated.");
         Assert.Empty(app.ValidationFailures);
     }
 
@@ -691,10 +695,13 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
-    [InlineData(null, HttpStatusCode.NotFound)]
-    [InlineData(true, HttpStatusCode.OK)]
-    [InlineData(false, HttpStatusCode.NotFound)]
-    public async Task ApiEnabled_ReturnsExpectedStatusAndWarning(bool? enabled, HttpStatusCode expectedStatusCode)
+    [InlineData("Dashboard:Api:Enabled", null, HttpStatusCode.OK, true)]
+    [InlineData("Dashboard:Api:Enabled", true, HttpStatusCode.OK, true)]
+    [InlineData("Dashboard:Api:Enabled", false, HttpStatusCode.NotFound, false)]
+    [InlineData("Dashboard:Api:Disabled", null, HttpStatusCode.OK, true)]
+    [InlineData("Dashboard:Api:Disabled", true, HttpStatusCode.NotFound, false)]
+    [InlineData("Dashboard:Api:Disabled", false, HttpStatusCode.OK, true)]
+    public async Task ApiEnabledDisabled_ReturnsExpectedStatusAndWarning(string configKey, bool? value, HttpStatusCode expectedStatusCode, bool expectWarning)
     {
         const string ApiUnsecuredWarning = "Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.";
 
@@ -703,13 +710,13 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
             additionalConfiguration: config =>
             {
-                if (enabled is not null)
+                if (value is not null)
                 {
-                    config[DashboardConfigNames.DashboardApiEnabledName.ConfigKey] = enabled.Value.ToString();
+                    config[configKey] = value.Value.ToString();
                 }
                 else
                 {
-                    config.Remove(DashboardConfigNames.DashboardApiEnabledName.ConfigKey);
+                    config.Remove(configKey);
                 }
             },
             testSink: testSink);
@@ -727,7 +734,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             .Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName && w.LogLevel >= LogLevel.Warning)
             .ToList();
 
-        if (enabled == true)
+        if (expectWarning)
         {
             Assert.Contains(warnings, w => LogTestHelpers.GetValue(w, "{OriginalFormat}")?.ToString() == ApiUnsecuredWarning);
         }

--- a/tests/Aspire.Dashboard.Tests/Integration/TelemetryApiTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/TelemetryApiTests.cs
@@ -32,14 +32,17 @@ public class TelemetryApiTests
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
         {
             config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.Unsecured.ToString();
-            // Don't set any Api config
+            // Remove Api auth config to test defaults
+            config.Remove(DashboardConfigNames.DashboardApiAuthModeName.ConfigKey);
+            config.Remove(DashboardConfigNames.DashboardApiPrimaryApiKeyName.ConfigKey);
         });
         await app.StartAsync().DefaultTimeout();
 
-        // Assert - verify ApiOptions defaults
+        // Assert - verify ApiOptions defaults to ApiKey with auto-generated key
         var options = app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>().CurrentValue;
         Assert.NotNull(options.Api);
-        Assert.Equal(ApiAuthMode.Unsecured, options.Api.AuthMode);
+        Assert.Equal(ApiAuthMode.ApiKey, options.Api.AuthMode);
+        Assert.False(string.IsNullOrEmpty(options.Api.PrimaryApiKey), "A primary API key should be auto-generated.");
     }
 
     #endregion


### PR DESCRIPTION
## Description

Improve the standalone dashboard experience for `aspire otel` commands by enabling the telemetry API by default with API key authentication, and adding automatic authentication via login token exchange.

### Dashboard API defaults

- **Default `Api.Enabled` to `true`** — The dashboard API is now enabled by default. Previously it defaulted to disabled unless explicitly configured.
- **Default `Api.AuthMode` to `ApiKey`** — The API authentication mode now defaults to `ApiKey` instead of being conditional on whether a key was provided.
- **Auto-generate API key** — When `AuthMode` is `ApiKey` but no `PrimaryApiKey` is specified, a 128-bit key is auto-generated (matching the existing `BrowserToken` pattern in `PostConfigureDashboardOptions`).
- **Add `Api.Disabled` property** — New `Disabled` property on `ApiOptions`. `Api.Enabled` is marked `[Obsolete]` and delegates to `Disabled` via a shared backing field. Setting either property updates the other.
- **Add `ASPIRE_DASHBOARD_API_DISABLED` / `Dashboard:Api:Disabled` config** — New config names (`DashboardAspireApiDisabledName`, `DashboardApiDisabledName`). `DashboardAspireApiDisabledName` takes precedence over `DashboardAspireApiEnabledName` in `PostConfigureDashboardOptions`.

### CLI changes

1. **Enable telemetry API by default in `aspire dashboard run`** — Removed the `--enable-api` option. The API is now always enabled unless explicitly overridden via unmatched tokens or environment variable.

2. **Auto-exchange login token for API key** — When a user passes a login URL (e.g. `http://localhost:18888/login?t=abc123`) to `--dashboard-url`, the CLI automatically extracts the browser token from the `t` query parameter and exchanges it for an API key via the `POST /api/telemetry/validateToken` endpoint. Users can copy-paste the login URL from dashboard output and `aspire otel logs` just works.

3. **Improved error messages** — Better error messages in telemetry commands when the dashboard API is not enabled or authentication fails. The `DashboardApiNotEnabled` message now suggests the CLI command alongside the raw config key.

4. **Error handling fix** — In `TelemetryLogsCommand` and `TelemetrySpansCommand`, the initial `/api/telemetry/resources` call was outside the `HttpRequestException` try/catch block. When the API was disabled, the 404 surfaced as a raw exception. Moved the try/catch to wrap the entire fetch method body.

### Dashboard endpoint

- **Add `POST /api/telemetry/validateToken`** — New endpoint that accepts a frontend browser token and returns the telemetry API key (or null if unsecured). Uses constant-time comparison via `CompareHelpers.CompareKey`. Returns 401 for invalid tokens.

### Other

- **Login URL normalization** — `--dashboard-url` strips `/login` path and query string automatically.
- **localhive scripts** — Clean stale managed publish output before rebuilding.

Fixes #16236

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - `ApiOptions.Disabled` property (new)
    - `ApiOptions.Enabled` marked `[Obsolete]`
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
    - The `validateToken` endpoint validates the browser token before returning the API key. It uses `CompareHelpers.CompareKey` (constant-time comparison) and requires the frontend auth mode to be `BrowserToken`. The endpoint is scoped under `/api/telemetry` and returns 401 for invalid tokens. API keys are auto-generated using `RandomNumberGenerator` with 128-bit entropy.
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
