### PR TITLE
Fix OTLP JSON deserialization of numeric histogram bucketCounts

### DIFF
--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -584,7 +584,7 @@ public sealed class TelemetryExportService
                     TimeUnixNano = OtlpHelpers.DateTimeToUnixNanoseconds(value.End),
                     Count = histogramValue.Count,
                     Sum = histogramValue.Sum,
-                    BucketCounts = histogramValue.Values.Select(v => v.ToString(CultureInfo.InvariantCulture)).ToArray(),
+                    BucketCounts = histogramValue.Values,
                     ExplicitBounds = histogramValue.ExplicitBounds,
                     Exemplars = value.HasExemplars ? ConvertExemplars(value.Exemplars) : null
                 };

--- a/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpJsonProtobufConverter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpJsonProtobufConverter.cs
@@ -566,7 +566,7 @@ internal static class OtlpJsonToProtobufConverter
         {
             foreach (var bc in json.BucketCounts)
             {
-                dataPoint.BucketCounts.Add(ulong.Parse(bc, System.Globalization.CultureInfo.InvariantCulture));
+                dataPoint.BucketCounts.Add(bc);
             }
         }
         if (json.ExplicitBounds is not null)
@@ -662,7 +662,7 @@ internal static class OtlpJsonToProtobufConverter
         {
             foreach (var bc in json.BucketCounts)
             {
-                buckets.BucketCounts.Add(ulong.Parse(bc, System.Globalization.CultureInfo.InvariantCulture));
+                buckets.BucketCounts.Add(bc);
             }
         }
         return buckets;

--- a/src/Shared/Otlp/Serialization/OtlpMetricsJson.cs
+++ b/src/Shared/Otlp/Serialization/OtlpMetricsJson.cs
@@ -289,10 +289,11 @@ internal sealed class OtlpHistogramDataPointJson
     public double? Sum { get; set; }
 
     /// <summary>
-    /// Bucket counts for each bucket.
+    /// Bucket counts for each bucket. Serialized as strings per protojson spec for uint64.
     /// </summary>
     [JsonPropertyName("bucketCounts")]
-    public string[]? BucketCounts { get; set; }
+    [JsonNumberHandling(JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString)]
+    public ulong[]? BucketCounts { get; set; }
 
     /// <summary>
     /// Explicit bucket boundaries.
@@ -439,7 +440,8 @@ internal sealed class OtlpExponentialHistogramBucketsJson
     /// An array of count values. Serialized as strings per protojson spec for uint64.
     /// </summary>
     [JsonPropertyName("bucketCounts")]
-    public string[]? BucketCounts { get; set; }
+    [JsonNumberHandling(JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString)]
+    public ulong[]? BucketCounts { get; set; }
 }
 
 /// <summary>

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpJsonTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpJsonTests.cs
@@ -7,6 +7,7 @@ using Aspire.Dashboard.Authentication.OtlpApiKey;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Http;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Hosting;
 using Aspire.Otlp.Serialization;
@@ -259,6 +260,101 @@ public class OtlpHttpJsonTests
                             }
                           ]
                         }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// Metrics JSON with histogram bucketCounts as numbers instead of strings.
