### PR TITLE
Add reviewing-aspire-architecture agent trained from full repo review  history

### DIFF
--- a/.github/agents/reviewing-aspire-architecture.agent.md
+++ b/.github/agents/reviewing-aspire-architecture.agent.md
@@ -1,0 +1,179 @@
+---
+name: reviewing-aspire-architecture
+description: "Reviews PRs for Aspire-specific architectural patterns across 15 dimensions including API design, resource lifecycle, deployment architecture, component conformance, dashboard UX, CLI behavior, and more. Complements the code-review skill with domain knowledge that generic review cannot catch. Triggers on deep review, architectural review, or PRs touching hosting core, components, dashboard, CLI, or Azure integrations."
+---
+
+# Reviewing Aspire Architecture
+
+You review PRs for **Aspire domain-specific correctness** — patterns, conventions, and design decisions that generic code review cannot catch. Only flag issues requiring Aspire domain knowledge. Zero duplicate comments is a hard requirement — check ALL existing review comments before posting.
+
+**Owns**: resource model, Azure/Bicep, dashboard UI/telemetry, CLI UX, component conformance, containers, cross-dimension interactions.
+**Out of scope**: generic bugs/security/perf/concurrency/error-handling (code-review covers these), formatting/CA (CI), flaky test patterns (test-review-guidelines), API file guards (AGENTS.md).
+**Overlap note**: Some dimensions (Security, Performance, Error Handling) share *topic areas* with code-review but contain only Aspire-specific checks that require domain knowledge. Generic versions of those checks are code-review's responsibility.
+
+## Principles
+
+- **Backward compatibility by default.** Add overloads; don't change existing signatures.
+- **Secure by default.** Never weaken security defaults. Credentials, certs, and secret masking must be correct everywhere including tests.
+- **Resource model consistency.** Minimize manifest primitives. Use `EndpointReference` and named endpoints. Differentiate Run vs Publish explicitly.
+- **Simplicity first.** Centralize shared logic. Remove dead code. Avoid unnecessary dependency expansion.
+- **Explicit over implicit.** Actionable errors. Specific config feedback. Document resolution precedence.
+- **Platform parity.** Windows, Linux, macOS. Path separators, file locking, container runtimes, platform-specific crypto.
+
+---
+
+## API Design
+
+- Add overloads instead of changing existing public API signatures.
+- Keep types internal until a clear customer scenario requires public exposure; prefer extension methods on builders.
+- Endpoint API changes must preserve backward compatibility with existing app models.
+- Minimize manifest primitive types (container, project, value, parameter, azure.bicep).
+- Service discovery endpoint selection: typed API extensions, not URL syntax conventions.
+- Connection string references are injected via `WithReference()` with optional `connectionName`; `Add*` methods create resources, `With*` methods configure them.
+- Connection name mapping between AppHost and service projects must be clear and consistent.
+- Publishing extensions should use the `PipelineStep` architecture rather than the deprecated `IDistributedApplicationPublisher` interface.
+- Aspire deprecations must include migration path to the replacement API (e.g., `AfterEndpointsAllocatedEvent` → `ResourceEndpointsAllocatedEvent`). Generic `[Obsolete]` without Aspire-specific guidance is insufficient.
+- When upstream libraries ship major breaking changes, pin dependency range and provide separate package for new major.
+
+## Resource Model
+
+- Resources referenced by other resources must be in the deployment manifest.
+- Use `EndpointReference` over `AllocatedEndpointAnnotation`; define named primary endpoints for type-safe references.
+- Centralize endpoint URL construction in `EndpointReference`; callers must not reconstruct URLs from individual endpoint properties.
+- Use canonical API for querying endpoints — consistent across Run and Publish contexts.
+- Lifecycle hooks must branch by Run vs Publish mode.
+- Container resource secrets must use environment variables or `BuildImageSecretValue`, never command-line arguments passed to `ProcessSpec.CommandLineArgs`.
+- `ConnectionStringExpression` values containing semicolons, equals signs, or other delimiters in resource names must be escaped per the target driver's connection string format.
+- Manifest must include all child resource details (topic/queue names) for deployment tools.
+
+## Azure Provisioning
+
+- Bicep generation: external parameters, not hardcoded values.
+- `AzureResourceInfrastructure` should aggregate all related Azure resources into a single Bicep module via the `Infrastructure` class rather than emitting separate deployment per resource.
+- Sub-resources without Bicep files: `value.v0` manifest type, not custom types.
+- New manifest type versions (e.g., `container.v1`) must be additive; existing type schemas must not remove or rename fields consumed by azd or other deployment tools.
+- Allow sharing infrastructure resources (e.g., single KeyVault) across Azure resources.
+- When `Azure.Provisioning` library updates fix output expression bugs, update the package reference rather than adding string manipulation workarounds in Aspire provisioning code.
+- Azure integrations must use `DefaultAzureCredential` via the Aspire credential provider abstractions; secrets in resource annotations must be marked `IsSecret=true` for dashboard masking.
+- Iterate Azure integrations in separate NuGet packages based on Azure.Provisioning before merging to core.
+
+## Dashboard UI/UX
+
+- Resources entering `FailedToStart` or error states must remain visible in the Dashboard resources page with their last-known log output accessible, rather than being removed from the resource list.
+- OTLP HTTP endpoints: same auth policy as gRPC; never `AllowAnonymous` on telemetry ingestion.
+- OTLP HTTP: validate `Content-Type`, support Protobuf/JSON content negotiation.
+- No CORS on telemetry endpoints without full security analysis.
+- Resource properties annotated with `IsSecret=true` in the app model must have `IsValueSensitive=true` in `PropertyGrid` rendering, ensuring the Dashboard masks them by default with a reveal toggle.
+- Show resource references and reverse references explicitly.
+- `OtlpCompositeAuthenticationHandler` must support both `OtlpAuthMode.ApiKey` and `OtlpAuthMode.ClientCertificate` modes. New auth modes require corresponding test coverage in Dashboard tests.
+- When OTLP HTTP endpoints use port 0 (dynamic allocation), CORS `AllowedOrigins` validation must account for the runtime-assigned port in origin matching.
+- Console log pages: virtualization or paging for thousands of lines.
+- DashboardClient/ResourceService: handle concurrent disposal and reconnection without races.
+
+## CLI Behavior
+
+- Display resource endpoint URLs after deployment completes.
+- Handle empty states gracefully with helpful guidance.
+- Errors to stderr, normal output to stdout; never mix.
+- CLI commands must surface configuration file parse errors as user-visible warnings, not suppress them at Debug log level.
+- Sensitive features (like telemetry API) default to disabled.
+- When a CLI command fails due to missing context (no running AppHost, no project found), the error message must include the specific flag or command that resolves the situation.
+- Output formatting must work across terminals (no color/emoji assumption).
+- Consistent option naming across all root command arguments.
+- Interactive prompts need non-interactive fallbacks for CI/automation.
+
+## Test Quality
+
+Coverage beyond flaky patterns (already in test-review-guidelines).
+
+- Run binaries from a different folder than source for realistic user environment testing.
+- Validate across Helix, GitHub Actions, and local dev loop runners.
+- When provisioning logic changes, update test expectations rather than weakening assertions.
+- Test both Run and Publish execution contexts for resources with different behavior.
+- Use full CLI archive (native AOT) in integration tests, not `dotnet run` of tool project.
+- Test fakes (e.g., `FakeContainerRuntime`, `FakeAcrLoginService`) must implement the same interface and replicate key behavioral constraints of the real implementation, especially for container runtime startup sequencing and Azure token refresh flows.
+
+## Feature Extensibility
+
+- Endpoint changes: validate service discovery, containers, and `AllocatedEndpoint` annotations end-to-end.
+- `ResourceNotificationService` and `ResourceLoggerService` are concrete services; new resource notification or log handling code should use these services rather than creating parallel notification mechanisms.
+- Health check endpoints secured by default.
+- Unsupported interactions: fail explicitly, not silently empty results.
+- Balance liveness checks against startup latency impact on other resources.
+- Database migrations in AppHost risk dependency conflicts — keep in service projects.
+
+## Pattern Conformance
+
+- OTLP auth: `AuthenticationHandler` for identity, not `AuthorizationHandler`.
+- Extension method names: `Add*`/`With*`/`RunAs*` patterns.
+- New hosting integrations: same builder-pattern structure as existing.
+- Resource configuration immutable after build phase; mutable annotations only during builder config.
+
+## Build & Contributor Workflow
+
+- Never ship package versions not publicly available on nuget.org.
+- Support shipping specific packages as preview when upstream deps lack stable versions.
+- Deployment output must be scannable — surface errors prominently, avoid excessive output.
+- Missing approved-feed dependencies: update feed config rather than working around it.
+
+## Documentation & Naming
+
+- Document endpoint resolution precedence (allocated vs configured ports).
+- Azure hosting integration READMEs must document both `Add{Service}` for creating new resources and `AddConnectionString` for using existing resources.
+- Password generation: exact names like `length`, not ambiguous `minLength`.
+- Consistent option/argument naming across similar CLI commands.
+
+## Error Handling
+
+- Retry strategies for transient failures (gRPC reconnection, backchannel socket connection, port binding) must use exponential backoff with configurable maximum delay, not fixed-interval or linear retry.
+- `DefaultTimeout` patterns that disable timeout while debugging.
+- JSON config: allow comments and trailing commas for user-edited files.
+
+## Container Management
+
+- Hostname resolution: support both Docker and Podman.
+- Default container images in hosting integration packages (e.g., `*ContainerImageTags.cs`) should use floating `major.minor` tags for automatic security patches. This does not apply to the generic `AddContainer`/`WithImage` API where users specify their own images.
+- Ensure output directory exists before Docker image builds.
+- Fully qualify image references; manage tag versioning explicitly.
+
+## Security
+
+- Connection strings and sensitive properties must be markable as secrets in dashboard.
+- Certificate allow lists for client cert auth.
+- Distinguish cert validity from cert identity in auth logic.
+- Test security config bindings to catch key naming mismatches.
+
+## Platform Compatibility
+
+- Filter platform-specific paths by current OS, not unconditionally.
+- Dashboard endpoint URLs: actual accessible host for user's environment.
+- Account for path handling, file locking, container runtime platform differences.
+- Container runtime startup: integrate with IDE startup flows.
+
+## Performance
+
+- Defer provisioning until application run or manifest write.
+- Rate-limit dashboard updates; avoid unnecessary data processing.
+- Minimize re-renders to avoid expensive `Expression.Compile` in FluentUI Blazor.
+
+---
+
+## Review Workflow
+
+1. Read PR description, linked issues, and ALL existing review comments.
+2. Map changed files → relevant dimensions (use routing table below).
+3. Check each relevant dimension's rules against the diff.
+4. Drop any finding that overlaps with an existing comment.
+5. Present findings grouped by dimension, ordered by severity. Do NOT post automatically — present to user for triage.
+
+### Folder → Dimension Routing
+
+| Folder | Dimensions |
+|---|---|
+| `src/Aspire.Hosting/**` (not Azure*) | Resource Model, API Design, Pattern Conformance, Containers |
+| `src/Aspire.Hosting.Azure*/**` | Azure Provisioning, Resource Model, API Design, Security |
+| `src/Aspire.Dashboard/**` | Dashboard UI/UX, Security, Performance |
+| `src/Aspire.Cli/**` | CLI Behavior, Error Handling, Platform Compatibility |
+| `src/Components/**` | Pattern Conformance, API Design, Build & Contributor Workflow |
+| `tests/**` | Test Quality + mirror dimensions of code under test |
+| `eng/**`, `.github/**` | Build & Contributor Workflow, Documentation & Naming |

