### PR TITLE
Improve NuGetPackagePrefetcher cancellation logging

### DIFF
--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -24,25 +24,29 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
         if (shouldPrefetchTemplates)
         {
             _ = Task.Run(async () =>
-             {
-                 try
-                 {
-                     var channels = await packagingService.GetChannelsAsync(stoppingToken);
+            {
+                try
+                {
+                    var channels = await packagingService.GetChannelsAsync(stoppingToken);
 
-                     foreach (var channel in channels)
-                     {
-                         // Discard the results here, we just want them in the cache.
-                         _ = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, stoppingToken);
-                     }
-                 }
-                 catch (System.Exception ex)
-                 {
-                     logger.LogDebug(ex, "Non-fatal error while prefetching template packages. This is not critical to the operation of the CLI.");
-                     // This prefetching is best effort. If it fails we log (above) and then the
-                     // background service will exit gracefully. Code paths that depend on this
-                     // data will handle the absence of pre-fetched packages gracefully.
-                 }
-             }, stoppingToken);
+                    foreach (var channel in channels)
+                    {
+                        // Discard the results here, we just want them in the cache.
+                        _ = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, stoppingToken);
+                    }
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    logger.LogTrace("Template package prefetching was cancelled because the CLI is shutting down.");
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Non-fatal error while prefetching template packages. This is not critical to the operation of the CLI.");
+                    // This prefetching is best effort. If it fails we log (above) and then the
+                    // background service will exit gracefully. Code paths that depend on this
+                    // data will handle the absence of pre-fetched packages gracefully.
+                }
+            }, stoppingToken);
         }
 
         // Prefetch CLI packages if needed
@@ -59,7 +63,11 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
                             cancellationToken: stoppingToken
                             );
                     }
-                    catch (System.Exception ex)
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        logger.LogTrace("CLI package prefetching was cancelled because the CLI is shutting down.");
+                    }
+                    catch (Exception ex)
                     {
                         logger.LogDebug(ex, "Non-fatal error while prefetching CLI packages. This is not critical to the operation of the CLI.");
                     }

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Diagnostics;
 using Aspire.Cli.Commands;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.AspNetCore.InternalTesting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Cli.Tests.NuGet;
@@ -82,21 +82,33 @@ public class NuGetPackagePrefetcherTests
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.UpdateNotificationsEnabled, true);
 
+        // Async barrier: each callback signals arrival, then waits for the other before cancelling.
+        // This ensures both Task.Run calls have started before either cancels the token.
+        var templateArrived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cliArrived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _ = Task.Run(async () =>
+        {
+            await Task.WhenAll(templateArrived.Task, cliArrived.Task);
+            stoppingCts.Cancel();
+        });
+
         var packagingService = new TestPackagingService
         {
-            GetChannelsAsyncCallback = _ =>
+            GetChannelsAsyncCallback = async _ =>
             {
-                stoppingCts.Cancel();
-                throw new OperationCanceledException(stoppingCts.Token);
+                templateArrived.SetResult();
+                await AsyncTestHelpers.WaitForCancellationAsync(stoppingCts.Token);
+                throw new UnreachableException();
             }
         };
 
         var updateNotifier = new TestCliUpdateNotifier
         {
-            CheckForCliUpdatesAsyncCallback = (_, _) =>
+            CheckForCliUpdatesAsyncCallback = async (_, _) =>
             {
-                stoppingCts.Cancel();
-                throw new OperationCanceledException(stoppingCts.Token);
+                cliArrived.SetResult();
+                await AsyncTestHelpers.WaitForCancellationAsync(stoppingCts.Token);
             }
         };
 
@@ -137,7 +149,6 @@ public class NuGetPackagePrefetcherTests
         var sink = new TestSink();
         var logger = new TestLogger<NuGetPackagePrefetcher>(new TestLoggerFactory(sink, enabled: true));
 
-        using var stoppingCts = new CancellationTokenSource();
         var executionContext = CreateExecutionContext();
         executionContext.CommandSelected.TrySetResult(new TestCommand("new"));
 
@@ -165,10 +176,10 @@ public class NuGetPackagePrefetcherTests
             packagingService,
             new TestCliUpdateNotifier());
 
-        await prefetcher.StartAsync(stoppingCts.Token);
+        await prefetcher.StartAsync(CancellationToken.None);
 
         // This will timeout if the expected log messages are not produced.
-        await errorTcs.Task.DefaultTimeout();
+        await errorTcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
         await prefetcher.StopAsync(CancellationToken.None);
     }

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -135,12 +135,12 @@ public class NuGetPackagePrefetcherTests
             packagingService,
             updateNotifier);
 
-        await prefetcher.StartAsync(stoppingCts.Token);
+        await prefetcher.StartAsync(stoppingCts.Token).DefaultTimeout();
 
         // This will timeout if the expected log messages are not produced.
         await Task.WhenAll(templateTcs.Task, cliTcs.Task).DefaultTimeout();
 
-        await prefetcher.StopAsync(CancellationToken.None);
+        await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
     }
 
     [Fact]
@@ -176,12 +176,12 @@ public class NuGetPackagePrefetcherTests
             packagingService,
             new TestCliUpdateNotifier());
 
-        await prefetcher.StartAsync(CancellationToken.None);
+        await prefetcher.StartAsync(CancellationToken.None).DefaultTimeout();
 
         // This will timeout if the expected log messages are not produced.
-        await errorTcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        await errorTcs.Task.DefaultTimeout();
 
-        await prefetcher.StopAsync(CancellationToken.None);
+        await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
     }
 
     private static CliExecutionContext CreateExecutionContext()

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -4,6 +4,10 @@
 using System.CommandLine;
 using Aspire.Cli.Commands;
 using Aspire.Cli.NuGet;
