### PR TITLE
Fix flaky ProcessExecutionTests cleanup failure on Windows CI

### DIFF
--- a/tests/Aspire.Cli.Tests/DotNet/ProcessExecutionTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/ProcessExecutionTests.cs
@@ -30,8 +30,8 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
 
         var stdoutBuilder = new StringBuilder();
         var stderrBuilder = new StringBuilder();
-        var firstLineSeen = new TaskCompletionSource();
-        var releaseCallback = new TaskCompletionSource();
+        var firstLineSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var releaseTask = Task.Run(async () =>
         {
@@ -96,8 +96,8 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
 
         var stdoutBuilder = new StringBuilder();
         var stderrBuilder = new StringBuilder();
-        var firstLineSeen = new TaskCompletionSource();
-        var releaseCallback = new TaskCompletionSource();
+        var firstLineSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var releaseTask = Task.Run(async () =>
         {

--- a/tests/Aspire.Cli.Tests/DotNet/ProcessExecutionTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/ProcessExecutionTests.cs
@@ -30,18 +30,15 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
 
         var stdoutBuilder = new StringBuilder();
         var stderrBuilder = new StringBuilder();
-        using var firstLineSeen = new ManualResetEventSlim();
-        using var releaseCallback = new ManualResetEventSlim();
+        var firstLineSeen = new TaskCompletionSource();
+        var releaseCallback = new TaskCompletionSource();
 
         var releaseTask = Task.Run(async () =>
         {
-            if (!firstLineSeen.Wait(TimeSpan.FromSeconds(10)))
-            {
-                throw new TimeoutException("Timed out waiting for the first stdout line.");
-            }
+            await firstLineSeen.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             await Task.Delay(TimeSpan.FromMilliseconds(500));
-            releaseCallback.Set();
+            releaseCallback.SetResult();
         });
 
         var isFirstLine = true;
@@ -55,9 +52,9 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
                     if (isFirstLine)
                     {
                         isFirstLine = false;
-                        firstLineSeen.Set();
+                        firstLineSeen.TrySetResult();
 
-                        if (!releaseCallback.Wait(TimeSpan.FromSeconds(20)))
+                        if (!releaseCallback.Task.Wait(TimeSpan.FromSeconds(20)))
                         {
                             throw new TimeoutException("Timed out waiting to release the blocked stdout callback.");
                         }
@@ -99,18 +96,15 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
 
         var stdoutBuilder = new StringBuilder();
         var stderrBuilder = new StringBuilder();
-        using var firstLineSeen = new ManualResetEventSlim();
-        using var releaseCallback = new ManualResetEventSlim();
+        var firstLineSeen = new TaskCompletionSource();
+        var releaseCallback = new TaskCompletionSource();
 
         var releaseTask = Task.Run(async () =>
         {
-            if (!firstLineSeen.Wait(TimeSpan.FromSeconds(10)))
-            {
-                throw new TimeoutException("Timed out waiting for the initial stdout marker.");
-            }
+            await firstLineSeen.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             await Task.Delay(TimeSpan.FromMilliseconds(6500));
-            releaseCallback.Set();
+            releaseCallback.SetResult();
         });
 
         using var execution = new ProcessExecution(
@@ -124,9 +118,9 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
 
                     if (line == "ready")
                     {
-                        firstLineSeen.Set();
+                        firstLineSeen.TrySetResult();
 
-                        if (!releaseCallback.Wait(TimeSpan.FromSeconds(20)))
+                        if (!releaseCallback.Task.Wait(TimeSpan.FromSeconds(20)))
                         {
                             throw new TimeoutException("Timed out waiting to release the blocked stdout callback.");
                         }

--- a/tests/Shared/TemporaryRepo.cs
+++ b/tests/Shared/TemporaryRepo.cs
@@ -56,7 +56,14 @@ internal sealed class TemporaryWorkspace(ITestOutputHelper outputHelper, Directo
 
         outputHelper.WriteLine($"Disposing temporary workspace at: {repoDirectory.FullName}");
 
-        DeleteDirectoryWithRetries(repoDirectory);
+        try
+        {
+            DeleteDirectoryWithRetries(repoDirectory);
+        }
+        catch (IOException ex)
+        {
+            outputHelper.WriteLine($"Failed to delete temporary workspace '{repoDirectory.FullName}': {ex.Message}");
+        }
     }
 
     private static void DeleteDirectoryWithRetries(DirectoryInfo directory)


### PR DESCRIPTION
## Description

Fix flaky `ProcessExecutionTests.WaitForExitAsync_AllowsBufferedTailOutputAfterLongIdlePeriod` test that fails on Windows CI with `IOException: The process cannot access the file 'output.json' because it is being used by another process` during `TemporaryWorkspace.Dispose()`.

**Changes:**

1. **ProcessExecutionTests.cs** — Replace `ManualResetEventSlim` with `TaskCompletionSource` in both tests. This avoids disposing synchronization primitives while forwarder callbacks may still reference them.

2. **TemporaryRepo.cs** — Catch `IOException` in `TemporaryWorkspace.Dispose()` and log to test output instead of failing the test when transient OS-level file locks (e.g. antivirus scanning on Windows CI) prevent immediate cleanup.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