--- a/.github/agents/reviewing-aspire-architecture.agent.md
+++ b/.github/agents/reviewing-aspire-architecture.agent.md
@@ -38,7 +38,7 @@ You review PRs for **Aspire domain-specific correctness** — patterns, conventi
 ## Resource Model
 
 - Resources referenced by other resources must be in the deployment manifest.
-- Use `EndpointReference` over `AllocatedEndpointAnnotation`; define named primary endpoints for type-safe references.
+- Use `EndpointReference` over `AllocatedEndpoint`; define named primary endpoints for type-safe references.
 - Centralize endpoint URL construction in `EndpointReference`; callers must not reconstruct URLs from individual endpoint properties.
 - Use canonical API for querying endpoints — consistent across Run and Publish contexts.
 - Lifecycle hooks must branch by Run vs Publish mode.

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: "src/Components/**/*.cs"
+---
+
+# Client Integration Review Patterns
+
+- Prefer reusing the DI-registered client for health checks when the health check library supports it; if it does not, justify any separate client/connection.
+- Standard pattern: bind the integration section, then the named subsection, then override from `ConnectionStrings:{name}`, then invoke `configureSettings` last. If a component diverges, make the exception explicit.
+- Do not throw for a missing connection string before the `configureSettings` delegate runs — the user may supply connection info programmatically.
+- Client-side extension methods (on `IHostApplicationBuilder`) must have names distinct from AppHost-side methods (on `IDistributedApplicationBuilder`) — e.g., `AddRedisClient` vs `AddRedis`.
+- For components round-tripping through AppHost `WithReference()`, all required connection details should fit in `ConnectionStrings:{name}` or be derivable from it.
+- Use `exclusionPaths` when the generated `ConfigurationSchema` would expose misleading or non-bindable members (for example Azure client-option `Default` singletons or certificate-context members).

