### PR TITLE
Add telemetry activity for running app host in CLI

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Processes;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Commands;
@@ -240,6 +241,9 @@ internal sealed class AppHostLauncher(
 
         try
         {
+            // Set detached mode env var so the child RunCommand records it in telemetry
+            Environment.SetEnvironmentVariable(KnownConfigNames.CliRunDetached, "true");
+
             childProcess = DetachedProcessLauncher.Start(
                 executablePath,
                 childArgs,
@@ -250,6 +254,11 @@ internal sealed class AppHostLauncher(
         {
             logger.LogError(ex, "Failed to start child CLI process");
             return new LaunchResult(null, null, null, false, 0);
+        }
+        finally
+        {
+            // Clear the detached env var in the parent process to avoid affecting future launches
+            Environment.SetEnvironmentVariable(KnownConfigNames.CliRunDetached, null);
         }
 
         logger.LogDebug("Child CLI process started with PID: {PID}", childProcess.Id);

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -241,24 +241,17 @@ internal sealed class AppHostLauncher(
 
         try
         {
-            // Set detached mode env var so the child RunCommand records it in telemetry
-            Environment.SetEnvironmentVariable(KnownConfigNames.CliRunDetached, "true");
-
             childProcess = DetachedProcessLauncher.Start(
                 executablePath,
                 childArgs,
                 executionContext.WorkingDirectory.FullName,
-                IsExtensionEnvironmentVariable);
+                IsExtensionEnvironmentVariable,
+                new Dictionary<string, string> { [KnownConfigNames.CliRunDetached] = "true" });
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to start child CLI process");
             return new LaunchResult(null, null, null, false, 0);
-        }
-        finally
-        {
-            // Clear the detached env var in the parent process to avoid affecting future launches
-            Environment.SetEnvironmentVariable(KnownConfigNames.CliRunDetached, null);
         }
 
         logger.LogDebug("Child CLI process started with PID: {PID}", childProcess.Id);

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -185,11 +185,19 @@ internal sealed class RunCommand : BaseCommand
         {
             using var activity = Telemetry.StartDiagnosticActivity(this.Name);
 
+            // Start a reported telemetry activity for the app host run early so that
+            // all failure paths (project not found, incompatible version, etc.) are captured.
+            runActivity = Telemetry.StartReportedActivity(name: TelemetryConstants.Activities.RunAppHost);
+            runActivity?.SetTag(TelemetryConstants.Tags.AppHostLanguage, "unknown"); // Will be updated once the project is found.
+            runActivity?.SetTag(TelemetryConstants.Tags.AppHostDetached, _configuration.GetBool(KnownConfigNames.CliRunDetached) is true);
+            runActivity?.SetTag(TelemetryConstants.Tags.AppHostIsolated, isolated);
+
             var searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, MultipleAppHostProjectsFoundBehavior.Prompt, createSettingsFile: true, cancellationToken);
             var effectiveAppHostFile = searchResult.SelectedProjectFile;
 
             if (effectiveAppHostFile is null)
             {
+                runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "project_not_found");
                 return ExitCodeConstants.FailedToFindProject;
             }
 
@@ -197,15 +205,12 @@ internal sealed class RunCommand : BaseCommand
             var project = _projectFactory.TryGetProject(effectiveAppHostFile);
             if (project is null)
             {
+                runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "project_not_found");
                 InteractionService.DisplayError("Unrecognized app host type.");
                 return ExitCodeConstants.FailedToFindProject;
             }
 
-            // Start a reported telemetry activity for the app host run
-            runActivity = Telemetry.StartReportedActivity(name: TelemetryConstants.Activities.RunAppHost);
             runActivity?.SetTag(TelemetryConstants.Tags.AppHostLanguage, project.LanguageId);
-            runActivity?.SetTag(TelemetryConstants.Tags.AppHostDetached, _configuration.GetBool(KnownConfigNames.CliRunDetached) is true);
-            runActivity?.SetTag(TelemetryConstants.Tags.AppHostIsolated, isolated);
 
             // Check for running instance — even if we fail to stop we won't
             // block the apphost starting to make sure we don't ever break flow.
@@ -378,6 +383,7 @@ internal sealed class RunCommand : BaseCommand
         }
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || ex is ExtensionOperationCanceledException)
         {
+            runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "canceled");
             InteractionService.DisplayCancellationMessage();
             return ExitCodeConstants.Success;
         }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -179,6 +179,7 @@ internal sealed class RunCommand : BaseCommand
         }
 
         AppHostProjectContext? context = null;
