### PR TITLE
Use CheckMarkButton emoji instead of CheckMark for consistent green rendering

### DIFF
--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -234,7 +234,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
                         foreach (var mcp in mcpApplicators)
                         {
                             await mcp.ApplyAsync(ct);
-                            _interactionService.DisplayMessage(KnownEmojis.CheckMark, mcp.Description);
+                            _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, mcp.Description);
                         }
                     },
                     promptGroup: McpInitPromptGroup.AdditionalOptions);
@@ -318,7 +318,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
                 switch (status)
                 {
                     case PlaywrightInstallStatus.Installed:
-                        _interactionService.DisplayMessage(KnownEmojis.CheckMark, AgentCommandStrings.InitCommand_InstalledPlaywrightCli);
+                        _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, AgentCommandStrings.InitCommand_InstalledPlaywrightCli);
                         break;
                     case PlaywrightInstallStatus.InstalledWithWarnings:
                         _interactionService.DisplayMessage(KnownEmojis.Warning, message!);
@@ -428,7 +428,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
                 .Replace(Path.DirectorySeparatorChar, '/')
                 .Replace(Path.AltDirectorySeparatorChar, '/');
             var displayPath = isUserLevel ? $"~/{displayRelativeSkillPath}" : displayRelativeSkillPath;
-            _interactionService.DisplayMessage(KnownEmojis.CheckMark,
+            _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton,
                 string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_InstalledSkill, skill.Name, displayPath));
             return true;
         }

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -177,7 +177,7 @@ internal sealed class DoctorCommand : BaseCommand
     {
         return status switch
         {
-            EnvironmentCheckStatus.Pass => (KnownEmojis.CheckMark, "green"),
+            EnvironmentCheckStatus.Pass => (KnownEmojis.CheckMarkButton, "green"),
             EnvironmentCheckStatus.Warning => (KnownEmojis.Warning, "yellow"),
             EnvironmentCheckStatus.Fail => (KnownEmojis.CrossMark, "red"),
             _ => (KnownEmojis.Information, "grey")

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -235,7 +235,7 @@ internal sealed class ExportCommand : BaseCommand
         var fullPath = Path.GetFullPath(outputPath);
         exportArchive.WriteToFile(fullPath);
 
-        _interactionService.DisplayMessage(KnownEmojis.CheckMark, string.Format(CultureInfo.CurrentCulture, ExportCommandStrings.ExportComplete, fullPath));
+        _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, ExportCommandStrings.ExportComplete, fullPath));
         return ExitCodeConstants.Success;
     }
 

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -258,7 +258,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         if (initContext.AlreadyHasAppHost)
         {
-            InteractionService.DisplayMessage(KnownEmojis.CheckMark, InitCommandStrings.SolutionAlreadyInitialized);
+            InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, InitCommandStrings.SolutionAlreadyInitialized);
             return ExitCodeConstants.Success;
         }
 
@@ -595,7 +595,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             var appHostPath = Path.Combine(workingDirectory.FullName, appHostFileName);
             if (File.Exists(appHostPath))
             {
-                InteractionService.DisplayMessage(KnownEmojis.CheckMark, $"{appHostFileName} already exists in this directory.");
+                InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"{appHostFileName} already exists in this directory.");
                 return ExitCodeConstants.Success;
             }
         }

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -326,7 +326,7 @@ internal sealed class RenderCommand : BaseCommand
             binding: PromptBinding.CreateDefault<string?>("hello"),
             cancellationToken: cancellationToken);
 