--- a/.github/instructions/dashboard.instructions.md
+++ b/.github/instructions/dashboard.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "src/Aspire.Dashboard/**/*.{cs,razor,js}"
+---
+
+# Dashboard Review Patterns
+
+- Dashboard subscription/watch callbacks can run concurrently; protect shared mutable state with locking or concurrent collections.
+- Prefer FluentUI for standard interactive controls. Raw HTML is fine when semantics, performance, or UX require it; if working around a FluentUI limitation, cite the FluentUI issue.
+- Use `ViewportInformation.IsDesktop` / `IsUltraLowHeight` cascading parameter for responsive layout; throttle (not debounce) resize events to avoid excessive re-renders of the entire component tree.
+- Use `@onclick:stopPropagation="true"` on interactive elements inside `FluentDataGrid` rows that have row-click handlers to prevent unintended navigation.
+- Prefer JS interop for browser-only, latency-sensitive interactions (clipboard, global DOM listeners). If you register a persistent JS listener, keep a handle and unregister in `DisposeAsync`.
+- For high-throughput log/trace/metric streams with a fixed cap, use `CircularBuffer<T>` instead of repeatedly removing the first item from a `List<T>`.
+- For bounded channels feeding one consumer, prefer `BoundedChannelFullMode.DropOldest` and set `SingleReader = true`.
+- Use `FormatHelpers` for culture-aware date/time/number display. Reserve invariant formatting for intentionally fixed diagnostic formats.
+- Localize user-visible dashboard text with resource-backed localizers. Prefer typed localizers and `nameof` keys when practical, but existing model/helpers also generate localized UI text.

