### PR TITLE
Expose missing Docker Compose polyglot APIs

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -1216,7 +1216,9 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             c.CapabilityKind != AtsCapabilityKind.PropertyGetter &&
             c.CapabilityKind != AtsCapabilityKind.PropertySetter))
         {
-            var (requiredParams, optionalParams) = SeparateParameters(capability.Parameters);
+            var targetParamName = capability.TargetParameterName ?? "builder";
+            var userParams = capability.Parameters.Where(p => p.Name != targetParamName).ToList();
+            var (requiredParams, optionalParams) = SeparateParameters(userParams);
             var hasOptionals = optionalParams.Count > 0;
             var hasDirectOptionsParameter = TryGetDirectOptionsParameter(optionalParams, out var directOptionsParam);
             var optionsInterfaceName = hasDirectOptionsParameter ? MapParameterToTypeScript(directOptionsParam!) : ResolveOptionsInterfaceName(capability);
@@ -1256,7 +1258,9 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         foreach (var capability in capabilities)
         {
-            var (requiredParams, optionalParams) = SeparateParameters(capability.Parameters);
+            var targetParamName = capability.TargetParameterName ?? "builder";
+            var userParams = capability.Parameters.Where(p => p.Name != targetParamName).ToList();
+            var (requiredParams, optionalParams) = SeparateParameters(userParams);
             var hasOptionals = optionalParams.Count > 0;
             var hasDirectOptionsParameter = TryGetDirectOptionsParameter(optionalParams, out var directOptionsParam);
             var optionsInterfaceName = hasDirectOptionsParameter ? MapParameterToTypeScript(directOptionsParam!) : ResolveOptionsInterfaceName(capability);
@@ -1440,9 +1444,11 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     {
         var methodName = capability.MethodName;
         var internalMethodName = $"_{methodName}Internal";
+        var targetParamName = capability.TargetParameterName ?? "builder";
+        var userParams = capability.Parameters.Where(p => p.Name != targetParamName).ToList();
 
         // Separate required and optional parameters
-        var (requiredParams, optionalParams) = SeparateParameters(capability.Parameters);
+        var (requiredParams, optionalParams) = SeparateParameters(userParams);
         var hasOptionals = optionalParams.Count > 0;
         var hasDirectOptionsParameter = TryGetDirectOptionsParameter(optionalParams, out var directOptionsParam);
         var optionsTypeName = hasDirectOptionsParameter ? MapParameterToTypeScript(directOptionsParam!) : ResolveOptionsInterfaceName(capability);
@@ -1462,16 +1468,13 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         // Build parameter list for internal method (all params positional for callback registration)
         var internalParamDefs = new List<string>();
-        foreach (var param in capability.Parameters)
+        foreach (var param in userParams)
         {
             var tsType = MapParameterToTypeScript(param);
             var optional = param.IsOptional || param.IsNullable ? "?" : "";
             internalParamDefs.Add($"{param.Name}{optional}: {tsType}");
         }
         var internalParamsString = string.Join(", ", internalParamDefs);
-
-        // Use the actual target parameter name from the capability (e.g., "resource" for withReference)
-        var targetParamName = capability.TargetParameterName ?? "builder";
 
         // Determine return type - for factory methods returning a different builder type,
         // use the return type's class name instead of the receiver's.
@@ -1514,14 +1517,14 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             }
 
             // Handle callback registration if any
-            var callbackParams2 = capability.Parameters.Where(p => p.IsCallback).ToList();
+            var callbackParams2 = userParams.Where(p => p.IsCallback).ToList();
             foreach (var callbackParam in callbackParams2)
             {
                 GenerateCallbackRegistration(callbackParam);
             }
 
             // Resolve any promise-like handle parameters before building rpcArgs
-            GeneratePromiseResolution(capability.Parameters);
+            GeneratePromiseResolution(userParams);
 
             // Build args object with conditional inclusion
             GenerateArgsObjectWithConditionals(targetParamName, requiredParams, optionalParams);
@@ -1554,14 +1557,14 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         WriteLine();
 
         // Handle callback registration if any
-        var callbackParams = capability.Parameters.Where(p => p.IsCallback).ToList();
+        var callbackParams = userParams.Where(p => p.IsCallback).ToList();
         foreach (var callbackParam in callbackParams)
         {
             GenerateCallbackRegistration(callbackParam);
         }
 
         // Resolve any promise-like handle parameters before building rpcArgs
-        GeneratePromiseResolution(capability.Parameters);
+        GeneratePromiseResolution(userParams);
 
         // Build args object with conditional inclusion
         GenerateArgsObjectWithConditionals(targetParamName, requiredParams, optionalParams);
@@ -1601,7 +1604,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         }
 
         // Forward all params to internal method
-        var allParamNames = capability.Parameters.Select(p => p.Name);
+        var allParamNames = userParams.Select(p => p.Name);
         var internalCall = $"this.{internalMethodName}({string.Join(", ", allParamNames)})";
 
         // For build(), flush pending promises before invoking the internal method.
@@ -1833,9 +1836,11 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         foreach (var capability in capabilities)
         {
             var methodName = capability.MethodName;
+            var targetParamName = capability.TargetParameterName ?? "builder";
+            var userParams = capability.Parameters.Where(p => p.Name != targetParamName).ToList();
 
             // Separate required and optional parameters
-            var (requiredParams, optionalParams) = SeparateParameters(capability.Parameters);
+            var (requiredParams, optionalParams) = SeparateParameters(userParams);
             var hasOptionals = optionalParams.Count > 0;
             var hasDirectOptionsParameter = TryGetDirectOptionsParameter(optionalParams, out var directOptionsParam);
             var optionsTypeName = hasDirectOptionsParameter ? MapParameterToTypeScript(directOptionsParam!) : ResolveOptionsInterfaceName(capability);

--- a/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Docker;
 /// This resource is used to visualize telemetry data in the Aspire Hosting environment.
 /// </summary>
 /// <param name="name">The name of the Aspire Dashboard resource.</param>
-[global::Aspire.Hosting.AspireExport(ExposeProperties = true)]
+[AspireExport(ExposeProperties = true)]
 public class DockerComposeAspireDashboardResource(string name) : ContainerResource(name)
 {
     /// <summary>

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -79,8 +79,11 @@ public static class DockerComposeEnvironmentExtensions
     /// <param name="builder"> The Docker compose environment resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="ComposeFile"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks>This method is not available in polyglot app hosts because <see cref="ComposeFile"/> and its nested types are not exported to ATS.</remarks>
-    [AspireExportIgnore(Reason = "ComposeFile and its nested types are not exported to ATS.")]
+    /// <remarks>
+    /// This callback runs after the Docker Compose model has been generated and before it is written to disk.
+    /// Use it to customize the generated <see cref="ComposeFile"/> for the environment.
+    /// </remarks>
+    [AspireExport(Description = "Configures the generated Docker Compose file before it is written to disk")]
     public static IResourceBuilder<DockerComposeEnvironmentResource> ConfigureComposeFile(this IResourceBuilder<DockerComposeEnvironmentResource> builder, Action<ComposeFile> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -26,7 +26,7 @@ namespace Aspire.Hosting.Docker;
 /// <remarks>
 /// Initializes a new instance of the <see cref="DockerComposeEnvironmentResource"/> class.
 /// </remarks>
-[global::Aspire.Hosting.AspireExport(ExposeProperties = true)]
+[AspireExport(ExposeProperties = true)]
 public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentResource
 {
     private const string DockerComposeUpTag = "docker-compose-up";
@@ -249,6 +249,7 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
     }
 
     /// <inheritdoc/>
+    [AspireExport(Description = "Gets the host address expression used to reach a resource endpoint from Docker Compose")]
     [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference)
     {

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -26,7 +26,7 @@ namespace Aspire.Hosting.Docker;
 /// <remarks>
 /// Initializes a new instance of the <see cref="DockerComposeEnvironmentResource"/> class.
 /// </remarks>
-[AspireExport(ExposeProperties = true)]
+[AspireExport(ExposeProperties = true, ExposeMethods = true)]
 public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentResource
 {
     private const string DockerComposeUpTag = "docker-compose-up";
@@ -249,7 +249,6 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
     }
 
     /// <inheritdoc/>
-    [AspireExport(Description = "Gets the host address expression used to reach a resource endpoint from Docker Compose")]
     [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference)
     {

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceExtensions.cs
@@ -54,8 +54,8 @@ public static class DockerComposeServiceExtensions
     /// <param name="manifestExpressionProvider">The manifest expression provider.</param>
     /// <param name="dockerComposeService">The Docker Compose service resource to associate the environment variable with.</param>
     /// <returns>A string representing the environment variable placeholder in Docker Compose syntax (e.g., <c>${ENV_VAR}</c>).</returns>
-    /// <remarks>This overload is not available in polyglot app hosts.</remarks>
-    [AspireExportIgnore(Reason = "Polyglot projection for Docker Compose placeholder helpers is not currently available.")]
+    /// <remarks>This overload is not available in polyglot app hosts because <see cref="IManifestExpressionProvider"/> is not ATS-compatible.</remarks>
+    [AspireExportIgnore(Reason = "IManifestExpressionProvider parameters are not ATS-compatible. Use the parameter-builder overload in polyglot app hosts.")]
     public static string AsEnvironmentPlaceholder(this IManifestExpressionProvider manifestExpressionProvider, DockerComposeServiceResource dockerComposeService)
     {
         var env = manifestExpressionProvider.ValueExpression.Replace("{", "")
@@ -76,8 +76,10 @@ public static class DockerComposeServiceExtensions
     /// <param name="builder">The resource builder for the parameter resource.</param>
     /// <param name="dockerComposeService">The Docker Compose service resource to associate the environment variable with.</param>
     /// <returns>A string representing the environment variable placeholder in Docker Compose syntax (e.g., <c>${ENV_VAR}</c>).</returns>
-    /// <remarks>This overload is not available in polyglot app hosts.</remarks>
-    [AspireExportIgnore(Reason = "Polyglot projection for Docker Compose placeholder helpers is not currently available.")]
+    /// <remarks>
+    /// Use this overload with parameter builders returned by methods such as <see cref="ParameterResourceBuilderExtensions.AddParameter(IDistributedApplicationBuilder, string, bool)"/>.
+    /// </remarks>
+    [AspireExport(Description = "Creates a Docker Compose environment variable placeholder from a parameter builder")]
     public static string AsEnvironmentPlaceholder(this IResourceBuilder<ParameterResource> builder, DockerComposeServiceResource dockerComposeService)
     {
         return builder.Resource.AsEnvironmentPlaceholder(dockerComposeService);
@@ -89,8 +91,8 @@ public static class DockerComposeServiceExtensions
     /// <param name="parameter">The parameter resource for which to create the environment variable placeholder.</param>
     /// <param name="dockerComposeService">The Docker Compose service resource to associate the environment variable with.</param>
     /// <returns>A string representing the environment variable placeholder in Docker Compose syntax (e.g., <c>${ENV_VAR}</c>).</returns>
-    /// <remarks>This overload is not available in polyglot app hosts.</remarks>
-    [AspireExportIgnore(Reason = "Polyglot projection for Docker Compose placeholder helpers is not currently available.")]
+    /// <remarks>This overload is not available in polyglot app hosts. Use the builder or manifest-expression overload instead.</remarks>
+    [AspireExportIgnore(Reason = "Prefer the builder or IManifestExpressionProvider overloads in polyglot app hosts to avoid duplicate asEnvironmentPlaceholder projections on ParameterResource.")]
     public static string AsEnvironmentPlaceholder(this ParameterResource parameter, DockerComposeServiceResource dockerComposeService)
     {
         // Placeholder for resolving the actual parameter value

--- a/src/Aspire.Hosting.Docker/Resources/ComposeFile.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeFile.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.Docker.Resources.ComposeNodes;
 using Aspire.Hosting.Docker.Resources.ServiceNodes;
 using Aspire.Hosting.Yaml;
-using Aspire.Hosting;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 

--- a/src/Aspire.Hosting.Docker/Resources/ComposeFile.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeFile.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.Docker.Resources.ComposeNodes;
 using Aspire.Hosting.Docker.Resources.ServiceNodes;
 using Aspire.Hosting.Yaml;
+using Aspire.Hosting;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -16,6 +17,7 @@ namespace Aspire.Hosting.Docker.Resources;
 /// This class is designed to encapsulate the structure of a Docker Compose file as a strongly-typed model.
 /// It supports serialization to YAML format for usage in Docker Compose operations.
 /// </remarks>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class ComposeFile
 {

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Config.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Config.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
 /// file-based or external configurations. It includes properties to define the
 /// source file, external flag, custom name, and additional labels for the configuration.
 /// </remarks>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class Config : NamedComposeMember
 {
@@ -50,4 +52,3 @@ public sealed class Config : NamedComposeMember
     [YamlMember(Alias = "labels", DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
     public Dictionary<string, string> Labels { get; set; } = [];
 }
-

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Config.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Config.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes;

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Network.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Network.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Docker.Resources.ServiceNodes;
-using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes;

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Network.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Network.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Docker.Resources.ServiceNodes;
+using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
 /// This class encapsulates the properties and options related to a network in a Docker Compose file.
 /// It includes configurations such as driver type, options, labels, IPAM settings, and more.
 /// </remarks>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class Network : NamedComposeMember
 {

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Secret.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Secret.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
 /// such as passwords, keys, or certificates. These secrets can either be externally managed
 /// or provided locally from a specific file.
 /// </remarks>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class Secret
 {

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Secret.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Secret.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes;

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/ServiceDependency.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/ServiceDependency.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
@@ -8,6 +9,7 @@ namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
 /// <summary>
 /// Represents a service dependency in a Docker Compose file.
 /// </summary>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class ServiceDependency
 {

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/ServiceDependency.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/ServiceDependency.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes;

--- a/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Volume.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Volume.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Docker.Resources.ComposeNodes;
-using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ServiceNodes;

--- a/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Volume.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Volume.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Docker.Resources.ComposeNodes;
+using Aspire.Hosting;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Docker.Resources.ServiceNodes;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Docker.Resources.ServiceNodes;
 /// The <see cref="Volume"/> class is used to define properties and options for volumes in a Docker environment.
 /// Volumes are used to persist data beyond the lifecycle of a container and can be shared among multiple containers.
 /// </remarks>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class Volume : NamedComposeMember
 {

--- a/src/Aspire.Hosting.Docker/api/Aspire.Hosting.Docker.cs
+++ b/src/Aspire.Hosting.Docker/api/Aspire.Hosting.Docker.cs
@@ -10,46 +10,46 @@ namespace Aspire.Hosting
 {
     public static partial class DockerComposeAspireDashboardResourceBuilderExtensions
     {
-        [AspireExport("withForwardedHeaders", Description = "Enables or disables forwarded headers support for the Aspire dashboard")]
+        [AspireExport(Description = "Enables or disables forwarded headers support for the Aspire dashboard")]
         public static ApplicationModel.IResourceBuilder<Docker.DockerComposeAspireDashboardResource> WithForwardedHeaders(this ApplicationModel.IResourceBuilder<Docker.DockerComposeAspireDashboardResource> builder, bool enabled = true) { throw null; }
 
-        [AspireExport("withHostPort", Description = "Sets the host port for the Aspire dashboard")]
+        [AspireExport(Description = "Sets the host port for the Aspire dashboard")]
         public static ApplicationModel.IResourceBuilder<Docker.DockerComposeAspireDashboardResource> WithHostPort(this ApplicationModel.IResourceBuilder<Docker.DockerComposeAspireDashboardResource> builder, int? port = null) { throw null; }
     }
 
     public static partial class DockerComposeEnvironmentExtensions
     {
-        [AspireExport("addDockerComposeEnvironment", Description = "Adds a Docker Compose publishing environment")]
+        [AspireExport(Description = "Adds a Docker Compose publishing environment")]
         public static ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> AddDockerComposeEnvironment(this IDistributedApplicationBuilder builder, string name) { throw null; }
 
-        [AspireExportIgnore(Reason = "ComposeFile and its nested types are not exported to ATS.")]
+        [AspireExport(Description = "Configures the generated Docker Compose file before it is written to disk")]
         public static ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> ConfigureComposeFile(this ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> builder, System.Action<Docker.Resources.ComposeFile> configure) { throw null; }
 
-        [AspireExportIgnore(Reason = "Action<IDictionary<string, CapturedEnvironmentVariable>> callbacks are not ATS-compatible.")]
+        [AspireExport(Description = "Configures the captured environment variables written to the Docker Compose .env file")]
         public static ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> ConfigureEnvFile(this ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> builder, System.Action<System.Collections.Generic.IDictionary<string, Docker.CapturedEnvironmentVariable>> configure) { throw null; }
 
         [AspireExport("configureDashboard", MethodName = "configureDashboard", Description = "Configures the Aspire dashboard resource for the Docker Compose environment", RunSyncOnBackgroundThread = true)]
         public static ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> WithDashboard(this ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> builder, System.Action<ApplicationModel.IResourceBuilder<Docker.DockerComposeAspireDashboardResource>> configure) { throw null; }
 
-        [AspireExport("withDashboard", Description = "Enables or disables the Aspire dashboard for the Docker Compose environment")]
+        [AspireExport(Description = "Enables or disables the Aspire dashboard for the Docker Compose environment")]
         public static ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> WithDashboard(this ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> builder, bool enabled = true) { throw null; }
 
-        [AspireExport("withProperties", Description = "Configures properties of the Docker Compose environment", RunSyncOnBackgroundThread = true)]
+        [AspireExport(Description = "Configures properties of the Docker Compose environment", RunSyncOnBackgroundThread = true)]
         public static ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> WithProperties(this ApplicationModel.IResourceBuilder<Docker.DockerComposeEnvironmentResource> builder, System.Action<Docker.DockerComposeEnvironmentResource> configure) { throw null; }
     }
 
     public static partial class DockerComposeServiceExtensions
     {
-        [AspireExportIgnore(Reason = "Polyglot projection for Docker Compose placeholder helpers is not currently available.")]
+        [AspireExportIgnore(Reason = "IManifestExpressionProvider parameters are not ATS-compatible. Use the parameter-builder overload in polyglot app hosts.")]
         public static string AsEnvironmentPlaceholder(this ApplicationModel.IManifestExpressionProvider manifestExpressionProvider, Docker.DockerComposeServiceResource dockerComposeService) { throw null; }
 
-        [AspireExportIgnore(Reason = "Polyglot projection for Docker Compose placeholder helpers is not currently available.")]
+        [AspireExport(Description = "Creates a Docker Compose environment variable placeholder from a parameter builder")]
         public static string AsEnvironmentPlaceholder(this ApplicationModel.IResourceBuilder<ApplicationModel.ParameterResource> builder, Docker.DockerComposeServiceResource dockerComposeService) { throw null; }
 
-        [AspireExportIgnore(Reason = "Polyglot projection for Docker Compose placeholder helpers is not currently available.")]
+        [AspireExportIgnore(Reason = "Prefer the builder or IManifestExpressionProvider overloads in polyglot app hosts to avoid duplicate asEnvironmentPlaceholder projections on ParameterResource.")]
         public static string AsEnvironmentPlaceholder(this ApplicationModel.ParameterResource parameter, Docker.DockerComposeServiceResource dockerComposeService) { throw null; }
 
-        [AspireExport("publishAsDockerComposeService", Description = "Publishes the resource as a Docker Compose service with custom service configuration")]
+        [AspireExport(Description = "Publishes the resource as a Docker Compose service with custom service configuration")]
         public static ApplicationModel.IResourceBuilder<T> PublishAsDockerComposeService<T>(this ApplicationModel.IResourceBuilder<T> builder, System.Action<Docker.DockerComposeServiceResource, Docker.Resources.ComposeNodes.Service> configure)
             where T : ApplicationModel.IComputeResource { throw null; }
     }
@@ -57,16 +57,20 @@ namespace Aspire.Hosting
 
 namespace Aspire.Hosting.Docker
 {
+    [AspireExport(ExposeProperties = true)]
     public sealed partial class CapturedEnvironmentVariable
     {
         public string? DefaultValue { get { throw null; } set { } }
 
         public string? Description { get { throw null; } set { } }
 
+        [AspireExportIgnore(Reason = "The dictionary key already identifies the captured environment variable in polyglot callbacks.")]
         public required string Name { get { throw null; } init { } }
 
+        [AspireExportIgnore(Reason = "Resource is provenance metadata only; exporting it here would pull the broader IResource surface into the callback even though polyglot configureEnvFile only needs to mutate Description and DefaultValue.")]
         public ApplicationModel.IResource? Resource { get { throw null; } set { } }
 
+        [AspireUnion(new[] { typeof(ApplicationModel.ParameterResource), typeof(ApplicationModel.ContainerMountAnnotation), typeof(ApplicationModel.ContainerImageReference), typeof(ApplicationModel.ContainerPortReference) })]
         public object? Source { get { throw null; } set { } }
     }
 
@@ -89,6 +93,7 @@ namespace Aspire.Hosting.Docker
 
         public string? DefaultNetworkName { get { throw null; } set { } }
 
+        [AspireExport(Description = "Gets the host address expression used to reach a resource endpoint from Docker Compose")]
         [System.Diagnostics.CodeAnalysis.Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
         public ApplicationModel.ReferenceExpression GetHostAddressExpression(ApplicationModel.EndpointReference endpointReference) { throw null; }
     }
@@ -111,6 +116,7 @@ namespace Aspire.Hosting.Docker
 
 namespace Aspire.Hosting.Docker.Resources
 {
+    [AspireExport(ExposeProperties = true)]
     [YamlDotNet.Serialization.YamlSerializable]
     public sealed partial class ComposeFile
     {
@@ -152,6 +158,7 @@ namespace Aspire.Hosting.Docker.Resources
 
 namespace Aspire.Hosting.Docker.Resources.ComposeNodes
 {
+    [AspireExport(ExposeProperties = true)]
     [YamlDotNet.Serialization.YamlSerializable]
     public sealed partial class Config : NamedComposeMember
     {
@@ -174,6 +181,7 @@ namespace Aspire.Hosting.Docker.Resources.ComposeNodes
         public required string Name { get { throw null; } set { } }
     }
 
+    [AspireExport(ExposeProperties = true)]
     [YamlDotNet.Serialization.YamlSerializable]
     public sealed partial class Network : NamedComposeMember
     {
@@ -202,6 +210,7 @@ namespace Aspire.Hosting.Docker.Resources.ComposeNodes
         public System.Collections.Generic.Dictionary<string, string> Labels { get { throw null; } set { } }
     }
 
+    [AspireExport(ExposeProperties = true)]
     [YamlDotNet.Serialization.YamlSerializable]
     public sealed partial class Secret
     {
@@ -381,6 +390,7 @@ namespace Aspire.Hosting.Docker.Resources.ComposeNodes
         public Service AddVolumes(System.Collections.Generic.IEnumerable<ServiceNodes.Volume> volumes) { throw null; }
     }
 
+    [AspireExport(ExposeProperties = true)]
     [YamlDotNet.Serialization.YamlSerializable]
     public sealed partial class ServiceDependency
     {
@@ -503,6 +513,7 @@ namespace Aspire.Hosting.Docker.Resources.ServiceNodes
         public int? Soft { get { throw null; } set { } }
     }
 
+    [AspireExport(ExposeProperties = true)]
     [YamlDotNet.Serialization.YamlSerializable]
     public sealed partial class Volume : ComposeNodes.NamedComposeMember
     {
@@ -617,7 +628,7 @@ namespace Aspire.Hosting.Docker.Resources.ServiceNodes.Swarm
         public string? Delay { get { throw null; } set { } }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "failure_action")]
-        public bool? FailOnError { get { throw null; } set { } }
+        public string? FailureAction { get { throw null; } set { } }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "max_failure_ratio")]
         public string? MaxFailureRatio { get { throw null; } set { } }
@@ -629,6 +640,6 @@ namespace Aspire.Hosting.Docker.Resources.ServiceNodes.Swarm
         public string? Order { get { throw null; } set { } }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "parallelism")]
-        public string? Parallelism { get { throw null; } set { } }
+        public int? Parallelism { get { throw null; } set { } }
     }
 }

--- a/src/Aspire.Hosting.Docker/api/Aspire.Hosting.Docker.cs
+++ b/src/Aspire.Hosting.Docker/api/Aspire.Hosting.Docker.cs
@@ -84,7 +84,7 @@ namespace Aspire.Hosting.Docker
         public ApplicationModel.EndpointReference PrimaryEndpoint { get { throw null; } }
     }
 
-    [AspireExport(ExposeProperties = true)]
+    [AspireExport(ExposeProperties = true, ExposeMethods = true)]
     public partial class DockerComposeEnvironmentResource : ApplicationModel.Resource, ApplicationModel.IComputeEnvironmentResource, ApplicationModel.IResource
     {
         public DockerComposeEnvironmentResource(string name) : base(default!) { }
@@ -93,7 +93,6 @@ namespace Aspire.Hosting.Docker
 
         public string? DefaultNetworkName { get { throw null; } set { } }
 
-        [AspireExport(Description = "Gets the host address expression used to reach a resource endpoint from Docker Compose")]
         [System.Diagnostics.CodeAnalysis.Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
         public ApplicationModel.ReferenceExpression GetHostAddressExpression(ApplicationModel.EndpointReference endpointReference) { throw null; }
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Java/AppHost.java
@@ -9,7 +9,7 @@ void main() throws Exception {
         api.withHttpEndpoint(new WithHttpEndpointOptions().name("http").targetPort(80.0));
         var apiEndpoint = api.getEndpoint("http");
         var hostAddressExpression = compose.getHostAddressExpression(apiEndpoint);
-        var _hostAddressValueExpression = hostAddressExpression.valueExpression();
+        var _hostAddressValueExpression = hostAddressExpression.getValue();
         compose.withProperties((environment) -> {
             environment.setDefaultNetworkName("validation-network");
             var _defaultNetworkName = environment.defaultNetworkName();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Java/AppHost.java
@@ -3,7 +3,13 @@ import aspire.*;
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
         var compose = builder.addDockerComposeEnvironment("compose");
+        var containerName = builder.addParameter("container-name");
         var api = builder.addContainer("api", "nginx:alpine");
+        api.withBindMount("/host/path/data", "/container/data");
+        api.withHttpEndpoint(new WithHttpEndpointOptions().name("http").targetPort(80.0));
+        var apiEndpoint = api.getEndpoint("http");
+        var hostAddressExpression = compose.getHostAddressExpression(apiEndpoint);
+        var _hostAddressValueExpression = hostAddressExpression.valueExpression();
         compose.withProperties((environment) -> {
             environment.setDefaultNetworkName("validation-network");
             var _defaultNetworkName = environment.defaultNetworkName();
@@ -17,6 +23,13 @@ void main() throws Exception {
             var _bindMountDescription = bindMount.description();
             bindMount.setDefaultValue("./data");
             var _bindMountDefaultValue = bindMount.defaultValue();
+        });
+        compose.configureComposeFile((composeFile) -> {
+            composeFile.setName("validation-compose");
+            var _composeFileName = composeFile.name();
+            var composeApi = composeFile.services().get("api");
+            composeApi.setPullPolicy("always");
+            var _composeApiPullPolicy = composeApi.pullPolicy();
         });
         compose.withDashboard(false);
         compose.withDashboard();
@@ -33,14 +46,12 @@ void main() throws Exception {
             var _otlpGrpcPort = otlpGrpcEndpoint.port();
         });
         api.publishAsDockerComposeService((composeService, service) -> {
-            service.setContainerName("validation-api");
-            service.setPullPolicy("always");
+            service.setContainerName(containerName.asEnvironmentPlaceholder(composeService));
             service.setRestart("unless-stopped");
             var _composeServiceName = composeService.name();
             var composeEnvironment = composeService.parent();
             var _composeEnvironmentName = composeEnvironment.name();
             var _serviceContainerName = service.containerName();
-            var _servicePullPolicy = service.pullPolicy();
             var _serviceRestart = service.restart();
         });
         var _resolvedDefaultNetworkName = compose.defaultNetworkName();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Python/apphost.py
@@ -6,8 +6,13 @@ from aspire_app import create_builder
 
 with create_builder() as builder:
     compose = builder.add_docker_compose_environment("compose")
+    container_name = builder.add_parameter("container-name")
     api = builder.add_container("api", "nginx:alpine")
     api.with_bind_mount("/host/path/data", "/container/data")
+    api.with_http_endpoint(name="http", target_port=80)
+    api_endpoint = api.get_endpoint("http")
+    host_address_expression = compose.get_host_address_expression(api_endpoint)
+    _host_address_value_expression = host_address_expression.value_expression.get()
 
     def configure_environment(environment):
         environment.default_network_name = "validation-network"
@@ -28,10 +33,27 @@ with create_builder() as builder:
         _bind_mount_default_value = bind_mount.default_value
 
     compose.configure_env_file(configure_env_file)
+
+    def configure_compose_file(compose_file):
+        compose_file.name = "validation-compose"
+        _compose_file_name = compose_file.name
+        compose_api = compose_file.services["api"]
+        compose_api.pull_policy = "always"
+        _compose_api_pull_policy = compose_api.pull_policy
+
+    def configure_service(compose_service, service):
+        service.set_container_name(container_name.as_environment_placeholder(compose_service))
+        service.set_restart("unless-stopped")
+        compose_service.name()
+        compose_service.parent().name()
+        service.container_name()
+        service.restart()
+
+    compose.configure_compose_file(configure_compose_file)
     compose.with_dashboard()
     compose.with_dashboard()
     compose.configure_dashboard()
-    api.publish_as_docker_compose_service()
+    api.publish_as_docker_compose_service(configure_service)
     _resolved_default_network_name = compose.default_network_name
     _resolved_dashboard_enabled = compose.dashboard_enabled
     _resolved_name = compose.name

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Python/apphost.py
@@ -12,7 +12,7 @@ with create_builder() as builder:
     api.with_http_endpoint(name="http", target_port=80)
     api_endpoint = api.get_endpoint("http")
     host_address_expression = compose.get_host_address_expression(api_endpoint)
-    _host_address_value_expression = host_address_expression.value_expression.get()
+    _host_address_value_expression = repr(host_address_expression)
 
     def configure_environment(environment):
         environment.default_network_name = "validation-network"

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
@@ -3,8 +3,14 @@ import { createBuilder } from './.modules/aspire.js';
 const builder = await createBuilder();
 
 const compose = await builder.addDockerComposeEnvironment("compose");
+const containerName = await builder.addParameter("container-name");
 const api = await builder.addContainer("api", "nginx:alpine");
 await api.withBindMount("/host/path/data", "/container/data");
+await api.withHttpEndpoint({ name: "http", targetPort: 80 });
+
+const apiEndpoint = await api.getEndpoint("http");
+const hostAddressExpression = await compose.getHostAddressExpression(apiEndpoint);
+const _hostAddressValueExpression: string = await hostAddressExpression.valueExpression.get();
 
 await compose.withProperties(async (environment) => {
     await environment.defaultNetworkName.set("validation-network");
@@ -22,6 +28,15 @@ await compose.configureEnvFile(async (envVars) => {
     const _bindMountDescription: string | null = await bindMount.description.get();
     await bindMount.defaultValue.set("./data");
     const _bindMountDefaultValue: string | null = await bindMount.defaultValue.get();
+});
+
+await compose.configureComposeFile(async (composeFile) => {
+    await composeFile.name.set("validation-compose");
+    const _composeFileName: string | null = await composeFile.name.get();
+
+    const composeApi = await composeFile.services.get("api");
+    await composeApi.pullPolicy.set("always");
+    const _composeApiPullPolicy: string | null = await composeApi.pullPolicy.get();
 });
 
 await compose.withDashboard({ enabled: false });
@@ -44,8 +59,7 @@ await compose.configureDashboard(async (dashboard) => {
 });
 
 await api.publishAsDockerComposeService(async (composeService, service) => {
-    await service.containerName.set("validation-api");
-    await service.pullPolicy.set("always");
+    await service.containerName.set(await containerName.asEnvironmentPlaceholder(composeService));
     await service.restart.set("unless-stopped");
 
     const _composeServiceName: string = await composeService.name.get();
@@ -53,7 +67,6 @@ await api.publishAsDockerComposeService(async (composeService, service) => {
     const _composeEnvironmentName: string = await composeEnvironment.name.get();
 
     const _serviceContainerName: string = await service.containerName.get();
-    const _servicePullPolicy: string = await service.pullPolicy.get();
     const _serviceRestart: string = await service.restart.get();
 });
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
@@ -10,7 +10,7 @@ await api.withHttpEndpoint({ name: "http", targetPort: 80 });
 
 const apiEndpoint = await api.getEndpoint("http");
 const hostAddressExpression = await compose.getHostAddressExpression(apiEndpoint);
-const _hostAddressValueExpression: string = await hostAddressExpression.valueExpression.get();
+const _hostAddressValueExpression: string | null = await hostAddressExpression.getValue();
 
 await compose.withProperties(async (environment) => {
     await environment.defaultNetworkName.set("validation-network");


### PR DESCRIPTION
## Description

TypeScript and other polyglot AppHosts could already publish with Docker Compose, but the exported ATS surface was still missing key Docker Compose customization APIs. This change exposes the missing Docker Compose polyglot APIs, regenerates the checked-in API surface file, and updates the Docker polyglot validation apphosts in TypeScript, Python, and Java to cover the expanded surface.

Notable details:
- Export `ConfigureComposeFile(...)` and `GetHostAddressExpression(...)` for Docker Compose environments.
- Export the parameter-builder `AsEnvironmentPlaceholder(...)` overload for Docker Compose services.
- Keep the `IManifestExpressionProvider` placeholder overload ignored because that parameter type is not ATS-compatible.
- Export the minimal Compose model types needed by `ConfigureComposeFile(...)` callbacks.

Fixes #16363

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No