### PR TITLE
Fix --apphost directory resolution for commands

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -142,7 +142,12 @@ internal sealed class AppHostConnectionResolver(
                 }
             }
 
-            return new AppHostConnectionResult { ErrorMessage = notFoundMessage };
+            var displayPath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, targetPath);
+
+            return new AppHostConnectionResult
+            {
+                ErrorMessage = string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.AppHostNotRunningAtPath, displayPath)
+            };
         }
 
         // Socket-first approach: Scan for running AppHosts via their sockets

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -106,7 +106,7 @@ internal sealed class AppHostConnectionResolver(
                 }
                 catch (ProjectLocatorException ex)
                 {
-                    var (exitCode, errorMessage) = GetProjectResolutionError(ex, explicitDirectory);
+                    var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex, projectOptionSpecifiedAsDirectory: true);
                     return new AppHostConnectionResult
                     {
                         ErrorMessage = errorMessage,
@@ -216,25 +216,6 @@ internal sealed class AppHostConnectionResolver(
         }
 
         return new AppHostConnectionResult { Connection = selectedConnection };
-    }
-
-    private static (int ExitCode, string ErrorMessage) GetProjectResolutionError(ProjectLocatorException ex, bool explicitDirectory)
-    {
-        ArgumentNullException.ThrowIfNull(ex);
-
-        if (!explicitDirectory)
-        {
-            return ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
-        }
-
-        return ex.FailureReason switch
-        {
-            ProjectLocatorFailureReason.MultipleProjectFilesFound
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts),
-            ProjectLocatorFailureReason.ProjectFileDoesntExist or ProjectLocatorFailureReason.NoProjectFileFound
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts),
-            _ => ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex)
-        };
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -90,31 +90,44 @@ internal sealed class AppHostConnectionResolver(
         // Fast path: If --apphost was specified, check directly for its socket
         if (projectFile is not null)
         {
-            try
-            {
-                var searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
-                    projectFile,
-                    MultipleAppHostProjectsFoundBehavior.Throw,
-                    createSettingsFile: false,
-                    cancellationToken).ConfigureAwait(false);
+            var explicitDirectory = Directory.Exists(projectFile.FullName);
 
-                projectFile = searchResult.SelectedProjectFile;
-            }
-            catch (ProjectLocatorException ex)
+            if (explicitDirectory)
             {
-                var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
+                try
+                {
+                    var searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
+                        projectFile,
+                        MultipleAppHostProjectsFoundBehavior.Throw,
+                        createSettingsFile: false,
+                        cancellationToken).ConfigureAwait(false);
+
+                    projectFile = searchResult.SelectedProjectFile;
+                }
+                catch (ProjectLocatorException ex)
+                {
+                    var (exitCode, errorMessage) = GetProjectResolutionError(ex, explicitDirectory);
+                    return new AppHostConnectionResult
+                    {
+                        ErrorMessage = errorMessage,
+                        ExitCode = exitCode,
+                    };
+                }
+
+                if (projectFile is null)
+                {
+                    return new AppHostConnectionResult
+                    {
+                        ErrorMessage = InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts,
+                        ExitCode = ExitCodeConstants.FailedToFindProject,
+                    };
+                }
+            }
+            else if (!projectFile.Exists)
+            {
                 return new AppHostConnectionResult
                 {
-                    ErrorMessage = errorMessage,
-                    ExitCode = exitCode,
-                };
-            }
-
-            if (projectFile is null)
-            {
-                return new AppHostConnectionResult
-                {
-                    ErrorMessage = InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound,
+                    ErrorMessage = InteractionServiceStrings.ProjectOptionDoesntExist,
                     ExitCode = ExitCodeConstants.FailedToFindProject,
                 };
             }
@@ -203,6 +216,25 @@ internal sealed class AppHostConnectionResolver(
         }
 
         return new AppHostConnectionResult { Connection = selectedConnection };
+    }
+
+    private static (int ExitCode, string ErrorMessage) GetProjectResolutionError(ProjectLocatorException ex, bool explicitDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!explicitDirectory)
+        {
+            return ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
+        }
+
+        return ex.FailureReason switch
+        {
+            ProjectLocatorFailureReason.MultipleProjectFilesFound
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts),
+            ProjectLocatorFailureReason.ProjectFileDoesntExist or ProjectLocatorFailureReason.NoProjectFileFound
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts),
+            _ => ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex)
+        };
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
@@ -23,6 +24,11 @@ internal sealed class AppHostConnectionResult
     public bool Success => Connection is not null;
 
     public string? ErrorMessage { get; init; }
+
+    public int? ExitCode { get; init; }
+
+    [MemberNotNullWhen(true, nameof(ExitCode))]
+    public bool IsProjectResolutionError => ExitCode is not null;
 }
 
 /// <summary>