+        Activity? runActivity = null;
 
         try
         {
@@ -199,6 +200,12 @@ internal sealed class RunCommand : BaseCommand
                 InteractionService.DisplayError("Unrecognized app host type.");
                 return ExitCodeConstants.FailedToFindProject;
             }
+
+            // Start a reported telemetry activity for the app host run
+            runActivity = Telemetry.StartReportedActivity(name: TelemetryConstants.Activities.RunAppHost);
+            runActivity?.SetTag(TelemetryConstants.Tags.AppHostLanguage, project.LanguageId);
+            runActivity?.SetTag(TelemetryConstants.Tags.AppHostDetached, _configuration.GetBool(KnownConfigNames.CliRunDetached) is true);
+            runActivity?.SetTag(TelemetryConstants.Tags.AppHostIsolated, isolated);
 
             // Check for running instance — even if we fail to stop we won't
             // block the apphost starting to make sure we don't ever break flow.
@@ -240,6 +247,7 @@ internal sealed class RunCommand : BaseCommand
             var buildSuccess = await buildCompletionSource.Task.WaitAsync(cancellationToken);
             if (!buildSuccess)
             {
+                runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "build_failed");
                 // Build failed - display captured output and return exit code
                 if (context.OutputCollector is { } outputCollector)
                 {
@@ -375,15 +383,18 @@ internal sealed class RunCommand : BaseCommand
         }
         catch (ProjectLocatorException ex)
         {
+            runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "project_not_found");
             return HandleProjectLocatorException(ex, InteractionService, Telemetry);
         }
         catch (AppHostIncompatibleException ex)
         {
+            runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "incompatible_version");
             Telemetry.RecordError(ex.Message, ex);
             return InteractionService.DisplayIncompatibleVersionError(ex, ex.AspireHostingVersion ?? ex.RequiredCapability);
         }
         catch (CertificateServiceException ex)
         {
+            runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "certificate_trust_failed");
             var errorMessage = string.Format(CultureInfo.CurrentCulture, TemplatingStrings.CertificateTrustError, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
@@ -391,6 +402,7 @@ internal sealed class RunCommand : BaseCommand
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
+            runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "backchannel_connection_failed");
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ErrorConnectingToAppHost, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
@@ -406,12 +418,17 @@ internal sealed class RunCommand : BaseCommand
         }
         catch (Exception ex)
         {
+            runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, ex.GetType().FullName);
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
             // Don't display raw output - it's already in the log file
             InteractionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
             return ExitCodeConstants.FailedToDotnetRunAppHost;
+        }
+        finally
+        {
+            runActivity?.Dispose();
         }
     }
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -188,7 +188,6 @@ internal sealed class RunCommand : BaseCommand
             // Start a reported telemetry activity for the app host run early so that
             // all failure paths (project not found, incompatible version, etc.) are captured.
             runActivity = Telemetry.StartReportedActivity(name: TelemetryConstants.Activities.RunAppHost);
-            runActivity?.SetTag(TelemetryConstants.Tags.AppHostLanguage, "unknown"); // Will be updated once the project is found.
             runActivity?.SetTag(TelemetryConstants.Tags.AppHostDetached, _configuration.GetBool(KnownConfigNames.CliRunDetached) is true);
             runActivity?.SetTag(TelemetryConstants.Tags.AppHostIsolated, isolated);
 
@@ -283,6 +282,7 @@ internal sealed class RunCommand : BaseCommand
 
             if (dashboardUrls.DashboardHealthy is false)
             {
+                runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "dashboard_failed");
                 InteractionService.DisplayError(RunCommandStrings.DashboardFailedToStart);
                 return ExitCodeConstants.DashboardFailure;
             }

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -315,9 +315,12 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             }
         }
 
