### PR TITLE
Bump cbl-mariner/base/core playground image and update es-metadata area path

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -5,4 +5,4 @@ accountableOwners:
 routing:
   defaultAreaPath:
     org: devdiv
-    path: DevDiv\ASP.NET Core
+    path: DevDiv\ASP.NET Core\Aspire

--- a/playground/publishers/Publishers.AppHost/qots/Dockerfile
+++ b/playground/publishers/Publishers.AppHost/qots/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go build qots.go
 
 # Stage 2: Run the Go program
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260102
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260311
 WORKDIR /app
 COPY --from=builder /app/qots .
 CMD ["./qots"]

--- a/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go build qots.go
 
 # Stage 2: Run the Go program
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260102
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260311
 WORKDIR /app
 RUN --mount=type=secret,id=SECRET_ASENV cp /run/secrets/SECRET_ASENV /app/SECRET_ASENV
 COPY --from=builder /app/qots .


### PR DESCRIPTION
This PR contains two small, unrelated maintenance updates:

1. **Bump `cbl-mariner/base/core` image to `2.0.20260311`** in the `qots` helper Dockerfiles under `playground/publishers/Publishers.AppHost` and `playground/withdockerfile/WithDockerfile.AppHost`. Routine dependency update to keep the pinned base image tag current (previously `2.0.20260102`).

2. **Update default area path in `es-metadata.yml`** from `DevDiv\ASP.NET Core` to `DevDiv\ASP.NET Core\Aspire`. The previous area path no longer exists in the `devdiv` AzDO organization; the new path matches what other Aspire-owned repositories under the same accountable service use.