### PR TITLE
Move Windows CLI NativeAOT build to build_sign_native stage

### DIFF
--- a/eng/clipack/Aspire.Cli.win-arm64.csproj
+++ b/eng/clipack/Aspire.Cli.win-arm64.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <CliRuntime>win-arm64</CliRuntime>
     <CliPlatformType>Windows</CliPlatformType>
+
+    <!-- IMAGE_FILE_MACHINE_ARM64 -->
+    <PEExpectedMachine>AA64</PEExpectedMachine>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />

--- a/eng/clipack/Aspire.Cli.win-x64.csproj
+++ b/eng/clipack/Aspire.Cli.win-x64.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <CliRuntime>win-x64</CliRuntime>
     <CliPlatformType>Windows</CliPlatformType>
+
+    <!-- IMAGE_FILE_MACHINE_AMD64 -->
+    <PEExpectedMachine>8664</PEExpectedMachine>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -15,6 +15,9 @@
     <!-- Run `file` on the native binary and check the output but only on Linux/macOS -->
     <_CheckFileSignature Condition="'$(PublishNativeAot)' == 'true' and !$([System.OperatingSystem]::IsWindows())">true</_CheckFileSignature>
 
+    <!-- Read the PE Machine field from the binary and compare against PEExpectedMachine (hex) — Windows only -->
+    <_CheckPEMachine Condition="'$(PublishNativeAot)' == 'true' and $([System.OperatingSystem]::IsWindows())">true</_CheckPEMachine>
+
     <_NativeBinaryPath>$([MSBuild]::NormalizePath($(OutputPath), 'aspire'))</_NativeBinaryPath>
     <_NativeBinaryPath Condition="$(CliRuntime.StartsWith('win-'))">$(_NativeBinaryPath).exe</_NativeBinaryPath>
   </PropertyGroup>
@@ -24,7 +27,7 @@
   </ItemGroup>
 
   <Target Name="PublishToDisk"
-          DependsOnTargets="_PublishProject;_ValidateNativeBinaryFileSignatureOnUnix;PrepareOutputPathForPublishToDisk" />
+          DependsOnTargets="_PublishProject;_ValidateNativeBinaryFileSignatureOnUnix;_ValidateNativeBinaryPEMachineOnWindows;PrepareOutputPathForPublishToDisk" />
 
   <Target Name="PrepareOutputPathForPublishToDisk">
     <!-- TODO: avoid generating the file instead of manually deleting it here -->
@@ -105,6 +108,24 @@
            Text="`file` signature for `$(CliRuntime)` did not match the expected regex.
            Got     : $(_FileCommandOutput)
            vs regex: $(FileSignatureRegex)" />
+  </Target>
+
+  <!--
+    Validate that the PE Machine type in the Windows native binary header matches the
+    expected architecture.  Uses a small PowerShell snippet that reads the PE header:
+      MZ @ 0x00 → e_lfanew @ 0x3C → PE\0\0 → Machine @ PE+4
+    PEExpectedMachine must be set to a 4-digit hex string (e.g. 8664 for AMD64, AA64 for ARM64).
+  -->
+  <Target Name="_ValidateNativeBinaryPEMachineOnWindows" Condition="'$(_CheckPEMachine)' == 'true'">
+    <Error Condition="'$(PEExpectedMachine)' == ''" Text="Property %24(PEExpectedMachine) is unset for $(CliRuntime)." />
+
+    <Exec Command="powershell -NoProfile -NonInteractive -Command &quot;$b=[System.IO.File]::ReadAllBytes('$(_NativeBinaryPath)'); $p=[BitConverter]::ToInt32($b,0x3C); Write-Host ([BitConverter]::ToUInt16($b,$p+4)).ToString('X4')&quot;"
+          ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_PEMachineHex" />
+    </Exec>
+
+    <Error Condition="'$(_PEMachineHex)' != '$(PEExpectedMachine)'"
+           Text="PE Machine type mismatch for $(CliRuntime). Expected: $(PEExpectedMachine), Got: $(_PEMachineHex)" />
   </Target>
 
 </Project>

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -119,7 +119,7 @@
   <Target Name="_ValidateNativeBinaryPEMachineOnWindows" Condition="'$(_CheckPEMachine)' == 'true'">
     <Error Condition="'$(PEExpectedMachine)' == ''" Text="Property %24(PEExpectedMachine) is unset for $(CliRuntime)." />
 