@@ -34,6 +40,7 @@ internal sealed class AppHostConnectionResult
 internal sealed class AppHostConnectionResolver(
     IAuxiliaryBackchannelMonitor backchannelMonitor,
     IInteractionService interactionService,
+    IProjectLocator projectLocator,
     CliExecutionContext executionContext,
     ILogger logger)
 {
@@ -83,6 +90,35 @@ internal sealed class AppHostConnectionResolver(
         // Fast path: If --apphost was specified, check directly for its socket
         if (projectFile is not null)
         {
+            try
+            {
+                var searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
+                    projectFile,
+                    MultipleAppHostProjectsFoundBehavior.Throw,
+                    createSettingsFile: false,
+                    cancellationToken).ConfigureAwait(false);
+
+                projectFile = searchResult.SelectedProjectFile;
+            }
+            catch (ProjectLocatorException ex)
+            {
+                var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
+                return new AppHostConnectionResult
+                {
+                    ErrorMessage = errorMessage,
+                    ExitCode = exitCode,
+                };
+            }
+
+            if (projectFile is null)
+            {
+                return new AppHostConnectionResult
+                {
+                    ErrorMessage = InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound,
+                    ExitCode = ExitCodeConstants.FailedToFindProject,
+                };
+            }
+
             var targetPath = projectFile.FullName;
             var matchingSockets = AppHostHelper.FindMatchingSockets(
                 targetPath,

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -28,7 +28,7 @@ internal sealed class AppHostConnectionResult
     public int? ExitCode { get; init; }
 
     [MemberNotNullWhen(true, nameof(ExitCode))]
-    public bool IsProjectResolutionError => ExitCode is not null;
+    public bool IsProjectResolutionError => ExitCode is ExitCodeConstants.FailedToFindProject or ExitCodeConstants.SdkNotInstalled;
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Commands/AppHostConnectionResultHandler.cs
+++ b/src/Aspire.Cli/Commands/AppHostConnectionResultHandler.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Interaction;
+
+namespace Aspire.Cli.Commands;
+
+internal static class AppHostConnectionResultHandler
+{
+    public static int DisplayFailureAsError(AppHostConnectionResult result, IInteractionService interactionService, int fallbackExitCode)
+    {
+        var errorMessage = GetFailureMessage(result);
+        interactionService.DisplayError(errorMessage);
+
+        return result.IsProjectResolutionError
+            ? result.ExitCode.Value
+            : fallbackExitCode;
+    }
+
+    public static int DisplayFailureAsInformation(AppHostConnectionResult result, IInteractionService interactionService)
+    {
+        var errorMessage = GetFailureMessage(result);
+
+        if (result.IsProjectResolutionError)
+        {
+            interactionService.DisplayError(errorMessage);
+            return result.ExitCode.Value;
+        }
+
+        interactionService.DisplayMessage(KnownEmojis.Information, errorMessage);
+        return ExitCodeConstants.Success;
+    }
+
+    private static string GetFailureMessage(AppHostConnectionResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.Success)
+        {
+            throw new InvalidOperationException("Cannot handle a successful AppHost connection result as a failure.");
+        }
+
+        return result.ErrorMessage;
+    }
+}

--- a/src/Aspire.Cli/Commands/AppHostConnectionResultHandler.cs
+++ b/src/Aspire.Cli/Commands/AppHostConnectionResultHandler.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 
@@ -36,11 +37,8 @@ internal static class AppHostConnectionResultHandler
     {
         ArgumentNullException.ThrowIfNull(result);
 
-        if (result.Success)
-        {
-            throw new InvalidOperationException("Cannot handle a successful AppHost connection result as a failure.");
-        }
+        Debug.Assert(!result.Success, "Cannot handle a successful AppHost connection result as a failure.");
 
-        return result.ErrorMessage;
+        return result.ErrorMessage!;
     }
 }

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Globalization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
-using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 
@@ -99,22 +97,7 @@ internal abstract class BaseCommand : Command
         ArgumentNullException.ThrowIfNull(ex);
         ArgumentNullException.ThrowIfNull(interactionService);
 
-        var (exitCode, errorMessage) = ex.FailureReason switch
-        {
-            ProjectLocatorFailureReason.UnsupportedProjects
-                => (ExitCodeConstants.SdkNotInstalled, "No supported app hosts were found."),
-            ProjectLocatorFailureReason.ProjectFileNotAppHostProject
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject),
-            ProjectLocatorFailureReason.ProjectFileDoesntExist
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionDoesntExist),
-            ProjectLocatorFailureReason.MultipleProjectFilesFound
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedMultipleAppHostsFound),
-            ProjectLocatorFailureReason.NoProjectFileFound
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound),
-            ProjectLocatorFailureReason.AppHostsMayNotBeBuildable
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.UnbuildableAppHostsDetected),
-            _ => (ExitCodeConstants.FailedToFindProject, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message))
-        };
+        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
 
         telemetry.RecordError(errorMessage, ex);
         interactionService.DisplayError(errorMessage);

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -138,15 +138,7 @@ internal sealed class DescribeCommand : BaseCommand
 
         if (!result.Success)
         {
-            if (result.IsProjectResolutionError)
-            {
-                _interactionService.DisplayError(result.ErrorMessage);
-                return result.ExitCode.Value;
-            }
-
-            // No running AppHosts is not an error - similar to Unix 'ps' returning empty
-            _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
-            return ExitCodeConstants.Success;
+            return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
         }
 
         var connection = result.Connection!;

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -100,6 +101,7 @@ internal sealed class DescribeCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         AspireCliTelemetry telemetry,
         ResourceColorMap resourceColorMap,
         ILogger<DescribeCommand> logger)
@@ -108,7 +110,7 @@ internal sealed class DescribeCommand : BaseCommand
         Aliases.Add("resources");
         _interactionService = interactionService;
         _resourceColorMap = resourceColorMap;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);
@@ -136,6 +138,12 @@ internal sealed class DescribeCommand : BaseCommand
 
         if (!result.Success)
         {
+            if (result.IsProjectResolutionError)
+            {
+                _interactionService.DisplayError(result.ErrorMessage);
+                return result.ExitCode.Value;
+            }
+
             // No running AppHosts is not an error - similar to Unix 'ps' returning empty
             _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return ExitCodeConstants.Success;

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -58,6 +59,7 @@ internal sealed class ExportCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         AspireCliTelemetry telemetry,
         IHttpClientFactory httpClientFactory,
         TimeProvider timeProvider,
@@ -68,7 +70,7 @@ internal sealed class ExportCommand : BaseCommand
         _httpClientFactory = httpClientFactory;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -114,6 +115,7 @@ internal sealed class LogsCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         AspireCliTelemetry telemetry,
         ICliHostEnvironment hostEnvironment,
         ResourceColorMap resourceColorMap,
@@ -124,7 +126,7 @@ internal sealed class LogsCommand : BaseCommand
         _interactionService = interactionService;
         _hostEnvironment = hostEnvironment;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);
