### PR TITLE
Harden bundled CLI layout recovery, diagnostics, and lock handling

### DIFF
--- a/src/Aspire.Cli/Bundles/BundleLayoutRepairHelper.cs
+++ b/src/Aspire.Cli/Bundles/BundleLayoutRepairHelper.cs
@@ -47,12 +47,38 @@ internal static class BundleLayoutRepairHelper
         managedPath ??= await EnsureManagedToolPathAsync(bundleService, logger, operationName, cancellationToken).ConfigureAwait(false);
         var bundleRoot = GetBundleRootFromManagedPath(managedPath);
 
-        var (exitCode, output, error) = await processRunner.RunAsync(
-            managedPath,
-            arguments,
-            workingDirectory: workingDirectory,
-            environmentVariables: environmentVariables,
-            ct: cancellationToken).ConfigureAwait(false);
+        (int exitCode, string output, string error) result;
+
+        try
+        {
+            result = await processRunner.RunAsync(
+                managedPath,
+                arguments,
+                workingDirectory: workingDirectory,
+                environmentVariables: environmentVariables,
+                ct: cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            if (!ShouldRepairAfterManagedToolStartFailure(ex, bundleRoot) ||
+                !await TryRepairAsync(bundleService, logger, operationName, cancellationToken, bundleRoot).ConfigureAwait(false))
+            {
+                throw;
+            }
+
+            managedPath = await EnsureManagedToolPathAsync(bundleService, logger, operationName, cancellationToken, allowRepair: false, bundleRoot).ConfigureAwait(false);
+            bundleRoot = GetBundleRootFromManagedPath(managedPath);
+            logger.LogWarning("Retrying {OperationName} after repairing the bundled layout.", operationName);
+
+            result = await processRunner.RunAsync(
+                managedPath,
+                arguments,
+                workingDirectory: workingDirectory,
+                environmentVariables: environmentVariables,
+                ct: cancellationToken).ConfigureAwait(false);
+        }
+
+        var (exitCode, output, error) = result;
 
         if (exitCode == 0 || !BundleService.LooksLikeBundleCorruption(error: error, output: output, bundleRoot: bundleRoot))
         {
@@ -117,5 +143,11 @@ internal static class BundleLayoutRepairHelper
     {
         var managedDirectory = Path.GetDirectoryName(managedPath);
         return string.IsNullOrEmpty(managedDirectory) ? null : Path.GetDirectoryName(managedDirectory);
+    }
+
+    private static bool ShouldRepairAfterManagedToolStartFailure(InvalidOperationException exception, string? bundleRoot)
+    {
+        return exception.Message.StartsWith("Failed to start process:", StringComparison.Ordinal)
+            && BundleService.LooksLikeBundleCorruption(exception: exception, bundleRoot: bundleRoot);
     }
 }

--- a/src/Aspire.Cli/Bundles/BundleLayoutRepairHelper.cs
+++ b/src/Aspire.Cli/Bundles/BundleLayoutRepairHelper.cs
@@ -60,7 +60,7 @@ internal static class BundleLayoutRepairHelper
         }
         catch (InvalidOperationException ex)
         {
-            if (!ShouldRepairAfterManagedToolStartFailure(ex, bundleRoot) ||
+            if (!ShouldRepairAfterManagedToolStartFailure(bundleService, ex, bundleRoot) ||
                 !await TryRepairAsync(bundleService, logger, operationName, cancellationToken, bundleRoot).ConfigureAwait(false))
             {
                 throw;
@@ -80,7 +80,7 @@ internal static class BundleLayoutRepairHelper
 
         var (exitCode, output, error) = result;
 
-        if (exitCode == 0 || !BundleService.LooksLikeBundleCorruption(error: error, output: output, bundleRoot: bundleRoot))
+        if (exitCode == 0 || !bundleService.GetLayoutState(bundleRoot).IsIncompleteLayout)
         {
             return (managedPath, exitCode, output, error);
         }
@@ -145,9 +145,9 @@ internal static class BundleLayoutRepairHelper
         return string.IsNullOrEmpty(managedDirectory) ? null : Path.GetDirectoryName(managedDirectory);
     }
 
-    private static bool ShouldRepairAfterManagedToolStartFailure(InvalidOperationException exception, string? bundleRoot)
+    private static bool ShouldRepairAfterManagedToolStartFailure(IBundleService bundleService, InvalidOperationException exception, string? bundleRoot)
     {
         return exception.Message.StartsWith("Failed to start process:", StringComparison.Ordinal)
-            && BundleService.LooksLikeBundleCorruption(exception: exception, bundleRoot: bundleRoot);
+            && bundleService.GetLayoutState(bundleRoot).IsIncompleteLayout;
     }
 }

--- a/src/Aspire.Cli/Bundles/BundleLayoutRepairHelper.cs
+++ b/src/Aspire.Cli/Bundles/BundleLayoutRepairHelper.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Layout;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Bundles;
+
+internal static class BundleLayoutRepairHelper
+{
+    public static async Task<string> EnsureManagedToolPathAsync(
+        IBundleService bundleService,
+        ILogger logger,
+        string operationName,
+        CancellationToken cancellationToken,
+        bool allowRepair = true,
+        string? bundleRoot = null)
+    {
+        var layout = await bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
+        var managedPath = layout?.GetManagedPath();
+        bundleRoot ??= layout?.LayoutPath;
+
+        if (managedPath is not null && File.Exists(managedPath))
+        {
+            return managedPath;
+        }
+
+        if (allowRepair && await TryRepairAsync(bundleService, logger, operationName, cancellationToken, bundleRoot).ConfigureAwait(false))
+        {
+            return await EnsureManagedToolPathAsync(bundleService, logger, operationName, cancellationToken, allowRepair: false, bundleRoot).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException("aspire-managed not found in layout.");
+    }
+
+    public static async Task<(string ManagedPath, int ExitCode, string Output, string Error)> RunManagedToolWithRepairAsync(
+        IBundleService bundleService,
+        LayoutProcessRunner processRunner,
+        ILogger logger,
+        string operationName,
+        IEnumerable<string> arguments,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        string? managedPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        managedPath ??= await EnsureManagedToolPathAsync(bundleService, logger, operationName, cancellationToken).ConfigureAwait(false);
+        var bundleRoot = GetBundleRootFromManagedPath(managedPath);
+
+        var (exitCode, output, error) = await processRunner.RunAsync(
+            managedPath,
+            arguments,
+            workingDirectory: workingDirectory,
+            environmentVariables: environmentVariables,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        if (exitCode == 0 || !BundleService.LooksLikeBundleCorruption(error: error, output: output, bundleRoot: bundleRoot))
+        {
+            return (managedPath, exitCode, output, error);
+        }
+
+        if (!await TryRepairAsync(bundleService, logger, operationName, cancellationToken, bundleRoot).ConfigureAwait(false))
+        {
+            return (managedPath, exitCode, output, error);
+        }
+
+        managedPath = await EnsureManagedToolPathAsync(bundleService, logger, operationName, cancellationToken, allowRepair: false, bundleRoot).ConfigureAwait(false);
+        logger.LogWarning("Retrying {OperationName} after repairing the bundled layout.", operationName);
+
+        (exitCode, output, error) = await processRunner.RunAsync(
+            managedPath,
+            arguments,
+            workingDirectory: workingDirectory,
+            environmentVariables: environmentVariables,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        return (managedPath, exitCode, output, error);
+    }
+
+    public static async Task<bool> TryRepairAsync(
+        IBundleService bundleService,
+        ILogger logger,
+        string operationName,
+        CancellationToken cancellationToken,
+        string? bundleRoot = null)
+    {
+        if (!bundleService.IsBundle)
+        {
+            return false;
+        }
+
+        var bundleState = bundleService.GetLayoutState(bundleRoot);
+        if (!bundleState.HasKnownLayoutPath)
+        {
+            logger.LogWarning("Unable to repair the bundled layout while {OperationName} because the bundle root could not be determined. {BundleState}",
+                operationName,
+                bundleState.Describe());
+            return false;
+        }
+
+        logger.LogWarning("Detected an incomplete or inconsistent bundled layout while {OperationName}. Attempting forced bundle repair. {BundleState}",
+            operationName,
+            bundleState.Describe());
+
+        var result = await bundleService.RepairAsync(bundleState.LayoutPath, cancellationToken).ConfigureAwait(false);
+        var repairedState = bundleService.GetLayoutState(bundleState.LayoutPath);
+
+        logger.LogInformation("Bundle repair result while {OperationName}: {Result}. {BundleState}",
+            operationName,
+            result,
+            repairedState.Describe());
+
+        return result is BundleExtractResult.Extracted or BundleExtractResult.AlreadyUpToDate;
+    }
+
+    private static string? GetBundleRootFromManagedPath(string managedPath)
+    {
+        var managedDirectory = Path.GetDirectoryName(managedPath);
+        return string.IsNullOrEmpty(managedDirectory) ? null : Path.GetDirectoryName(managedDirectory);
+    }
+}

--- a/src/Aspire.Cli/Bundles/BundleLayoutState.cs
+++ b/src/Aspire.Cli/Bundles/BundleLayoutState.cs
@@ -19,7 +19,7 @@ internal readonly record struct BundleLayoutState(
 
     public bool IsExtractionComplete => !HasExtractionInProgressMarker && HasVersionMarker;
 
-    public bool IsUsableExtractedLayout => !HasExtractionInProgressMarker && (HasVersionMarker || HasRequiredLayoutStructure);
+    public bool IsUsableExtractedLayout => HasRequiredLayoutStructure && !HasExtractionInProgressMarker;
 
     public bool IsIncompleteLayout => HasKnownLayoutPath && (!HasRequiredLayoutStructure || !IsUsableExtractedLayout);
 

--- a/src/Aspire.Cli/Bundles/BundleLayoutState.cs
+++ b/src/Aspire.Cli/Bundles/BundleLayoutState.cs
@@ -31,7 +31,47 @@ internal readonly record struct BundleLayoutState(
                $"ManagedExe={HasManagedExecutable}, " +
                $"DcpDir={HasDcpDirectory}, " +
                $"VersionMarker={HasVersionMarker}, " +
-               $"ExtractionInProgressMarker={HasExtractionInProgressMarker}";
+               $"ExtractionInProgressMarker={HasExtractionInProgressMarker}, " +
+               $"Availability={DescribeAvailability()}";
+    }
+
+    public string DescribeAvailability()
+    {
+        if (!HasKnownLayoutPath)
+        {
+            return "bundle root could not be determined";
+        }
+
+        if (HasExtractionInProgressMarker)
+        {
+            return "layout is marked as extraction in progress";
+        }
+
+        List<string> missingItems = [];
+
+        if (!HasManagedDirectory)
+        {
+            missingItems.Add($"{BundleDiscovery.ManagedDirectoryName}/");
+        }
+
+        if (HasManagedDirectory && !HasManagedExecutable)
+        {
+            missingItems.Add($"{BundleDiscovery.ManagedDirectoryName}/{BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)}");
+        }
+
+        if (!HasDcpDirectory)
+        {
+            missingItems.Add($"{BundleDiscovery.DcpDirectoryName}/");
+        }
+
+        if (missingItems.Count > 0)
+        {
+            return $"layout is missing required content: {string.Join(", ", missingItems)}";
+        }
+
+        return HasVersionMarker
+            ? "layout is complete"
+            : "layout is complete but missing the version marker (legacy layout)";
     }
 
     public static BundleLayoutState Inspect(string? layoutPath)

--- a/src/Aspire.Cli/Bundles/BundleLayoutState.cs
+++ b/src/Aspire.Cli/Bundles/BundleLayoutState.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Shared;
+
+namespace Aspire.Cli.Bundles;
+
+internal readonly record struct BundleLayoutState(
+    string? LayoutPath,
+    bool HasManagedDirectory,
+    bool HasManagedExecutable,
+    bool HasDcpDirectory,
+    bool HasVersionMarker,
+    bool HasExtractionInProgressMarker)
+{
+    public bool HasKnownLayoutPath => !string.IsNullOrEmpty(LayoutPath);
+
+    public bool HasRequiredLayoutStructure => HasManagedDirectory && HasManagedExecutable && HasDcpDirectory;
+
+    public bool IsExtractionComplete => !HasExtractionInProgressMarker && HasVersionMarker;
+
+    public bool IsUsableExtractedLayout => !HasExtractionInProgressMarker && (HasVersionMarker || HasRequiredLayoutStructure);
+
+    public bool IsIncompleteLayout => HasKnownLayoutPath && (!HasRequiredLayoutStructure || !IsUsableExtractedLayout);
+
+    public string Describe()
+    {
+        return $"ProcessPath={Environment.ProcessPath ?? "<null>"}, " +
+               $"BundleRoot={LayoutPath ?? "<unavailable>"}, " +
+               $"ManagedDir={HasManagedDirectory}, " +
+               $"ManagedExe={HasManagedExecutable}, " +
+               $"DcpDir={HasDcpDirectory}, " +
+               $"VersionMarker={HasVersionMarker}, " +
+               $"ExtractionInProgressMarker={HasExtractionInProgressMarker}";
+    }
+
+    public static BundleLayoutState Inspect(string? layoutPath)
+    {
+        if (string.IsNullOrEmpty(layoutPath))
+        {
+            return default;
+        }
+
+        var managedDirectory = Path.Combine(layoutPath, BundleDiscovery.ManagedDirectoryName);
+        var managedPath = Path.Combine(managedDirectory, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        var dcpDirectory = Path.Combine(layoutPath, BundleDiscovery.DcpDirectoryName);
+        var versionMarkerPath = Path.Combine(layoutPath, BundleService.VersionMarkerFileName);
+        var extractionInProgressMarkerPath = Path.Combine(layoutPath, BundleService.ExtractionInProgressMarkerFileName);
+
+        return new BundleLayoutState(
+            LayoutPath: layoutPath,
+            HasManagedDirectory: Directory.Exists(managedDirectory),
+            HasManagedExecutable: File.Exists(managedPath),
+            HasDcpDirectory: Directory.Exists(dcpDirectory),
+            HasVersionMarker: File.Exists(versionMarkerPath),
+            HasExtractionInProgressMarker: File.Exists(extractionInProgressMarkerPath));
+    }
+}

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -17,7 +17,6 @@ namespace Aspire.Cli.Bundles;
 internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<BundleService> logger) : IBundleService
 {
     private const string PayloadResourceName = "bundle.tar.gz";
-    private const string AssemblyLoadFailureIndicator = "Could not load file or assembly";
 
     /// <summary>
     /// Name of the marker file written after successful extraction.
@@ -31,21 +30,6 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
 
     private static readonly bool s_isBundle =
         typeof(BundleService).Assembly.GetManifestResourceInfo(PayloadResourceName) is not null;
-
-    private static readonly string[] s_bundleCorruptionIndicators =
-    [
-        "System.Private.CoreLib.dll",
-        "Failed to create CoreCLR",
-        "aspire-managed not found in layout"
-    ];
-
-    private static readonly string[] s_managedLayoutIndicators =
-    [
-        "aspire-managed",
-        $"{Path.DirectorySeparatorChar}{BundleDiscovery.ManagedDirectoryName}{Path.DirectorySeparatorChar}",
-        "/managed/",
-        "\\managed\\"
-    ];
 
     /// <inheritdoc/>
     public bool IsBundle => s_isBundle;
@@ -436,27 +420,6 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     internal static bool IsUsableExtractedLayout(string extractDir)
         => BundleLayoutState.Inspect(extractDir).IsUsableExtractedLayout;
 
-    /// <summary>
-    /// Returns whether failure evidence from the extracted <c>aspire-managed</c> process
-    /// looks like bundle corruption rather than an unrelated command failure.
-    /// </summary>
-    internal static bool LooksLikeBundleCorruption(
-        Exception? exception = null,
-        string? error = null,
-        string? output = null,
-        IEnumerable<string>? additionalLines = null,
-        string? bundleRoot = null)
-    {
-        if (BundleLayoutState.Inspect(bundleRoot).IsIncompleteLayout)
-        {
-            return true;
-        }
-
-        var evidence = string.Join(Environment.NewLine, EnumerateFailureEvidence(exception, error, output, additionalLines));
-
-        return ContainsAny(evidence, s_bundleCorruptionIndicators) || HasManagedLayoutAssemblyLoadFailure(evidence);
-    }
-
     private static string? TryGetDefaultExtractDir()
     {
         var processPath = Environment.ProcessPath;
@@ -484,60 +447,6 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
         {
             File.Delete(markerPath);
         }
-    }
-
-    private static IEnumerable<string> EnumerateFailureEvidence(
-        Exception? exception,
-        string? error,
-        string? output,
-        IEnumerable<string>? additionalLines)
-    {
-        if (exception is not null)
-        {
-            yield return exception.ToString();
-        }
-
-        if (!string.IsNullOrWhiteSpace(error))
-        {
-            yield return error;
-        }
-
-        if (!string.IsNullOrWhiteSpace(output))
-        {
-            yield return output;
-        }
-
-        if (additionalLines is null)
-        {
-            yield break;
-        }
-
-        foreach (var line in additionalLines)
-        {
-            if (!string.IsNullOrWhiteSpace(line))
-            {
-                yield return line;
-            }
-        }
-    }
-
-    private static bool HasManagedLayoutAssemblyLoadFailure(string evidence)
-    {
-        return evidence.Contains(AssemblyLoadFailureIndicator, StringComparison.OrdinalIgnoreCase)
-            && ContainsAny(evidence, s_managedLayoutIndicators);
-    }
-
-    private static bool ContainsAny(string evidence, IEnumerable<string> indicators)
-    {
-        foreach (var indicator in indicators)
-        {
-            if (evidence.Contains(indicator, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -66,6 +66,9 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
         BundleDiscovery.DcpDirectoryName
     ];
 
+    private static readonly TimeSpan s_lockedLayoutDirectoryRetryDelay = TimeSpan.FromMilliseconds(200);
+    private static readonly TimeSpan s_lockedLayoutDirectoryTimeout = TimeSpan.FromSeconds(30);
+
     /// <inheritdoc/>
     public async Task EnsureExtractedAsync(CancellationToken cancellationToken = default)
     {
@@ -188,7 +191,7 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
 
         // Clean existing layout directories before extraction to avoid file conflicts
         logger.LogDebug("Cleaning existing layout directories in {Path}.", destinationPath);
-        CleanLayoutDirectories(destinationPath);
+        await CleanLayoutDirectoriesAsync(destinationPath, cancellationToken).ConfigureAwait(false);
 
         // Publish the in-progress marker before unpacking files so any concurrent or
         // future discovery can distinguish "rewrite interrupted" from "legacy layout
@@ -253,10 +256,23 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     /// Preserves the bin/ directory (which contains the CLI binary itself).
     /// If a directory cannot be deleted (e.g. a process is still using files
     /// inside it), it is renamed to {dir}.old.{timestamp} so extraction can
-    /// proceed. The stale directory will be cleaned up on the next successful
-    /// extraction.
+    /// proceed. If the directory cannot be deleted or renamed because it is
+    /// still locked, extraction waits briefly for the active process to exit
+    /// before surfacing a specific error.
     /// </summary>
     internal static void CleanLayoutDirectories(string layoutPath)
+        => CleanLayoutDirectoriesAsync(layoutPath, CancellationToken.None).GetAwaiter().GetResult();
+
+    private Task CleanLayoutDirectoriesAsync(string layoutPath, CancellationToken cancellationToken)
+        => CleanLayoutDirectoriesAsync(
+            layoutPath,
+            cancellationToken,
+            onFirstBlocked: path => logger.LogWarning("Bundle layout directory {Path} is still in use by another process. Waiting before extraction continues.", path));
+
+    internal static async Task CleanLayoutDirectoriesAsync(
+        string layoutPath,
+        CancellationToken cancellationToken,
+        Action<string>? onFirstBlocked = null)
     {
         foreach (var dir in s_layoutDirectories)
         {
@@ -264,11 +280,65 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
             FileDeleteHelper.TryCleanupOldItems(layoutPath, dir);
 
             var fullPath = Path.Combine(layoutPath, dir);
-            FileDeleteHelper.TryDeleteDirectory(fullPath);
+            await EnsureDirectoryReadyForExtractionAsync(
+                fullPath,
+                cancellationToken,
+                onFirstBlocked: onFirstBlocked)
+                .ConfigureAwait(false);
         }
 
         DeleteVersionMarker(layoutPath);
         DeleteExtractionInProgressMarker(layoutPath);
+    }
+
+    internal static async Task EnsureDirectoryReadyForExtractionAsync(
+        string path,
+        CancellationToken cancellationToken,
+        Func<string, FileDeleteHelper.DeleteDirectoryResult>? tryDeleteDirectory = null,
+        Action<string>? onFirstBlocked = null,
+        TimeSpan? retryDelay = null,
+        TimeSpan? timeout = null)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        tryDeleteDirectory ??= FileDeleteHelper.TryDeleteDirectory;
+        retryDelay ??= s_lockedLayoutDirectoryRetryDelay;
+        timeout ??= s_lockedLayoutDirectoryTimeout;
+
+        var startedAt = Stopwatch.GetTimestamp();
+        var reportedBlocked = false;
+
+        while (true)
+        {
+            switch (tryDeleteDirectory(path))
+            {
+                case FileDeleteHelper.DeleteDirectoryResult.NotFound:
+                case FileDeleteHelper.DeleteDirectoryResult.Deleted:
+                case FileDeleteHelper.DeleteDirectoryResult.Renamed:
+                    return;
+
+                case FileDeleteHelper.DeleteDirectoryResult.Blocked:
+                    if (!reportedBlocked)
+                    {
+                        onFirstBlocked?.Invoke(path);
+                        reportedBlocked = true;
+                    }
+
+                    if (Stopwatch.GetElapsedTime(startedAt) >= timeout.Value)
+                    {
+                        throw new IOException($"Bundle layout directory '{path}' is still locked by another process. Stop the running Aspire command and retry extraction.");
+                    }
+
+                    await Task.Delay(retryDelay.Value, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                default:
+                    throw new UnreachableException();
+            }
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -17,14 +17,35 @@ namespace Aspire.Cli.Bundles;
 internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<BundleService> logger) : IBundleService
 {
     private const string PayloadResourceName = "bundle.tar.gz";
+    private const string AssemblyLoadFailureIndicator = "Could not load file or assembly";
 
     /// <summary>
     /// Name of the marker file written after successful extraction.
     /// </summary>
     internal const string VersionMarkerFileName = ".aspire-bundle-version";
 
+    /// <summary>
+    /// Name of the marker file written while extraction is in progress.
+    /// </summary>
+    internal const string ExtractionInProgressMarkerFileName = ".aspire-bundle-extracting";
+
     private static readonly bool s_isBundle =
         typeof(BundleService).Assembly.GetManifestResourceInfo(PayloadResourceName) is not null;
+
+    private static readonly string[] s_bundleCorruptionIndicators =
+    [
+        "System.Private.CoreLib.dll",
+        "Failed to create CoreCLR",
+        "aspire-managed not found in layout"
+    ];
+
+    private static readonly string[] s_managedLayoutIndicators =
+    [
+        "aspire-managed",
+        $"{Path.DirectorySeparatorChar}{BundleDiscovery.ManagedDirectoryName}{Path.DirectorySeparatorChar}",
+        "/managed/",
+        "\\managed\\"
+    ];
 
     /// <inheritdoc/>
     public bool IsBundle => s_isBundle;
@@ -54,17 +75,10 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
             return;
         }
 
-        var processPath = Environment.ProcessPath;
-        if (string.IsNullOrEmpty(processPath))
-        {
-            logger.LogDebug("ProcessPath is null or empty, skipping bundle extraction.");
-            return;
-        }
-
-        var extractDir = GetDefaultExtractDir(processPath);
+        var extractDir = TryGetDefaultExtractDir();
         if (extractDir is null)
         {
-            logger.LogDebug("Could not determine extraction directory from {ProcessPath}, skipping.", processPath);
+            logger.LogDebug("Could not determine extraction directory from {ProcessPath}, skipping.", Environment.ProcessPath);
             return;
         }
 
@@ -86,6 +100,29 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     }
 
     /// <inheritdoc/>
+    public BundleLayoutState GetLayoutState(string? destinationPath = null)
+        => BundleLayoutState.Inspect(destinationPath ?? TryGetDefaultExtractDir());
+
+    /// <inheritdoc/>
+    public Task<BundleExtractResult> RepairAsync(string? destinationPath = null, CancellationToken cancellationToken = default)
+    {
+        if (!IsBundle)
+        {
+            logger.LogDebug("No embedded bundle payload, skipping repair.");
+            return Task.FromResult(BundleExtractResult.NoPayload);
+        }
+
+        destinationPath ??= TryGetDefaultExtractDir();
+        if (destinationPath is null)
+        {
+            logger.LogDebug("Could not determine extraction directory from {ProcessPath}, skipping repair.", Environment.ProcessPath);
+            return Task.FromResult(BundleExtractResult.ExtractionFailed);
+        }
+
+        return ExtractAsync(destinationPath, force: true, cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public async Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
     {
         if (!IsBundle)
@@ -102,8 +139,21 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
 
         try
         {
-            // Re-check after acquiring lock — another process may have already extracted
-            if (!force && layoutDiscovery.DiscoverLayout() is not null)
+            // This marker is only written by newer CLIs. If it survives, a previous
+            // extraction cleaned the layout but never published a complete one.
+            if (HasExtractionInProgressMarker(destinationPath))
+            {
+                logger.LogWarning("Found bundle extraction in-progress marker at {Path}. Re-extracting to recover from an incomplete prior extraction.",
+                    destinationPath);
+            }
+
+            // Re-check after acquiring lock — another process may have already extracted.
+            // "Usable" intentionally includes legacy markerless layouts so new code can
+            // continue to run against old installs. We still require a matching version
+            // marker before we skip extraction; markerless legacy layouts fall through
+            // to re-extract because we cannot prove they match this CLI binary.
+            if (!force &&
+                IsUsableExtractedLayout(destinationPath))
             {
                 var existingVersion = ReadVersionMarker(destinationPath);
                 var currentVersion = GetCurrentVersion();
@@ -128,25 +178,47 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     private async Task<BundleExtractResult> ExtractCoreAsync(string destinationPath, CancellationToken cancellationToken)
     {
         logger.LogInformation("Extracting embedded bundle to {Path}...", destinationPath);
+        var currentVersion = GetCurrentVersion();
 
         // Clean existing layout directories before extraction to avoid file conflicts
         logger.LogDebug("Cleaning existing layout directories in {Path}.", destinationPath);
         CleanLayoutDirectories(destinationPath);
+
+        // Publish the in-progress marker before unpacking files so any concurrent or
+        // future discovery can distinguish "rewrite interrupted" from "legacy layout
+        // that predates markers entirely".
+        WriteExtractionInProgressMarker(destinationPath, currentVersion);
+        logger.LogDebug("Extraction in-progress marker written (version: {Version}).", currentVersion);
 
         var sw = Stopwatch.StartNew();
         await ExtractPayloadAsync(destinationPath, cancellationToken);
         sw.Stop();
         logger.LogDebug("Payload extraction completed in {ElapsedMs}ms.", sw.ElapsedMilliseconds);
 
-        // Write version marker so subsequent runs skip extraction
-        var currentVersion = GetCurrentVersion();
+        // Verify extraction produced the required on-disk layout before declaring success.
+        if (!LayoutDiscovery.HasRequiredLayoutStructure(destinationPath))
+        {
+            logger.LogError("Extraction completed but the required bundle layout structure was not found in {Path}.", destinationPath);
+            return BundleExtractResult.ExtractionFailed;
+        }
+
+        // Write version marker so subsequent runs can recognize a complete layout.
         WriteVersionMarker(destinationPath, currentVersion);
         logger.LogDebug("Version marker written (version: {Version}).", currentVersion);
 
-        // Verify extraction produced a valid layout
-        if (layoutDiscovery.DiscoverLayout() is null)
+        // Remove the in-progress marker only after the success marker is present so
+        // every observable state is unambiguous:
+        // - extracting marker present => incomplete
+        // - version marker present, extracting marker absent => complete
+        DeleteExtractionInProgressMarker(destinationPath);
+
+        // Final validation checks the explicit extraction target rather than rediscovering through ambient state.
+        if (!LayoutDiscovery.HasRequiredLayoutStructure(destinationPath) || !IsExtractionComplete(destinationPath))
         {
-            logger.LogError("Extraction completed but no valid layout found in {Path}.", destinationPath);
+            logger.LogError("Extraction completed but the marker state or required layout structure was invalid in {Path}. Restoring incomplete-extraction marker.",
+                destinationPath);
+            WriteExtractionInProgressMarker(destinationPath, currentVersion);
+            DeleteVersionMarker(destinationPath);
             return BundleExtractResult.ExtractionFailed;
         }
 
@@ -189,12 +261,8 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
             FileDeleteHelper.TryDeleteDirectory(fullPath);
         }
 
-        // Remove version marker so it's rewritten after extraction
-        var markerPath = Path.Combine(layoutPath, VersionMarkerFileName);
-        if (File.Exists(markerPath))
-        {
-            File.Delete(markerPath);
-        }
+        DeleteVersionMarker(layoutPath);
+        DeleteExtractionInProgressMarker(layoutPath);
     }
 
     /// <summary>
@@ -245,6 +313,16 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     }
 
     /// <summary>
+    /// Writes an extraction in-progress marker file to the extraction directory.
+    /// </summary>
+    internal static void WriteExtractionInProgressMarker(string extractDir, string version)
+    {
+        Directory.CreateDirectory(extractDir);
+        var markerPath = Path.Combine(extractDir, ExtractionInProgressMarkerFileName);
+        File.WriteAllText(markerPath, version);
+    }
+
+    /// <summary>
     /// Reads the version string from a previously written marker file.
     /// Returns null if the marker doesn't exist or is empty.
     /// </summary>
@@ -258,6 +336,132 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
 
         var content = File.ReadAllText(markerPath).Trim();
         return string.IsNullOrEmpty(content) ? null : content;
+    }
+
+    /// <summary>
+    /// Returns whether an extraction in-progress marker exists.
+    /// </summary>
+    internal static bool HasExtractionInProgressMarker(string extractDir)
+        => BundleLayoutState.Inspect(extractDir).HasExtractionInProgressMarker;
+
+    /// <summary>
+    /// Returns whether the extracted layout is marked complete under the
+    /// current marker protocol.
+    /// </summary>
+    internal static bool IsExtractionComplete(string extractDir)
+        => BundleLayoutState.Inspect(extractDir).IsExtractionComplete;
+
+    /// <summary>
+    /// Returns whether the extracted layout is usable, including legacy layouts
+    /// that predate extraction markers but still have the required structure.
+    /// This is broader than <see cref="IsExtractionComplete"/> and must not be
+    /// treated as evidence that the layout matches the current CLI version.
+    /// </summary>
+    internal static bool IsUsableExtractedLayout(string extractDir)
+        => BundleLayoutState.Inspect(extractDir).IsUsableExtractedLayout;
+
+    /// <summary>
+    /// Returns whether failure evidence from the extracted <c>aspire-managed</c> process
+    /// looks like bundle corruption rather than an unrelated command failure.
+    /// </summary>
+    internal static bool LooksLikeBundleCorruption(
+        Exception? exception = null,
+        string? error = null,
+        string? output = null,
+        IEnumerable<string>? additionalLines = null,
+        string? bundleRoot = null)
+    {
+        if (BundleLayoutState.Inspect(bundleRoot).IsIncompleteLayout)
+        {
+            return true;
+        }
+
+        var evidence = string.Join(Environment.NewLine, EnumerateFailureEvidence(exception, error, output, additionalLines));
+
+        return ContainsAny(evidence, s_bundleCorruptionIndicators) || HasManagedLayoutAssemblyLoadFailure(evidence);
+    }
+
+    private static string? TryGetDefaultExtractDir()
+    {
+        var processPath = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(processPath))
+        {
+            return null;
+        }
+
+        return GetDefaultExtractDir(processPath);
+    }
+
+    private static void DeleteVersionMarker(string extractDir)
+    {
+        var markerPath = Path.Combine(extractDir, VersionMarkerFileName);
+        if (File.Exists(markerPath))
+        {
+            File.Delete(markerPath);
+        }
+    }
+
+    private static void DeleteExtractionInProgressMarker(string extractDir)
+    {
+        var markerPath = Path.Combine(extractDir, ExtractionInProgressMarkerFileName);
+        if (File.Exists(markerPath))
+        {
+            File.Delete(markerPath);
+        }
+    }
+
+    private static IEnumerable<string> EnumerateFailureEvidence(
+        Exception? exception,
+        string? error,
+        string? output,
+        IEnumerable<string>? additionalLines)
+    {
+        if (exception is not null)
+        {
+            yield return exception.ToString();
+        }
+
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            yield return error;
+        }
+
+        if (!string.IsNullOrWhiteSpace(output))
+        {
+            yield return output;
+        }
+
+        if (additionalLines is null)
+        {
+            yield break;
+        }
+
+        foreach (var line in additionalLines)
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                yield return line;
+            }
+        }
+    }
+
+    private static bool HasManagedLayoutAssemblyLoadFailure(string evidence)
+    {
+        return evidence.Contains(AssemblyLoadFailureIndicator, StringComparison.OrdinalIgnoreCase)
+            && ContainsAny(evidence, s_managedLayoutIndicators);
+    }
+
+    private static bool ContainsAny(string evidence, IEnumerable<string> indicators)
+    {
+        foreach (var indicator in indicators)
+        {
+            if (evidence.Contains(indicator, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -96,7 +96,13 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     public async Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
     {
         await EnsureExtractedAsync(cancellationToken).ConfigureAwait(false);
-        return layoutDiscovery.DiscoverLayout();
+        var layout = layoutDiscovery.DiscoverLayout();
+        if (layout is null)
+        {
+            logger.LogWarning("No usable bundle layout could be discovered. {BundleState}", GetLayoutState().Describe());
+        }
+
+        return layout;
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Cli/Bundles/IBundleService.cs
+++ b/src/Aspire.Cli/Bundles/IBundleService.cs
@@ -32,6 +32,21 @@ internal interface IBundleService
     Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Inspects the current bundle layout state.
+    /// </summary>
+    /// <param name="destinationPath">Optional directory to inspect. Defaults to the current bundle root.</param>
+    /// <returns>The current bundle layout state.</returns>
+    BundleLayoutState GetLayoutState(string? destinationPath = null);
+
+    /// <summary>
+    /// Forces a bundle re-extraction using the same default destination logic as normal extraction.
+    /// </summary>
+    /// <param name="destinationPath">Optional directory to repair. Defaults to the current bundle root.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The result of the repair attempt.</returns>
+    Task<BundleExtractResult> RepairAsync(string? destinationPath = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Ensures the bundle is extracted and returns the discovered layout.
     /// Combines <see cref="EnsureExtractedAsync"/> and layout discovery into a single call
     /// so callers cannot forget to extract before discovering the layout.

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Bundles;
 using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
@@ -182,29 +183,35 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
 
     private LayoutConfiguration? TryInferLayout(string layoutPath)
     {
-        // Check for essential directories
-        var managedPath = Path.Combine(layoutPath, BundleDiscovery.ManagedDirectoryName);
-        var dcpPath = Path.Combine(layoutPath, BundleDiscovery.DcpDirectoryName);
+        var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
+        var layoutState = BundleLayoutState.Inspect(layoutPath);
 
         _logger.LogDebug("TryInferLayout: Checking layout at {Path}", layoutPath);
-        _logger.LogDebug("  {Dir}/: {Exists}", BundleDiscovery.ManagedDirectoryName, Directory.Exists(managedPath) ? "exists" : "MISSING");
-        _logger.LogDebug("  {Dir}/: {Exists}", BundleDiscovery.DcpDirectoryName, Directory.Exists(dcpPath) ? "exists" : "MISSING");
+        _logger.LogDebug("  {Dir}/: {Exists}", BundleDiscovery.ManagedDirectoryName, layoutState.HasManagedDirectory ? "exists" : "MISSING");
+        _logger.LogDebug("  {Dir}/: {Exists}", BundleDiscovery.DcpDirectoryName, layoutState.HasDcpDirectory ? "exists" : "MISSING");
+        _logger.LogDebug("  {Marker}: {Exists}", BundleService.VersionMarkerFileName, layoutState.HasVersionMarker ? "exists" : "MISSING");
+        _logger.LogDebug("  {Marker}: {Exists}", BundleService.ExtractionInProgressMarkerFileName, layoutState.HasExtractionInProgressMarker ? "exists" : "MISSING");
+        _logger.LogDebug("  managed/{ManagedExe}: {Exists}", managedExeName, layoutState.HasManagedExecutable ? "exists" : "MISSING");
 
-        if (!Directory.Exists(managedPath) || !Directory.Exists(dcpPath))
+        if (!layoutState.HasRequiredLayoutStructure)
         {
-            _logger.LogDebug("TryInferLayout: Layout rejected - missing required directories");
+            _logger.LogDebug("TryInferLayout: Layout rejected - required bundle contents are missing");
             return null;
         }
 
-        // Check for aspire-managed executable
-        var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
-        var managedExePath = Path.Combine(managedPath, managedExeName);
-        _logger.LogDebug("  managed/{ManagedExe}: {Exists}", managedExeName, File.Exists(managedExePath) ? "exists" : "MISSING");
-
-        if (!File.Exists(managedExePath))
+        // A newer extractor explicitly marked this layout as incomplete. Even if some
+        // files are present, discovery must not treat it as a valid bundle.
+        if (layoutState.HasExtractionInProgressMarker)
         {
-            _logger.LogDebug("TryInferLayout: Layout rejected - aspire-managed not found");
+            _logger.LogDebug("TryInferLayout: Layout rejected - extraction still marked in progress");
             return null;
+        }
+
+        if (!layoutState.HasVersionMarker)
+        {
+            // Older CLIs never wrote markers, so a structurally valid layout with no
+            // markers is treated as a legacy complete install for compatibility.
+            _logger.LogDebug("TryInferLayout: Accepting legacy layout without a version marker");
         }
 
         _logger.LogDebug("TryInferLayout: Layout is valid");
@@ -216,6 +223,9 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
             Components = new LayoutComponents()
         };
     }
+
+    internal static bool HasRequiredLayoutStructure(string layoutPath)
+        => BundleLayoutState.Inspect(layoutPath).HasRequiredLayoutStructure;
 
     private LayoutConfiguration LogEnvironmentOverrides(LayoutConfiguration config)
     {

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -108,18 +108,11 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
         FileInfo? nugetConfigFile,
         CancellationToken cancellationToken)
     {
-        // Ensure the bundle is extracted and get the layout in a single call
-        var layout = await _bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
-        if (layout is null)
-        {
-            throw new InvalidOperationException("Bundle layout not found. Cannot perform NuGet search in bundle mode.");
-        }
-
-        var managedPath = layout.GetManagedPath();
-        if (managedPath is null || !File.Exists(managedPath))
-        {
-            throw new InvalidOperationException("aspire-managed not found in layout.");
-        }
+        var managedPath = await BundleLayoutRepairHelper.EnsureManagedToolPathAsync(
+            _bundleService,
+            _logger,
+            "searching NuGet packages in bundle mode",
+            cancellationToken).ConfigureAwait(false);
 
         // Build arguments for NuGet search command (via aspire-managed nuget subcommand)
         var args = new List<string>
@@ -158,11 +151,16 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
         _logger.LogDebug("NuGet search args: {Args}", string.Join(" ", args));
         _logger.LogDebug("Working directory: {WorkingDir}", workingDirectory.FullName);
 
-        var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
-            managedPath,
+        var (managedToolPath, exitCode, output, error) = await BundleLayoutRepairHelper.RunManagedToolWithRepairAsync(
+            _bundleService,
+            _layoutProcessRunner,
+            _logger,
+            "searching NuGet packages in bundle mode",
             args,
             workingDirectory: workingDirectory.FullName,
-            ct: cancellationToken).ConfigureAwait(false);
+            managedPath: managedPath,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        managedPath = managedToolPath;
 
         // Log stderr output (verbose info from NuGetHelper)
         if (!string.IsNullOrWhiteSpace(error))
@@ -175,6 +173,7 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             _logger.LogError("NuGet search failed with exit code {ExitCode}", exitCode);
             _logger.LogError("NuGet search stderr: {Error}", error);
             _logger.LogError("NuGet search stdout: {Output}", output);
+            _logger.LogError("Bundle state at NuGet search failure: {BundleState}", _bundleService.GetLayoutState().Describe());
             throw new NuGetPackageCacheException($"Package search failed: {error}");
         }
 
@@ -277,4 +276,3 @@ internal sealed partial class BundleSearchJsonContext : JsonSerializerContext
 }
 
 #endregion
-

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Bundles;
 using Aspire.Cli.Layout;
 using Microsoft.Extensions.Logging;
 
@@ -37,7 +38,7 @@ public interface INuGetService
 /// </summary>
 internal sealed class BundleNuGetService : INuGetService
 {
-    private readonly ILayoutDiscovery _layoutDiscovery;
+    private readonly IBundleService _bundleService;
     private readonly LayoutProcessRunner _layoutProcessRunner;
     private readonly IFeatures _features;
     private readonly CliExecutionContext _executionContext;
@@ -45,13 +46,13 @@ internal sealed class BundleNuGetService : INuGetService
     private readonly string _cacheDirectory;
 
     public BundleNuGetService(
-        ILayoutDiscovery layoutDiscovery,
+        IBundleService bundleService,
         LayoutProcessRunner layoutProcessRunner,
         IFeatures features,
         CliExecutionContext executionContext,
         ILogger<BundleNuGetService> logger)
     {
-        _layoutDiscovery = layoutDiscovery;
+        _bundleService = bundleService;
         _layoutProcessRunner = layoutProcessRunner;
         _features = features;
         _executionContext = executionContext;
@@ -67,17 +68,11 @@ internal sealed class BundleNuGetService : INuGetService
         string? workingDirectory = null,
         CancellationToken ct = default)
     {
-        var layout = _layoutDiscovery.DiscoverLayout();
-        if (layout is null)
-        {
-            throw new InvalidOperationException("Bundle layout not found. Cannot perform NuGet restore in bundle mode.");
-        }
-
-        var managedPath = layout.GetManagedPath();
-        if (managedPath is null || !File.Exists(managedPath))
-        {
-            throw new InvalidOperationException("aspire-managed not found in layout.");
-        }
+        var managedPath = await BundleLayoutRepairHelper.EnsureManagedToolPathAsync(
+            _bundleService,
+            _logger,
+            "restoring integration packages in bundle mode",
+            ct).ConfigureAwait(false);
 
         var packageList = packages.ToList();
         if (packageList.Count == 0)
@@ -152,11 +147,16 @@ internal sealed class BundleNuGetService : INuGetService
         var environmentVariables = new Dictionary<string, string>();
         NuGetSignatureVerificationEnabler.Apply(environmentVariables, _features, _executionContext);
 
-        var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
-            managedPath,
+        var (managedToolPath, exitCode, output, error) = await BundleLayoutRepairHelper.RunManagedToolWithRepairAsync(
+            _bundleService,
+            _layoutProcessRunner,
+            _logger,
+            "restoring integration packages in bundle mode",
             restoreArgs,
             environmentVariables: environmentVariables,
-            ct: ct);
+            managedPath: managedPath,
+            cancellationToken: ct).ConfigureAwait(false);
+        managedPath = managedToolPath;
 
         // Log stderr at debug level for diagnostics
         if (!string.IsNullOrWhiteSpace(error))
@@ -169,6 +169,7 @@ internal sealed class BundleNuGetService : INuGetService
             _logger.LogError("Package restore failed with exit code {ExitCode}", exitCode);
             _logger.LogError("Package restore stderr: {Error}", error);
             _logger.LogError("Package restore stdout: {Output}", output);
+            _logger.LogError("Bundle state at package restore failure: {BundleState}", _bundleService.GetLayoutState().Describe());
             throw new InvalidOperationException($"Package restore failed: {error}");
         }
 
@@ -198,11 +199,15 @@ internal sealed class BundleNuGetService : INuGetService
         _logger.LogDebug("Creating layout from {AssetsPath}", assetsPath);
         _logger.LogDebug("NuGet layout args: {Args}", string.Join(" ", layoutArgs));
 
-        (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
-            managedPath,
+        (_, exitCode, output, error) = await BundleLayoutRepairHelper.RunManagedToolWithRepairAsync(
+            _bundleService,
+            _layoutProcessRunner,
+            _logger,
+            "creating the integration package layout in bundle mode",
             layoutArgs,
             environmentVariables: environmentVariables,
-            ct: ct);
+            managedPath: managedPath,
+            cancellationToken: ct).ConfigureAwait(false);
 
         // Log stderr at debug level for diagnostics
         if (!string.IsNullOrWhiteSpace(error))
@@ -215,6 +220,7 @@ internal sealed class BundleNuGetService : INuGetService
             _logger.LogError("Layout creation failed with exit code {ExitCode}", exitCode);
             _logger.LogError("Layout creation stderr: {Error}", error);
             _logger.LogError("Layout creation stdout: {Output}", output);
+            _logger.LogError("Bundle state at layout creation failure: {BundleState}", _bundleService.GetLayoutState().Describe());
             throw new InvalidOperationException($"Layout creation failed: {error}");
         }
 

--- a/src/Aspire.Cli/Projects/AppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerProject.cs
@@ -4,9 +4,11 @@
 using Aspire.Cli.Bundles;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
+using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Utils;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Projects;
@@ -30,16 +32,23 @@ internal sealed class AppHostServerProjectFactory(
     IBundleService bundleService,
     BundleNuGetService bundleNuGetService,
     IDotNetSdkInstaller sdkInstaller,
-    ILoggerFactory loggerFactory) : IAppHostServerProjectFactory
+    ILoggerFactory loggerFactory,
+    ILogger<AppHostServerProjectFactory> logger) : IAppHostServerProjectFactory
 {
     public async Task<IAppHostServerProject> CreateAsync(string appPath, CancellationToken cancellationToken = default)
     {
         var socketPath = CliPathHelper.CreateGuestAppHostSocketPath("apphost.sock");
 
+        logger.LogDebug("Creating AppHost server project for {AppPath}. IsBundle={IsBundle}. {BundleState}",
+            appPath,
+            bundleService.IsBundle,
+            bundleService.GetLayoutState().Describe());
+
         // Priority 1: Check for dev mode (ASPIRE_REPO_ROOT or running from Aspire source repo)
         var repoRoot = AspireRepositoryDetector.DetectRepositoryRoot(appPath);
         if (repoRoot is not null)
         {
+            logger.LogDebug("Using repository AppHost server project from {RepoRoot}", repoRoot);
             return new DotNetBasedAppHostServerProject(
                 appPath,
                 socketPath,
@@ -50,12 +59,24 @@ internal sealed class AppHostServerProjectFactory(
                 loggerFactory.CreateLogger<DotNetBasedAppHostServerProject>());
         }
 
+        logger.LogDebug("Repository AppHost server project unavailable for {AppPath}. ASPIRE_REPO_ROOT set={HasRepoRootEnvVar}.",
+            appPath,
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(BundleDiscovery.RepoRootEnvVar)));
+
         // Priority 2: Ensure bundle is extracted and check for layout
-        var layout = await bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken);
+        var layout = await bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!HasUsableManagedExecutable(layout, out var serverPath) &&
+            await BundleLayoutRepairHelper.TryRepairAsync(bundleService, logger, "creating the AppHost server project", cancellationToken, layout?.LayoutPath).ConfigureAwait(false))
+        {
+            layout = await bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
+            HasUsableManagedExecutable(layout, out serverPath);
+        }
 
         // Priority 3: Check if we have a bundle layout with a pre-built AppHost server
-        if (layout is not null && layout.GetManagedPath() is string serverPath && File.Exists(serverPath))
+        if (layout is not null && serverPath is not null && File.Exists(serverPath))
         {
+            logger.LogDebug("Using bundled AppHost server from {ServerPath}", serverPath);
             return new PrebuiltAppHostServer(
                 appPath,
                 socketPath,
@@ -68,8 +89,18 @@ internal sealed class AppHostServerProjectFactory(
                 loggerFactory.CreateLogger<PrebuiltAppHostServer>());
         }
 
+        logger.LogError("No usable Aspire AppHost server was found for {AppPath}. Repository mode was unavailable and the bundled layout did not provide a usable managed executable. {BundleState}",
+            appPath,
+            bundleService.GetLayoutState(layout?.LayoutPath).Describe());
+
         throw new InvalidOperationException(
             "No Aspire AppHost server is available. Ensure the Aspire CLI is installed " +
             "with a valid bundle layout, or reinstall using 'aspire setup --force'.");
+    }
+
+    private static bool HasUsableManagedExecutable(LayoutConfiguration? layout, out string? serverPath)
+    {
+        serverPath = layout?.GetManagedPath();
+        return serverPath is not null && File.Exists(serverPath);
     }
 }

--- a/src/Aspire.Cli/Projects/AppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerProject.cs
@@ -89,9 +89,11 @@ internal sealed class AppHostServerProjectFactory(
                 loggerFactory.CreateLogger<PrebuiltAppHostServer>());
         }
 
-        logger.LogError("No usable Aspire AppHost server was found for {AppPath}. Repository mode was unavailable and the bundled layout did not provide a usable managed executable. {BundleState}",
+        var bundleState = bundleService.GetLayoutState(layout?.LayoutPath);
+        logger.LogError("No usable Aspire AppHost server was found for {AppPath}. Repository mode was unavailable. {FailureReason} {BundleState}",
             appPath,
-            bundleService.GetLayoutState(layout?.LayoutPath).Describe());
+            DescribeBundleFailureReason(layout, serverPath, bundleState),
+            bundleState.Describe());
 
         throw new InvalidOperationException(
             "No Aspire AppHost server is available. Ensure the Aspire CLI is installed " +
@@ -102,5 +104,20 @@ internal sealed class AppHostServerProjectFactory(
     {
         serverPath = layout?.GetManagedPath();
         return serverPath is not null && File.Exists(serverPath);
+    }
+
+    private static string DescribeBundleFailureReason(LayoutConfiguration? layout, string? serverPath, BundleLayoutState bundleState)
+    {
+        if (layout is null)
+        {
+            return $"Bundled layout discovery did not return a usable layout ({bundleState.DescribeAvailability()}).";
+        }
+
+        if (serverPath is null)
+        {
+            return $"The bundled layout did not resolve a managed executable path ({bundleState.DescribeAvailability()}).";
+        }
+
+        return $"The bundled layout did not provide a usable managed executable at '{serverPath}' ({bundleState.DescribeAvailability()}).";
     }
 }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1268,8 +1268,20 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             return RunningInstanceResult.NoRunningInstance; // No directory, nothing to check
         }
 
-        var appHostServerProject = await _appHostServerProjectFactory.CreateAsync(directory.FullName, cancellationToken);
-        var genericAppHostPath = appHostServerProject.GetInstanceIdentifier();
+        string genericAppHostPath;
+
+        try
+        {
+            var appHostServerProject = await _appHostServerProjectFactory.CreateAsync(directory.FullName, cancellationToken);
+            genericAppHostPath = appHostServerProject.GetInstanceIdentifier();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or IOException)
+        {
+            _logger.LogWarning(ex,
+                "Failed to resolve the guest AppHost server while checking for running instances at {AppHostFile}. Continuing without attempting to stop existing instances.",
+                appHostFile.FullName);
+            return RunningInstanceResult.NoRunningInstance;
+        }
 
         // Find matching sockets for this AppHost
         var matchingSockets = AppHostHelper.FindMatchingSockets(genericAppHostPath, homeDirectory.FullName);

--- a/src/Aspire.Cli/Utils/FileDeleteHelper.cs
+++ b/src/Aspire.Cli/Utils/FileDeleteHelper.cs
@@ -18,23 +18,31 @@ namespace Aspire.Cli.Utils;
 /// </summary>
 internal static class FileDeleteHelper
 {
+    internal enum DeleteDirectoryResult
+    {
+        NotFound,
+        Deleted,
+        Renamed,
+        Blocked
+    }
+
     /// <summary>
     /// Attempts to delete a directory recursively. If deletion fails because
     /// a file inside the directory is locked by another process, the directory
     /// is renamed to <c>{path}.old.{tickcount}</c> so the caller can create a
-    /// fresh replacement. Returns <see langword="true"/> if the directory was
-    /// deleted or renamed, <see langword="false"/> if it did not exist.
+    /// fresh replacement.
     /// </summary>
-    internal static bool TryDeleteDirectory(string path)
+    internal static DeleteDirectoryResult TryDeleteDirectory(string path)
     {
         if (!Directory.Exists(path))
         {
-            return false;
+            return DeleteDirectoryResult.NotFound;
         }
 
         try
         {
             Directory.Delete(path, recursive: true);
+            return DeleteDirectoryResult.Deleted;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
@@ -45,16 +53,13 @@ internal static class FileDeleteHelper
             {
                 var renamedPath = $"{path}.old.{Environment.TickCount64}";
                 Directory.Move(path, renamedPath);
+                return DeleteDirectoryResult.Renamed;
             }
             catch (Exception)
             {
-                // Rename also failed — nothing more we can do.
-                // The caller's extraction will fail and surface a
-                // "run aspire setup --force" message.
+                return DeleteDirectoryResult.Blocked;
             }
         }
-
-        return true;
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
@@ -131,6 +131,69 @@ public class BundleRecoveryTests
     }
 
     [Fact]
+    public async Task RunManagedToolWithRepairAsync_RetriesWhenManagedToolFailsToStartAfterLayoutMutation()
+    {
+        var initialLayout = CreateLayout(includeManagedExecutable: true);
+        var repairedLayout = CreateLayout(includeManagedExecutable: true);
+
+        try
+        {
+            var bundleService = new RepairingBundleService(
+                initialLayout: new LayoutConfiguration { LayoutPath = initialLayout.FullName },
+                repairedLayout: new LayoutConfiguration { LayoutPath = repairedLayout.FullName });
+
+            var executionFactory = new TestProcessExecutionFactory();
+            executionFactory.CreateExecutionCallback = (args, env, workingDirectory, options) =>
+            {
+                if (executionFactory.AttemptCount == 1)
+                {
+                    var originalManagedPath = Path.Combine(initialLayout.FullName, BundleDiscovery.ManagedDirectoryName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+                    File.Delete(originalManagedPath);
+
+                    return new TestProcessExecution(
+                        "aspire-managed",
+                        args,
+                        env,
+                        options,
+                        (_, _) => (0, "unexpected", null),
+                        () => executionFactory.AttemptCount)
+                    {
+                        StartReturnValue = false
+                    };
+                }
+
+                return new TestProcessExecution(
+                    "aspire-managed",
+                    args,
+                    env,
+                    options,
+                    (_, _) => (0, "recovered", null),
+                    () => executionFactory.AttemptCount);
+            };
+
+            var (managedPath, exitCode, output, error) = await BundleLayoutRepairHelper.RunManagedToolWithRepairAsync(
+                bundleService,
+                new LayoutProcessRunner(executionFactory),
+                NullLogger.Instance,
+                "testing managed tool launch repair",
+                ["nuget", "search"],
+                cancellationToken: CancellationToken.None);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("recovered", output.Trim());
+            Assert.Equal(string.Empty, error);
+            Assert.Equal(1, bundleService.ExtractCallCount);
+            Assert.Equal(2, executionFactory.AttemptCount);
+            Assert.Contains(repairedLayout.FullName, managedPath, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectory(initialLayout);
+            DeleteDirectory(repairedLayout);
+        }
+    }
+
+    [Fact]
     public async Task AppHostServerProjectFactory_RepairsBrokenBundleLayout()
     {
 #if DEBUG

--- a/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Bundles;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Projects;
@@ -9,6 +10,7 @@ using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests;
@@ -178,6 +180,123 @@ public class BundleRecoveryTests
         }
     }
 
+    [Fact]
+    public async Task EnsureExtractedAndGetLayoutAsync_LogsWarningWhenNoLayoutCanBeDiscovered()
+    {
+        using var output = new StringWriter();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new SpectreConsoleLoggerProvider(output)));
+        var bundleService = new BundleService(new UnavailableLayoutDiscovery(), loggerFactory.CreateLogger<BundleService>());
+
+        var layout = await bundleService.EnsureExtractedAndGetLayoutAsync(CancellationToken.None);
+
+        Assert.Null(layout);
+        var logOutput = output.ToString();
+        Assert.Contains("No usable bundle layout could be discovered.", logOutput);
+        Assert.Contains("Availability=", logOutput);
+    }
+
+    [Fact]
+    public async Task AppHostServerProjectFactory_LogsSpecificReasonWhenManagedExecutableIsMissing()
+    {
+#if DEBUG
+        ForceRepositoryDetectionResult(null);
+#endif
+
+        var appDirectory = Directory.CreateTempSubdirectory("aspire-app-");
+        var brokenLayout = CreateLayout(includeManagedExecutable: false);
+
+        try
+        {
+            using var output = new StringWriter();
+            using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new SpectreConsoleLoggerProvider(output)));
+
+            var bundleService = new StaticLayoutBundleService(new LayoutConfiguration { LayoutPath = brokenLayout.FullName });
+
+            var bundleNuGetService = new BundleNuGetService(
+                bundleService,
+                new LayoutProcessRunner(new TestProcessExecutionFactory()),
+                new TestFeatures(),
+                TestExecutionContextFactory.CreateTestContext(),
+                NullLogger<BundleNuGetService>.Instance);
+
+            var factory = new AppHostServerProjectFactory(
+                new TestDotNetCliRunner(),
+                new MockPackagingService(),
+                new TestConfigurationService(),
+                bundleService,
+                bundleNuGetService,
+                new TestDotNetSdkInstaller(),
+                loggerFactory,
+                loggerFactory.CreateLogger<AppHostServerProjectFactory>());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateAsync(appDirectory.FullName, CancellationToken.None));
+
+            var logOutput = output.ToString();
+            Assert.Contains("did not provide a usable managed executable at", logOutput);
+            Assert.Contains(BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName), logOutput);
+            Assert.Contains("Availability=layout is missing required content: managed/", logOutput);
+        }
+        finally
+        {
+            DeleteDirectory(appDirectory);
+            DeleteDirectory(brokenLayout);
+#if DEBUG
+            AspireRepositoryDetector.ResetCache();
+#endif
+        }
+    }
+
+    [Fact]
+    public async Task AppHostServerProjectFactory_LogsSpecificReasonWhenLayoutDiscoveryReturnsNull()
+    {
+#if DEBUG
+        ForceRepositoryDetectionResult(null);
+#endif
+
+        var appDirectory = Directory.CreateTempSubdirectory("aspire-app-");
+        var incompleteLayout = Directory.CreateTempSubdirectory("aspire-layout-");
+
+        try
+        {
+            BundleService.WriteExtractionInProgressMarker(incompleteLayout.FullName, "test-version");
+
+            using var output = new StringWriter();
+            using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new SpectreConsoleLoggerProvider(output)));
+
+            var bundleService = new UnavailableLayoutBundleService(incompleteLayout.FullName);
+            var bundleNuGetService = new BundleNuGetService(
+                bundleService,
+                new LayoutProcessRunner(new TestProcessExecutionFactory()),
+                new TestFeatures(),
+                TestExecutionContextFactory.CreateTestContext(),
+                NullLogger<BundleNuGetService>.Instance);
+
+            var factory = new AppHostServerProjectFactory(
+                new TestDotNetCliRunner(),
+                new MockPackagingService(),
+                new TestConfigurationService(),
+                bundleService,
+                bundleNuGetService,
+                new TestDotNetSdkInstaller(),
+                loggerFactory,
+                loggerFactory.CreateLogger<AppHostServerProjectFactory>());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateAsync(appDirectory.FullName, CancellationToken.None));
+
+            var logOutput = output.ToString();
+            Assert.Contains("Bundled layout discovery did not return a usable layout", logOutput);
+            Assert.Contains("Availability=layout is marked as extraction in progress", logOutput);
+        }
+        finally
+        {
+            DeleteDirectory(appDirectory);
+            DeleteDirectory(incompleteLayout);
+#if DEBUG
+            AspireRepositoryDetector.ResetCache();
+#endif
+        }
+    }
+
     private static DirectoryInfo CreateLayout(bool includeManagedExecutable)
     {
         var root = Directory.CreateTempSubdirectory("aspire-layout-");
@@ -237,5 +356,54 @@ public class BundleRecoveryTests
 
         public Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(_repaired ? repairedLayout : initialLayout);
+    }
+
+    private sealed class UnavailableLayoutBundleService(string layoutPath) : IBundleService
+    {
+        public bool IsBundle => true;
+
+        public Task EnsureExtractedAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
+            => Task.FromResult(BundleExtractResult.ExtractionFailed);
+
+        public BundleLayoutState GetLayoutState(string? destinationPath = null)
+            => BundleLayoutState.Inspect(destinationPath ?? layoutPath);
+
+        public Task<BundleExtractResult> RepairAsync(string? destinationPath = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(BundleExtractResult.ExtractionFailed);
+
+        public Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<LayoutConfiguration?>(null);
+    }
+
+    private sealed class StaticLayoutBundleService(LayoutConfiguration? layout) : IBundleService
+    {
+        public bool IsBundle => true;
+
+        public Task EnsureExtractedAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
+            => Task.FromResult(BundleExtractResult.AlreadyUpToDate);
+
+        public BundleLayoutState GetLayoutState(string? destinationPath = null)
+            => BundleLayoutState.Inspect(destinationPath ?? layout?.LayoutPath);
+
+        public Task<BundleExtractResult> RepairAsync(string? destinationPath = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(BundleExtractResult.AlreadyUpToDate);
+
+        public Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(layout);
+    }
+
+    private sealed class UnavailableLayoutDiscovery : ILayoutDiscovery
+    {
+        public LayoutConfiguration? DiscoverLayout(string? projectDirectory = null) => null;
+
+        public string? GetComponentPath(LayoutComponent component, string? projectDirectory = null) => null;
+
+        public bool IsBundleModeAvailable(string? projectDirectory = null) => false;
     }
 }

--- a/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
@@ -1,0 +1,241 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Bundles;
+using Aspire.Cli.Layout;
+using Aspire.Cli.NuGet;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.Mcp;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Utils;
+using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests;
+
+public class BundleRecoveryTests
+{
+    [Fact]
+    public void BundleService_LooksLikeBundleCorruption_ReturnsTrueForKnownRuntimeFailure()
+    {
+        Assert.True(BundleService.LooksLikeBundleCorruption(
+            error: "Failed to create CoreCLR because System.Private.CoreLib.dll could not be loaded."));
+    }
+
+    [Fact]
+    public void BundleService_LooksLikeBundleCorruption_ReturnsTrueForManagedAssemblyLoadFailure()
+    {
+        Assert.True(BundleService.LooksLikeBundleCorruption(
+            error: "Could not load file or assembly 'Aspire.Foo'",
+            additionalLines: ["/tmp/.aspire/managed/Aspire.Foo.dll"]));
+    }
+
+    [Fact]
+    public void BundleService_LooksLikeBundleCorruption_ReturnsFalseForUnrelatedFailure()
+    {
+        Assert.False(BundleService.LooksLikeBundleCorruption(
+            error: "The requested package source could not be reached."));
+    }
+
+    [Fact]
+    public void BundleService_LooksLikeBundleCorruption_ReturnsTrueForIncompleteLayoutWhenBundleRootProvided()
+    {
+        var layoutDirectory = CreateLayout(includeManagedExecutable: false);
+
+        try
+        {
+            Assert.True(BundleService.LooksLikeBundleCorruption(bundleRoot: layoutDirectory.FullName));
+        }
+        finally
+        {
+            DeleteDirectory(layoutDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureManagedToolPathAsync_RepairsMissingManagedExecutable()
+    {
+        var brokenLayout = CreateLayout(includeManagedExecutable: false);
+        var repairedLayout = CreateLayout(includeManagedExecutable: true);
+
+        try
+        {
+            var bundleService = new RepairingBundleService(
+                initialLayout: new LayoutConfiguration { LayoutPath = brokenLayout.FullName },
+                repairedLayout: new LayoutConfiguration { LayoutPath = repairedLayout.FullName });
+
+            var managedPath = await BundleLayoutRepairHelper.EnsureManagedToolPathAsync(
+                bundleService,
+                NullLogger.Instance,
+                "testing bundle repair",
+                CancellationToken.None,
+                bundleRoot: brokenLayout.FullName);
+
+            Assert.Equal(Path.Combine(repairedLayout.FullName, BundleDiscovery.ManagedDirectoryName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)), managedPath);
+            Assert.Equal(1, bundleService.ExtractCallCount);
+        }
+        finally
+        {
+            DeleteDirectory(brokenLayout);
+            DeleteDirectory(repairedLayout);
+        }
+    }
+
+    [Fact]
+    public async Task BundleNuGetPackageCache_RetriesSearchAfterBundleRepair()
+    {
+        var layoutDirectory = CreateLayout(includeManagedExecutable: true);
+
+        try
+        {
+            var bundleService = new RepairingBundleService(
+                initialLayout: new LayoutConfiguration { LayoutPath = layoutDirectory.FullName },
+                repairedLayout: new LayoutConfiguration { LayoutPath = layoutDirectory.FullName });
+
+            var executionFactory = new TestProcessExecutionFactory
+            {
+                AttemptWithErrorCallback = (attempt, _) => attempt switch
+                {
+                    1 => (134, null, $"Failed to load System.Private.CoreLib.dll{Environment.NewLine}Path: {Path.Combine(layoutDirectory.FullName, "managed", "System.Private.CoreLib.dll")}"),
+                    _ => (0, """{"packages":[{"id":"Aspire.Hosting.Redis","version":"9.2.0","source":"nuget"}],"totalHits":1}""", null)
+                }
+            };
+
+            var cache = new BundleNuGetPackageCache(
+                bundleService,
+                new LayoutProcessRunner(executionFactory),
+                NullLogger<BundleNuGetPackageCache>.Instance,
+                new TestFeatures());
+
+            var packages = await cache.GetPackagesAsync(
+                layoutDirectory,
+                "Aspire.Hosting.Redis",
+                filter: null,
+                prerelease: false,
+                nugetConfigFile: null,
+                useCache: false,
+                CancellationToken.None);
+
+            var package = Assert.Single(packages);
+            Assert.Equal("Aspire.Hosting.Redis", package.Id);
+            Assert.Equal("9.2.0", package.Version);
+            Assert.Equal(1, bundleService.ExtractCallCount);
+            Assert.Equal(2, executionFactory.AttemptCount);
+        }
+        finally
+        {
+            DeleteDirectory(layoutDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task AppHostServerProjectFactory_RepairsBrokenBundleLayout()
+    {
+#if DEBUG
+        ForceRepositoryDetectionResult(null);
+#endif
+
+        var appDirectory = Directory.CreateTempSubdirectory("aspire-app-");
+        var brokenLayout = CreateLayout(includeManagedExecutable: false);
+        var repairedLayout = CreateLayout(includeManagedExecutable: true);
+
+        try
+        {
+            var bundleService = new RepairingBundleService(
+                initialLayout: new LayoutConfiguration { LayoutPath = brokenLayout.FullName },
+                repairedLayout: new LayoutConfiguration { LayoutPath = repairedLayout.FullName });
+
+            var bundleNuGetService = new BundleNuGetService(
+                bundleService,
+                new LayoutProcessRunner(new TestProcessExecutionFactory()),
+                new TestFeatures(),
+                TestExecutionContextFactory.CreateTestContext(),
+                NullLogger<BundleNuGetService>.Instance);
+
+            var factory = new AppHostServerProjectFactory(
+                new TestDotNetCliRunner(),
+                new MockPackagingService(),
+                new TestConfigurationService(),
+                bundleService,
+                bundleNuGetService,
+                new TestDotNetSdkInstaller(),
+                NullLoggerFactory.Instance,
+                NullLogger<AppHostServerProjectFactory>.Instance);
+
+            var project = await factory.CreateAsync(appDirectory.FullName, CancellationToken.None);
+
+            Assert.IsType<PrebuiltAppHostServer>(project);
+            Assert.Equal(1, bundleService.ExtractCallCount);
+        }
+        finally
+        {
+            DeleteDirectory(appDirectory);
+            DeleteDirectory(brokenLayout);
+            DeleteDirectory(repairedLayout);
+#if DEBUG
+            AspireRepositoryDetector.ResetCache();
+#endif
+        }
+    }
+
+    private static DirectoryInfo CreateLayout(bool includeManagedExecutable)
+    {
+        var root = Directory.CreateTempSubdirectory("aspire-layout-");
+        var managedDirectory = root.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName);
+        root.CreateSubdirectory(BundleDiscovery.DcpDirectoryName);
+
+        if (includeManagedExecutable)
+        {
+            var managedPath = Path.Combine(managedDirectory.FullName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+            File.WriteAllText(managedPath, "test");
+        }
+
+        File.WriteAllText(Path.Combine(root.FullName, BundleService.VersionMarkerFileName), "test");
+        return root;
+    }
+
+    private static void DeleteDirectory(DirectoryInfo directory)
+    {
+        if (directory.Exists)
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+#if DEBUG
+    private static void ForceRepositoryDetectionResult(string? repoRoot)
+    {
+        var detectorType = typeof(AspireRepositoryDetector);
+        detectorType.GetField("s_cachedRepoRoot", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!.SetValue(null, repoRoot);
+        detectorType.GetField("s_cacheInitialized", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!.SetValue(null, true);
+    }
+#endif
+
+    private sealed class RepairingBundleService(LayoutConfiguration? initialLayout, LayoutConfiguration? repairedLayout) : IBundleService
+    {
+        private bool _repaired;
+
+        public bool IsBundle => true;
+
+        public int ExtractCallCount { get; private set; }
+
+        public Task EnsureExtractedAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
+        {
+            ExtractCallCount++;
+            _repaired = true;
+            return Task.FromResult(BundleExtractResult.Extracted);
+        }
+
+        public BundleLayoutState GetLayoutState(string? destinationPath = null)
+            => BundleLayoutState.Inspect(destinationPath ?? (_repaired ? repairedLayout?.LayoutPath : initialLayout?.LayoutPath));
+
+        public Task<BundleExtractResult> RepairAsync(string? destinationPath = null, CancellationToken cancellationToken = default)
+            => ExtractAsync(destinationPath ?? string.Empty, force: true, cancellationToken);
+
+        public Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_repaired ? repairedLayout : initialLayout);
+    }
+}

--- a/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
@@ -18,43 +18,6 @@ namespace Aspire.Cli.Tests;
 public class BundleRecoveryTests
 {
     [Fact]
-    public void BundleService_LooksLikeBundleCorruption_ReturnsTrueForKnownRuntimeFailure()
-    {
-        Assert.True(BundleService.LooksLikeBundleCorruption(
-            error: "Failed to create CoreCLR because System.Private.CoreLib.dll could not be loaded."));
-    }
-
-    [Fact]
-    public void BundleService_LooksLikeBundleCorruption_ReturnsTrueForManagedAssemblyLoadFailure()
-    {
-        Assert.True(BundleService.LooksLikeBundleCorruption(
-            error: "Could not load file or assembly 'Aspire.Foo'",
-            additionalLines: ["/tmp/.aspire/managed/Aspire.Foo.dll"]));
-    }
-
-    [Fact]
-    public void BundleService_LooksLikeBundleCorruption_ReturnsFalseForUnrelatedFailure()
-    {
-        Assert.False(BundleService.LooksLikeBundleCorruption(
-            error: "The requested package source could not be reached."));
-    }
-
-    [Fact]
-    public void BundleService_LooksLikeBundleCorruption_ReturnsTrueForIncompleteLayoutWhenBundleRootProvided()
-    {
-        var layoutDirectory = CreateLayout(includeManagedExecutable: false);
-
-        try
-        {
-            Assert.True(BundleService.LooksLikeBundleCorruption(bundleRoot: layoutDirectory.FullName));
-        }
-        finally
-        {
-            DeleteDirectory(layoutDirectory);
-        }
-    }
-
-    [Fact]
     public async Task EnsureManagedToolPathAsync_RepairsMissingManagedExecutable()
     {
         var brokenLayout = CreateLayout(includeManagedExecutable: false);
@@ -84,22 +47,30 @@ public class BundleRecoveryTests
     }
 
     [Fact]
-    public async Task BundleNuGetPackageCache_RetriesSearchAfterBundleRepair()
+    public async Task BundleNuGetPackageCache_RetriesSearchAfterLayoutBecomesIncomplete()
     {
-        var layoutDirectory = CreateLayout(includeManagedExecutable: true);
+        var initialLayout = CreateLayout(includeManagedExecutable: true);
+        var repairedLayout = CreateLayout(includeManagedExecutable: true);
 
         try
         {
             var bundleService = new RepairingBundleService(
-                initialLayout: new LayoutConfiguration { LayoutPath = layoutDirectory.FullName },
-                repairedLayout: new LayoutConfiguration { LayoutPath = layoutDirectory.FullName });
+                initialLayout: new LayoutConfiguration { LayoutPath = initialLayout.FullName },
+                repairedLayout: new LayoutConfiguration { LayoutPath = repairedLayout.FullName });
 
             var executionFactory = new TestProcessExecutionFactory
             {
-                AttemptWithErrorCallback = (attempt, _) => attempt switch
+                AttemptWithErrorCallback = (attempt, _) =>
                 {
-                    1 => (134, null, $"Failed to load System.Private.CoreLib.dll{Environment.NewLine}Path: {Path.Combine(layoutDirectory.FullName, "managed", "System.Private.CoreLib.dll")}"),
-                    _ => (0, """{"packages":[{"id":"Aspire.Hosting.Redis","version":"9.2.0","source":"nuget"}],"totalHits":1}""", null)
+                    if (attempt == 1)
+                    {
+                        var managedPath = Path.Combine(initialLayout.FullName, BundleDiscovery.ManagedDirectoryName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+                        File.Delete(managedPath);
+
+                        return (134, null, "bundle process failed");
+                    }
+
+                    return (0, "{\"packages\":[{\"id\":\"Aspire.Hosting.Redis\",\"version\":\"9.2.0\",\"source\":\"nuget\"}],\"totalHits\":1}", null);
                 }
             };
 
@@ -110,7 +81,7 @@ public class BundleRecoveryTests
                 new TestFeatures());
 
             var packages = await cache.GetPackagesAsync(
-                layoutDirectory,
+                initialLayout,
                 "Aspire.Hosting.Redis",
                 filter: null,
                 prerelease: false,
@@ -123,6 +94,48 @@ public class BundleRecoveryTests
             Assert.Equal("9.2.0", package.Version);
             Assert.Equal(1, bundleService.ExtractCallCount);
             Assert.Equal(2, executionFactory.AttemptCount);
+        }
+        finally
+        {
+            DeleteDirectory(initialLayout);
+            DeleteDirectory(repairedLayout);
+        }
+    }
+
+    [Fact]
+    public async Task BundleNuGetPackageCache_DoesNotRetryWhenRuntimeFailureLeavesLayoutUsable()
+    {
+        var layoutDirectory = CreateLayout(includeManagedExecutable: true);
+
+        try
+        {
+            var bundleService = new RepairingBundleService(
+                initialLayout: new LayoutConfiguration { LayoutPath = layoutDirectory.FullName },
+                repairedLayout: new LayoutConfiguration { LayoutPath = layoutDirectory.FullName });
+
+            var executionFactory = new TestProcessExecutionFactory
+            {
+                AttemptWithErrorCallback = (_, _) =>
+                    (134, null, $"Failed to load System.Private.CoreLib.dll{Environment.NewLine}Path: {Path.Combine(layoutDirectory.FullName, "managed", "System.Private.CoreLib.dll")}")
+            };
+
+            var cache = new BundleNuGetPackageCache(
+                bundleService,
+                new LayoutProcessRunner(executionFactory),
+                NullLogger<BundleNuGetPackageCache>.Instance,
+                new TestFeatures());
+
+            await Assert.ThrowsAsync<NuGetPackageCacheException>(() => cache.GetPackagesAsync(
+                layoutDirectory,
+                "Aspire.Hosting.Redis",
+                filter: null,
+                prerelease: false,
+                nugetConfigFile: null,
+                useCache: false,
+                CancellationToken.None));
+
+            Assert.Equal(0, bundleService.ExtractCallCount);
+            Assert.Equal(1, executionFactory.AttemptCount);
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleRecoveryTests.cs
@@ -219,7 +219,7 @@ public class BundleRecoveryTests
 
             var factory = new AppHostServerProjectFactory(
                 new TestDotNetCliRunner(),
-                new MockPackagingService(),
+                new TestPackagingService(),
                 new TestConfigurationService(),
                 bundleService,
                 bundleNuGetService,
@@ -284,7 +284,7 @@ public class BundleRecoveryTests
 
             var factory = new AppHostServerProjectFactory(
                 new TestDotNetCliRunner(),
-                new MockPackagingService(),
+                new TestPackagingService(),
                 new TestConfigurationService(),
                 bundleService,
                 bundleNuGetService,
@@ -336,7 +336,7 @@ public class BundleRecoveryTests
 
             var factory = new AppHostServerProjectFactory(
                 new TestDotNetCliRunner(),
-                new MockPackagingService(),
+                new TestPackagingService(),
                 new TestConfigurationService(),
                 bundleService,
                 bundleNuGetService,

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -106,6 +106,22 @@ public class BundleServiceTests
     }
 
     [Fact]
+    public void IsUsableExtractedLayout_ReturnsFalse_WhenVersionMarkerExistsButRequiredContentsAreMissing()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
+        try
+        {
+            BundleService.WriteVersionMarker(tempDir.FullName, "13.2.0-dev");
+
+            Assert.False(BundleService.IsUsableExtractedLayout(tempDir.FullName));
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void CleanLayoutDirectories_RemovesExtractionMarkers()
     {
         var tempDir = Directory.CreateTempSubdirectory("aspire-test");

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Bundles;
+using Aspire.Cli.Utils;
 using Aspire.Shared;
 
 namespace Aspire.Cli.Tests;
@@ -122,7 +123,7 @@ public class BundleServiceTests
     }
 
     [Fact]
-    public void CleanLayoutDirectories_RemovesExtractionMarkers()
+    public async Task CleanLayoutDirectoriesAsync_RemovesExtractionMarkers()
     {
         var tempDir = Directory.CreateTempSubdirectory("aspire-test");
         try
@@ -130,7 +131,7 @@ public class BundleServiceTests
             BundleService.WriteVersionMarker(tempDir.FullName, "13.2.0-dev");
             BundleService.WriteExtractionInProgressMarker(tempDir.FullName, "13.2.0-dev");
 
-            BundleService.CleanLayoutDirectories(tempDir.FullName);
+            await BundleService.CleanLayoutDirectoriesAsync(tempDir.FullName, CancellationToken.None);
 
             Assert.Null(BundleService.ReadVersionMarker(tempDir.FullName));
             Assert.False(BundleService.HasExtractionInProgressMarker(tempDir.FullName));
@@ -182,6 +183,56 @@ public class BundleServiceTests
             var secondVersion = BundleService.GetCurrentVersion(processPath);
 
             Assert.NotEqual(firstVersion, secondVersion);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureDirectoryReadyForExtractionAsync_RetriesUntilDirectoryCanBeReplaced()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
+        try
+        {
+            var managedPath = tempDir.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName).FullName;
+            var attempts = 0;
+
+            await BundleService.EnsureDirectoryReadyForExtractionAsync(
+                managedPath,
+                CancellationToken.None,
+                tryDeleteDirectory: _ => ++attempts < 3
+                    ? FileDeleteHelper.DeleteDirectoryResult.Blocked
+                    : FileDeleteHelper.DeleteDirectoryResult.Deleted,
+                retryDelay: TimeSpan.Zero,
+                timeout: TimeSpan.FromSeconds(1));
+
+            Assert.Equal(3, attempts);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureDirectoryReadyForExtractionAsync_ThrowsWhenDirectoryRemainsLocked()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
+        try
+        {
+            var managedPath = tempDir.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName).FullName;
+
+            var exception = await Assert.ThrowsAsync<IOException>(
+                () => BundleService.EnsureDirectoryReadyForExtractionAsync(
+                    managedPath,
+                    CancellationToken.None,
+                    tryDeleteDirectory: _ => FileDeleteHelper.DeleteDirectoryResult.Blocked,
+                    retryDelay: TimeSpan.Zero,
+                    timeout: TimeSpan.Zero));
+
+            Assert.Contains("still locked by another process", exception.Message);
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Bundles;
+using Aspire.Shared;
 
 namespace Aspire.Cli.Tests;
 
@@ -45,6 +46,78 @@ public class BundleServiceTests
         {
             var readVersion = BundleService.ReadVersionMarker(tempDir.FullName);
             Assert.Null(readVersion);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExtractionInProgressMarker_IsDetected()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
+        try
+        {
+            BundleService.WriteExtractionInProgressMarker(tempDir.FullName, "13.2.0-dev");
+
+            Assert.True(BundleService.HasExtractionInProgressMarker(tempDir.FullName));
+            Assert.False(BundleService.IsExtractionComplete(tempDir.FullName));
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsExtractionComplete_ReturnsTrue_WhenVersionMarkerExistsAndNoExtractionInProgressMarker()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
+        try
+        {
+            BundleService.WriteVersionMarker(tempDir.FullName, "13.2.0-dev");
+
+            Assert.True(BundleService.IsExtractionComplete(tempDir.FullName));
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsUsableExtractedLayout_ReturnsTrue_ForLegacyLayoutWithoutMarkers()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
+        try
+        {
+            var managedDirectory = tempDir.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName);
+            tempDir.CreateSubdirectory(BundleDiscovery.DcpDirectoryName);
+            File.WriteAllText(Path.Combine(managedDirectory.FullName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)), "test");
+
+            Assert.True(BundleService.IsUsableExtractedLayout(tempDir.FullName));
+            Assert.False(BundleService.IsExtractionComplete(tempDir.FullName));
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CleanLayoutDirectories_RemovesExtractionMarkers()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
+        try
+        {
+            BundleService.WriteVersionMarker(tempDir.FullName, "13.2.0-dev");
+            BundleService.WriteExtractionInProgressMarker(tempDir.FullName, "13.2.0-dev");
+
+            BundleService.CleanLayoutDirectories(tempDir.FullName);
+
+            Assert.Null(BundleService.ReadVersionMarker(tempDir.FullName));
+            Assert.False(BundleService.HasExtractionInProgressMarker(tempDir.FullName));
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/LayoutDiscoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/LayoutDiscoveryTests.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Bundles;
+using Aspire.Cli.Layout;
+using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests;
+
+public class LayoutDiscoveryTests
+{
+    [Fact]
+    public void DiscoverLayout_ReturnsLayout_ForLegacyLayoutWithoutMarkers()
+    {
+        var layoutDirectory = CreateLayout(writeVersionMarker: false, writeExtractionInProgressMarker: false);
+
+        try
+        {
+            using var scope = new LayoutPathEnvironmentVariableScope(layoutDirectory.FullName);
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
+
+            var layout = discovery.DiscoverLayout();
+
+            Assert.NotNull(layout);
+            Assert.Equal(layoutDirectory.FullName, layout!.LayoutPath);
+        }
+        finally
+        {
+            layoutDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DiscoverLayout_ReturnsNull_WhenExtractionInProgressMarkerExists()
+    {
+        var layoutDirectory = CreateLayout(writeVersionMarker: true, writeExtractionInProgressMarker: true);
+
+        try
+        {
+            using var scope = new LayoutPathEnvironmentVariableScope(layoutDirectory.FullName);
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
+
+            Assert.Null(discovery.DiscoverLayout());
+        }
+        finally
+        {
+            layoutDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DiscoverLayout_ReturnsLayout_WhenMarkersIndicateComplete()
+    {
+        var layoutDirectory = CreateLayout(writeVersionMarker: true, writeExtractionInProgressMarker: false);
+
+        try
+        {
+            using var scope = new LayoutPathEnvironmentVariableScope(layoutDirectory.FullName);
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
+
+            var layout = discovery.DiscoverLayout();
+
+            Assert.NotNull(layout);
+            Assert.Equal(layoutDirectory.FullName, layout!.LayoutPath);
+        }
+        finally
+        {
+            layoutDirectory.Delete(recursive: true);
+        }
+    }
+
+    private static DirectoryInfo CreateLayout(bool writeVersionMarker, bool writeExtractionInProgressMarker)
+    {
+        var root = Directory.CreateTempSubdirectory("aspire-layout-");
+        var managedDirectory = root.CreateSubdirectory(BundleDiscovery.ManagedDirectoryName);
+        root.CreateSubdirectory(BundleDiscovery.DcpDirectoryName);
+
+        var managedPath = Path.Combine(managedDirectory.FullName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        File.WriteAllText(managedPath, "test");
+
+        if (writeVersionMarker)
+        {
+            BundleService.WriteVersionMarker(root.FullName, "test-version");
+        }
+
+        if (writeExtractionInProgressMarker)
+        {
+            BundleService.WriteExtractionInProgressMarker(root.FullName, "test-version");
+        }
+
+        return root;
+    }
+
+    private sealed class LayoutPathEnvironmentVariableScope : IDisposable
+    {
+        private readonly string? _originalValue = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
+
+        public LayoutPathEnvironmentVariableScope(string layoutPath)
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, layoutPath);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, _originalValue);
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -530,7 +530,23 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
         Assert.Equal("Testing", envVars["ASPIRE_ENVIRONMENT"]);
     }
 
-    private static GuestAppHostProject CreateGuestAppHostProject()
+    [Fact]
+    public async Task FindAndStopRunningInstanceAsync_ReturnsNoRunningInstanceWhenServerFactoryFails()
+    {
+        var appHostFile = new FileInfo(Path.Combine(_workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "// test");
+
+        var project = CreateGuestAppHostProject(new ThrowingAppHostServerProjectFactory());
+
+        var result = await project.FindAndStopRunningInstanceAsync(
+            appHostFile,
+            new DirectoryInfo(Path.GetTempPath()),
+            CancellationToken.None);
+
+        Assert.Equal(RunningInstanceResult.NoRunningInstance, result);
+    }
+
+    private static GuestAppHostProject CreateGuestAppHostProject(IAppHostServerProjectFactory? appHostServerProjectFactory = null)
     {
         var language = new LanguageInfo(
             LanguageId: "typescript/nodejs",
@@ -547,7 +563,7 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
             language: language,
             interactionService: new TestInteractionService(),
             backchannel: new TestAppHostBackchannel(),
-            appHostServerProjectFactory: new TestAppHostServerProjectFactory(),
+            appHostServerProjectFactory: appHostServerProjectFactory ?? new TestAppHostServerProjectFactory(),
             certificateService: new TestCertificateService(),
             runner: new TestDotNetCliRunner(),
             packagingService: new TestPackagingService(),
@@ -556,5 +572,11 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
             languageDiscovery: new TestLanguageDiscovery(),
             logger: NullLogger<GuestAppHostProject>.Instance,
             fileLoggerProvider: new FileLoggerProvider(logFilePath, new TestStartupErrorWriter()));
+    }
+
+    private sealed class ThrowingAppHostServerProjectFactory : IAppHostServerProjectFactory
+    {
+        public Task<IAppHostServerProject> CreateAsync(string appPath, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Simulated AppHost server failure.");
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -156,7 +156,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
-        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), TestExecutionContextFactory.CreateTestContext(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
+        var nugetService = new BundleNuGetService(new NullBundleService(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), TestExecutionContextFactory.CreateTestContext(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
         var server = new PrebuiltAppHostServer(
             workspace.WorkspaceRoot.FullName,
             "test.sock",
@@ -210,7 +210,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             OnGetConfiguration = key => key == "channel" ? "pr-old" : null
         };
 
-        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), TestExecutionContextFactory.CreateTestContext(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
+        var nugetService = new BundleNuGetService(new NullBundleService(), new LayoutProcessRunner(new TestProcessExecutionFactory()), new TestFeatures(), TestExecutionContextFactory.CreateTestContext(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
         var server = new PrebuiltAppHostServer(
             workspace.WorkspaceRoot.FullName,
             "test.sock",

--- a/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
@@ -37,6 +37,12 @@ internal sealed class TestProcessExecutionFactory : IProcessExecutionFactory
     public Func<int, ProcessInvocationOptions, (int ExitCode, string? Stdout)>? AttemptCallback { get; set; }
 
     /// <summary>
+    /// Gets or sets a callback that is invoked for each execution attempt, receiving the attempt number (1-based)
+    /// and options, and returning the exit code, stdout, and stderr content.
+    /// </summary>
+    public Func<int, ProcessInvocationOptions, (int ExitCode, string? Stdout, string? Stderr)>? AttemptWithErrorCallback { get; set; }
+
+    /// <summary>
     /// When set, the execution will use this exit code when <see cref="IProcessExecution.WaitForExitAsync"/> is called.
     /// </summary>
     public int DefaultExitCode { get; set; }
@@ -65,7 +71,15 @@ internal sealed class TestProcessExecutionFactory : IProcessExecutionFactory
         }
 
         // Use AttemptCallback if provided, otherwise create a simple callback that returns the default exit code
-        var callback = AttemptCallback ?? ((_, _) => (DefaultExitCode, null));
+        var callback = AttemptWithErrorCallback is not null
+            ? new Func<int, ProcessInvocationOptions, (int ExitCode, string? Stdout, string? Stderr)>(AttemptWithErrorCallback)
+            : ((AttemptCallback is not null)
+                ? (attempt, options) =>
+                {
+                    var (exitCode, stdout) = AttemptCallback(attempt, options);
+                    return (exitCode, stdout, null);
+                }
+                : (_, _) => (DefaultExitCode, null, null));
         return new TestProcessExecution(fileName, args, env, options, callback, () => _attemptCount);
     }
 }
@@ -73,7 +87,7 @@ internal sealed class TestProcessExecutionFactory : IProcessExecutionFactory
 internal sealed class TestProcessExecution : IProcessExecution
 {
     private readonly ProcessInvocationOptions _options;
-    private readonly Func<int, ProcessInvocationOptions, (int ExitCode, string? Stdout)> _attemptCallback;
+    private readonly Func<int, ProcessInvocationOptions, (int ExitCode, string? Stdout, string? Stderr)> _attemptCallback;
     private readonly Func<int> _attemptCounter;
     private bool _started;
 
@@ -83,6 +97,27 @@ internal sealed class TestProcessExecution : IProcessExecution
         IDictionary<string, string>? env,
         ProcessInvocationOptions options,
         Func<int, ProcessInvocationOptions, (int ExitCode, string? Stdout)> attemptCallback,
+        Func<int> attemptCounter)
+        : this(
+            fileName,
+            args,
+            env,
+            options,
+            (attempt, invocationOptions) =>
+            {
+                var (exitCode, stdout) = attemptCallback(attempt, invocationOptions);
+                return (exitCode, stdout, null);
+            },
+            attemptCounter)
+    {
+    }
+
+    public TestProcessExecution(
+        string fileName,
+        string[] args,
+        IDictionary<string, string>? env,
+        ProcessInvocationOptions options,
+        Func<int, ProcessInvocationOptions, (int ExitCode, string? Stdout, string? Stderr)> attemptCallback,
         Func<int> attemptCounter)
     {
         FileName = fileName;
@@ -125,10 +160,14 @@ internal sealed class TestProcessExecution : IProcessExecution
         }
 
         var attempt = _attemptCounter();
-        var (exitCode, stdout) = _attemptCallback(attempt, _options);
+        var (exitCode, stdout, stderr) = _attemptCallback(attempt, _options);
         if (stdout is not null)
         {
             _options.StandardOutputCallback?.Invoke(stdout);
+        }
+        if (stderr is not null)
+        {
+            _options.StandardErrorCallback?.Invoke(stderr);
         }
         return Task.FromResult(exitCode);
     }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -640,6 +640,11 @@ internal sealed class NullBundleService : IBundleService
     public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
         => Task.FromResult(BundleExtractResult.NoPayload);
 
+    public BundleLayoutState GetLayoutState(string? destinationPath = null) => default;
+
+    public Task<BundleExtractResult> RepairAsync(string? destinationPath = null, CancellationToken cancellationToken = default)
+        => Task.FromResult(BundleExtractResult.NoPayload);
+
     public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<Layout.LayoutConfiguration?>(null);
 }
@@ -656,6 +661,12 @@ internal sealed class TestBundleService(bool isBundle) : IBundleService
     public Task EnsureExtractedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
     public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
+        => Task.FromResult(isBundle ? BundleExtractResult.AlreadyUpToDate : BundleExtractResult.NoPayload);
+
+    public BundleLayoutState GetLayoutState(string? destinationPath = null)
+        => BundleLayoutState.Inspect(destinationPath ?? Layout?.LayoutPath);
+
+    public Task<BundleExtractResult> RepairAsync(string? destinationPath = null, CancellationToken cancellationToken = default)
         => Task.FromResult(isBundle ? BundleExtractResult.AlreadyUpToDate : BundleExtractResult.NoPayload);
 
     public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description

This PR hardens bundled CLI layout recovery, improves diagnostics around bundled AppHost server resolution failures, and makes forced re-extraction safer when a prior layout is still in use.

- adds extraction markers and compatibility-aware layout inspection so interrupted and legacy layouts are classified correctly
- adds one-shot repair/retry flow for bundled managed-tool execution and bundled AppHost server creation
- logs the concrete bundle-mode rejection reason when layout discovery returns no usable layout or `managed/aspire-managed` is missing
- waits for locked `managed/` and `dcp/` directories to be deleted or renamed before re-extraction, and surfaces a specific error if another process still owns the layout
- adds regression coverage for recovery, retry, guest preflight, diagnostics, and locked-layout cleanup

Motivation/context: the bundled CLI can fail against an incomplete or actively mutated shared layout, and older logs collapsed too many of those cases into the generic `No Aspire AppHost server is available` error. This change makes those failures recoverable when possible and actionable when they still fail. Related to #16306.

Dependencies: none.

Validation:
- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.BundleRecoveryTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- merge-context build of `tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj` against `origin/main`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