-    <Exec Command="powershell -NoProfile -NonInteractive -Command &quot;$b=[System.IO.File]::ReadAllBytes('$(_NativeBinaryPath)'); $p=[BitConverter]::ToInt32($b,0x3C); Write-Host ([BitConverter]::ToUInt16($b,$p+4)).ToString('X4')&quot;"
+    <Exec Command="powershell -NoProfile -NonInteractive -Command &quot;$b=[System.IO.File]::ReadAllBytes('$(_NativeBinaryPath)'); $p=[BitConverter]::ToInt32($b,0x3C); [Console]::Write(([BitConverter]::ToUInt16($b,$p+4)).ToString('X4'))&quot;"
           ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_PEMachineHex" />
     </Exec>

--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -95,6 +95,18 @@ extends:
           teamName: $(_TeamName)
           extraBuildArgs: >-
             /p:Configuration=$(_BuildConfig)
+            $(_OfficialBuildIdArgs)
+
+      - template: /eng/pipelines/templates/build_sign_native.yml@self
+        parameters:
+          agentOs: windows
+          targetRidsForSameOS:
+            - win-x64
+            - win-arm64
+          codeSign: true
+          teamName: $(_TeamName)
+          extraBuildArgs: >-
+            /p:Configuration=$(_BuildConfig)
             $(_SignArgs)
             $(_OfficialBuildIdArgs)
 
@@ -210,9 +222,6 @@ extends:
                   repoLogPath: $(Build.Arcade.LogsPath)
                   repoTestResultsPath: $(Build.Arcade.TestResultsPath)
                   isWindows: true
-                  targetRids:
-                    - win-x64
-                    - win-arm64
               - pwsh: |
                   $ErrorActionPreference = 'Stop'
                   $shippingDir = "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping"

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -183,6 +183,18 @@ extends:
           teamName: $(_TeamName)
           extraBuildArgs: >-
             /p:Configuration=$(_BuildConfig)
+            $(_OfficialBuildIdArgs)
+
+      - template: /eng/pipelines/templates/build_sign_native.yml@self
+        parameters:
+          agentOs: windows
+          targetRidsForSameOS:
+            - win-x64
+            - win-arm64
+          codeSign: true
+          teamName: $(_TeamName)
+          extraBuildArgs: >-
+            /p:Configuration=$(_BuildConfig)
             $(_SignArgs)
             $(_OfficialBuildIdArgs)
 
@@ -298,9 +310,6 @@ extends:
                   repoLogPath: $(Build.Arcade.LogsPath)
                   repoTestResultsPath: $(Build.Arcade.TestResultsPath)
                   isWindows: true
-                  targetRids:
-                    - win-x64
-                    - win-arm64
                   publishVSCodeExtension: ${{ parameters.publishVSCodeExtension }}
                   vscePublishToken: $(VscePublishToken)
                   vscePublishPreRelease: ${{ parameters.vscePublishPreRelease }}

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -16,9 +16,6 @@ parameters:
     type: string
   - name: dotnetScript
     type: string
-  - name: targetRids
-    type: object
-    default: ''
   - name: runHelixTests
     type: boolean
     default: false
@@ -40,44 +37,10 @@ parameters:
 
 steps:
   # Internal pipeline: Build with pack+sign
+  # Native archives are produced by the build_sign_native stage for all platforms
+  # (macOS, Linux, Windows). This job builds all managed packages, signs them,
+  # and publishes.
   - ${{ if ne(parameters.runAsPublic, 'true') }}:
-    # Build, publish, and sign aspire-managed for each target RID before the main build.
-    # This ensures aspire-managed is signed before CreateLayout packs it into the bundle archive.
-    # Step 1: dotnet publish produces the self-contained single-file binary.
-    # Step 2: build.cmd -sign runs Arcade's signing, which picks up the binary via ItemsToSign in Signing.props.
-    # Step 3: Bundle.proj creates the bundle layout and archive using the signed binary.
-    - ${{ each targetRid in parameters.targetRids }}:
-      - script: ${{ parameters.dotnetScript }}
-                publish
-                $(Build.SourcesDirectory)/src/Aspire.Managed/Aspire.Managed.csproj
-                -c ${{ parameters.buildConfig }}
-                -r ${{ targetRid }}
-                --self-contained
-                /p:GenerateDocumentationFile=false
-                /p:EnforceCodeStyleInBuild=false
-                $(_OfficialBuildIdArgs)
-                /bl:${{ parameters.repoLogPath }}/PublishManaged-${{ targetRid }}.binlog
-        displayName: 🟣Publish aspire-managed (${{ targetRid }})
-
-      - script: ${{ parameters.buildScript }}
-                -restore -sign $(_SignArgs)
-                -configuration ${{ parameters.buildConfig }}
-                $(_OfficialBuildIdArgs)
-                -projects $(Build.SourcesDirectory)/src/Aspire.Managed/Aspire.Managed.csproj
-                /bl:${{ parameters.repoLogPath }}/SignManaged-${{ targetRid }}.binlog
-        displayName: 🟣Sign aspire-managed (${{ targetRid }})
-
-      - script: ${{ parameters.dotnetScript }}
-                msbuild
-                $(Build.SourcesDirectory)/eng/Bundle.proj
-                "/t:_RestoreDcpPackage;_RunCreateLayout"
-                /p:Configuration=${{ parameters.buildConfig }}
-                /p:TargetRid=${{ targetRid }}
-                /p:BundleVersion=ci-bundlepayload
-                /p:ContinuousIntegrationBuild=true
-                /bl:${{ parameters.repoLogPath }}/BundleLayout-${{ targetRid }}.binlog
-        displayName: 🟣Create bundle layout (${{ targetRid }})
-
     - script: ${{ parameters.buildScript }}
               -restore -build
               -pack
@@ -87,31 +50,10 @@ steps:
               /bl:${{ parameters.repoLogPath }}/build.binlog
               $(_OfficialBuildIdArgs)
               $(_InternalBuildArgs)
-              /p:TargetRids=${{ join(':', parameters.targetRids) }}
+              /p:SkipNativeBuild=true
               /p:SkipTestProjects=true
               /p:BuildExtension=true
       displayName: 🟣Build
-
-    # Verify the signed win-x64 CLI archive works (version check + project creation)
-    - pwsh: |
-        $ErrorActionPreference = 'Stop'
-        $archiveDir = "${{ parameters.repoArtifactsPath }}/packages/${{ parameters.buildConfig }}"
-        $archive = Get-ChildItem -Path $archiveDir -Filter "aspire-cli-win-x64-*.zip" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-        if (-not $archive) {
-          Write-Host "##[warning]No win-x64 CLI archive found - skipping verification"
-          exit 0
-        }
-        Write-Host "Found archive: $($archive.FullName)"
-        & "$(Build.SourcesDirectory)/eng/scripts/verify-cli-archive.ps1" -ArchivePath $archive.FullName
-        if ($LASTEXITCODE -ne 0) {
-          Write-Host "##[error]CLI archive verification failed"
-          exit 1
-        }
-      displayName: 🟣Verify CLI archive (win-x64)
-      condition: succeeded()
-      env:
-        ASPIRE_CLI_TELEMETRY_OPTOUT: 'true'
-        DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
 
     # Log MicroBuild environment for debugging
     # MicroBuildOutputFolderOverride is set by the MicroBuildSigningPlugin task in eng/common/templates-official/job/onelocbuild.yml
@@ -163,7 +105,7 @@ steps:
           $baseName = [System.IO.Path]::GetFileNameWithoutExtension($vsix.FullName)
           $manifestPath = Join-Path $vsixDir "$baseName.manifest"
           $signaturePath = Join-Path $vsixDir "$baseName.signature.p7s"
