### PR TITLE
Add regression test for getConnectionProperty builder-to-resource unwrapping

### DIFF
--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -1801,6 +1801,28 @@ public class CapabilityDispatcherTests
         Assert.DoesNotContain("on resource", capabilityException.Message);
     }
 
+    [Fact]
+    public void Invoke_ExtensionMethodTakingRawResource_UnwrapsBuilderHandle()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestRawResourceCapabilities).Assembly]);
+
+        var resource = new TestConnectionStringResource("mydb");
+        var builder = new TestResourceBuilder<TestConnectionStringResource>(resource);
+        var handleId = handles.Register(builder, "Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.TestConnectionStringResource");
+
+        var args = new JsonObject
+        {
+            ["resource"] = new JsonObject { ["$handle"] = handleId },
+            ["key"] = "Host"
+        };
+
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/getConnectionPropertyKey", args);
+
+        Assert.NotNull(result);
+        Assert.Equal("Host", result.GetValue<string>());
+    }
+
     private static CapabilityDispatcher CreateDispatcher(params System.Reflection.Assembly[] assemblies)
     {
         var handles = new HandleRegistry();
@@ -2251,5 +2273,43 @@ internal sealed class TestResourceWithMethods : Resource
     public string Greet(string prefix)
     {
         return $"{prefix}, {Name}!";
+    }
+}
+
+/// <summary>
+/// Test resource implementing IResourceWithConnectionString for testing
+/// extension methods that take a raw resource type (not wrapped in IResourceBuilder).
+/// </summary>
+internal sealed class TestConnectionStringResource : Resource, IResourceWithConnectionString
+{
+    public TestConnectionStringResource(string name) : base(name) { }
+
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"Host=localhost;Database={Name}");
+
+    public IEnumerable<KeyValuePair<string, ReferenceExpression>> GetConnectionProperties()
+    {
+        yield return new("Host", ReferenceExpression.Create($"localhost"));
+        yield return new("Database", ReferenceExpression.Create($"{Name}"));
+    }
+}
+
+/// <summary>
+/// Test capabilities for extension methods that take raw resource types (not builder-wrapped).
+/// Exercises the builder-to-resource unwrapping path in RegisterFromCapability.
+/// </summary>
+internal static class TestRawResourceCapabilities
+{
+    [AspireExport(Description = "Gets a connection property by key from a raw resource")]
+    public static string GetConnectionPropertyKey(IResourceWithConnectionString resource, string key)
+    {
+        foreach (var prop in resource.GetConnectionProperties())
+        {
+            if (string.Equals(prop.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                return prop.Key;
+            }
+        }
+        return string.Empty;
     }
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -1802,7 +1802,7 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
-    public void Invoke_ExtensionMethodTakingRawResource_UnwrapsBuilderHandle()
+    public void Invoke_StaticMethodTakingRawResource_UnwrapsBuilderHandle()
     {
         var handles = new HandleRegistry();
         var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestRawResourceCapabilities).Assembly]);
@@ -1817,7 +1817,7 @@ public class CapabilityDispatcherTests
             ["key"] = "Host"
         };
 
-        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/getConnectionPropertyKey", args);
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/findConnectionPropertyKey", args);
 
         Assert.NotNull(result);
         Assert.Equal("Host", result.GetValue<string>());
@@ -2295,13 +2295,13 @@ internal sealed class TestConnectionStringResource : Resource, IResourceWithConn
 }
 
 /// <summary>
-/// Test capabilities for extension methods that take raw resource types (not builder-wrapped).
+/// Test capabilities for static methods that take raw resource types (not builder-wrapped).
 /// Exercises the builder-to-resource unwrapping path in RegisterFromCapability.
 /// </summary>
 internal static class TestRawResourceCapabilities
 {
-    [AspireExport(Description = "Gets a connection property by key from a raw resource")]
-    public static string GetConnectionPropertyKey(IResourceWithConnectionString resource, string key)
+    [AspireExport(Description = "Finds a matching connection property key")]
+    public static string FindConnectionPropertyKey(this IResourceWithConnectionString resource, string key)
     {
         foreach (var prop in resource.GetConnectionProperties())
         {


### PR DESCRIPTION
## Description

Adds a regression test for the builder→resource unwrapping fix in `CapabilityDispatcher.RegisterFromCapability` that was introduced by PR #15230.

**Background**: In TypeScript AppHosts, calling `getConnectionProperty()` on a Foundry project resource (or any resource implementing `IResourceWithConnectionString`) failed because the dispatcher received an `IResourceBuilder<T>` handle but the C# extension method `GetConnectionProperty(this IResourceWithConnectionString resource, string key)` expects the raw resource type. The released version (13.2) used `_marshaller.UnmarshalFromJson()` which doesn't unwrap builders. PR #15230 added `UnmarshalArgument` → `ResolveHandleArgument` → `TryConvertHandle` which correctly extracts `.Resource` from the builder.

This test ensures no regression by verifying that a static extension method taking `IResourceWithConnectionString` works correctly when the handle registry contains an `IResourceBuilder<T>` wrapper.

Fixes #16391

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