+        var shortTraceId = OtlpHelpers.ToShortenedId(traceId);
+        var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, shortTraceId);
+
         if (spans.Count == 0)
         {
-            _interactionService.DisplayMarkupLine($"[bold]Trace: {traceId}[/]");
+            _interactionService.DisplayMarkupLine($"[bold]Trace:[/] {traceLink}");
             _interactionService.DisplayMarkupLine("[dim]No spans found[/]");
             return;
         }
@@ -327,7 +330,6 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var totalDuration = rootSpans.Count > 0 ? rootSpans.Max(s => s.Duration) : spans.Max(s => s.Duration);
 
         // Header
-        var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, traceId);
         _interactionService.DisplayMarkupLine($"[bold]Trace:[/] {traceLink}");
         _interactionService.DisplayMarkupLine($"[bold]Duration:[/] {TelemetryCommandHelpers.FormatDuration(totalDuration)}  [bold]Spans:[/] {spans.Count}");
         _interactionService.DisplayEmptyLine();

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -315,12 +315,9 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             }
         }
 
-        var shortTraceId = OtlpHelpers.ToShortenedId(traceId);
-        var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, shortTraceId);
-
         if (spans.Count == 0)
         {
-            _interactionService.DisplayMarkupLine($"[bold]Trace:[/] {traceLink}");
+            _interactionService.DisplayMarkupLine($"[bold]Trace: {traceId}[/]");
             _interactionService.DisplayMarkupLine("[dim]No spans found[/]");
             return;
         }
@@ -330,6 +327,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var totalDuration = rootSpans.Count > 0 ? rootSpans.Max(s => s.Duration) : spans.Max(s => s.Duration);
 
         // Header
+        var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, traceId);
         _interactionService.DisplayMarkupLine($"[bold]Trace:[/] {traceLink}");
         _interactionService.DisplayMarkupLine($"[bold]Duration:[/] {TelemetryCommandHelpers.FormatDuration(totalDuration)}  [bold]Spans:[/] {spans.Count}");
         _interactionService.DisplayEmptyLine();

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
@@ -15,7 +15,7 @@ internal static partial class DetachedProcessLauncher
     /// pipe has no reader and writes produce EPIPE (harmless). The key difference from
     /// Windows is that on Unix, only fds 0/1/2 survive exec — no extra handle leakage.
     /// </summary>
-    private static Process StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable)
+    private static Process StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -49,6 +49,15 @@ internal static partial class DetachedProcessLauncher
             foreach (var key in keysToRemove)
             {
                 startInfo.Environment.Remove(key);
+            }
+        }
+
+        // Add additional environment variables to the child process without mutating the parent.
+        if (additionalEnvironmentVariables is not null)
+        {
+            foreach (var (key, value) in additionalEnvironmentVariables)
+            {
+                startInfo.Environment[key] = value;
             }
         }
 

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -17,7 +17,7 @@ internal static partial class DetachedProcessLauncher
     /// PROC_THREAD_ATTRIBUTE_HANDLE_LIST to prevent handle inheritance to grandchildren.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    private static Process StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable)
