### PR TITLE
Add expanded AKS E2E deployment tests for Azure.Kubernetes features

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
@@ -1,0 +1,281 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying an Aspire starter application to AKS with multiple node pools
+/// and verifying that pods are scheduled on the correct pool using <c>WithNodePool</c>.
+/// AKS cluster, ACR, and resource group are all provisioned automatically by the pipeline.
+/// </summary>
+public sealed class AksMultipleNodePoolsDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 45 minutes to allow for AKS provisioning (~10-15 min) plus deployment.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployAksWithMultipleNodePools()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployAksWithMultipleNodePoolsCore(cancellationToken);
+    }
+
+    private async Task DeployAksWithMultipleNodePoolsCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("akspools");
+        var projectName = "AksPools";
+
+        output.WriteLine($"Test: {nameof(DeployAksWithMultipleNodePools)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            // Step 2: Set up CLI environment
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+            // Step 3: Create starter project without Redis
+            output.WriteLine("Step 3: Creating starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            // Step 4: Navigate to project directory
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 5: Add Aspire.Hosting.Azure.Kubernetes package
+            output.WriteLine("Step 5: Adding Azure Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
+            await auto.EnterAsync();
+
+            // aspire add may show a version selection prompt
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 6: Modify AppHost.cs to add Azure Kubernetes Environment with multiple node pools
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+
+            // Add using directive for WithNodePool extension method
+            content = "using Aspire.Hosting.Kubernetes.Extensions;\n" + content;
+
+            // Insert the Azure Kubernetes Environment with multiple node pools before builder.Build().Run();
+            var buildRunPattern = "builder.Build().Run();";
+            var replacement = """
+// AKS environment with multiple node pools
+var aks = builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D2as_v5", minCount: 1, maxCount: 2);
+
+var workerPool = aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3);
+
+builder.Build().Run();
+""";
+
+            content = content.Replace(buildRunPattern, replacement);
+
+            // Pin apiservice to the worker node pool
+            content = content.Replace(
+                "builder.AddProject<Projects." + projectName + "_ApiService>(\"apiservice\")",
+                "builder.AddProject<Projects." + projectName + "_ApiService>(\"apiservice\")\n    .WithNodePool(workerPool)");
+
+            File.WriteAllText(appHostFilePath, content);
+
+            output.WriteLine($"Modified AppHost.cs at: {appHostFilePath}");
+
+            // Step 7: Navigate to AppHost project directory
+            output.WriteLine("Step 7: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 8: Set environment variables for deployment
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 9: Deploy to AKS using aspire deploy
+            output.WriteLine("Step 9: Starting AKS deployment...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            // Wait for pipeline to complete successfully
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Step 10: Get AKS credentials for the provisioned cluster
+            output.WriteLine("Step 10: Getting AKS credentials...");
+            await auto.TypeAsync($"AKS_NAME=$(az aks list -g {resourceGroupName} --query '[0].name' -o tsv) && " +
+                  $"az aks get-credentials -g {resourceGroupName} -n $AKS_NAME --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 11: Wait for all pods to be ready
+            output.WriteLine("Step 11: Waiting for pods to be ready...");
+            await auto.TypeAsync("kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s 2>/dev/null || true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            // Step 12: Verify node pools exist (system + workers)
+            output.WriteLine("Step 12: Verifying node pools...");
+            await auto.TypeAsync($"az aks nodepool list -g {resourceGroupName} --cluster-name $AKS_NAME --query \"[].{{name:name,vmSize:vmSize,mode:mode,count:count}}\" -o table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 13: Show pods with node info
+            output.WriteLine("Step 13: Showing pods with node info...");
+            await auto.TypeAsync("kubectl get pods --all-namespaces -o wide");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 14: Verify API pod is on a worker pool node
+            output.WriteLine("Step 14: Verifying API pod scheduling on workers pool...");
+            await auto.TypeAsync("NS=$(kubectl get svc --all-namespaces -o jsonpath='{range .items[?(@.metadata.name==\"apiservice-service\")]}{.metadata.namespace}{end}') && " +
+                      "POD_NODE=$(kubectl get pods -n $NS -l app=apiservice -o jsonpath='{.items[0].spec.nodeName}') && " +
+                      "NODE_POOL=$(kubectl get node $POD_NODE -o jsonpath='{.metadata.labels.agentpool}') && " +
+                      "echo \"API pod node: $POD_NODE, pool: $NODE_POOL\" && " +
+                      "[ \"$NODE_POOL\" = \"workers\" ] && echo 'PASS: API pod on workers pool' || echo 'WARN: API pod not on expected pool'");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 15: Verify apiservice is reachable via port-forward
+            output.WriteLine("Step 15: Verifying apiservice endpoint via port-forward...");
+            await auto.TypeAsync("kubectl port-forward svc/apiservice-service 18082:8080 -n $NS > /dev/null 2>&1 &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync("sleep 3");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Verify /weatherforecast endpoint (default starter API)
+            await auto.TypeAsync("OK=0; for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18082/weatherforecast -o /dev/null -w '%{http_code}' && echo ' OK' && OK=1 && break; done; [ \"$OK\" = \"1\" ] || { echo 'FAIL: apiservice unreachable after 10 retries'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Clean up port-forward
+            await auto.TypeAsync("kill %1 2>/dev/null; true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Step 16: Clean up using aspire destroy
+            output.WriteLine("Step 16: Destroying deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            // Step 17: Exit terminal
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            // Report success
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployAksWithMultipleNodePools),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployAksWithMultipleNodePools),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            // Clean up the resource group created by the pipeline
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName);
+        }
+    }
+
+    /// <summary>
+    /// Triggers cleanup of a specific resource group.
+    /// This is fire-and-forget — the hourly cleanup workflow handles any missed resources.
+    /// </summary>
+    private void TriggerCleanupResourceGroup(string resourceGroupName)
+    {
+        using var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
@@ -107,19 +107,19 @@ public sealed class AksMultipleNodePoolsDeploymentTests(ITestOutputHelper output
             // Add using directive for WithNodePool extension method
             content = "using Aspire.Hosting.Kubernetes.Extensions;\n" + content;
 
-            // Insert the Azure Kubernetes Environment with multiple node pools before builder.Build().Run();
-            var buildRunPattern = "builder.Build().Run();";
-            var replacement = """
+            // Insert the Azure Kubernetes Environment with multiple node pools AFTER CreateBuilder
+            // so workerPool variable is available when apiservice references it.
+            content = content.Replace(
+                "var builder = DistributedApplication.CreateBuilder(args);",
+                """
+var builder = DistributedApplication.CreateBuilder(args);
+
 // AKS environment with multiple node pools
 var aks = builder.AddAzureKubernetesEnvironment("aks")
     .WithSystemNodePool("Standard_D2as_v5", minCount: 1, maxCount: 2);
 
 var workerPool = aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3);
-
-builder.Build().Run();
-""";
-
-            content = content.Replace(buildRunPattern, replacement);
+""");
 
             // Pin apiservice to the worker node pool
             content = content.Replace(

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
@@ -200,10 +200,6 @@ var workerPool = aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3);
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
 
-            await auto.TypeAsync("sleep 3");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
-
             // Verify /weatherforecast endpoint (default starter API)
             await auto.TypeAsync("OK=0; for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18082/weatherforecast -o /dev/null -w '%{http_code}' && echo ' OK' && OK=1 && break; done; [ \"$OK\" = \"1\" ] || { echo 'FAIL: apiservice unreachable after 10 retries'; exit 1; }");
             await auto.EnterAsync();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
@@ -162,23 +162,30 @@ var workerPool = aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3);
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
 
-            // Step 12: Verify node pools exist (system + workers)
-            output.WriteLine("Step 12: Verifying node pools...");
+            // Step 12: Discover deployment namespace and wait for app pods
+            output.WriteLine("Step 12: Waiting for application pods...");
+            await auto.TypeAsync("NS=$(kubectl get svc --all-namespaces -o jsonpath='{range .items[?(@.metadata.name==\"apiservice-service\")]}{.metadata.namespace}{end}') && " +
+                      "echo \"Namespace: $NS\" && " +
+                      "kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=apiservice -n $NS --timeout=300s");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            // Step 13: Verify node pools exist (system + workers)
+            output.WriteLine("Step 13: Verifying node pools...");
             await auto.TypeAsync($"az aks nodepool list -g {resourceGroupName} --cluster-name $AKS_NAME --query \"[].{{name:name,vmSize:vmSize,mode:mode,count:count}}\" -o table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Step 13: Show pods with node info
-            output.WriteLine("Step 13: Showing pods with node info...");
+            // Step 14: Show pods with node info
+            output.WriteLine("Step 14: Showing pods with node info...");
             await auto.TypeAsync("kubectl get pods --all-namespaces -o wide");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Step 14: Verify API pod is on a worker pool node
-            output.WriteLine("Step 14: Verifying API pod scheduling on workers pool...");
-            await auto.TypeAsync("NS=$(kubectl get svc --all-namespaces -o jsonpath='{range .items[?(@.metadata.name==\"apiservice-service\")]}{.metadata.namespace}{end}') && " +
-                      "[ -n \"$NS\" ] || { echo 'ERROR: apiservice-service namespace not found'; exit 1; }; " +
-                      "POD_NODE=$(kubectl get pods -n \"$NS\" -l app=apiservice -o jsonpath='{.items[0].spec.nodeName}') && " +
+            // Step 15: Verify API pod is on a worker pool node
+            output.WriteLine("Step 15: Verifying API pod scheduling on workers pool...");
+            await auto.TypeAsync("[ -n \"$NS\" ] || { echo 'ERROR: namespace not set'; exit 1; }; " +
+                      "POD_NODE=$(kubectl get pods -n \"$NS\" -l app.kubernetes.io/component=apiservice -o jsonpath='{.items[0].spec.nodeName}') && " +
                       "[ -n \"$POD_NODE\" ] || { echo 'ERROR: apiservice pod node not found'; exit 1; }; " +
                       "NODE_POOL=$(kubectl get node \"$POD_NODE\" -o jsonpath='{.metadata.labels.agentpool}') && " +
                       "[ -n \"$NODE_POOL\" ] || { echo 'ERROR: node pool label not found'; exit 1; }; " +
@@ -187,8 +194,8 @@ var workerPool = aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3);
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Step 15: Verify apiservice is reachable via port-forward
-            output.WriteLine("Step 15: Verifying apiservice endpoint via port-forward...");
+            // Step 16: Verify apiservice is reachable via port-forward
+            output.WriteLine("Step 16: Verifying apiservice endpoint via port-forward...");
             await auto.TypeAsync("kubectl port-forward svc/apiservice-service 18082:8080 -n $NS > /dev/null 2>&1 &");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
@@ -177,10 +177,13 @@ var workerPool = aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3);
             // Step 14: Verify API pod is on a worker pool node
             output.WriteLine("Step 14: Verifying API pod scheduling on workers pool...");
             await auto.TypeAsync("NS=$(kubectl get svc --all-namespaces -o jsonpath='{range .items[?(@.metadata.name==\"apiservice-service\")]}{.metadata.namespace}{end}') && " +
-                      "POD_NODE=$(kubectl get pods -n $NS -l app=apiservice -o jsonpath='{.items[0].spec.nodeName}') && " +
-                      "NODE_POOL=$(kubectl get node $POD_NODE -o jsonpath='{.metadata.labels.agentpool}') && " +
+                      "[ -n \"$NS\" ] || { echo 'ERROR: apiservice-service namespace not found'; exit 1; }; " +
+                      "POD_NODE=$(kubectl get pods -n \"$NS\" -l app=apiservice -o jsonpath='{.items[0].spec.nodeName}') && " +
+                      "[ -n \"$POD_NODE\" ] || { echo 'ERROR: apiservice pod node not found'; exit 1; }; " +
+                      "NODE_POOL=$(kubectl get node \"$POD_NODE\" -o jsonpath='{.metadata.labels.agentpool}') && " +
+                      "[ -n \"$NODE_POOL\" ] || { echo 'ERROR: node pool label not found'; exit 1; }; " +
                       "echo \"API pod node: $POD_NODE, pool: $NODE_POOL\" && " +
-                      "[ \"$NODE_POOL\" = \"workers\" ] && echo 'PASS: API pod on workers pool' || echo 'WARN: API pod not on expected pool'");
+                      "if [ \"$NODE_POOL\" = \"workers\" ]; then echo 'PASS: API pod on workers pool'; else echo 'ERROR: API pod not on expected pool'; exit 1; fi");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
@@ -214,11 +214,10 @@ var workerPool = aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3);
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
 
-            // Step 16: Clean up using aspire destroy
-            output.WriteLine("Step 16: Destroying deployment...");
-            await auto.AspireDestroyAsync(counter);
+            // Step 17: Clean up using aspire destroy
+            output.WriteLine("Step 17: Destroying deployment...");            await auto.AspireDestroyAsync(counter);
 
-            // Step 17: Exit terminal
+            // Step 18: Exit terminal
             await auto.TypeAsync("exit");
             await auto.EnterAsync();
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
@@ -71,28 +71,38 @@ public sealed class AksVnetInfraDeploymentTests(ITestOutputHelper output)
 
             await auto.InstallCurrentBuildAspireCliAsync(counter, output);
 
-            // Step 3: Create single-file AppHost using aspire init
-            output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            await auto.AspireInitAsync(counter);
+            // Step 3: Create starter project using aspire new
+            // (Using aspire new instead of aspire init to avoid pre-existing
+            // AspireInitAsync helper issue with the *.dev.localhost prompt)
+            var projectName = "AksVnet";
+            output.WriteLine("Step 3: Creating starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
 
-            // Step 4a: Add Aspire.Hosting.Azure.Kubernetes
-            output.WriteLine("Step 4a: Adding Azure Kubernetes hosting package...");
+            // Step 4: Navigate to project directory
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 5a: Add Aspire.Hosting.Azure.Kubernetes
+            output.WriteLine("Step 5a: Adding Azure Kubernetes hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
             await auto.EnterAsync();
 
             await auto.WaitForAspireAddCompletionAsync(counter);
 
-            // Step 4b: Add Aspire.Hosting.Azure.Network
-            output.WriteLine("Step 4b: Adding Azure Network hosting package...");
+            // Step 5b: Add Aspire.Hosting.Azure.Network
+            output.WriteLine("Step 5b: Adding Azure Network hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Network");
             await auto.EnterAsync();
 
             await auto.WaitForAspireAddCompletionAsync(counter);
 
-            // Step 5: Modify apphost.cs to add VNet + AKS infrastructure
+            // Step 6: Modify AppHost.cs to add VNet + AKS infrastructure
             {
-                var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
-                output.WriteLine($"Looking for apphost.cs at: {appHostFilePath}");
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+                var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+                output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
 
                 var content = File.ReadAllText(appHostFilePath);
 
@@ -102,8 +112,8 @@ public sealed class AksVnetInfraDeploymentTests(ITestOutputHelper output)
 
 // VNet with separate subnets for system and worker node pools
 var vnet = builder.AddAzureVirtualNetwork("vnet");
-var systemSubnet = vnet.AddSubnet("system-subnet", "10.0.0.0/22");
-var workerSubnet = vnet.AddSubnet("worker-subnet", "10.0.4.0/22");
+var systemSubnet = vnet.AddSubnet("system-subnet", "10.1.0.0/22");
+var workerSubnet = vnet.AddSubnet("worker-subnet", "10.1.4.0/22");
 
 // AKS environment with VNet integration and per-pool subnets
 var aks = builder.AddAzureKubernetesEnvironment("aks")
@@ -125,13 +135,19 @@ builder.Build().Run();
                 output.WriteLine($"New content:\n{content}");
             }
 
-            // Step 6: Set environment variables for deployment
+            // Step 7: Navigate to AppHost project directory
+            output.WriteLine("Step 7: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 8: Set environment variables for deployment
             await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 
-            // Step 7: Deploy to Azure
-            output.WriteLine("Step 7: Starting Azure deployment...");
+            // Step 9: Deploy to Azure
+            output.WriteLine("Step 9: Starting Azure deployment...");
             await auto.TypeAsync("aspire deploy --clear-cache");
             await auto.EnterAsync();
             await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
@@ -111,7 +111,7 @@ public sealed class AksVnetInfraDeploymentTests(ITestOutputHelper output)
 #pragma warning disable ASPIREAZURE003
 
 // VNet with separate subnets for system and worker node pools
-var vnet = builder.AddAzureVirtualNetwork("vnet");
+var vnet = builder.AddAzureVirtualNetwork("vnet", "10.1.0.0/16");
 var systemSubnet = vnet.AddSubnet("system-subnet", "10.1.0.0/22");
 var workerSubnet = vnet.AddSubnet("worker-subnet", "10.1.4.0/22");
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
@@ -71,38 +71,28 @@ public sealed class AksVnetInfraDeploymentTests(ITestOutputHelper output)
 
             await auto.InstallCurrentBuildAspireCliAsync(counter, output);
 
-            // Step 3: Create starter project using aspire new
-            // (Using aspire new instead of aspire init to avoid pre-existing
-            // AspireInitAsync helper issue with the *.dev.localhost prompt)
-            var projectName = "AksVnet";
-            output.WriteLine("Step 3: Creating starter project...");
-            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+            // Step 3: Create single-file AppHost using aspire init
+            output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
+            await auto.AspireInitAsync(counter);
 
-            // Step 4: Navigate to project directory
-            await auto.TypeAsync($"cd {projectName}");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter);
-
-            // Step 5a: Add Aspire.Hosting.Azure.Kubernetes
-            output.WriteLine("Step 5a: Adding Azure Kubernetes hosting package...");
+            // Step 4: Add Aspire.Hosting.Azure.Kubernetes
+            output.WriteLine("Step 4: Adding Azure Kubernetes hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
             await auto.EnterAsync();
 
             await auto.WaitForAspireAddCompletionAsync(counter);
 
-            // Step 5b: Add Aspire.Hosting.Azure.Network
-            output.WriteLine("Step 5b: Adding Azure Network hosting package...");
+            // Step 5: Add Aspire.Hosting.Azure.Network
+            output.WriteLine("Step 5: Adding Azure Network hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Network");
             await auto.EnterAsync();
 
             await auto.WaitForAspireAddCompletionAsync(counter);
 
-            // Step 6: Modify AppHost.cs to add VNet + AKS infrastructure
+            // Step 6: Modify apphost.cs to add VNet + AKS infrastructure
             {
-                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
-                var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
-                var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
-                output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+                var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
+                output.WriteLine($"Looking for apphost.cs at: {appHostFilePath}");
 
                 var content = File.ReadAllText(appHostFilePath);
 
@@ -135,26 +125,20 @@ builder.Build().Run();
                 output.WriteLine($"New content:\n{content}");
             }
 
-            // Step 7: Navigate to AppHost project directory
-            output.WriteLine("Step 7: Navigating to AppHost directory...");
-            await auto.TypeAsync($"cd {projectName}.AppHost");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter);
-
-            // Step 8: Set environment variables for deployment
+            // Step 7: Set environment variables for deployment
             await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 
-            // Step 9: Deploy to Azure
-            output.WriteLine("Step 9: Starting Azure deployment...");
+            // Step 8: Deploy to Azure
+            output.WriteLine("Step 8: Starting Azure deployment...");
             await auto.TypeAsync("aspire deploy --clear-cache");
             await auto.EnterAsync();
             await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
-            // Step 8: Verify VNet infrastructure
-            output.WriteLine("Step 8: Verifying VNet infrastructure...");
+            // Step 9: Verify VNet infrastructure
+            output.WriteLine("Step 9: Verifying VNet infrastructure...");
             await auto.TypeAsync($"az network vnet list -g \"{resourceGroupName}\" --query \"[].name\" -o tsv");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
@@ -165,8 +149,8 @@ builder.Build().Run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
-            // Step 9: Verify AKS cluster and node pools
-            output.WriteLine("Step 9: Verifying AKS cluster and node pools...");
+            // Step 10: Verify AKS cluster and node pools
+            output.WriteLine("Step 10: Verifying AKS cluster and node pools...");
             await auto.TypeAsync($"AKS_NAME=$(az aks list -g {resourceGroupName} --query '[0].name' -o tsv) && " +
                       $"echo \"AKS Cluster: $AKS_NAME\"");
             await auto.EnterAsync();
@@ -177,11 +161,11 @@ builder.Build().Run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Step 10: Clean up Azure resources using aspire destroy
-            output.WriteLine("Step 10: Destroying Azure deployment...");
+            // Step 11: Clean up Azure resources using aspire destroy
+            output.WriteLine("Step 11: Destroying Azure deployment...");
             await auto.AspireDestroyAsync(counter);
 
-            // Step 11: Exit terminal
+            // Step 12: Exit terminal
             await auto.TypeAsync("exit");
             await auto.EnterAsync();
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
@@ -1,0 +1,235 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// L1 infrastructure verification test for AKS with VNet and per-pool subnets.
+/// Deploys VNet + subnets + AKS cluster with system and worker pools on separate subnets,
+/// then verifies infrastructure via az CLI.
+/// </summary>
+public sealed class AksVnetInfraDeploymentTests(ITestOutputHelper output)
+{
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployAksWithVnetInfrastructure()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployAksWithVnetInfrastructureCore(cancellationToken);
+    }
+
+    private async Task DeployAksWithVnetInfrastructureCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aksvnet-l1");
+
+        output.WriteLine($"Test: {nameof(DeployAksWithVnetInfrastructure)}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+            // Step 3: Create single-file AppHost using aspire init
+            output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
+            await auto.AspireInitAsync(counter);
+
+            // Step 4a: Add Aspire.Hosting.Azure.Kubernetes
+            output.WriteLine("Step 4a: Adding Azure Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
+            await auto.EnterAsync();
+
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 4b: Add Aspire.Hosting.Azure.Network
+            output.WriteLine("Step 4b: Adding Azure Network hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Network");
+            await auto.EnterAsync();
+
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 5: Modify apphost.cs to add VNet + AKS infrastructure
+            {
+                var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
+                output.WriteLine($"Looking for apphost.cs at: {appHostFilePath}");
+
+                var content = File.ReadAllText(appHostFilePath);
+
+                var buildRunPattern = "builder.Build().Run();";
+                var replacement = """
+#pragma warning disable ASPIREAZURE003
+
+// VNet with separate subnets for system and worker node pools
+var vnet = builder.AddAzureVirtualNetwork("vnet");
+var systemSubnet = vnet.AddSubnet("system-subnet", "10.0.0.0/22");
+var workerSubnet = vnet.AddSubnet("worker-subnet", "10.0.4.0/22");
+
+// AKS environment with VNet integration and per-pool subnets
+var aks = builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D2as_v5")
+    .WithSubnet(systemSubnet);
+
+aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3)
+    .WithSubnet(workerSubnet);
+
+#pragma warning restore ASPIREAZURE003
+
+builder.Build().Run();
+""";
+
+                content = content.Replace(buildRunPattern, replacement);
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine($"Modified apphost.cs with VNet + AKS infrastructure");
+                output.WriteLine($"New content:\n{content}");
+            }
+
+            // Step 6: Set environment variables for deployment
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 7: Deploy to Azure
+            output.WriteLine("Step 7: Starting Azure deployment...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Step 8: Verify VNet infrastructure
+            output.WriteLine("Step 8: Verifying VNet infrastructure...");
+            await auto.TypeAsync($"az network vnet list -g \"{resourceGroupName}\" --query \"[].name\" -o tsv");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Verify subnets exist
+            await auto.TypeAsync($"VNET_NAME=$(az network vnet list -g \"{resourceGroupName}\" --query \"[0].name\" -o tsv) && " +
+                      $"az network vnet subnet list -g \"{resourceGroupName}\" --vnet-name $VNET_NAME --query \"[].{{name:name,addressPrefix:addressPrefix}}\" -o table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 9: Verify AKS cluster and node pools
+            output.WriteLine("Step 9: Verifying AKS cluster and node pools...");
+            await auto.TypeAsync($"AKS_NAME=$(az aks list -g {resourceGroupName} --query '[0].name' -o tsv) && " +
+                      $"echo \"AKS Cluster: $AKS_NAME\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Verify node pools (should have system + workers)
+            await auto.TypeAsync($"az aks nodepool list -g {resourceGroupName} --cluster-name $AKS_NAME --query \"[].{{name:name,vmSize:vmSize,mode:mode,count:count,vnetSubnetId:vnetSubnetId}}\" -o table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 10: Clean up Azure resources using aspire destroy
+            output.WriteLine("Step 10: Destroying Azure deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            // Step 11: Exit terminal
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployAksWithVnetInfrastructure),
+                resourceGroupName,
+                new Dictionary<string, string>(),
+                duration);
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Test failed: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployAksWithVnetInfrastructure),
+                resourceGroupName,
+                ex.Message);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+
+    private async Task CleanupResourceGroupAsync(string resourceGroupName)
+    {
+        try
+        {
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "az",
+                    Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                }
+            };
+
+            process.Start();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode == 0)
+            {
+                output.WriteLine($"Resource group deletion initiated: {resourceGroupName}");
+            }
+            else
+            {
+                var error = await process.StandardError.ReadToEndAsync();
+                output.WriteLine($"Resource group deletion may have failed (exit code {process.ExitCode}): {error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to cleanup resource group: {ex.Message}");
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
@@ -202,7 +202,7 @@ builder.Build().Run();
     {
         try
         {
-            var process = new System.Diagnostics.Process
+            using var process = new System.Diagnostics.Process
             {
                 StartInfo = new System.Diagnostics.ProcessStartInfo
                 {

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
@@ -140,8 +140,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 // VNet with subnets for AKS and Private Endpoints
 var vnet = builder.AddAzureVirtualNetwork("vnet");
-var aksSubnet = vnet.AddSubnet("aks-subnet", "10.0.0.0/22");
-var peSubnet = vnet.AddSubnet("pe-subnet", "10.0.4.0/24");
+var aksSubnet = vnet.AddSubnet("aks-subnet", "10.1.0.0/22");
+var peSubnet = vnet.AddSubnet("pe-subnet", "10.1.4.0/24");
 
 // AKS environment with VNet integration
 var aks = builder.AddAzureKubernetesEnvironment("aks")

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
@@ -129,9 +129,13 @@ public sealed class AksVnetWithAzureResourcesDeploymentTests(ITestOutputHelper o
 
                 var content = File.ReadAllText(appHostFilePath);
 
-                // Replace builder.Build().Run() with full infrastructure
-                var buildRunPattern = "builder.Build().Run();";
-                var replacement = """
+                // Insert full infrastructure AFTER CreateBuilder so variables
+                // are available when apiservice references them.
+                content = content.Replace(
+                    "var builder = DistributedApplication.CreateBuilder(args);",
+                    """
+var builder = DistributedApplication.CreateBuilder(args);
+
 #pragma warning disable ASPIREAZURE003
 
 // VNet with subnets for AKS and Private Endpoints
@@ -154,11 +158,7 @@ var storage = builder.AddAzureStorage("storage");
 var blobs = storage.AddBlobs("blobs");
 
 #pragma warning restore ASPIREAZURE003
-
-builder.Build().Run();
-""";
-
-                content = content.Replace(buildRunPattern, replacement);
+""");
 
                 // Add WithReference and WithNodePool to apiservice
                 content = content.Replace(
@@ -190,7 +190,7 @@ builder.Build().Run();
                     """
 builder.AddServiceDefaults();
 builder.AddAzureKeyVaultClient("vault");
-builder.AddAzureBlobClient("blobs");
+builder.AddAzureBlobServiceClient("blobs");
 """);
 
                 apiContent = apiContent.Replace(

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
@@ -139,7 +139,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 #pragma warning disable ASPIREAZURE003
 
 // VNet with subnets for AKS and Private Endpoints
-var vnet = builder.AddAzureVirtualNetwork("vnet");
+var vnet = builder.AddAzureVirtualNetwork("vnet", "10.1.0.0/16");
 var aksSubnet = vnet.AddSubnet("aks-subnet", "10.1.0.0/22");
 var peSubnet = vnet.AddSubnet("pe-subnet", "10.1.4.0/24");
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
@@ -285,10 +285,6 @@ app.Run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
 
-            await auto.TypeAsync("sleep 3");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
-
             // Verify Key Vault connectivity via PE
             output.WriteLine("Step 17: Verifying Key Vault connectivity...");
             await auto.TypeAsync("OK=0; for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18082/test-keyvault -o /dev/null -w '%{http_code}' && echo ' OK' && OK=1 && break; done; [ \"$OK\" = \"1\" ] || { echo 'FAIL: /test-keyvault unreachable after 10 retries'; exit 1; }");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
@@ -1,0 +1,383 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// Full-stack end-to-end test for deploying an Aspire application to AKS with VNet integration,
+/// multiple node pools, Azure Key Vault with Private Endpoint, and Azure Storage.
+/// Verifies workload identity connectivity from pods to Azure services.
+/// </summary>
+public sealed class AksVnetWithAzureResourcesDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 45 minutes to allow for AKS + VNet + PE provisioning plus deployment.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployAksVnetWithAzureResources()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployAksVnetWithAzureResourcesCore(cancellationToken);
+    }
+
+    private async Task DeployAksVnetWithAzureResourcesCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aksvnetres");
+        var projectName = "AksVnetRes";
+
+        output.WriteLine($"Test: {nameof(DeployAksVnetWithAzureResources)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            // Step 2: Set up CLI environment
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+            // Step 3: Create starter project (no Redis)
+            output.WriteLine("Step 3: Creating starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            // Step 4: Navigate to project directory
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 5: Add hosting packages
+            output.WriteLine("Step 5a: Adding Azure Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            output.WriteLine("Step 5b: Adding Azure Network hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Network");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            output.WriteLine("Step 5c: Adding Azure Key Vault hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.KeyVault");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            output.WriteLine("Step 5d: Adding Azure Storage hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Storage");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 6: Add client packages to ApiService
+            output.WriteLine("Step 6a: Adding Key Vault client package to ApiService...");
+            await auto.TypeAsync($"dotnet add {projectName}.ApiService package Aspire.Azure.Security.KeyVault --prerelease");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            output.WriteLine("Step 6b: Adding Storage Blobs client package to ApiService...");
+            await auto.TypeAsync($"dotnet add {projectName}.ApiService package Aspire.Azure.Storage.Blobs --prerelease");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            // Step 7: Modify AppHost.cs to add VNet + AKS + Key Vault PE + Storage
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+                var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+                output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+                var content = File.ReadAllText(appHostFilePath);
+
+                // Replace builder.Build().Run() with full infrastructure
+                var buildRunPattern = "builder.Build().Run();";
+                var replacement = """
+#pragma warning disable ASPIREAZURE003
+
+// VNet with subnets for AKS and Private Endpoints
+var vnet = builder.AddAzureVirtualNetwork("vnet");
+var aksSubnet = vnet.AddSubnet("aks-subnet", "10.0.0.0/22");
+var peSubnet = vnet.AddSubnet("pe-subnet", "10.0.4.0/24");
+
+// AKS environment with VNet integration
+var aks = builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D2as_v5")
+    .WithSubnet(aksSubnet);
+
+var workerPool = aks.AddNodePool("workload", "Standard_D2as_v5", 1, 3);
+
+// Azure resources with Private Endpoint
+var vault = builder.AddAzureKeyVault("vault");
+peSubnet.AddPrivateEndpoint(vault);
+
+var storage = builder.AddAzureStorage("storage");
+var blobs = storage.AddBlobs("blobs");
+
+#pragma warning restore ASPIREAZURE003
+
+builder.Build().Run();
+""";
+
+                content = content.Replace(buildRunPattern, replacement);
+
+                // Add WithReference and WithNodePool to apiservice
+                content = content.Replace(
+                    "builder.AddProject<Projects." + projectName + "_ApiService>(\"apiservice\")",
+                    "builder.AddProject<Projects." + projectName + "_ApiService>(\"apiservice\")\n    .WithReference(vault)\n    .WithReference(blobs)\n    .WithNodePool(workerPool)");
+
+                // Add required using directive for WithNodePool
+                content = "using Aspire.Hosting.Kubernetes.Extensions;\n" + content;
+
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine($"Modified AppHost.cs at: {appHostFilePath}");
+                output.WriteLine($"New content:\n{content}");
+            }
+
+            // Step 8: Modify ApiService Program.cs to register Key Vault and Storage clients
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var apiProgramPath = Path.Combine(projectDir, $"{projectName}.ApiService", "Program.cs");
+
+                output.WriteLine($"Looking for ApiService Program.cs at: {apiProgramPath}");
+
+                var apiContent = File.ReadAllText(apiProgramPath);
+
+                apiContent = "using Azure.Security.KeyVault.Secrets;\nusing Azure.Storage.Blobs;\n" + apiContent;
+
+                apiContent = apiContent.Replace(
+                    "builder.AddServiceDefaults();",
+                    """
+builder.AddServiceDefaults();
+builder.AddAzureKeyVaultClient("vault");
+builder.AddAzureBlobClient("blobs");
+""");
+
+                apiContent = apiContent.Replace(
+                    "app.Run();",
+                    """
+app.MapGet("/test-keyvault", async (SecretClient client) =>
+{
+    await foreach (var _ in client.GetPropertiesOfSecretsAsync()) { break; }
+    return "ok";
+});
+
+app.MapGet("/test-storage", async (BlobServiceClient client) =>
+{
+    await foreach (var _ in client.GetBlobContainersAsync()) { break; }
+    return "ok";
+});
+
+app.Run();
+""");
+
+                File.WriteAllText(apiProgramPath, apiContent);
+
+                output.WriteLine($"Modified ApiService Program.cs at: {apiProgramPath}");
+                output.WriteLine($"New content:\n{apiContent}");
+            }
+
+            // Step 9: Navigate to AppHost project directory
+            output.WriteLine("Step 9: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 10: Set environment variables for deployment
+            output.WriteLine("Step 10: Setting environment variables...");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 11: Deploy using aspire deploy
+            output.WriteLine("Step 11: Starting deployment...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Step 12: Get AKS credentials for the provisioned cluster
+            output.WriteLine("Step 12: Getting AKS credentials...");
+            await auto.TypeAsync($"AKS_NAME=$(az aks list -g {resourceGroupName} --query '[0].name' -o tsv) && " +
+                  $"az aks get-credentials -g {resourceGroupName} -n $AKS_NAME --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 13: Wait for all pods to be ready
+            output.WriteLine("Step 13: Waiting for pods to be ready...");
+            await auto.TypeAsync("kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s 2>/dev/null || true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            // Show pod and service status for debugging
+            await auto.TypeAsync("kubectl get pods --all-namespaces && kubectl get svc --all-namespaces");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 14: Verify VNet and subnets
+            output.WriteLine("Step 14: Verifying VNet and subnets...");
+            await auto.TypeAsync($"az network vnet list -g \"{resourceGroupName}\" --query \"[].name\" -o tsv");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 15: Verify Private Endpoint and DNS zones
+            output.WriteLine("Step 15: Verifying Private Endpoint infrastructure...");
+            await auto.TypeAsync($"az network private-endpoint list -g \"{resourceGroupName}\" --query \"[].{{name:name,state:provisioningState}}\" -o table && " +
+                      $"az network private-dns zone list -g \"{resourceGroupName}\" --query \"[].name\" -o tsv");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 16: Verify Azure resources (Key Vault and Storage)
+            output.WriteLine("Step 16: Verifying Azure resources...");
+            await auto.TypeAsync($"az keyvault list -g {resourceGroupName} --query \"[].name\" -o tsv && " +
+                      $"az storage account list -g {resourceGroupName} --query \"[].name\" -o tsv");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 17: Verify connectivity via port-forward
+            output.WriteLine("Step 17: Discovering deployment namespace...");
+            await auto.TypeAsync("NS=$(kubectl get svc --all-namespaces -o jsonpath='{range .items[?(@.metadata.name==\"apiservice-service\")]}{.metadata.namespace}{end}') && echo \"Namespace: $NS\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            output.WriteLine("Step 17: Port-forwarding to apiservice...");
+            await auto.TypeAsync("kubectl port-forward svc/apiservice-service 18082:8080 -n $NS > /dev/null 2>&1 &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync("sleep 3");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Verify Key Vault connectivity via PE
+            output.WriteLine("Step 17: Verifying Key Vault connectivity...");
+            await auto.TypeAsync("OK=0; for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18082/test-keyvault -o /dev/null -w '%{http_code}' && echo ' OK' && OK=1 && break; done; [ \"$OK\" = \"1\" ] || { echo 'FAIL: /test-keyvault unreachable after 10 retries'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            // Verify Storage connectivity
+            output.WriteLine("Step 17: Verifying Storage connectivity...");
+            await auto.TypeAsync("OK=0; for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18082/test-storage -o /dev/null -w '%{http_code}' && echo ' OK' && OK=1 && break; done; [ \"$OK\" = \"1\" ] || { echo 'FAIL: /test-storage unreachable after 10 retries'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            // Kill port-forward
+            await auto.TypeAsync("kill %1 2>/dev/null; true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Step 18: Clean up using aspire destroy
+            output.WriteLine("Step 18: Destroying deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            // Step 19: Exit terminal
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            // Report success
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployAksVnetWithAzureResources),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployAksVnetWithAzureResources),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            // Clean up the resource group created by the pipeline
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName);
+        }
+    }
+
+    /// <summary>
+    /// Triggers cleanup of a specific resource group.
+    /// This is fire-and-forget — the hourly cleanup workflow handles any missed resources.
+    /// </summary>
+    private void TriggerCleanupResourceGroup(string resourceGroupName)
+    {
+        using var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksWithAzureResourcesDeploymentTests.cs
@@ -268,11 +268,6 @@ app.Run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
 
-            // Wait for port-forward to establish
-            await auto.TypeAsync("sleep 3");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
-
             // Verify Key Vault connectivity
             await auto.TypeAsync("OK=0; for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18082/test-keyvault -o /dev/null -w '%{http_code}' && echo ' OK' && OK=1 && break; done; [ \"$OK\" = \"1\" ] || { echo 'FAIL: /test-keyvault unreachable after 10 retries'; exit 1; }");
             await auto.EnterAsync();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksWithAzureResourcesDeploymentTests.cs
@@ -1,0 +1,365 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying an Aspire starter app to AKS with Azure Key Vault and
+/// Azure Storage, verifying workload identity connectivity to both Azure resources from the
+/// API service running inside the AKS cluster.
+/// </summary>
+public sealed class AksWithAzureResourcesDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 45 minutes to allow for AKS provisioning (~10-15 min) plus deployment.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployAksWithAzureResources()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployAksWithAzureResourcesCore(cancellationToken);
+    }
+
+    private async Task DeployAksWithAzureResourcesCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aksazure");
+        var projectName = "AksAzureRes";
+
+        output.WriteLine($"Test: {nameof(DeployAksWithAzureResources)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            // Step 2: Set up CLI environment
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+            // Step 3: Create starter project without Redis
+            output.WriteLine("Step 3: Creating starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            // Step 4: Navigate to project directory
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 5a: Add Aspire.Hosting.Azure.Kubernetes package
+            output.WriteLine("Step 5a: Adding Azure Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 5b: Add Aspire.Hosting.Azure.KeyVault package
+            output.WriteLine("Step 5b: Adding Azure Key Vault hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.KeyVault");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 5c: Add Aspire.Hosting.Azure.Storage package
+            output.WriteLine("Step 5c: Adding Azure Storage hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Storage");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 6a: Add Key Vault client package to ApiService project
+            output.WriteLine("Step 6a: Adding Key Vault client package to ApiService...");
+            await auto.TypeAsync($"dotnet add {projectName}.ApiService package Aspire.Azure.Security.KeyVault --prerelease");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            // Step 6b: Add Storage Blobs client package to ApiService project
+            output.WriteLine("Step 6b: Adding Storage Blobs client package to ApiService...");
+            await auto.TypeAsync($"dotnet add {projectName}.ApiService package Aspire.Azure.Storage.Blobs --prerelease");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            // Step 7: Modify AppHost.cs to add AKS + Azure resources + WithReference
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+                var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+                output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+                var content = File.ReadAllText(appHostFilePath);
+
+                // Insert AKS environment and Azure resources before builder.Build().Run()
+                var buildRunPattern = "builder.Build().Run();";
+                var replacement = """
+#pragma warning disable ASPIREAZURE003
+
+// AKS environment with DASv5 SKUs
+var aks = builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D2as_v5");
+aks.AddNodePool("workload", "Standard_D2as_v5", 1, 3);
+
+// Azure resources co-deployed alongside AKS
+var vault = builder.AddAzureKeyVault("vault");
+var storage = builder.AddAzureStorage("storage");
+var blobs = storage.AddBlobs("blobs");
+
+#pragma warning restore ASPIREAZURE003
+
+builder.Build().Run();
+""";
+
+                content = content.Replace(buildRunPattern, replacement);
+
+                // Wire Azure resources to the API service
+                content = content.Replace(
+                    "builder.AddProject<Projects." + projectName + "_ApiService>(\"apiservice\")",
+                    "builder.AddProject<Projects." + projectName + "_ApiService>(\"apiservice\")\n    .WithReference(vault)\n    .WithReference(blobs)");
+
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine($"Modified AppHost.cs with AKS + Key Vault + Storage + WithReference");
+                output.WriteLine($"New content:\n{content}");
+            }
+
+            // Step 8: Modify ApiService Program.cs to add Azure client registrations and test endpoints
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var apiProgramPath = Path.Combine(projectDir, $"{projectName}.ApiService", "Program.cs");
+
+                output.WriteLine($"Looking for ApiService Program.cs at: {apiProgramPath}");
+
+                var apiContent = File.ReadAllText(apiProgramPath);
+
+                // Add using directives
+                apiContent = "using Azure.Security.KeyVault.Secrets;\nusing Azure.Storage.Blobs;\n" + apiContent;
+
+                // Add client registrations after builder.AddServiceDefaults()
+                apiContent = apiContent.Replace(
+                    "builder.AddServiceDefaults();",
+                    """
+builder.AddServiceDefaults();
+builder.AddAzureKeyVaultClient("vault");
+builder.AddAzureBlobClient("blobs");
+""");
+
+                // Add test endpoints before app.Run()
+                apiContent = apiContent.Replace(
+                    "app.Run();",
+                    """
+// Test endpoints for verifying Azure resource connectivity via workload identity
+app.MapGet("/test-keyvault", async (SecretClient client) =>
+{
+    await foreach (var _ in client.GetPropertiesOfSecretsAsync()) { break; }
+    return "ok";
+});
+
+app.MapGet("/test-storage", async (BlobServiceClient client) =>
+{
+    await foreach (var _ in client.GetBlobContainersAsync()) { break; }
+    return "ok";
+});
+
+app.Run();
+""");
+
+                File.WriteAllText(apiProgramPath, apiContent);
+
+                output.WriteLine($"Modified ApiService Program.cs with Azure client registrations and test endpoints");
+            }
+
+            // Step 9: Navigate to AppHost project directory
+            output.WriteLine("Step 9: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 10: Set environment variables for deployment
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 11: Deploy to AKS using aspire deploy
+            output.WriteLine("Step 11: Starting AKS deployment...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Step 12: Get AKS credentials for the provisioned cluster
+            output.WriteLine("Step 12: Getting AKS credentials...");
+            await auto.TypeAsync($"AKS_NAME=$(az aks list -g {resourceGroupName} --query '[0].name' -o tsv) && " +
+                  $"az aks get-credentials -g {resourceGroupName} -n $AKS_NAME --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 13: Wait for all pods to be ready
+            output.WriteLine("Step 13: Waiting for pods to be ready...");
+            await auto.TypeAsync("kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s 2>/dev/null || true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            // Step 14: Show pod and service status for debugging
+            await auto.TypeAsync("kubectl get pods --all-namespaces && kubectl get svc --all-namespaces");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 15: Verify Azure resources exist
+            output.WriteLine("Step 15: Verifying Azure resources...");
+            await auto.TypeAsync($"az keyvault list -g {resourceGroupName} --query \"[].name\" -o tsv && " +
+                      $"az storage account list -g {resourceGroupName} --query \"[].name\" -o tsv");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 16: Verify workload identity service account
+            output.WriteLine("Step 16: Verifying workload identity service account...");
+            await auto.TypeAsync("kubectl get sa --all-namespaces -o json | jq '.items[] | select(.metadata.annotations[\"azure.workload.identity/client-id\"] != null) | .metadata.name'");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 17: Port-forward apiservice and verify Azure resource connectivity
+            output.WriteLine("Step 17: Verifying Azure resource connectivity via apiservice...");
+
+            // Discover namespace
+            await auto.TypeAsync("NS=$(kubectl get svc --all-namespaces -o jsonpath='{range .items[?(@.metadata.name==\"apiservice-service\")]}{.metadata.namespace}{end}') && echo \"Namespace: $NS\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Port forward apiservice
+            await auto.TypeAsync("kubectl port-forward svc/apiservice-service 18082:8080 -n $NS > /dev/null 2>&1 &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Wait for port-forward to establish
+            await auto.TypeAsync("sleep 3");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Verify Key Vault connectivity
+            await auto.TypeAsync("OK=0; for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18082/test-keyvault -o /dev/null -w '%{http_code}' && echo ' OK' && OK=1 && break; done; [ \"$OK\" = \"1\" ] || { echo 'FAIL: /test-keyvault unreachable after 10 retries'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            // Verify Storage connectivity
+            await auto.TypeAsync("OK=0; for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18082/test-storage -o /dev/null -w '%{http_code}' && echo ' OK' && OK=1 && break; done; [ \"$OK\" = \"1\" ] || { echo 'FAIL: /test-storage unreachable after 10 retries'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            // Clean up port-forward
+            await auto.TypeAsync("kill %1 2>/dev/null; true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Step 18: Clean up using aspire destroy
+            output.WriteLine("Step 18: Destroying deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            // Step 19: Exit terminal
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            // Report success
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployAksWithAzureResources),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployAksWithAzureResources),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            // Clean up the resource group created by the pipeline
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName);
+        }
+    }
+
+    /// <summary>
+    /// Triggers cleanup of a specific resource group.
+    /// This is fire-and-forget — the hourly cleanup workflow handles any missed resources.
+    /// </summary>
+    private void TriggerCleanupResourceGroup(string resourceGroupName)
+    {
+        using var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksWithAzureResourcesDeploymentTests.cs
@@ -127,9 +127,13 @@ public sealed class AksWithAzureResourcesDeploymentTests(ITestOutputHelper outpu
 
                 var content = File.ReadAllText(appHostFilePath);
 
-                // Insert AKS environment and Azure resources before builder.Build().Run()
-                var buildRunPattern = "builder.Build().Run();";
-                var replacement = """
+                // Insert AKS environment and Azure resources AFTER CreateBuilder
+                // so variables are available when apiservice references them.
+                content = content.Replace(
+                    "var builder = DistributedApplication.CreateBuilder(args);",
+                    """
+var builder = DistributedApplication.CreateBuilder(args);
+
 #pragma warning disable ASPIREAZURE003
 
 // AKS environment with DASv5 SKUs
@@ -143,11 +147,7 @@ var storage = builder.AddAzureStorage("storage");
 var blobs = storage.AddBlobs("blobs");
 
 #pragma warning restore ASPIREAZURE003
-
-builder.Build().Run();
-""";
-
-                content = content.Replace(buildRunPattern, replacement);
+""");
 
                 // Wire Azure resources to the API service
                 content = content.Replace(
@@ -178,7 +178,7 @@ builder.Build().Run();
                     """
 builder.AddServiceDefaults();
 builder.AddAzureKeyVaultClient("vault");
-builder.AddAzureBlobClient("blobs");
+builder.AddAzureBlobServiceClient("blobs");
 """);
 
                 // Add test endpoints before app.Run()

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -641,7 +641,7 @@ internal static class Hex1bAutomatorTestHelpers
     }
 
     /// <summary>
-    /// Runs <c>aspire init --language csharp</c> and handles the NuGet.config and agent init prompts.
+    /// Runs <c>aspire init --language csharp</c> and handles the NuGet.config, URLs, and agent init prompts.
     /// </summary>
     internal static async Task AspireInitAsync(
         this Hex1bTerminalAutomator auto,
@@ -650,20 +650,37 @@ internal static class Hex1bAutomatorTestHelpers
         var waitingForNuGetConfigPrompt = new CellPatternSearcher()
             .Find("NuGet.config");
 
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find("Use *.dev.localhost URLs");
+
         var waitingForInitComplete = new CellPatternSearcher()
             .Find("Aspire initialization complete");
 
         await auto.TypeAsync("aspire init --language csharp");
         await auto.EnterAsync();
 
-        // NuGet.config prompt may or may not appear depending on environment.
-        // Wait for either the NuGet.config prompt or init completion.
+        // The init flow may show these prompts in varying order depending on environment:
+        // 1. NuGet.config prompt (only when NuGet.config doesn't already exist)
+        // 2. "Use *.dev.localhost URLs" interactive prompt
+        // 3. "Aspire initialization complete" message
+        // Wait for whichever appears first, then dismiss and continue.
         await auto.WaitUntilAsync(
             s => waitingForNuGetConfigPrompt.Search(s).Count > 0
+                || waitingForUrlsPrompt.Search(s).Count > 0
                 || waitingForInitComplete.Search(s).Count > 0,
             timeout: TimeSpan.FromMinutes(2),
-            description: "NuGet.config prompt or init completion");
-        await auto.EnterAsync(); // Dismiss NuGet.config prompt if present
+            description: "NuGet.config prompt, URLs prompt, or init completion");
+        await auto.EnterAsync(); // Dismiss NuGet.config or URLs prompt if present
+
+        // If NuGet.config appeared first, the URLs prompt comes next.
+        // If URLs prompt appeared first, we just dismissed it.
+        // Either way, wait for URLs prompt or init completion.
+        await auto.WaitUntilAsync(
+            s => waitingForUrlsPrompt.Search(s).Count > 0
+                || waitingForInitComplete.Search(s).Count > 0,
+            timeout: TimeSpan.FromMinutes(2),
+            description: "URLs prompt or init completion");
+        await auto.EnterAsync(); // Dismiss URLs prompt (accept default "No") or no-op if already complete
 
         await auto.WaitUntilAsync(
             s => waitingForInitComplete.Search(s).Count > 0,

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -659,28 +659,22 @@ internal static class Hex1bAutomatorTestHelpers
         await auto.TypeAsync("aspire init --language csharp");
         await auto.EnterAsync();
 
-        // The init flow may show these prompts in varying order depending on environment:
-        // 1. NuGet.config prompt (only when NuGet.config doesn't already exist)
-        // 2. "Use *.dev.localhost URLs" interactive prompt
-        // 3. "Aspire initialization complete" message
-        // Wait for whichever appears first, then dismiss and continue.
+        // NuGet.config prompt may or may not appear depending on environment.
+        // Wait for either the NuGet.config prompt or the URLs prompt.
         await auto.WaitUntilAsync(
             s => waitingForNuGetConfigPrompt.Search(s).Count > 0
-                || waitingForUrlsPrompt.Search(s).Count > 0
-                || waitingForInitComplete.Search(s).Count > 0,
+                || waitingForUrlsPrompt.Search(s).Count > 0,
             timeout: TimeSpan.FromMinutes(2),
-            description: "NuGet.config prompt, URLs prompt, or init completion");
-        await auto.EnterAsync(); // Dismiss NuGet.config or URLs prompt if present
+            description: "NuGet.config prompt or URLs prompt");
+        await auto.EnterAsync(); // Dismiss NuGet.config prompt if present
 
-        // If NuGet.config appeared first, the URLs prompt comes next.
-        // If URLs prompt appeared first, we just dismissed it.
-        // Either way, wait for URLs prompt or init completion.
+        // Wait for the URLs prompt (if NuGet.config appeared first) or init completion.
         await auto.WaitUntilAsync(
             s => waitingForUrlsPrompt.Search(s).Count > 0
                 || waitingForInitComplete.Search(s).Count > 0,
             timeout: TimeSpan.FromMinutes(2),
             description: "URLs prompt or init completion");
-        await auto.EnterAsync(); // Dismiss URLs prompt (accept default "No") or no-op if already complete
+        await auto.EnterAsync(); // Dismiss URLs prompt (accept default "No")
 
         await auto.WaitUntilAsync(
             s => waitingForInitComplete.Search(s).Count > 0,


### PR DESCRIPTION
## Description

Expands AKS E2E deployment test coverage to exercise more features from `Aspire.Hosting.Azure.Kubernetes`. Uses the existing `AksBlazorRedisDeploymentTests` as the baseline pattern (`aspire deploy` pipeline + Hex1b automation).

### New Tests

1. **AksWithAzureResourcesDeploymentTests** — Deploys AKS with co-deployed Azure Key Vault and Storage. Verifies workload identity connectivity from pods to Azure services via real SDK endpoint calls (`/test-keyvault`, `/test-storage`).

2. **AksMultipleNodePoolsDeploymentTests** — Deploys AKS with system + worker node pools. Verifies pod scheduling via `WithNodePool<T>()` by checking that API pods land on the `workers` pool node.

3. **AksVnetInfraDeploymentTests** — L1 infrastructure-only test for AKS deployed into a VNet with per-pool subnet assignment (`WithSubnet`). Verifies VNet/subnet creation and AKS network integration via `az` CLI.

4. **AksVnetWithAzureResourcesDeploymentTests** — Full stack test combining VNet, multiple node pools, Key Vault with Private Endpoint, Storage, and workload identity. Verifies end-to-end connectivity through private endpoints.

All tests use `Standard_D2as_v5` VMs in `westus3`.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