@@ -163,6 +165,12 @@ internal sealed class LogsCommand : BaseCommand
 
         if (!result.Success)
         {
+            if (result.IsProjectResolutionError)
+            {
+                _interactionService.DisplayError(result.ErrorMessage);
+                return result.ExitCode.Value;
+            }
+
             // No running AppHosts is not an error - similar to Unix 'ps' returning empty
             _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return ExitCodeConstants.Success;

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -165,15 +165,7 @@ internal sealed class LogsCommand : BaseCommand
 
         if (!result.Success)
         {
-            if (result.IsProjectResolutionError)
-            {
-                _interactionService.DisplayError(result.ErrorMessage);
-                return result.ExitCode.Value;
-            }
-
-            // No running AppHosts is not an error - similar to Unix 'ps' returning empty
-            _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
-            return ExitCodeConstants.Success;
+            return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
         }
 
         var connection = result.Connection!;

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -48,12 +49,13 @@ internal sealed class McpCallCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         AspireCliTelemetry telemetry,
         ILogger<McpCallCommand> logger)
         : base("call", McpCommandStrings.CallCommand_Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
 
         Arguments.Add(s_resourceArgument);
         Arguments.Add(s_toolArgument);
@@ -78,7 +80,9 @@ internal sealed class McpCallCommand : BaseCommand
         if (!result.Success)
         {
             _interactionService.DisplayError(result.ErrorMessage);
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
+            return result.IsProjectResolutionError
+                ? result.ExitCode.Value
+                : ExitCodeConstants.FailedToDotnetRunAppHost;
         }
 
         var connection = result.Connection!;

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -79,10 +79,7 @@ internal sealed class McpCallCommand : BaseCommand
 
         if (!result.Success)
         {
-            _interactionService.DisplayError(result.ErrorMessage);
-            return result.IsProjectResolutionError
-                ? result.ExitCode.Value
-                : ExitCodeConstants.FailedToDotnetRunAppHost;
+            return AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToDotnetRunAppHost);
         }
 
         var connection = result.Connection!;

--- a/src/Aspire.Cli/Commands/McpToolsCommand.cs
+++ b/src/Aspire.Cli/Commands/McpToolsCommand.cs
@@ -64,14 +64,7 @@ internal sealed class McpToolsCommand : BaseCommand
 
         if (!result.Success)
         {
-            if (result.IsProjectResolutionError)
-            {
-                _interactionService.DisplayError(result.ErrorMessage);
-                return result.ExitCode.Value;
-            }
-
-            _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
-            return ExitCodeConstants.Success;
+            return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
         }
 
         var connection = result.Connection!;