+    private static Process StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables)
     {
         // Open NUL device for stdout/stderr — child writes go nowhere
         using var nulHandle = CreateFileW(
@@ -89,15 +89,15 @@ internal static partial class DetachedProcessLauncher
 
                     var flags = CreateUnicodeEnvironment | ExtendedStartupInfoPresent | CreateNewProcessGroup;
 
-                    // Build a filtered environment block if variables need to be removed.
+                    // Build a custom environment block if variables need to be removed or added.
                     // CreateProcessW with lpEnvironment=nint.Zero inherits the parent's
-                    // environment, so we only build a custom block when filtering is needed.
+                    // environment, so we only build a custom block when customization is needed.
                     var envBlockHandle = nint.Zero;
                     try
                     {
-                        if (shouldRemoveEnvironmentVariable is not null)
+                        if (shouldRemoveEnvironmentVariable is not null || additionalEnvironmentVariables is not null)
                         {
-                            envBlockHandle = BuildFilteredEnvironmentBlock(shouldRemoveEnvironmentVariable);
+                            envBlockHandle = BuildCustomEnvironmentBlock(shouldRemoveEnvironmentVariable, additionalEnvironmentVariables);
                         }
 
                         if (!CreateProcessW(
@@ -238,21 +238,31 @@ internal static partial class DetachedProcessLauncher
     }
 
     /// <summary>
-    /// Builds a Unicode environment block for CreateProcessW with specified variables removed.
-    /// The block is sorted by variable name (case-insensitive, as required by Windows)
-    /// and double-null-terminated. The caller must free the returned pointer with Marshal.FreeHGlobal.
+    /// Builds a Unicode environment block for CreateProcessW with specified variables
+    /// removed and/or added. The block is sorted by variable name (case-insensitive,
+    /// as required by Windows) and double-null-terminated. The caller must free the
+    /// returned pointer with Marshal.FreeHGlobal.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    private static nint BuildFilteredEnvironmentBlock(Func<string, bool> shouldRemove)
+    private static nint BuildCustomEnvironmentBlock(Func<string, bool>? shouldRemove, IReadOnlyDictionary<string, string>? additionalVariables)
     {
         // Collect current environment variables, excluding the ones to remove.
         var envVars = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
         {
             var key = (string)entry.Key;
-            if (!shouldRemove(key))
+            if (shouldRemove is null || !shouldRemove(key))
             {
                 envVars[key] = (string?)entry.Value ?? string.Empty;
+            }
+        }
+
+        // Add additional variables (overwrites any existing keys with the same name).
+        if (additionalVariables is not null)
+        {
+            foreach (var (key, value) in additionalVariables)
+            {
+                envVars[key] = value;
             }
         }
 

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
@@ -68,14 +68,15 @@ internal static partial class DetachedProcessLauncher
     /// <param name="arguments">The command-line arguments for the child process.</param>
     /// <param name="workingDirectory">The working directory for the child process.</param>
     /// <param name="shouldRemoveEnvironmentVariable">Optional predicate that returns <see langword="true" /> for environment variable names that should be removed from the child process.</param>
+    /// <param name="additionalEnvironmentVariables">Optional dictionary of environment variables to add to the child process without mutating the parent.</param>
     /// <returns>A <see cref="Process"/> object representing the launched child.</returns>
-    public static Process Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable = null)
+    public static Process Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable = null, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables = null)
     {
         if (OperatingSystem.IsWindows())
         {
-            return StartWindows(fileName, arguments, workingDirectory, shouldRemoveEnvironmentVariable);
+            return StartWindows(fileName, arguments, workingDirectory, shouldRemoveEnvironmentVariable, additionalEnvironmentVariables);
         }
 
-        return StartUnix(fileName, arguments, workingDirectory, shouldRemoveEnvironmentVariable);
+        return StartUnix(fileName, arguments, workingDirectory, shouldRemoveEnvironmentVariable, additionalEnvironmentVariables);
     }
 }

--- a/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
@@ -102,6 +102,28 @@ internal static class TelemetryConstants
         /// Tag for the operating system version.
         /// </summary>
         public const string OsVersion = "os.version";
+
+        /// <summary>
+        /// Tag for the app host language identifier.
+        /// </summary>
+        public const string AppHostLanguage = "aspire.cli.apphost.language";
+
+        /// <summary>
+        /// Tag indicating whether the app host was launched in detached mode.
+        /// </summary>
+        public const string AppHostDetached = "aspire.cli.apphost.detached";
+
+        /// <summary>
+        /// Tag indicating whether the app host was launched in isolated mode.
+        /// </summary>
+        public const string AppHostIsolated = "aspire.cli.apphost.isolated";
+
+        /// <summary>
+        /// Tag for the error type when the operation fails.
+        /// Set to the exception type name or a descriptive error category.
+        /// Absence of this tag indicates success.
+        /// </summary>
+        public const string ErrorType = "error.type";
     }
 
     /// <summary>
@@ -118,6 +140,11 @@ internal static class TelemetryConstants
         /// Activity name for ensuring the SDK is installed.
         /// </summary>
         public const string EnsureSdkInstalled = "aspire/cli/ensure_sdk_installed";
+
+        /// <summary>
+        /// Activity name for running an app host.
+        /// </summary>
+        public const string RunAppHost = "aspire/cli/run_apphost";
     }
 
     /// <summary>

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -32,6 +32,7 @@ internal static class KnownConfigNames
     public const string RemoteAppHostToken = "ASPIRE_REMOTE_APPHOST_TOKEN";
     public const string CliProcessId = "ASPIRE_CLI_PID";
     public const string CliProcessStarted = "ASPIRE_CLI_STARTED";
