### PR TITLE
Update Hex1b packages to 0.133.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,7 +9,7 @@
       "type": "stdio",
       "command": "dnx",
       "args": [
-        "Hex1b.McpServer@0.132.0",
+        "Hex1b.McpServer@0.133.0",
         "--yes"
       ]
     },

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,7 +9,7 @@
       "type": "stdio",
       "command": "dnx",
       "args": [
-        "Hex1b.McpServer@0.105.0",
+        "Hex1b.McpServer@0.132.0",
         "--yes"
       ]
     },

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -100,9 +100,9 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
-    <PackageVersion Include="Hex1b" Version="0.132.0" />
-    <PackageVersion Include="Hex1b.McpServer" Version="0.132.0" />
-    <PackageVersion Include="Hex1b.Tool" Version="0.132.0" />
+    <PackageVersion Include="Hex1b" Version="0.133.0" />
+    <PackageVersion Include="Hex1b.McpServer" Version="0.133.0" />
+    <PackageVersion Include="Hex1b.Tool" Version="0.133.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="18.0.13" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -100,9 +100,9 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
-    <PackageVersion Include="Hex1b" Version="0.126.0" />
-    <PackageVersion Include="Hex1b.McpServer" Version="0.126.0" />
-    <PackageVersion Include="Hex1b.Tool" Version="0.126.0" />
+    <PackageVersion Include="Hex1b" Version="0.132.0" />
+    <PackageVersion Include="Hex1b.McpServer" Version="0.132.0" />
+    <PackageVersion Include="Hex1b.Tool" Version="0.132.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="18.0.13" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />


### PR DESCRIPTION
## Description

Update Hex1b, Hex1b.McpServer, and Hex1b.Tool packages from 0.126.0 to 0.133.0 (latest available in internal feeds).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