--- a/.github/instructions/hosting-azure.instructions.md
+++ b/.github/instructions/hosting-azure.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "src/Aspire.Hosting.Azure*/**/*.cs"
+---
+
+# Hosting Azure Review Patterns
+
+- Child Azure resource types should implement `IResourceWithParent<TParent>`. Expose parent-scoped domain methods like `AddDatabase`/`AddHub` on the parent builder instead of top-level creation APIs.
+- Keep emulator/access-key/managed-identity branching centralized in the parent/base resource. Child resources may append child-specific segments but should not re-implement auth-mode branching.
+- For override-style annotations where repeated calls should replace earlier values, use `ResourceAnnotationMutationBehavior.Replace`. Only rely on `TryGetLastAnnotation` without `Replace` when accumulating multiple annotations is intentional.
+- Child resource names must be globally unique in the Aspire model; provide a separate physical-name parameter (e.g., `databaseName`) that defaults to the resource name.
+- When a resource is marked existing via `RunAsExisting`/`PublishAsExisting`, treat it as read-only. Do not apply auth or provisioning mutations that only make sense for newly created resources.
+- Customize Azure provisioning/Bicep through the `AzureProvisioningResource` parent. Child resources are usually plain `Resource` types — expose typed child properties instead of separate provisioning callback APIs.
+- Keep health checks side-effect-free. Perform resource initialization (creating databases, containers, queues) in `OnResourceReady` after the resource becomes healthy.

--- a/.github/instructions/hosting-core.instructions.md
+++ b/.github/instructions/hosting-core.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "src/Aspire.Hosting/**/*.cs"
+---
+
+# Hosting Core Review Patterns
+
+- Callbacks that read runtime-only values must branch on `context.ExecutionContext.IsPublishMode`; in Publish mode emit references/placeholders instead of resolving concrete values.
+- If an annotation caches callback results, provide and use an invalidation path on restart/retry; only keep faulted tasks cached when the inputs cannot change.
+- Do not introduce circular constructor injection between hosting services; extract a small interface/service boundary (for example, `IDcpObjectFactory`) to break the cycle.
+- Exceptions that should surface from pipeline steps without extra wrapping should derive from `DistributedApplicationException`.
+- Treat null `ExitCode` as unknown, not success; DCP can report `Exited` before the real exit code arrives.