+    public const string CliRunDetached = "ASPIRE_CLI_RUN_DETACHED";
     public const string ForceRichConsole = "ASPIRE_FORCE_RICH_CONSOLE";
     public const string TestingDisableHttpClient = "ASPIRE_TESTING_DISABLE_HTTP_CLIENT";
     public const string InteractivityEnabled = "ASPIRE_INTERACTIVITY_ENABLED";

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -13,6 +13,8 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Tests.Telemetry;
 using Aspire.Shared.UserSecrets;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -1634,6 +1636,58 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DebugSessionToken));
         Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DebugSessionServerCertificate));
         Assert.False(AppHostLauncher.IsExtensionEnvironmentVariable(KnownConfigNames.DcpInstanceIdPrefix));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task RunCommand_RecordsRunAppHostTelemetryActivity(bool detached, bool isolated)
+    {
+        using var fixture = new TelemetryFixture();
+
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+            return runner;
+        };
+
+        var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateServiceFactory = _ => new ThrowingCertificateService();
+            options.DotNetCliRunnerFactory = runnerFactory;
+            options.ProjectLocatorFactory = projectLocatorFactory;
+            options.TelemetryFactory = _ => fixture.Telemetry;
+
+            if (detached)
+            {
+                options.ConfigurationCallback += config =>
+                {
+                    config[KnownConfigNames.CliRunDetached] = "true";
+                };
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var args = isolated ? "run --isolated" : "run";
+        var result = command.Parse(args);
+
+        await result.InvokeAsync().DefaultTimeout();
+
+        Assert.NotNull(fixture.CapturedActivity);
+        Assert.Equal(TelemetryConstants.Activities.RunAppHost, fixture.CapturedActivity.OperationName);
+
+        var tags = fixture.CapturedActivity.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+        Assert.Equal(KnownLanguageId.CSharp, tags[TelemetryConstants.Tags.AppHostLanguage]);
+        Assert.Equal(detached, tags[TelemetryConstants.Tags.AppHostDetached]);
+        Assert.Equal(isolated, tags[TelemetryConstants.Tags.AppHostIsolated]);
+        Assert.Equal("certificate_trust_failed", tags[TelemetryConstants.Tags.ErrorType]);
     }
 
 }


### PR DESCRIPTION
## Description

Add a reported telemetry activity (`aspire/cli/run_apphost`) to `RunCommand` that tracks app host runs with the following tags:

- `aspire.cli.apphost.language` – the app host language (e.g. CSharp, TypeScript). Only set when the project is successfully resolved.
- `aspire.cli.apphost.detached` – whether the run is in detached mode
- `aspire.cli.apphost.isolated` – whether the run is in isolated mode
- `error.type` – friendly error category for known failure modes (`project_not_found`, `build_failed`, `incompatible_version`, `certificate_trust_failed`, `backchannel_connection_failed`, `dashboard_failed`, `canceled`), or the exception type for unexpected errors. Absence of this tag indicates success.

The activity is started early (before project discovery) so that all failure paths are captured in telemetry.

The activity uses `StartReportedActivity` so it is exported to the telemetry backend.

To support detached mode telemetry, the `ASPIRE_CLI_RUN_DETACHED` environment variable is passed to the child process via `DetachedProcessLauncher.Start`'s `additionalEnvironmentVariables` parameter (no parent-process mutation), and read from `IConfiguration` in `RunCommand`.

`DetachedProcessLauncher.Start` gains an optional `additionalEnvironmentVariables` dictionary parameter that is applied to the child process environment on both Windows (via the custom environment block) and Unix (via `ProcessStartInfo.Environment`).

Includes a parameterized test (`Theory`) covering all 4 combinations of `(detached, isolated)`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