-        InteractionService.DisplayMessage(KnownEmojis.CheckMark, $"You entered: {name}");
+        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"You entered: {name}");
 
         var confirmed = await InteractionService.PromptConfirmAsync(
             "Do you want to continue?",

--- a/src/Aspire.Cli/Commands/SetupCommand.cs
+++ b/src/Aspire.Cli/Commands/SetupCommand.cs
@@ -85,11 +85,11 @@ internal sealed class SetupCommand : BaseCommand
                 break;
 
             case BundleExtractResult.AlreadyUpToDate:
-                InteractionService.DisplayMessage(KnownEmojis.CheckMark, "Bundle is already extracted and up to date. Use --force to re-extract.");
+                InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Bundle is already extracted and up to date. Use --force to re-extract.");
                 break;
 
             case BundleExtractResult.Extracted:
-                InteractionService.DisplayMessage(KnownEmojis.CheckMark, $"Bundle extracted to {installPath}");
+                InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Bundle extracted to {installPath}");
                 break;
 
             case BundleExtractResult.ExtractionFailed:

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -419,7 +419,7 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
     {
-        DisplayMessage(KnownEmojis.CheckMark, message, allowMarkup);
+        DisplayMessage(KnownEmojis.CheckMarkButton, message, allowMarkup);
     }
 
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -30,7 +30,6 @@ internal readonly struct KnownEmoji(string name, string? textColor = null)
 internal static class KnownEmojis
 {
     public static readonly KnownEmoji Bug = new("bug", "red");
-    public static readonly KnownEmoji CheckMark = new("check_mark", "green");
     public static readonly KnownEmoji CheckMarkButton = new("check_mark_button", "green");
     public static readonly KnownEmoji CrossMark = new("cross_mark", "red");
     public static readonly KnownEmoji FileFolder = new("file_folder", "yellow");

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1190,7 +1190,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
         if (updates.Count == 0 && newSdkVersion is null)
         {
-            _interactionService.DisplayMessage(KnownEmojis.CheckMark, UpdateCommandStrings.ProjectUpToDateMessage);
+            _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, UpdateCommandStrings.ProjectUpToDateMessage);
             return new UpdatePackagesResult { UpdatesApplied = false };
         }
 

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -135,7 +135,7 @@ internal sealed class LanguageService : ILanguageService
         if (saveSelection)
         {
             await SetLanguageAsync(selectedLanguage.LanguageId, isGlobal: false, cancellationToken);
-            _interactionService.DisplayMessage(KnownEmojis.CheckMark, $"Language preference saved to local configuration: {selectedProject.DisplayName}");
+            _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Language preference saved to local configuration: {selectedProject.DisplayName}");
         }
 
         return selectedProject;

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -36,7 +36,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         if (!updateSteps.Any())
         {
             logger.LogInformation("No updates required for project: {ProjectFile}", projectFile.FullName);
-            interactionService.DisplayMessage(KnownEmojis.CheckMark, UpdateCommandStrings.ProjectUpToDateMessage);
+            interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, UpdateCommandStrings.ProjectUpToDateMessage);
             return new ProjectUpdateResult { UpdatedApplied = false };
         }
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -121,7 +121,7 @@ internal sealed partial class CliTemplateFactory
 
         if (useLocalhostTld)
         {
-            _interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
+            _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
         }
 
         return useLocalhostTld;

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -134,7 +134,7 @@ internal sealed partial class CliTemplateFactory
 
         if (useRedisCache)
         {
-            _interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseRedisCache_UsingRedisCache);
+            _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, TemplatingStrings.UseRedisCache_UsingRedisCache);
         }
 
         return useRedisCache;

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -301,7 +301,7 @@ internal class DotNetTemplateFactory(
 
         if (string.Equals(selected, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput))
         {
-            interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
+            interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
             extraArgs.Add("--localhost-tld");
         }
     }
@@ -319,7 +319,7 @@ internal class DotNetTemplateFactory(
 
         if (string.Equals(selected, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput))
         {
-            interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseRedisCache_UsingRedisCache);
+            interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, TemplatingStrings.UseRedisCache_UsingRedisCache);
             extraArgs.Add("--use-redis-cache");
         }
     }
@@ -362,7 +362,7 @@ internal class DotNetTemplateFactory(
                 await PromptForXUnitVersionOptionsAsync(result, extraArgs, cancellationToken);
             }
 
-            interactionService.DisplayMessage(KnownEmojis.CheckMark, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.PromptForTFM_UsingForTesting, testFramework));
+            interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.PromptForTFM_UsingForTesting, testFramework));
 
             extraArgs.Add("--test-framework");
             extraArgs.Add(testFramework);

--- a/src/Aspire.Cli/Utils/CliDownloader.cs
+++ b/src/Aspire.Cli/Utils/CliDownloader.cs
@@ -76,7 +76,7 @@ internal class CliDownloader(
             });
 
             // Validate checksum
-            interactionService.DisplayMessage(KnownEmojis.CheckMark, "Validating downloaded file...");
+            interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Validating downloaded file...");
             await ValidateChecksumAsync(archivePath, checksumPath, cancellationToken);
 
             interactionService.DisplaySuccess("Download completed successfully");


### PR DESCRIPTION
## Description

Replace all usages of `KnownEmojis.CheckMark` (`check_mark` / U+2714) with `KnownEmojis.CheckMarkButton` (`check_mark_button` / U+2705) in the Aspire CLI, and remove the now-unused `CheckMark` field.

**Motivation:** The `check_mark` emoji (✔️) renders as purple/blue on Windows terminals because the Segoe UI Emoji font bakes that color into the glyph. Most other platforms also render it as purple/black. See https://emojipedia.org/check-mark#designs

The ANSI `green` foreground color set via `TextColor` is ignored when the terminal renders full-color emoji. In contrast, `check_mark_button` (✅) embeds green in the emoji itself and renders consistently across all platforms.

**Before:**

doctor:
<img width="781" height="322" alt="image" src="https://github.com/user-attachments/assets/631a8e03-b7d9-4e83-bf79-72af2dd44296" />

new:
<img width="1085" height="333" alt="image" src="https://github.com/user-attachments/assets/38ddb453-0098-4f41-ac77-1213398ee655" />

---

**After:**

docter:
<img width="775" height="278" alt="image" src="https://github.com/user-attachments/assets/3308841e-e0e7-4f58-bcc7-279f9672d97d" />

new:
<img width="1093" height="318" alt="image" src="https://github.com/user-attachments/assets/46597d24-852c-4fd9-b157-b3721db2e903" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