--- a/.github/skills/reviewing-aspire-architecture/SKILL.md
+++ b/.github/skills/reviewing-aspire-architecture/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: reviewing-aspire-architecture
+description: "Triggers deep architectural review across 15 Aspire-specific dimensions. Activated by requests for deep review, architectural review, pattern review, or PRs touching hosting core, Azure integrations, dashboard, CLI, or components."
+---
+
+# Aspire Architectural Review
+
+Aspire-specific architectural review via the `reviewing-aspire-architecture` agent. Catches domain patterns that generic `code-review` cannot.
+
+## When to Use
+
+**Use**: "deep review," "architectural review," "pattern review," PRs touching hosting core, Azure integrations, dashboard, CLI, components, new resource types, app model changes, deployment behavior.
+
+**Don't use**: doc/config-only PRs → `code-review` · generic PR review → `code-review` · CI failures → `ci-analysis` · flaky tests → `fix-flaky-test` · API surface → `api-review`
+
+## Relationship to code-review
+
+`code-review` covers generic bugs, security, perf, concurrency, and error handling. This skill covers only checks requiring Aspire domain knowledge. Some topic areas (Security, Performance, Error Handling) exist in both, but the checks are disjoint: generic patterns belong to `code-review`, Aspire-specific patterns belong here. Run `code-review` first for breadth, then this for domain depth.
+
+## Folder → Dimension Routing
+
+| Folder | Dimensions |
+|---|---|
+| `src/Aspire.Hosting/**` | Resource Model, API Design, Patterns, Containers |
+| `src/Aspire.Hosting.Azure*/**` | Azure Provisioning, Resource Model, Security |
+| `src/Aspire.Dashboard/**` | Dashboard UI/UX, Security, Performance |
+| `src/Aspire.Cli/**` | CLI Behavior, Error Handling, Platform Compatibility |
+| `src/Components/**` | Patterns, API Design, Build & Contributor Workflow |
+| `tests/**` | Test Quality + mirror dimensions of code under test |
+| `eng/**`, `.github/**` | Build & Contributor Workflow, Documentation & Naming |
+
+Full review rules in the `reviewing-aspire-architecture` agent.

--- a/.github/skills/reviewing-aspire-architecture/SKILL.md
+++ b/.github/skills/reviewing-aspire-architecture/SKILL.md
@@ -11,7 +11,7 @@ Aspire-specific architectural review via the `reviewing-aspire-architecture` age
 
 **Use**: "deep review," "architectural review," "pattern review," PRs touching hosting core, Azure integrations, dashboard, CLI, components, new resource types, app model changes, deployment behavior.
 
-**Don't use**: doc/config-only PRs → `code-review` · generic PR review → `code-review` · CI failures → `ci-analysis` · flaky tests → `fix-flaky-test` · API surface → `api-review`
+**Don't use**: doc/config-only PRs → `code-review` · generic PR review → `code-review` · CI failures → `ci-test-failures` · flaky tests → `fix-flaky-test` · API surface → `api-review`
 
 ## Relationship to code-review
 
@@ -21,11 +21,11 @@ Aspire-specific architectural review via the `reviewing-aspire-architecture` age
 
 | Folder | Dimensions |
 |---|---|
-| `src/Aspire.Hosting/**` | Resource Model, API Design, Patterns, Containers |
-| `src/Aspire.Hosting.Azure*/**` | Azure Provisioning, Resource Model, Security |
+| `src/Aspire.Hosting/**` | Resource Model, API Design, Pattern Conformance, Containers |
+| `src/Aspire.Hosting.Azure*/**` | Azure Provisioning, Resource Model, API Design, Security |
 | `src/Aspire.Dashboard/**` | Dashboard UI/UX, Security, Performance |
 | `src/Aspire.Cli/**` | CLI Behavior, Error Handling, Platform Compatibility |
