### PR TITLE
Downgrade AuxiliaryBackchannelRpcTarget log messages from Info to Debug

### DIFF
--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -517,7 +517,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
     /// <returns>The dashboard URL state including health and resolved dashboard URLs.</returns>
     public async Task<DashboardUrlsState> GetDashboardUrlsAsync(CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("GetDashboardUrlsAsync called on auxiliary backchannel");
+        logger.LogDebug("GetDashboardUrlsAsync called on auxiliary backchannel");
         return await DashboardUrlsHelper.GetDashboardUrlsAsync(serviceProvider, logger, cancellationToken).ConfigureAwait(false);
     }
 
@@ -902,7 +902,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
     public Task StopAppHostAsync(CancellationToken cancellationToken = default)
     {
         _ = cancellationToken; // Unused but kept for API consistency
-        logger.LogInformation("Received request to stop AppHost");
+        logger.LogDebug("Received request to stop AppHost");
 
         // Start a background task to delay the stop by 500ms to allow the RPC response to be sent
         _ = Task.Run(async () =>
@@ -918,7 +918,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
                 var lifetime = serviceProvider.GetService<IHostApplicationLifetime>();
                 if (lifetime is not null)
                 {
-                    logger.LogInformation("Stopping AppHost application");
+                    logger.LogDebug("Stopping AppHost application");
                     lifetime.StopApplication();
                 }
                 else


### PR DESCRIPTION
## Description

Downgrade `LogInformation` calls in `AuxiliaryBackchannelRpcTarget` to `LogDebug`. It's displayed on startup:

<img width="1212" height="295" alt="image" src="https://github.com/user-attachments/assets/b16ae935-9b4c-47a2-925a-8f5688f3d45e" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