--- a/src/Aspire.Cli/Commands/McpToolsCommand.cs
+++ b/src/Aspire.Cli/Commands/McpToolsCommand.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -37,12 +38,13 @@ internal sealed class McpToolsCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         AspireCliTelemetry telemetry,
         ILogger<McpToolsCommand> logger)
         : base("tools", McpCommandStrings.ToolsCommand_Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
 
         Options.Add(s_appHostOption);
         Options.Add(s_formatOption);
@@ -62,6 +64,12 @@ internal sealed class McpToolsCommand : BaseCommand
 
         if (!result.Success)
         {
+            if (result.IsProjectResolutionError)
+            {
+                _interactionService.DisplayError(result.ErrorMessage);
+                return result.ExitCode.Value;
+            }
+
             _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return ExitCodeConstants.Success;
         }

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -80,10 +80,7 @@ internal sealed class ResourceCommand : BaseCommand
 
         if (!result.Success)
         {
-            _interactionService.DisplayError(result.ErrorMessage);
-            return result.IsProjectResolutionError
-                ? result.ExitCode.Value
-                : ExitCodeConstants.FailedToFindProject;
+            return AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToFindProject);
         }
 
         // Map well-known friendly names (start/stop/restart) to their display metadata

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -50,12 +51,13 @@ internal sealed class ResourceCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         ILogger<ResourceCommand> logger,
         AspireCliTelemetry telemetry)
         : base("resource", ResourceCommandStrings.CommandDescription, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
         _logger = logger;
 
         Arguments.Add(s_resourceArgument);
@@ -79,7 +81,9 @@ internal sealed class ResourceCommand : BaseCommand
         if (!result.Success)
         {
             _interactionService.DisplayError(result.ErrorMessage);
-            return ExitCodeConstants.FailedToFindProject;
+            return result.IsProjectResolutionError
+                ? result.ExitCode.Value
+                : ExitCodeConstants.FailedToFindProject;
         }
 
         // Map well-known friendly names (start/stop/restart) to their display metadata

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -37,6 +37,7 @@ internal sealed class StopCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         ICliHostEnvironment hostEnvironment,
         ILogger<StopCommand> logger,
         AspireCliTelemetry telemetry,
@@ -44,7 +45,7 @@ internal sealed class StopCommand : BaseCommand
         : base("stop", StopCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
         _hostEnvironment = hostEnvironment;
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
@@ -133,6 +134,12 @@ internal sealed class StopCommand : BaseCommand
 
         if (!result.Success)
         {
+            if (result.IsProjectResolutionError)
+            {
+                _interactionService.DisplayError(result.ErrorMessage);
+                return result.ExitCode.Value;
+            }
+
             _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return ExitCodeConstants.Success;
         }

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -134,14 +134,7 @@ internal sealed class StopCommand : BaseCommand
 
         if (!result.Success)
         {
-            if (result.IsProjectResolutionError)
-            {
-                _interactionService.DisplayError(result.ErrorMessage);
-                return result.ExitCode.Value;
-            }
-
-            _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
-            return ExitCodeConstants.Success;
+            return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
         }
 
         return await StopAppHostAsync(result.Connection!, cancellationToken);

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -259,14 +259,8 @@ internal static class TelemetryCommandHelpers
 
         if (!result.Success)
         {
-            if (result.IsProjectResolutionError)
-            {
-                interactionService.DisplayError(result.ErrorMessage);
-                return DashboardApiResult.Failure(result.ExitCode.Value);
-            }
-
-            interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
-            return DashboardApiResult.Failure(ExitCodeConstants.Success);
+            var exitCode = AppHostConnectionResultHandler.DisplayFailureAsInformation(result, interactionService);
+            return DashboardApiResult.Failure(exitCode);
         }
 
         var connection = result.Connection!;

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -259,6 +259,12 @@ internal static class TelemetryCommandHelpers
 
         if (!result.Success)
         {
+            if (result.IsProjectResolutionError)
+            {
+                interactionService.DisplayError(result.ErrorMessage);
+                return DashboardApiResult.Failure(result.ExitCode.Value);
+            }
+
             interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return DashboardApiResult.Failure(ExitCodeConstants.Success);
         }

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -52,6 +53,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         AspireCliTelemetry telemetry,
         ICliHostEnvironment hostEnvironment,
         IHttpClientFactory httpClientFactory,
@@ -66,7 +68,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -46,6 +47,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         AspireCliTelemetry telemetry,
         IHttpClientFactory httpClientFactory,
         ResourceColorMap resourceColorMap,
@@ -58,7 +60,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Otlp.Serialization;
@@ -46,6 +47,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         AspireCliTelemetry telemetry,
         IHttpClientFactory httpClientFactory,
         ResourceColorMap resourceColorMap,
@@ -58,7 +60,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -47,13 +48,14 @@ internal sealed class WaitCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
+        IProjectLocator projectLocator,
         ILogger<WaitCommand> logger,
         AspireCliTelemetry telemetry,
         TimeProvider? timeProvider = null)
         : base("wait", WaitCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
 
@@ -97,7 +99,9 @@ internal sealed class WaitCommand : BaseCommand
         if (!result.Success)
         {
             _interactionService.DisplayError(result.ErrorMessage);
-            return ExitCodeConstants.FailedToFindProject;
+            return result.IsProjectResolutionError
+                ? result.ExitCode.Value
+                : ExitCodeConstants.FailedToFindProject;
         }
 
         var connection = result.Connection!;

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -98,10 +98,7 @@ internal sealed class WaitCommand : BaseCommand
 
         if (!result.Success)
         {
-            _interactionService.DisplayError(result.ErrorMessage);
-            return result.IsProjectResolutionError
-                ? result.ExitCode.Value
-                : ExitCodeConstants.FailedToFindProject;
+            return AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToFindProject);
         }
 
         var connection = result.Connection!;

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -588,6 +588,31 @@ internal class ProjectLocatorException(string message, ProjectLocatorFailureReas
     public ProjectLocatorFailureReason FailureReason { get; } = failureReason;
 }
 
+internal static class ProjectLocatorErrorHelper
+{
+    public static (int ExitCode, string ErrorMessage) GetExitCodeAndMessage(ProjectLocatorException ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        return ex.FailureReason switch
+        {
+            ProjectLocatorFailureReason.UnsupportedProjects
+                => (ExitCodeConstants.SdkNotInstalled, InteractionServiceStrings.NoSupportedAppHostsFound),
+            ProjectLocatorFailureReason.ProjectFileNotAppHostProject
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject),
+            ProjectLocatorFailureReason.ProjectFileDoesntExist
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionDoesntExist),
+            ProjectLocatorFailureReason.MultipleProjectFilesFound
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedMultipleAppHostsFound),
+            ProjectLocatorFailureReason.NoProjectFileFound
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound),
+            ProjectLocatorFailureReason.AppHostsMayNotBeBuildable
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.UnbuildableAppHostsDetected),
+            _ => (ExitCodeConstants.FailedToFindProject, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message))
+        };
+    }
+}
+
 internal enum ProjectLocatorFailureReason
 {
     ProjectFileDoesntExist,

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -590,12 +590,16 @@ internal class ProjectLocatorException(string message, ProjectLocatorFailureReas
 
 internal static class ProjectLocatorErrorHelper
 {
-    public static (int ExitCode, string ErrorMessage) GetExitCodeAndMessage(ProjectLocatorException ex)
+    public static (int ExitCode, string ErrorMessage) GetExitCodeAndMessage(ProjectLocatorException ex, bool projectOptionSpecifiedAsDirectory = false)
     {
         ArgumentNullException.ThrowIfNull(ex);
 
         return ex.FailureReason switch
         {
+            ProjectLocatorFailureReason.MultipleProjectFilesFound when projectOptionSpecifiedAsDirectory
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts),
+            ProjectLocatorFailureReason.ProjectFileDoesntExist or ProjectLocatorFailureReason.NoProjectFileFound when projectOptionSpecifiedAsDirectory
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts),
             ProjectLocatorFailureReason.UnsupportedProjects
                 => (ExitCodeConstants.SdkNotInstalled, InteractionServiceStrings.NoSupportedAppHostsFound),
             ProjectLocatorFailureReason.ProjectFileNotAppHostProject

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -124,7 +124,7 @@
     <value>The name of the integration to add (e.g. redis, postgres)</value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
-    <value>The path to the Aspire AppHost project file to add the integration to</value>
+    <value>The Aspire AppHost project file, or a directory to search, to add the integration to</value>
   </data>
   <data name="VersionArgumentDescription" xml:space="preserve">
     <value>The version of the integration to add</value>

--- a/src/Aspire.Cli/Resources/ExecCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ExecCommandStrings.resx
@@ -127,7 +127,7 @@ Examples:
     </value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
-    <value>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</value>
+    <value>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</value>
   </data>
   <data name="StartTargetResourceArgumentDescription" xml:space="preserve">
     <value>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</value>

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -322,6 +322,24 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The --apphost option specified a directory that contains multiple apphost project files..
+        /// </summary>
+        public static string ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts {
+            get {
+                return ResourceManager.GetString("ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The --apphost option specified a directory that does not contain any apphost project files..
+        /// </summary>
+        public static string ProjectOptionSpecifiedDirectoryContainsNoAppHosts {
+            get {
+                return ResourceManager.GetString("ProjectOptionSpecifiedDirectoryContainsNoAppHosts", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The --apphost option was not specified and multiple apphost project files were detected..
         /// </summary>
         public static string ProjectOptionNotSpecifiedMultipleAppHostsFound {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -241,6 +241,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to No supported app hosts were found..
+        /// </summary>
+        public static string NoSupportedAppHostsFound {
+            get {
+                return ResourceManager.GetString("NoSupportedAppHostsFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not valid for {1}..
         /// </summary>
         public static string NonInteractiveInvalidValue {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -179,6 +179,12 @@
   <data name="ProjectOptionDoesntExist" xml:space="preserve">
     <value>The --apphost option specified a project that does not exist.</value>
   </data>
+  <data name="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts" xml:space="preserve">
+    <value>The --apphost option specified a directory that contains multiple AppHost project files.</value>
+  </data>
+  <data name="ProjectOptionSpecifiedDirectoryContainsNoAppHosts" xml:space="preserve">
+    <value>The --apphost option specified a directory that does not contain any AppHost project files.</value>
+  </data>
   <data name="NoSupportedAppHostsFound" xml:space="preserve">
     <value>No supported app hosts were found.</value>
   </data>

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -179,6 +179,9 @@
   <data name="ProjectOptionDoesntExist" xml:space="preserve">
     <value>The --apphost option specified a project that does not exist.</value>
   </data>
+  <data name="NoSupportedAppHostsFound" xml:space="preserve">
+    <value>No supported app hosts were found.</value>
+  </data>
   <data name="ProjectOptionNotSpecifiedMultipleAppHostsFound" xml:space="preserve">
     <value>The --apphost option was not specified and multiple AppHost project files were detected.</value>
   </data>

--- a/src/Aspire.Cli/Resources/PublishCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/PublishCommandStrings.resx
@@ -124,7 +124,7 @@
     <value>Select a publisher:</value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
-    <value>The path to the Aspire AppHost project file</value>
+    <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>
   <data name="OutputPathArgumentDescription" xml:space="preserve">
     <value>The output path for the generated artifacts. Defaults to the AppHost directory's 'aspire-output' folder if not specified.</value>

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -124,7 +124,7 @@
     <value>Stop any running instance of the AppHost without prompting</value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
-    <value>The path to the Aspire AppHost project file</value>
+    <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>
   <data name="DetachArgumentDescription" xml:space="preserve">
     <value>Run the AppHost in the background and exit after it starts</value>

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -69,6 +69,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        internal static string AppHostNotRunningAtPath {
+            get {
+                return ResourceManager.GetString("AppHostNotRunningAtPath", resourceCulture);
+            }
+        }
+
         internal static string AppHostOptionDescription {
             get {
                 return ResourceManager.GetString("AppHostOptionDescription", resourceCulture);

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -134,7 +134,7 @@
     <comment>{0} is the AppHost project path.</comment>
   </data>
   <data name="AppHostOptionDescription" xml:space="preserve">
-    <value>The path to the Aspire AppHost project file</value>
+    <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>
   <data name="FormatOptionDescription" xml:space="preserve">
     <value>Output format for detached AppHost results</value>

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -130,7 +130,7 @@
     <value>No running AppHost found. Use 'aspire run' to start one first.</value>
   </data>
   <data name="AppHostNotRunningAtPath" xml:space="preserve">
-    <value>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</value>
+    <value>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</value>
     <comment>{0} is the AppHost project path.</comment>
   </data>
   <data name="AppHostOptionDescription" xml:space="preserve">

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -129,6 +129,10 @@
   <data name="AppHostNotRunning" xml:space="preserve">
     <value>No running AppHost found. Use 'aspire run' to start one first.</value>
   </data>
+  <data name="AppHostNotRunningAtPath" xml:space="preserve">
+    <value>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</value>
+    <comment>{0} is the AppHost project path.</comment>
+  </data>
   <data name="AppHostOptionDescription" xml:space="preserve">
     <value>The path to the Aspire AppHost project file</value>
   </data>

--- a/src/Aspire.Cli/Resources/StopCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/StopCommandStrings.resx
@@ -121,7 +121,7 @@
     <value>Stop a running AppHost</value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
-    <value>The path to the Aspire AppHost project file</value>
+    <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>
   <data name="StoppingAppHost" xml:space="preserve">
     <value>Stopping Aspire AppHost...</value>

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -16,7 +16,7 @@
     <value>Update integrations in the Aspire project (Preview)</value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
-    <value>The path to the Aspire AppHost project file</value>
+    <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>
   <data name="SelectChannelPrompt" xml:space="preserve">
     <value>Select a channel:</value>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Cesta k souboru projektu, do které se má integrace přidat</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Der Pfad zur Projektdatei, der die Integration hinzugefügt werden soll.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">La ruta al archivo del proyecto al que se agregará la integración.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Chemin du fichier projet auquel ajouter l’intégration.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Percorso del file di progetto a cui aggiungere l'integrazione.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">統合を追加するプロジェクト ファイルへのパス。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">통합을 추가할 프로젝트 파일의 경로입니다.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu, do którego ma zostać dodana integracja.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto ao qual adicionar a integração.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Путь к файлу проекта, в который необходимо добавить интеграцию.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Tümleştirmenin ekleneceği proje dosyasının yolu.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">要将集成添加到的项目文件的路径。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -48,7 +48,7 @@
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file to add the integration to</source>
+        <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">要新增整合的專案檔路徑。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.cs.xlf
@@ -35,7 +35,7 @@ Příklady:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Cesta k souboru projektu Aspire AppHost. Pokud není zadána, vyhledá se soubor projektu v aktuálním adresáři.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.de.xlf
@@ -35,7 +35,7 @@ Beispiele:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Der Pfad zur Aspire AppHost-Projektdatei. Wenn keine Angabe erfolgt, wird im aktuellen Verzeichnis nach einer Projektdatei gesucht.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.es.xlf
@@ -35,7 +35,7 @@ Ejemplos:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">La ruta de acceso al archivo del proyecto host de la aplicación Aspire. Si no se especifica, se busca un archivo de proyecto en el directorio actual.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.fr.xlf
@@ -35,7 +35,7 @@ Exemples :
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Chemin d’accès au fichier projet AppHost Aspire. Si rien n’est spécifié, recherche un fichier projet dans le répertoire actif.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.it.xlf
@@ -35,7 +35,7 @@ Esempi:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Percorso del file di un progetto AppHost di Aspire. Se non specificato, cerca un file di progetto nella directory corrente.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ja.xlf
@@ -35,7 +35,7 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Aspire AppHost プロセス プロジェクト ファイルへのパス。指定しない場合は、現在のディレクトリ内のプロジェクトファイルを検索します。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ko.xlf
@@ -35,7 +35,7 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Aspire AppHost 프로젝트 파일의 경로입니다. 지정하지 않으면 현재 디렉터리에서 프로젝트 파일을 검색합니다.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pl.xlf
@@ -35,7 +35,7 @@ Przykłady:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu AppHost usługi Aspire. Jeżeli nie określono, wyszukuje plik projektu w bieżącym katalogu.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pt-BR.xlf
@@ -35,7 +35,7 @@ Exemplos:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto Aspire AppHost. Se não especificado, procura por um arquivo de projeto no diretório atual.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ru.xlf
@@ -35,7 +35,7 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Путь к файлу проекта Aspire AppHost. Если не указано иное, ищет файл проекта в текущем каталоге.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.tr.xlf
@@ -35,7 +35,7 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Aspire AppHost proje dosyasının yolu. Belirtilmezse, geçerli dizinde bir proje dosyası aranır.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hans.xlf
@@ -35,7 +35,7 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Aspire AppHost 项目文件的路径。如果未指定，则在当前目录中搜索项目文件。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hant.xlf
@@ -35,7 +35,7 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <source>The path to the Aspire AppHost project file or a directory to search. If not specified, searches for a project file in the current directory.</source>
         <target state="needs-review-translation">Aspire AppHost 專案檔案的路徑。如果未指定，將在目前目錄中搜尋專案檔案。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Nejsou k dispozici žádné položky pro výběr: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">Nebyl zadán argument projektu a nebyly zjištěny žádné soubory projektů hostitele aplikace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Požadovaná funkce</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Es sind keine Elemente zur Auswahl verfügbar: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">Das Projektargument wurde nicht angegeben, und es wurden keine App-Hostprojektdateien erkannt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Erforderliche Funktion</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">No se especificó el argumento del proyecto y no se detectaron archivos de proyecto de host de aplicaciones.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Funcionalidad requerida</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -102,6 +102,11 @@
         <target state="translated">No hay elementos disponibles para la selección: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">L'argument de projet n'a pas été spécifié et aucun fichier de projet hôte d'application n'a été détecté.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Capacité requise</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Aucun élément disponible pour la sélection : {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">L'argomento del progetto non è stato specificato e non sono stati rilevati file del progetto host dell'app.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Funzionalità richiesta</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Nessun elemento disponibile per la selezione: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -102,6 +102,11 @@
         <target state="translated">選択できる項目がありません: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">プロジェクト引数が指定されておらず、アプリ ホスト プロジェクト ファイルが検出されませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">必要な機能</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">프로젝트 인수가 지정되지 않았고 앱 호스트 프로젝트 파일이 감지되지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">필수 기능</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -102,6 +102,11 @@
         <target state="translated">선택할 수 있는 항목 없음: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">Nie określono argumentu projektu i nie wykryto plików projektu hosta aplikacji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Wymagana możliwość</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Brak dostępnych elementów do wyboru: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Nenhum item disponível para seleção: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">O argumento do projeto não foi especificado e nenhum arquivo de projeto do host do aplicativo foi detectado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Funcionalidade Necessária</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">Аргумент проекта не указан. Не найдены файлы проекта узла приложений.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Нужная возможность</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Нет элементов, доступных для выбора: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">Proje bağımsız değişkeni belirtilmedi ve uygulama ana işlemi projesinin dosyaları tespit edilemedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">Gerekli Yetenek</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Seçim için herhangi bir öğe mevcut değil: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">未指定项目参数，并且未检测到应用主机项目文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">所需功能</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="translated">没有可供选择的项目: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="translated">沒有可供選取的項目: {0}</target>
         <note>{0} is the original selection prompt text.</note>
       </trans-unit>
+      <trans-unit id="NoSupportedAppHostsFound">
+        <source>No supported app hosts were found.</source>
+        <target state="new">No supported app hosts were found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveAvailableValues">
         <source>Available values: {0}</source>
         <target state="new">Available values: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -152,6 +152,16 @@
         <target state="needs-review-translation">未指定專案引數，且未偵測到任何主控處理程序專案檔案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">
+        <source>The --apphost option specified a directory that contains multiple AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that contains multiple AppHost project files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionSpecifiedDirectoryContainsNoAppHosts">
+        <source>The --apphost option specified a directory that does not contain any AppHost project files.</source>
+        <target state="new">The --apphost option specified a directory that does not contain any AppHost project files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCapability">
         <source>Required Capability</source>
         <target state="translated">必要的功能</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.cs.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Cesta k souboru projektu Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.de.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Der Pfad zur Aspire AppHost-Projektdatei.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.es.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">La ruta de acceso al archivo del proyecto host de la AppHost Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.fr.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Chemin d’accès au fichier projet AppHost Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.it.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Percorso del file di un progetto AppHost di Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ja.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire アプリ ホスティング プロセス プロジェクト ファイルへのパス。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ko.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 프로젝트 파일의 경로입니다.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pl.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu hosta AppHost platformy Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pt-BR.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto do Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ru.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Путь к файлу проекта Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.tr.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost proje dosyasının yolu.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hans.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 项目文件的路径。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hant.xlf
@@ -38,7 +38,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 專案檔案的路徑。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Cesta k souboru projektu Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Der Pfad zur Aspire AppHost-Projektdatei.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">La ruta de acceso al archivo del proyecto host de la AppHost Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Chemin d’accès au fichier projet AppHost Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Percorso del file di un progetto AppHost di Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost プロジェクト ファイルへのパス。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 프로젝트 파일의 경로입니다.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu hosta AppHost platformy Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto do Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Путь к файлу проекта Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost proje dosyasının yolu.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 项目文件的路径。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -153,7 +153,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 專案檔案的路徑。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotRunningAtPath">
+        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
+        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
       <trans-unit id="FormatOptionDescription">
         <source>Output format for detached AppHost results</source>
         <target state="new">Output format for detached AppHost results</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AppHostNotRunningAtPath">
-        <source>No running AppHost found at '{0}'. Use 'aspire run' to start one first.</source>
-        <target state="new">No running AppHost found at '{0}'. Use 'aspire run' to start one first.</target>
+        <source>No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</source>
+        <target state="new">No AppHost is currently running for '{0}'. Use 'aspire run' to start it first.</target>
         <note>{0} is the AppHost project path.</note>
       </trans-unit>
       <trans-unit id="FormatOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.cs.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Cesta k souboru projektu Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.de.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Der Pfad zur Aspire AppHost-Projektdatei.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.es.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">La ruta de acceso al archivo del proyecto host de la AppHost Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.fr.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Chemin d’accès au fichier projet AppHost Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.it.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Percorso del file di un progetto AppHost di Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ja.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost プロジェクト ファイルへのパス。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ko.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 프로젝트 파일의 경로입니다.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pl.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu hosta AppHost platformy Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pt-BR.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto do Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ru.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Путь к файлу проекта Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.tr.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost proje dosyasının yolu.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hans.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 项目文件的路径。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hant.xlf
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 專案檔案的路徑。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Cesta k souboru projektu Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Der Pfad zur Aspire AppHost-Projektdatei.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">La ruta de acceso al archivo del proyecto host de la AppHost Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Chemin d’accès au fichier projet AppHost Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Percorso del file di un progetto AppHost di Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire アプリ ホスティング プロセス プロジェクト ファイルへのパス。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 프로젝트 파일의 경로입니다.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu hosta AppHost platformy Aspire.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto do Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Путь к файлу проекта Aspire AppHost.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost proje dosyasının yolu.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 项目文件的路径。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -183,7 +183,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire AppHost project file</source>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 專案檔案的路徑。</target>
         <note />
       </trans-unit>

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -51,8 +51,9 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Clear screen to avoid matching old patterns
         await auto.ClearScreenAsync(counter);
 
-        // Navigate to the solution root and stop using a directory path so --apphost must resolve it.
-        await auto.TypeAsync("cd ..");
+        // Navigate above the solution root and stop using the solution directory path
+        // so --apphost must resolve it to the AppHost project.
+        await auto.TypeAsync("cd ../..");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -51,8 +51,13 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Clear screen to avoid matching old patterns
         await auto.ClearScreenAsync(counter);
 
-        // Stop the AppHost using aspire stop --non-interactive --project (targets specific AppHost)
-        await auto.TypeAsync("aspire stop --non-interactive --project TestStopApp.AppHost.csproj");
+        // Navigate to the solution root and stop using a directory path so --apphost must resolve it.
+        await auto.TypeAsync("cd ..");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Stop the AppHost using aspire stop --non-interactive --apphost with a directory path.
+        await auto.TypeAsync("aspire stop --non-interactive --apphost TestStopApp");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Backchannel;
+
+public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task ResolveConnectionAsync_WithExplicitProjectFile_PreservesFastPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectFile = CreateProjectFile(workspace.WorkspaceRoot, "TestAppHost", "TestAppHost.csproj");
+        var interactionService = new TestInteractionService();
+        var projectLocatorInvoked = false;
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+            {
+                projectLocatorInvoked = true;
+                throw new ProjectLocatorException("should not be invoked", ProjectLocatorFailureReason.ProjectFileDoesntExist);
+            }
+        };
+        var resolver = new AppHostConnectionResolver(
+            new TestAuxiliaryBackchannelMonitor(),
+            interactionService,
+            projectLocator,
+            executionContext,
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            projectFile,
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(projectLocatorInvoked);
+        Assert.False(result.Success);
+        Assert.False(result.IsProjectResolutionError);
+        Assert.Equal(
+            string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.AppHostNotRunningAtPath, Path.Combine("TestAppHost", "TestAppHost.csproj")),
+            result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_WithExplicitDirectoryAndMultipleAppHosts_ReturnsDirectorySpecificError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("Apps");
+        var interactionService = new TestInteractionService();
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                throw new ProjectLocatorException("multiple", ProjectLocatorFailureReason.MultipleProjectFilesFound)
+        };
+        var resolver = new AppHostConnectionResolver(
+            new TestAuxiliaryBackchannelMonitor(),
+            interactionService,
+            projectLocator,
+            executionContext,
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            new FileInfo(appHostDirectory.FullName),
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.True(result.IsProjectResolutionError);
+        Assert.Equal(ExitCodeConstants.FailedToFindProject, result.ExitCode);
+        Assert.Equal(InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts, result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_WithExplicitDirectoryAndNoAppHosts_ReturnsDirectorySpecificError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("Apps");
+        var interactionService = new TestInteractionService();
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                throw new ProjectLocatorException("missing", ProjectLocatorFailureReason.ProjectFileDoesntExist)
+        };
+        var resolver = new AppHostConnectionResolver(
+            new TestAuxiliaryBackchannelMonitor(),
+            interactionService,
+            projectLocator,
+            executionContext,
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            new FileInfo(appHostDirectory.FullName),
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.True(result.IsProjectResolutionError);
+        Assert.Equal(ExitCodeConstants.FailedToFindProject, result.ExitCode);
+        Assert.Equal(InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts, result.ErrorMessage);
+    }
+
+    private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
+    {
+        var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
+        var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
+        var cacheDirectory = settingsDirectory.CreateSubdirectory("cache");
+        var sdksDirectory = workingDirectory.CreateSubdirectory("sdks");
+        var logsDirectory = workingDirectory.CreateSubdirectory("logs");
+        var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
+
+        return new CliExecutionContext(
+            workingDirectory,
+            hivesDirectory,
+            cacheDirectory,
+            sdksDirectory,
+            logsDirectory,
+            logFilePath,
+            homeDirectory: workingDirectory);
+    }
+
+    private static FileInfo CreateProjectFile(DirectoryInfo workingDirectory, string directoryName, string fileName)
+    {
+        var directory = workingDirectory.CreateSubdirectory(directoryName);
+        var projectFile = new FileInfo(Path.Combine(directory.FullName, fileName));
+        File.WriteAllText(projectFile.FullName, "<Project />");
+        return projectFile;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -52,6 +52,18 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void IsProjectResolutionError_WithNonProjectResolutionExitCode_ReturnsFalse()
+    {
+        var result = new AppHostConnectionResult
+        {
+            ErrorMessage = "failed",
+            ExitCode = ExitCodeConstants.FailedToCreateNewProject
+        };
+
+        Assert.False(result.IsProjectResolutionError);
+    }
+
+    [Fact]
     public async Task ResolveConnectionAsync_WithExplicitDirectoryAndMultipleAppHosts_ReturnsDirectorySpecificError()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Commands;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
@@ -37,5 +39,56 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task StopCommand_WithInvalidExplicitAppHost_ReturnsFailedToFindProject()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                    throw new ProjectLocatorException("Project file does not exist.", ProjectLocatorFailureReason.ProjectFileDoesntExist)
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("stop --apphost missing-directory");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+    }
+
+    [Fact]
+    public async Task StopCommand_WithExplicitAppHost_UsesProjectLocatorResolution()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectLocatorInvoked = false;
+        var resolvedProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Resolved.AppHost", "Resolved.AppHost.csproj"));
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, _, _, _) =>
+                {
+                    projectLocatorInvoked = true;
+                    return Task.FromResult(new AppHostProjectSearchResult(resolvedProjectFile, [resolvedProjectFile]));
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("stop --apphost some-directory");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.True(projectLocatorInvoked);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -70,6 +70,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var projectLocatorInvoked = false;
         var interactionService = new TestInteractionService();
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("some-directory");
         var resolvedProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Resolved.AppHost", "Resolved.AppHost.csproj"));
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -87,7 +88,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("stop --apphost some-directory");
+        var result = command.Parse($"stop --apphost \"{appHostDirectory.FullName}\"");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Commands;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -68,10 +69,12 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var projectLocatorInvoked = false;
+        var interactionService = new TestInteractionService();
         var resolvedProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Resolved.AppHost", "Resolved.AppHost.csproj"));
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.InteractionServiceFactory = _ => interactionService;
             options.ProjectLocatorFactory = _ => new TestProjectLocator
             {
                 UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, _, _, _) =>
@@ -90,5 +93,9 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         Assert.True(projectLocatorInvoked);
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+        var displayedMessage = Assert.Single(interactionService.DisplayedMessages);
+        Assert.Equal(
+            string.Format(SharedCommandStrings.AppHostNotRunningAtPath, Path.Combine("Resolved.AppHost", "Resolved.AppHost.csproj")),
+            displayedMessage.Message);
     }
 }


### PR DESCRIPTION
## Description

Fix `--apphost` resolution for stop-side CLI commands.

Fixes #16360

This change:
- keeps explicit AppHost project-file paths on the direct socket lookup path so commands can still attach to an already-running AppHost
- continues to resolve directory-valued `--apphost` inputs via `IProjectLocator`, with explicit directory-specific diagnostics for zero or multiple AppHosts
- adds resolver unit tests and updates the non-interactive stop E2E scenario to cover directory-based `--apphost`

Reviewer testing steps using the built CLI:
1. `./localhive.sh`
2. `~/.aspire/bin/aspire --version`
3. `~/.aspire/bin/aspire new aspire-starter --name ReviewApp --output /tmp/ReviewApp --non-interactive`
4. In one terminal: `cd /tmp/ReviewApp/ReviewApp.AppHost && dotnet run`
5. In a second terminal from above the solution root: `cd /tmp && ~/.aspire/bin/aspire stop --non-interactive --apphost ReviewApp`

Expected result: the running AppHost is found and stopped via the solution directory path.

Validation performed:
- `./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