+using Aspire.Cli.Tests.TestServices;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Cli.Tests.NuGet;
 
@@ -63,6 +67,124 @@ public class NuGetPackagePrefetcherTests
         
         Assert.True(testCommandWithInterface.PrefetchesTemplatePackageMetadata);
         Assert.True(testCommandWithInterface.PrefetchesCliPackageMetadata);
+    }
+
+    [Fact]
+    public async Task PrefetchingCancellationDueToShutdownLogsCleanMessage()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger<NuGetPackagePrefetcher>(new TestLoggerFactory(sink, enabled: true));
+
+        using var stoppingCts = new CancellationTokenSource();
+        var executionContext = CreateExecutionContext();
+        executionContext.CommandSelected.TrySetResult(new TestCommand("new"));
+
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.UpdateNotificationsEnabled, true);
+
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                stoppingCts.Cancel();
+                throw new OperationCanceledException(stoppingCts.Token);
+            }
+        };
+
+        var updateNotifier = new TestCliUpdateNotifier
+        {
+            CheckForCliUpdatesAsyncCallback = (_, _) =>
+            {
+                stoppingCts.Cancel();
+                throw new OperationCanceledException(stoppingCts.Token);
+            }
+        };
+
+        // Wait for both cancellation messages to appear in the sink.
+        var templateTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cliTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        sink.MessageLogged += context =>
+        {
+            if (context.Message?.Contains("Template package prefetching was cancelled") == true)
+            {
+                templateTcs.TrySetResult();
+            }
+            if (context.Message?.Contains("CLI package prefetching was cancelled") == true)
+            {
+                cliTcs.TrySetResult();
+            }
+        };
+
+        var prefetcher = new NuGetPackagePrefetcher(
+            logger,
+            executionContext,
+            features,
+            packagingService,
+            updateNotifier);
+
+        await prefetcher.StartAsync(stoppingCts.Token);
+
+        // This will timeout if the expected log messages are not produced.
+        await Task.WhenAll(templateTcs.Task, cliTcs.Task).DefaultTimeout();
+
+        await prefetcher.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task TemplatePrefetchingNonCancellationExceptionLogsExceptionDetails()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger<NuGetPackagePrefetcher>(new TestLoggerFactory(sink, enabled: true));
+
+        using var stoppingCts = new CancellationTokenSource();
+        var executionContext = CreateExecutionContext();
+        executionContext.CommandSelected.TrySetResult(new TestCommand("new"));
+
+        var ex = new InvalidOperationException("Something went wrong");
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ => throw ex
+        };
+
+        // Wait for the error message to appear in the sink.
+        var errorTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        sink.MessageLogged += context =>
+        {
+            if (context.Exception == ex)
+            {
+                errorTcs.TrySetResult();
+            }
+        };
+
+        var prefetcher = new NuGetPackagePrefetcher(
+            logger,
+            executionContext,
+            new TestFeatures(),
+            packagingService,
+            new TestCliUpdateNotifier());
+
+        await prefetcher.StartAsync(stoppingCts.Token);
+
+        // This will timeout if the expected log messages are not produced.
+        await errorTcs.Task.DefaultTimeout();
+
+        await prefetcher.StopAsync(CancellationToken.None);
+    }
+
+    private static CliExecutionContext CreateExecutionContext()
+    {
+        var workingDir = new DirectoryInfo(Environment.CurrentDirectory);
+        var hivesDir = new DirectoryInfo(Path.Combine(Environment.CurrentDirectory, "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(workingDir.FullName, ".aspire", "cache"));
+        return new CliExecutionContext(
+            workingDir,
+            hivesDir,
+            cacheDir,
+            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
+            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")),
+            "test.log");
     }
 }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestCliUpdateNotifier.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCliUpdateNotifier.cs
@@ -11,8 +11,15 @@ internal sealed class TestCliUpdateNotifier : ICliUpdateNotifier
 
     public Func<bool>? IsUpdateAvailableCallback { get; set; }
 
+    public Func<DirectoryInfo, CancellationToken, Task>? CheckForCliUpdatesAsyncCallback { get; set; }
+
     public Task CheckForCliUpdatesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
     {
+        if (CheckForCliUpdatesAsyncCallback is not null)
+        {
+            return CheckForCliUpdatesAsyncCallback(workingDirectory, cancellationToken);
+        }
+
         return Task.CompletedTask;
     }
 

--- a/tests/Shared/AsyncTestHelpers.cs
+++ b/tests/Shared/AsyncTestHelpers.cs
@@ -237,4 +237,13 @@ internal static class AsyncTestHelpers
 
         throw new InvalidOperationException($"Assert failed after {retries} retries: {message}");
     }
+
+    public static Task WaitForCancellationAsync(CancellationToken token)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        token.Register(() => tcs.SetCanceled(token));
+
+        return tcs.Task;
+    }
 }


### PR DESCRIPTION
## Description

When the CLI shuts down quickly (e.g. `aspire otel traces` with no running AppHost), the `NuGetPackagePrefetcher` background service logs verbose `OperationCanceledException` / `TaskCanceledException` stack traces. These are expected cancellations due to shutdown, not real errors.

This change:
- Adds `catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)` blocks to both template and CLI package prefetch paths, logging a clean trace-level message instead of the full exception stack trace.
- Non-cancellation exceptions still log at debug level with full exception details.
- Adds `CheckForCliUpdatesAsyncCallback` to `TestCliUpdateNotifier` for testability.
- Adds unit tests verifying both cancellation and non-cancellation error logging behavior.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