+    /// Some OTLP exporters send small uint64 values as JSON numbers rather than strings,
+    /// even though the protojson spec requires string encoding for uint64 fields.
+    /// </summary>
+    private const string MetricsJsonWithNumericBucketCounts = """
+        {
+          "resourceMetrics": [
+            {
+              "resource": {
+                "attributes": [
+                  {
+                    "key": "service.name",
+                    "value": {
+                      "stringValue": "copilot-chat"
+                    }
+                  }
+                ]
+              },
+              "scopeMetrics": [
+                {
+                  "scope": {
+                    "name": "copilot-chat",
+                    "version": "0.45.2026042102"
+                  },
+                  "metrics": [
+                    {
+                      "name": "copilot_chat.tool.call.duration",
+                      "description": "",
+                      "unit": "",
+                      "histogram": {
+                        "aggregationTemporality": 2,
+                        "dataPoints": [
+                          {
+                            "attributes": [
+                              {
+                                "key": "gen_ai.tool.name",
+                                "value": {
+                                  "stringValue": "manage_todo_list"
+                                }
+                              }
+                            ],
+                            "bucketCounts": [
+                              0,
+                              2,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0
+                            ],
+                            "explicitBounds": [
+                              0,
+                              5,
+                              10,
+                              25,
+                              50,
+                              75,
+                              100,
+                              250,
+                              500,
+                              750,
+                              1000,
+                              2500,
+                              5000,
+                              7500,
+                              10000
+                            ],
+                            "count": 2,
+                            "sum": 5,
+                            "min": 2,
+                            "max": 3,
+                            "startTimeUnixNano": "1776863423819000000",
+                            "timeUnixNano": "1776864142921000000"
+                          }
+                        ]
                       }
                     }
                   ]
@@ -637,6 +733,91 @@ public class OtlpHttpJsonTests
                 Assert.Equal("I am a Histogram", histogram.Description);
                 Assert.Equal("1", histogram.Unit);
             });
+    }
+
+    [Fact]
+    public async Task CallService_Metrics_NumericBucketCounts_Success()
+    {
+        // Arrange
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper);
+        await app.StartAsync().DefaultTimeout();
+
+        using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
+
+        var content = new StringContent(MetricsJsonWithNumericBucketCounts, Encoding.UTF8, OtlpHttpEndpointsBuilder.JsonContentType);
+
+        // Act
+        var responseMessage = await httpClient.PostAsync("/v1/metrics", content).DefaultTimeout();
+        responseMessage.EnsureSuccessStatusCode();
+
+        // Assert
+        Assert.Equal(OtlpHttpEndpointsBuilder.JsonContentType, responseMessage.Content.Headers.ContentType?.MediaType);
+
+        var responseBody = await responseMessage.Content.ReadAsStringAsync().DefaultTimeout();
+        Assert.NotNull(responseBody);
+
+        var response = System.Text.Json.JsonSerializer.Deserialize(responseBody, OtlpJsonSerializerContext.Default.OtlpExportMetricsServiceResponseJson);
+        Assert.NotNull(response);
+
+        var telemetryRepository = app.Services.GetRequiredService<TelemetryRepository>();
+        var resources = telemetryRepository.GetResourcesByName("copilot-chat");
+        var resource = Assert.Single(resources);
+
+        var instruments = resource.GetInstrumentsSummary();
+        var summary = Assert.Single(instruments);
+        Assert.Equal("copilot_chat.tool.call.duration", summary.Name);
+
+        var instrumentData = telemetryRepository.GetInstrument(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            InstrumentName = "copilot_chat.tool.call.duration",
+            MeterName = "copilot-chat",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        });
+        Assert.NotNull(instrumentData);
+
+        var dimension = Assert.Single(instrumentData.Dimensions);
+        var metricValue = Assert.Single(dimension.Values);
+        var histogramValue = Assert.IsType<HistogramValue>(metricValue);
+
+        Assert.Equal(2UL, histogramValue.Count);
+        Assert.Equal(5.0, histogramValue.Sum);
+
+        Assert.Collection(histogramValue.ExplicitBounds,
+            b => Assert.Equal(0, b),
+            b => Assert.Equal(5, b),
+            b => Assert.Equal(10, b),
+            b => Assert.Equal(25, b),
+            b => Assert.Equal(50, b),
+            b => Assert.Equal(75, b),
+            b => Assert.Equal(100, b),
+            b => Assert.Equal(250, b),
+            b => Assert.Equal(500, b),
+            b => Assert.Equal(750, b),
+            b => Assert.Equal(1000, b),
+            b => Assert.Equal(2500, b),
+            b => Assert.Equal(5000, b),
+            b => Assert.Equal(7500, b),
+            b => Assert.Equal(10000, b));
+
+        Assert.Collection(histogramValue.Values,
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(2UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c),
+            c => Assert.Equal(0UL, c));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Some OTLP exporters (e.g. VS Code Copilot Chat) send histogram `bucketCounts` as JSON numbers (`[0, 2, 0, ...]`) instead of strings (`["0", "2", "0", ...]`). While the protojson spec requires string encoding for `uint64` fields, many exporters emit small values as bare numbers. This causes a `JsonException` in the Dashboard:

```
The JSON value could not be converted to System.String.
Path: $.resourceMetrics[0].scopeMetrics[0].metrics[2].histogram.dataPoints[0].bucketCounts[0]
```

### Changes

The fix changes `BucketCounts` from `string[]` to `ulong[]` with `[JsonNumberHandling(WriteAsString | AllowReadingFromString)]`, matching the pattern already used by `Count`, `TimeUnixNano`, and other `uint64` properties in the same file. This lets `System.Text.Json` handle both string and number tokens natively.

- **`OtlpMetricsJson.cs`** — `BucketCounts` on `OtlpHistogramDataPointJson` and `OtlpExponentialHistogramBucketsJson` changed from `string[]` to `ulong[]` with `JsonNumberHandling` attribute.
- **`OtlpJsonProtobufConverter.cs`** — removed `ulong.Parse()` calls, values are now added directly.
- **`TelemetryExportService.cs`** — removed `.Select(v => v.ToString(...)).ToArray()`, assigns `ulong[]` directly.
- **`OtlpHttpJsonTests.cs`** — added `CallService_Metrics_NumericBucketCounts_Success` integration test that posts metrics JSON with numeric bucket counts and asserts histogram data (bounds + counts) is deserialized correctly end-to-end.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