-| `src/Components/**` | Patterns, API Design, Build & Contributor Workflow |
+| `src/Components/**` | Pattern Conformance, API Design, Build & Contributor Workflow |
 | `tests/**` | Test Quality + mirror dimensions of code under test |
 | `eng/**`, `.github/**` | Build & Contributor Workflow, Documentation & Naming |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,6 +406,7 @@ The following specialized skills are available in `.github/skills/`:
 - **dependency-update**: Guides dependency version updates by checking nuget.org, triggering the dotnet-migrate-package Azure DevOps pipeline, and monitoring runs
 - **api-review**: Reviews .NET API surface area PRs for design guideline violations, applies rules from .NET Framework Design Guidelines and Aspire conventions, and attributes findings to the author who introduced each API
 - **startup-perf**: Measures Aspire application startup performance using dotnet-trace and the TraceAnalyzer tool
+- **reviewing-aspire-architecture**: Reviews PRs for Aspire-specific architectural patterns across 15 dimensions including API design, resource model, Azure provisioning, pattern conformance, dashboard UX, CLI behavior, and more. Complements the code-review skill with domain knowledge that generic review cannot catch.
 
 ## Pattern-Based Instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,10 @@ Additional instructions are automatically applied when editing files matching sp
 | Pattern | Instructions File |
 |---------|-------------------|
 | `src/**/*.cs` | `.github/instructions/xmldoc.instructions.md` - XML documentation standards |
+| `src/Aspire.Hosting/**/*.cs` | `.github/instructions/hosting-core.instructions.md` - Hosting core review patterns |
+| `src/Aspire.Hosting.Azure*/**/*.cs` | `.github/instructions/hosting-azure.instructions.md` - Hosting Azure review patterns |
+| `src/Aspire.Dashboard/**/*.{cs,razor,js}` | `.github/instructions/dashboard.instructions.md` - Dashboard review patterns |
+| `src/Components/**/*.cs` | `.github/instructions/components.instructions.md` - Client integration review patterns |
 | `src/Aspire.Hosting*/README.md` | `.github/instructions/hosting-readme.instructions.md` - Hosting integration READMEs |
 | `src/Components/**/README.md` | `.github/instructions/client-readme.instructions.md` - Client integration READMEs |
 | `tools/QuarantineTools/*` | `.github/instructions/quarantine.instructions.md` - QuarantineTools usage |


### PR DESCRIPTION
# Add reviewing-aspire-architecture agent trained from full repo review history

This agent was not hand-written. It was extracted from 29,444 review comments by davidfowl, JamesNK, and eerhardt -- every PR, issue, and discussion where they participated in this repo -- enriched with 20,218 conversation threads, 5,061 file patches at review time, and all linked docs followed for context. Rules that produced false positives on current code were removed. What remains are patterns these reviewers consistently enforce that require Aspire domain knowledge.

## Philosophy

The goal is not "provide feedback." The goal is **build trust that each important dimension of quality was checked with laser focus**.

When my wife asks me to do 20 things, I do 1, and it's the wrong one. When she asks me to do 1 clear thing, I nail it. Agents are the same -- a single agent juggling 28 concerns skims all of them. This agent assigns a focused dimension per check, and you can trust that dimension was actually checked, not lost in a pile.

The 15 dimensions are deliberately generalized -- they apply to future PRs about features that don't exist yet, not just the code that was reviewed when the data was collected. Specific examples (like Run/Publish branching or `IResourceWithParent<T>`) appear in the checks, but the dimensions themselves (Resource Model, Azure Provisioning, Dashboard UI/UX, ...) are stable architectural concerns that outlive any single PR.

## Why

Domain mistakes are hard to catch without codebase knowledge. This agent encodes that knowledge as 15 focused review dimensions covering API design, resource lifecycle, Azure provisioning, dashboard architecture, CLI contracts, test patterns, and more -- each adversarially validated against the live codebase.

## Usage

- `@reviewing-aspire-architecture` or ask for "deep review" / "architectural review"
- Picks dimensions relevant to changed folders via routing table
- Collects existing review comments first -- zero duplicate findings
- Designed for agentic loops: add to your local review prompt for domain feedback on every iteration

## What's added

- `.github/agents/reviewing-aspire-architecture.agent.md` -- 15 dimensions, review workflow
- `.github/skills/reviewing-aspire-architecture/SKILL.md` -- routing and invocation
- 4 folder-scoped instruction files (hosting-core, hosting-azure, dashboard, components) -- auto-loaded on edit, each rule mined from review data and validated against live code

No existing files modified except 4 lines in the AGENTS.md pattern table and a new entry in the skills table.
