### PR TITLE
[Dashboard] Fix resource action menu localization

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -10,15 +10,17 @@
         if (i < _highlightedCommands.Count)
         {
             var highlightedCommand = _highlightedCommands[i];
+            var highlightedCommandText = highlightedCommand.GetLocalizedDisplayName(Loc);
+            var highlightedCommandDescription = highlightedCommand.GetLocalizedDisplayDescription(Resource, Loc);
 
-            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.GetDisplayDescription()) ? highlightedCommand.GetDisplayDescription() : highlightedCommand.GetDisplayName())" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
+            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommandDescription) ? highlightedCommandDescription : highlightedCommandText)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
                 @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && IconResolver.ResolveIconName(highlightedCommand.IconName, IconSize.Size16, highlightedCommand.IconVariant) is { } icon)
                 {
                     <FluentIcon Value="@icon" Width="16px" />
                 }
                 else
                 {
-                    @highlightedCommand.GetDisplayName()
+                    @highlightedCommandText
                 }
             </FluentButton>
         }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -32,7 +32,7 @@
                                   OnPausedChanged="@OnPausedChanged"
                                   SelectedResource="@PageViewModel.SelectedResource" />
 
-            @if (GetSelectedResource() is { } selectedResource && PageViewModel.SelectedResource is not null && !IsAllSelected())
+            @if (GetSelectedResource() is { } selectedResource && !IsAllSelected())
             {
                 if (ViewportInformation.IsDesktop && (_highlightedCommands.Count > 0 || _resourceMenuItems.Count > 0))
                 {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -32,7 +32,7 @@
                                   OnPausedChanged="@OnPausedChanged"
                                   SelectedResource="@PageViewModel.SelectedResource" />
 
-            @if (PageViewModel.SelectedResource is { } selectedResource && !IsAllSelected())
+            @if (GetSelectedResource() is { } selectedResource && PageViewModel.SelectedResource is not null && !IsAllSelected())
             {
                 if (ViewportInformation.IsDesktop && (_highlightedCommands.Count > 0 || _resourceMenuItems.Count > 0))
                 {
@@ -41,8 +41,11 @@
 
                 @foreach (var command in _highlightedCommands)
                 {
+                    var commandText = command.GetLocalizedDisplayName(ResourcesLoc);
+                    var commandDescription = command.GetLocalizedDisplayDescription(selectedResource, ResourcesLoc);
+
                     <FluentButton Appearance="Appearance.Lightweight"
-                                  Title="@(!string.IsNullOrEmpty(command.GetDisplayDescription()) ? command.GetDisplayDescription() : command.GetDisplayName())"
+                                  Title="@(!string.IsNullOrEmpty(commandDescription) ? commandDescription : commandText)"
                                   Disabled="@(command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(selectedResource.Name, command.Name))"
                                   OnClick="@(() => ExecuteResourceCommandAsync(command))"
                                   Class="highlighted-command">
@@ -52,7 +55,7 @@
                         }
                         else
                         {
-                            @command.GetDisplayName()
+                            @commandText
                         }
                     </FluentButton>
                 }

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -96,7 +96,8 @@ public sealed class DashboardCommandExecutor(
             }
         }
 
-        var messageBarStartingTitle = string.Format(CultureInfo.InvariantCulture, loc[nameof(Dashboard.Resources.Resources.ResourceCommandStarting)], command.GetDisplayName());
+        var localizedDisplayName = command.GetLocalizedDisplayName(loc);
+        var messageBarStartingTitle = string.Format(CultureInfo.InvariantCulture, loc[nameof(Dashboard.Resources.Resources.ResourceCommandStarting)], localizedDisplayName);
         var toastStartingTitle = $"{getResourceName(resource)} {messageBarStartingTitle}";
 
         // Add a notification to the notification center for the in-progress command.
@@ -157,7 +158,7 @@ public sealed class DashboardCommandExecutor(
         // Update toast and notification with the result.
         if (response.Kind == ResourceCommandResponseKind.Succeeded)
         {
-            var successTitle = string.Format(CultureInfo.InvariantCulture, loc[nameof(Dashboard.Resources.Resources.ResourceCommandSuccess)], command.GetDisplayName());
+            var successTitle = string.Format(CultureInfo.InvariantCulture, loc[nameof(Dashboard.Resources.Resources.ResourceCommandSuccess)], localizedDisplayName);
             toastParameters.Title = $"{getResourceName(resource)} {successTitle}";
             toastParameters.Intent = ToastIntent.Success;
             toastParameters.Icon = GetIntentIcon(ToastIntent.Success);
@@ -195,7 +196,7 @@ public sealed class DashboardCommandExecutor(
         }
         else
         {
-            var failedTitle = string.Format(CultureInfo.InvariantCulture, loc[nameof(Dashboard.Resources.Resources.ResourceCommandFailed)], command.GetDisplayName());
+            var failedTitle = string.Format(CultureInfo.InvariantCulture, loc[nameof(Dashboard.Resources.Resources.ResourceCommandFailed)], localizedDisplayName);
             toastParameters.Title = $"{getResourceName(resource)} {failedTitle}";
             toastParameters.Intent = ToastIntent.Error;
             toastParameters.Icon = GetIntentIcon(ToastIntent.Error);
@@ -282,7 +283,7 @@ public sealed class DashboardCommandExecutor(
         await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
         {
             DialogService = dialogService,
-            ValueDescription = command.GetDisplayName(),
+            ValueDescription = command.GetLocalizedDisplayName(loc),
             Value = response.Result.Value,
             FixedFormat = fixedFormat
         }).ConfigureAwait(false);

--- a/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
@@ -337,8 +337,8 @@ public sealed class ResourceMenuBuilder
 
             return new MenuButtonItem
             {
-                Text = command.GetDisplayName(),
-                Tooltip = command.GetDisplayDescription(),
+                Text = command.GetLocalizedDisplayName(_loc),
+                Tooltip = command.GetLocalizedDisplayDescription(resource, _loc),
                 Icon = icon,
                 OnClick = () => commandSelected.InvokeAsync(command),
                 IsDisabled = command.State == CommandViewModelState.Disabled || isCommandExecuting(resource, command)

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -267,9 +267,33 @@ public sealed class CommandViewModel
         return DisplayName;
     }
 
+    internal string GetLocalizedDisplayName(IStringLocalizer<Resources.Resources> loc)
+    {
+        return Name switch
+        {
+            StartCommand => loc[nameof(Resources.Resources.ResourceCommandStartName)],
+            StopCommand => loc[nameof(Resources.Resources.ResourceCommandStopName)],
+            RestartCommand => loc[nameof(Resources.Resources.ResourceCommandRestartName)],
+            _ => DisplayName
+        };
+    }
+
     public string? GetDisplayDescription()
     {
         return DisplayDescription is { Length: > 0 } ? DisplayDescription : null;
+    }
+
+    internal string? GetLocalizedDisplayDescription(ResourceViewModel resource, IStringLocalizer<Resources.Resources> loc)
+    {
+        return Name switch
+        {
+            StartCommand => loc[nameof(Resources.Resources.ResourceCommandStartDescription)],
+            StopCommand => loc[nameof(Resources.Resources.ResourceCommandStopDescription)],
+            RestartCommand => loc[resource.IsProject()
+                ? nameof(Resources.Resources.ResourceCommandRestartProjectDescription)
+                : nameof(Resources.Resources.ResourceCommandRestartDescription)],
+            _ => GetDisplayDescription()
+        };
     }
 }
 

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -142,6 +142,69 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Restart resource.
+        /// </summary>
+        public static string ResourceCommandRestartDescription {
+            get {
+                return ResourceManager.GetString("ResourceCommandRestartDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restart.
+        /// </summary>
+        public static string ResourceCommandRestartName {
+            get {
+                return ResourceManager.GetString("ResourceCommandRestartName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restart resource. Source code is not recompiled..
+        /// </summary>
+        public static string ResourceCommandRestartProjectDescription {
+            get {
+                return ResourceManager.GetString("ResourceCommandRestartProjectDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start resource.
+        /// </summary>
+        public static string ResourceCommandStartDescription {
+            get {
+                return ResourceManager.GetString("ResourceCommandStartDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start.
+        /// </summary>
+        public static string ResourceCommandStartName {
+            get {
+                return ResourceManager.GetString("ResourceCommandStartName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stop resource.
+        /// </summary>
+        public static string ResourceCommandStopDescription {
+            get {
+                return ResourceManager.GetString("ResourceCommandStopDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stop.
+        /// </summary>
+        public static string ResourceCommandStopName {
+            get {
+                return ResourceManager.GetString("ResourceCommandStopName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; succeeded.
         /// </summary>
         public static string ResourceCommandSuccess {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -244,6 +244,27 @@
     <value>"{0}" starting</value>
     <comment>{0} is the display name of the command.</comment>
   </data>
+  <data name="ResourceCommandStartName" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="ResourceCommandStartDescription" xml:space="preserve">
+    <value>Start resource</value>
+  </data>
+  <data name="ResourceCommandStopName" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="ResourceCommandStopDescription" xml:space="preserve">
+    <value>Stop resource</value>
+  </data>
+  <data name="ResourceCommandRestartName" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="ResourceCommandRestartDescription" xml:space="preserve">
+    <value>Restart resource</value>
+  </data>
+  <data name="ResourceCommandRestartProjectDescription" xml:space="preserve">
+    <value>Restart resource. Source code is not recompiled.</value>
+  </data>
   <data name="ResourceActionTracesText" xml:space="preserve">
     <value>Traces</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -57,10 +57,45 @@
         <target state="new">"{0}" failed</target>
         <note>{0} is the display name of the command.</note>
       </trans-unit>
+      <trans-unit id="ResourceCommandRestartDescription">
+        <source>Restart resource</source>
+        <target state="new">Restart resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartName">
+        <source>Restart</source>
+        <target state="new">Restart</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandRestartProjectDescription">
+        <source>Restart resource. Source code is not recompiled.</source>
+        <target state="new">Restart resource. Source code is not recompiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartDescription">
+        <source>Start resource</source>
+        <target state="new">Start resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStartName">
+        <source>Start</source>
+        <target state="new">Start</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceCommandStarting">
         <source>"{0}" starting</source>
         <target state="new">"{0}" starting</target>
         <note>{0} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopDescription">
+        <source>Stop resource</source>
+        <target state="new">Stop resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceCommandStopName">
+        <source>Stop</source>
+        <target state="new">Stop</target>
+        <note />
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
         <source>"{0}" succeeded</source>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -16,6 +16,7 @@ namespace Aspire.Cli.EndToEnd.Tests.Helpers;
 internal static class CliE2ETestHelpers
 {
     internal const string CliArchiveWorkflowRunIdEnvironmentVariableName = CliInstallStrategy.CliArchiveWorkflowRunIdEnvironmentVariableName;
+    private static readonly TimeSpan[] s_dockerBuildRetryDelays = [TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10)];
 
     /// <summary>
     /// Gets whether the tests are running in CI (GitHub Actions) vs locally.
@@ -210,7 +211,7 @@ internal static class CliE2ETestHelpers
                 strategy.ConfigureContainer(c);
             });
 
-        return builder.Build();
+        return ExecuteWithDockerBuildRetry(builder.Build, output, $"create Docker test terminal for {testName}");
     }
 
     /// <summary>
@@ -305,22 +306,7 @@ internal static class CliE2ETestHelpers
             startInfo.ArgumentList.Add(PolyglotBaseImageName);
             startInfo.ArgumentList.Add(repoRoot);
 
-            using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start docker build process.");
-            var standardOutput = process.StandardOutput.ReadToEnd();
-            var standardError = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                throw new InvalidOperationException(
-                    $"Failed to build shared polyglot Docker base image.{Environment.NewLine}" +
-                    $"{standardOutput}{Environment.NewLine}{standardError}");
-            }
-
-            if (!string.IsNullOrWhiteSpace(standardOutput))
-            {
-                output.WriteLine(standardOutput.Trim());
-            }
+            BuildDockerImage(startInfo, output, "shared polyglot Docker base image");
 
             s_polyglotBaseImageBuilt = true;
         }
@@ -354,22 +340,7 @@ internal static class CliE2ETestHelpers
             startInfo.ArgumentList.Add(PodmanBaseImageName);
             startInfo.ArgumentList.Add(repoRoot);
 
-            using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start docker build process.");
-            var standardOutput = process.StandardOutput.ReadToEnd();
-            var standardError = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                throw new InvalidOperationException(
-                    $"Failed to build shared Podman Docker base image.{Environment.NewLine}" +
-                    $"{standardOutput}{Environment.NewLine}{standardError}");
-            }
-
-            if (!string.IsNullOrWhiteSpace(standardOutput))
-            {
-                output.WriteLine(standardOutput.Trim());
-            }
+            BuildDockerImage(startInfo, output, "shared Podman Docker base image");
 
             s_podmanBaseImageBuilt = true;
         }
@@ -432,6 +403,99 @@ internal static class CliE2ETestHelpers
     private static string GenerateDockerContainerName()
     {
         return $"hex1b-test-{Guid.NewGuid():N}".Substring(0, 32);
+    }
+
+    private static void BuildDockerImage(ProcessStartInfo startInfo, ITestOutputHelper output, string imageDescription)
+    {
+        ExecuteWithDockerBuildRetry(
+            () =>
+            {
+                using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start docker build process.");
+                var standardOutput = process.StandardOutput.ReadToEnd();
+                var standardError = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+
+                if (process.ExitCode != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to build {imageDescription}.{Environment.NewLine}" +
+                        $"{standardOutput}{Environment.NewLine}{standardError}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(standardOutput))
+                {
+                    output.WriteLine(standardOutput.Trim());
+                }
+            },
+            output,
+            $"build {imageDescription}");
+    }
+
+    internal static void ExecuteWithDockerBuildRetry(Action action, ITestOutputHelper output, string description, IReadOnlyList<TimeSpan>? retryDelays = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        _ = ExecuteWithDockerBuildRetry(
+            () =>
+            {
+                action();
+                return true;
+            },
+            output,
+            description,
+            retryDelays);
+    }
+
+    internal static T ExecuteWithDockerBuildRetry<T>(Func<T> action, ITestOutputHelper output, string description, IReadOnlyList<TimeSpan>? retryDelays = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+
+        retryDelays ??= s_dockerBuildRetryDelays;
+
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                return action();
+            }
+            catch (Exception ex) when (attempt < retryDelays.Count && IsTransientDockerBuildFailure(ex))
+            {
+                var delay = retryDelays[attempt];
+                output.WriteLine(
+                    $"Transient Docker build failure while attempting to {description} (attempt {attempt + 1} of {retryDelays.Count + 1}). Retrying in {delay.TotalSeconds:0}s.");
+                output.WriteLine(ex.Message);
+
+                if (delay > TimeSpan.Zero)
+                {
+                    Thread.Sleep(delay);
+                }
+            }
+        }
+    }
+
+    internal static bool IsTransientDockerBuildFailure(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (IsTransientDockerBuildFailureMessage(current.Message))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsTransientDockerBuildFailureMessage(string message)
+    {
+        return message.Contains("failed to resolve source metadata for mcr.microsoft.com/", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("unexpected status from HEAD request to https://mcr.microsoft.com/", StringComparison.OrdinalIgnoreCase)
+            || (message.Contains("failed to do request: Head", StringComparison.OrdinalIgnoreCase)
+                && message.Contains("mcr.microsoft.com", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpersTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpersTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests.Helpers;
+
+[Collection(CliInstallEnvironmentCollection.Name)]
+public sealed class CliE2ETestHelpersTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void ExecuteWithDockerBuildRetry_RetriesTransientMcrFailures()
+    {
+        var attempts = 0;
+
+        var result = CliE2ETestHelpers.ExecuteWithDockerBuildRetry(
+            () =>
+            {
+                attempts++;
+
+                if (attempts < 3)
+                {
+                    throw new InvalidOperationException(
+                        "docker build failed with exit code 1: failed to resolve source metadata for mcr.microsoft.com/dotnet/sdk:10.0: unexpected status from HEAD request to https://mcr.microsoft.com/v2/dotnet/sdk/manifests/10.0: 403 Forbidden");
+                }
+
+                return "success";
+            },
+            output,
+            "create Docker test terminal",
+            [TimeSpan.Zero, TimeSpan.Zero]);
+
+        Assert.Equal("success", result);
+        Assert.Equal(3, attempts);
+    }
+
+    [Fact]
+    public void ExecuteWithDockerBuildRetry_DoesNotRetryNonTransientFailures()
+    {
+        var attempts = 0;
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            CliE2ETestHelpers.ExecuteWithDockerBuildRetry(
+                () =>
+                {
+                    attempts++;
+                    throw new InvalidOperationException("docker build failed because the Dockerfile is invalid");
+                },
+                output,
+                "create Docker test terminal",
+                [TimeSpan.Zero, TimeSpan.Zero]));
+
+        Assert.Equal("docker build failed because the Dockerfile is invalid", exception.Message);
+        Assert.Equal(1, attempts);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
@@ -13,6 +13,7 @@ using Aspire.Tests.Shared.Telemetry;
 using Google.Protobuf.Collections;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.FluentUI.AspNetCore.Components;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
 
@@ -248,6 +249,53 @@ public sealed class ResourceMenuBuilderTests
             e => Assert.Equal("Localized:ActionViewDetailsText", e.Text),
             e => Assert.Equal("Localized:ResourceActionConsoleLogsText", e.Text),
             e => Assert.Equal("Localized:ExportJson", e.Text));
+    }
+
+    [Theory]
+    [InlineData(KnownResourceTypes.Container, CommandViewModel.StartCommand, "Localized:ResourceCommandStartName", "Localized:ResourceCommandStartDescription")]
+    [InlineData(KnownResourceTypes.Container, CommandViewModel.StopCommand, "Localized:ResourceCommandStopName", "Localized:ResourceCommandStopDescription")]
+    [InlineData(KnownResourceTypes.Container, CommandViewModel.RestartCommand, "Localized:ResourceCommandRestartName", "Localized:ResourceCommandRestartDescription")]
+    [InlineData(KnownResourceTypes.Project, CommandViewModel.RestartCommand, "Localized:ResourceCommandRestartName", "Localized:ResourceCommandRestartProjectDescription")]
+    public void AddMenuItems_KnownLifecycleCommands_UsesDashboardLocalization(string resourceType, string commandName, string expectedText, string expectedTooltip)
+    {
+        // Arrange
+        var command = new CommandViewModel(
+            commandName,
+            CommandViewModelState.Enabled,
+            displayName: "German label",
+            displayDescription: "German tooltip",
+            confirmationMessage: "",
+            parameter: null,
+            isHighlighted: false,
+            iconName: "",
+            iconVariant: IconVariant.Regular);
+        var resource = ModelTestHelpers.CreateResource(resourceType: resourceType, commands: [command]);
+        var repository = TelemetryTestHelpers.CreateRepository();
+        var aiContextProvider = new TestAIContextProvider();
+        var resourceMenuBuilder = CreateResourceMenuBuilder(repository, aiContextProvider);
+
+        // Act
+        var menuItems = new List<MenuButtonItem>();
+        resourceMenuBuilder.AddMenuItems(
+            menuItems,
+            resource,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
+            EventCallback.Empty,
+            EventCallback<CommandViewModel>.Empty,
+            (_, _) => false,
+            showViewDetails: false,
+            showConsoleLogsItem: false,
+            showUrls: false);
+
+        // Assert
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ExportJson", e.Text),
+            e => Assert.True(e.IsDivider),
+            e =>
+            {
+                Assert.Equal(expectedText, e.Text);
+                Assert.Equal(expectedTooltip, e.Tooltip);
+            });
     }
 
     private sealed class TestNavigationManager : NavigationManager


### PR DESCRIPTION
## Description

Fixes the dashboard resource action menu localization regression reported in #16333.

- Localizes the built-in lifecycle commands (`Start`, `Stop`, `Restart`) and their tooltips from dashboard resources instead of reusing AppHost-provided command text.
- Applies the same localization to action menu entries, highlighted command buttons, and command result UI.
- Adds regression coverage for known lifecycle command localization and updates dashboard localization files.

Fixes #16333

Validation:

- `.\dotnet.cmd test .\tests\Aspire.Dashboard.Tests\Aspire.Dashboard.Tests.csproj /p:InstallBrowsersForPlaywright=false -- --filter-class "*.ResourceMenuBuilderTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
