### PR TITLE
Clean stale managed publish output in localhive scripts

### DIFF
--- a/localhive.ps1
+++ b/localhive.ps1
@@ -308,6 +308,13 @@ if (-not $SkipBundle) {
   $bundleProjPath = Join-Path $RepoRoot "eng" "Bundle.proj"
   $skipNativeArg = if ($NativeAot) { '' } else { '/p:SkipNativeBuild=true' }
 
+  # Clean stale managed publish output so dotnet publish doesn't skip due to incremental builds
+  $staleManagedDir = Join-Path $RepoRoot "artifacts" "bundle" $bundleRid "managed"
+  if (Test-Path -LiteralPath $staleManagedDir) {
+    Write-Log "Cleaning stale managed publish output at $staleManagedDir"
+    Remove-Item -LiteralPath $staleManagedDir -Force -Recurse
+  }
+
   Write-Log "Building bundle (aspire-managed + DCP$(if ($NativeAot) { ' + native AOT CLI' }))..."
   $buildArgs = @($bundleProjPath, '-c', $effectiveConfig, "/p:VersionSuffix=$VersionSuffix", "/p:TargetRid=$bundleRid")
   if (-not $NativeAot) {

--- a/localhive.sh
+++ b/localhive.sh
@@ -315,6 +315,13 @@ fi
 if [[ $SKIP_BUNDLE -eq 0 ]]; then
   BUNDLE_PROJ="$REPO_ROOT/eng/Bundle.proj"
 
+  # Clean stale managed publish output so dotnet publish doesn't skip due to incremental builds
+  STALE_MANAGED_DIR="$REPO_ROOT/artifacts/bundle/$BUNDLE_RID/managed"
+  if [[ -d "$STALE_MANAGED_DIR" ]]; then
+    log "Cleaning stale managed publish output at $STALE_MANAGED_DIR"
+    rm -rf "$STALE_MANAGED_DIR"
+  fi
+
   if [[ $NATIVE_AOT -eq 1 ]]; then
     log "Building bundle (aspire-managed + DCP + native AOT CLI)..."
     dotnet build "$BUNDLE_PROJ" -c "$EFFECTIVE_CONFIG" "/p:VersionSuffix=$VERSION_SUFFIX" "/p:TargetRid=$BUNDLE_RID"


### PR DESCRIPTION
## Description

The `localhive.ps1` and `localhive.sh` scripts can produce stale `aspire-managed` binaries because `dotnet publish` uses incremental builds and skips the publish step when it thinks the output is up-to-date. The bundle layout directory (`artifacts/bundle/<rid>/managed/`) is never cleaned before building, so the copy step just copies the old binary to `~/.aspire/managed/`.

This change cleans the stale managed publish output directory before the bundle build step, ensuring `dotnet publish` always produces a fresh binary.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