-          
+
           if (-not (Test-Path $manifestPath)) {
             Write-Host "##[error]Manifest file not found: $manifestPath"
             exit 1
@@ -172,7 +114,7 @@ steps:
             Write-Host "##[error]Signature file not found: $signaturePath"
             exit 1
           }
-          
+
           # First verify the .signature.p7s is in PKCS#7 format (binary)
           $bytes = [System.IO.File]::ReadAllBytes($signaturePath)
           if ($bytes.Length -eq 0 -or $bytes[0] -ne 0x30) {
@@ -180,7 +122,7 @@ steps:
             Write-Host "##[error]$baseName.signature.p7s does NOT appear to be signed. First byte: $firstByte (expected 0x30 for PKCS#7)"
             exit 1
           }
-          
+
           Write-Host "Verifying signature for $($vsix.Name)..."
           npx vsce verify-signature --packagePath $vsix.FullName --manifestPath $manifestPath --signaturePath $signaturePath
           if ($LASTEXITCODE -ne 0) {
@@ -222,7 +164,7 @@ steps:
             $baseName = [System.IO.Path]::GetFileNameWithoutExtension($vsix.FullName)
             $manifestPath = Join-Path $vsixDir "$baseName.manifest"
             $signaturePath = Join-Path $vsixDir "$baseName.signature.p7s"
-            
+
             $publishArgs = @("vsce", "publish", "--packagePath", $vsix.FullName, "--manifestPath", $manifestPath, "--signaturePath", $signaturePath)
             if ($preRelease -eq 'True') {
               $publishArgs += "--pre-release"
@@ -230,7 +172,7 @@ steps:
             } else {
               Write-Host "Publishing $($vsix.Name) to VS Code Marketplace..."
             }
-            
+
             & npx @publishArgs
             if ($LASTEXITCODE -ne 0) {
               Write-Host "##[error]Failed to publish $($vsix.Name)"
@@ -249,36 +191,6 @@ steps:
       inputs:
         PathtoPublish: '${{ parameters.repoArtifactsPath }}/packages/Release/vscode'
         ArtifactName: aspire-vscode-extension
-
-    # Publish Windows CLI archives as separate artifacts so the Prepare Installers
-    # stage can download them by name (matching the native_archives_<rid> pattern
-    # used by build_sign_native for macOS/Linux).
-    - ${{ if eq(parameters.isWindows, 'true') }}:
-      - ${{ each targetRid in parameters.targetRids }}:
-        - pwsh: |
-            $ErrorActionPreference = 'Stop'
-            $sourceDir = '${{ parameters.repoArtifactsPath }}/packages'
-            $pattern = 'aspire-cli-${{ targetRid }}-*'
-            $stagingDir = '$(Build.StagingDirectory)/native_archives_${{ replace(targetRid, '-', '_') }}'
-
-            New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
-
-            $files = Get-ChildItem -Path $sourceDir -Recurse -Filter $pattern
-            if ($files.Count -eq 0) {
-              Write-Error "No CLI archives matching '$pattern' found under '$sourceDir'"
-              exit 1
-            }
-
-            foreach ($f in $files) {
-              Copy-Item $f.FullName $stagingDir
-              Write-Host "Staged: $($f.Name)"
-            }
-          displayName: 🟣Stage CLI archives (${{ targetRid }})
-        - task: 1ES.PublishBuildArtifacts@1
-          displayName: 🟣Publish native_archives_${{ replace(targetRid, '-', '_') }}
-          inputs:
-            PathtoPublish: $(Build.StagingDirectory)/native_archives_${{ replace(targetRid, '-', '_') }}
-            ArtifactName: native_archives_${{ replace(targetRid, '-', '_') }}
 
     - script: ${{ parameters.dotnetScript }}
               build

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -174,7 +174,7 @@ jobs:
                 ASPIRE_CLI_TELEMETRY_OPTOUT: 'true'
                 DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
 
-          - ${{ if ne(parameters.agentOs, 'windows') }}:
+          - ${{ if and(ne(parameters.agentOs, 'windows'), not(contains(targetRid, 'musl'))) }}:
             - script: |
                 set -euo pipefail
                 echo "Finding CLI archive for ${{ targetRid }}..."

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -17,7 +17,7 @@ jobs:
       enableTelemetry: true
       # Publish build logs
       enablePublishBuildArtifacts: true
-      ${{ if ne(parameters.agentOs, 'windows') }}:
+      ${{ if eq(parameters.agentOs, 'linux') }}:
         container: ${{ replace(targetRid, '-', '_') }}
 
       jobs:
@@ -75,7 +75,7 @@ jobs:
           # Build, publish, and sign aspire-managed before creating the bundle layout.
           # This ensures aspire-managed is signed before CreateLayout packs it into the bundle archive.
           # Step 1: dotnet publish produces the self-contained single-file binary.
-          # Step 2: build.sh --sign runs Arcade's signing (only when codeSign is enabled).
+          # Step 2: build.sh -sign runs Arcade's signing (only when codeSign is enabled).
           # Step 3: Bundle.proj creates the bundle layout and archive using the signed binary.
           - script: >-
               $(Build.SourcesDirectory)/$(dotnetScript)

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -17,7 +17,8 @@ jobs:
       enableTelemetry: true
       # Publish build logs
       enablePublishBuildArtifacts: true
-      container: ${{ replace(targetRid, '-', '_') }}
+      ${{ if ne(parameters.agentOs, 'windows') }}:
+        container: ${{ replace(targetRid, '-', '_') }}
 
       jobs:
       - job: BuildNative_${{ replace(targetRid, '-', '_') }}
@@ -27,7 +28,7 @@ jobs:
         variables:
         - TeamName: ${{ parameters.teamName }}
         - ${{ if eq(parameters.codeSign, true) }}:
-          - _buildArgs: '--sign'
+          - _buildArgs: '-sign'
         - ${{ else }}:
           - _buildArgs: ''
 
@@ -37,6 +38,14 @@ jobs:
         - ${{ else }}:
           - scriptName: build.sh
           - dotnetScript: dotnet.sh
+        # Map target RID architecture to Agent.OSArchitecture so the verify
+        # step only runs when the binary can execute natively on the agent.
+        - ${{ if contains(targetRid, 'arm64') }}:
+          - name: _ridAgentArch
+            value: ARM64
+        - ${{ if contains(targetRid, 'x64') }}:
+          - name: _ridAgentArch
+            value: X64
 
         pool:
           ${{ if eq(parameters.agentOs, 'windows') }}:
@@ -79,7 +88,7 @@ jobs:
               /p:EnforceCodeStyleInBuild=false
               ${{ parameters.extraBuildArgs }}
               /bl:$(Build.Arcade.LogsPath)PublishManaged.binlog
-            displayName: 🟣Publish aspire-managed
+            displayName: 🟣Prepare aspire-managed
 
           # On macOS, ad-hoc codesign aspire-managed with JIT entitlements BEFORE Arcade signing.
           # MicroBuild (MacDeveloperHardenWithNotarization) preserves entitlements from the prior
@@ -96,7 +105,7 @@ jobs:
           - ${{ if eq(parameters.codeSign, true) }}:
             - script: >-
                 $(Build.SourcesDirectory)/$(scriptName)
-                --restore --sign
+                -restore -sign
                 ${{ parameters.extraBuildArgs }}
                 -projects $(Build.SourcesDirectory)/src/Aspire.Managed/Aspire.Managed.csproj
                 /bl:$(Build.Arcade.LogsPath)SignManaged.binlog
@@ -127,9 +136,9 @@ jobs:
 
           - script: >-
               $(Build.SourcesDirectory)/$(scriptName)
-              --ci
-              --build
-              --restore
+              -ci
+              -build
+              -restore
               /p:SkipManagedBuild=true
               /p:TargetRids=${{ targetRid }}
               /p:BundlePayloadPath=$(Build.SourcesDirectory)/artifacts/bundle/aspire-ci-bundlepayload-${{ targetRid }}.tar.gz
@@ -141,11 +150,31 @@ jobs:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken) # Needed for the signing task
 
           # Verify the signed CLI archive can execute and create a project.
-          # Run for RIDs that can fully execute on the build agent:
-          #   macOS (Apple Silicon): osx-arm64 only (osx-x64 via Rosetta can run the CLI
-          #     but aspire-managed template resolution fails)
-          #   Linux (amd64): linux-x64 only (linux-arm64/linux-musl-x64 are cross-compiled)
-          - ${{ if or(and(eq(parameters.agentOs, 'macos'), eq(targetRid, 'osx-arm64')), and(eq(parameters.agentOs, 'linux'), eq(targetRid, 'linux-x64'))) }}:
+          # Only runs when the target RID architecture matches the build agent
+          # (i.e. the binary can execute natively without emulation).
+          - ${{ if eq(parameters.agentOs, 'windows') }}:
+            - pwsh: |
+                $ErrorActionPreference = 'Stop'
+                Write-Host "Finding CLI archive for ${{ targetRid }}..."
+                $archiveDir = "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
+                $archive = Get-ChildItem -Path $archiveDir -Filter "aspire-cli-${{ targetRid }}-*.zip" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+                if (-not $archive) {
+                  Write-Host "##[error]No CLI archive found for ${{ targetRid }}"
+                  exit 1
+                }
+                Write-Host "Found archive: $($archive.FullName)"
+                & "$(Build.SourcesDirectory)/eng/scripts/verify-cli-archive.ps1" -ArchivePath $archive.FullName
+                if ($LASTEXITCODE -ne 0) {
+                  Write-Host "##[error]CLI archive verification failed"
+                  exit 1
+                }
+              displayName: 🟣Verify CLI archive (${{ targetRid }})
+              condition: and(succeeded(), eq(variables['Agent.OSArchitecture'], variables['_ridAgentArch']))
+              env:
+                ASPIRE_CLI_TELEMETRY_OPTOUT: 'true'
+                DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+
+          - ${{ if ne(parameters.agentOs, 'windows') }}:
             - script: |
                 set -euo pipefail
                 echo "Finding CLI archive for ${{ targetRid }}..."
@@ -158,7 +187,7 @@ jobs:
                 chmod +x "$(Build.SourcesDirectory)/eng/scripts/verify-cli-archive.sh"
                 "$(Build.SourcesDirectory)/eng/scripts/verify-cli-archive.sh" "$ARCHIVE"
               displayName: 🟣Verify CLI archive (${{ targetRid }})
-              condition: succeeded()
+              condition: and(succeeded(), eq(variables['Agent.OSArchitecture'], variables['_ridAgentArch']))
               env:
                 ASPIRE_CLI_TELEMETRY_OPTOUT: 'true'
                 DOTNET_CLI_TELEMETRY_OPTOUT: 'true'


### PR DESCRIPTION
## Description

Move the Windows CLI NativeAOT compilation and signing from the main Windows build job (`BuildAndTest.yml`) into the `build_sign_native` template, matching how macOS and Linux native builds already work. This lets Windows native builds run in parallel with the managed build instead of serializing inside the main job.

### Changes

- Add `eng/clipack` projects for `win-x64` and `win-arm64` with PE machine type validation
- Add PE header validation target in `Common.projitems` for Windows binaries
- Add Windows entry in `build_sign_native` stage (both official and unofficial pipelines)
- Remove `targetRids` parameter and per-RID aspire-managed publish/sign loop from `BuildAndTest.yml` (now handled by `build_sign_native`)
- Pass `SkipNativeBuild=true` in the main build since native work moves to the dedicated stage
- Fix build script flag style (`--sign` → `-sign`, `--ci` → `-ci`) in `build_sign_native` for consistency
- Add Windows CLI archive verification in `build_sign_native`
- Unify Windows/Unix steps in GitHub Actions workflow using platform detection

### Motivation

Previously, the main Windows build job was responsible for both managed package builds and Windows-specific NativeAOT compilation. This serialized two independent concerns, making the pipeline slower than necessary. macOS and Linux already used the `build_sign_native` template for their native builds — this PR brings Windows in line.

This is a prerequisite cleanup for a follow-up PR that will add CLI dotnet-tool NativeAOT packaging through the same `build_sign_native` infrastructure.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
