### PR TITLE
Make trace ID a clickable link in trace detail view

### DIFF
--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -315,9 +315,12 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             }
         }
 
+        var shortTraceId = OtlpHelpers.ToShortenedId(traceId);
+        var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, shortTraceId);
+
         if (spans.Count == 0)
         {
-            _interactionService.DisplayMarkupLine($"[bold]Trace: {traceId}[/]");
+            _interactionService.DisplayMarkupLine($"[bold]Trace:[/] {traceLink}");
             _interactionService.DisplayMarkupLine("[dim]No spans found[/]");
             return;
         }
@@ -327,7 +330,6 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var totalDuration = rootSpans.Count > 0 ? rootSpans.Max(s => s.Duration) : spans.Max(s => s.Duration);
 
         // Header
-        var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, traceId);
         _interactionService.DisplayMarkupLine($"[bold]Trace:[/] {traceLink}");
         _interactionService.DisplayMarkupLine($"[bold]Duration:[/] {TelemetryCommandHelpers.FormatDuration(totalDuration)}  [bold]Spans:[/] {spans.Count}");
         _interactionService.DisplayEmptyLine();


### PR DESCRIPTION
## Description

Make the trace ID in the `aspire traces --trace-id` detail view a clickable hyperlink to the dashboard trace detail page. Previously the full trace ID was shown as plain bold text; now a shortened ID (7 chars) is displayed as a terminal hyperlink.

Changes:
- Use `OtlpHelpers.ToShortenedId` + `FormatTraceLink` for the trace header in both the empty-trace and normal paths.
- Hoist `shortTraceId` / `traceLink` above the empty-check so the computation is shared.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
