### PR TITLE
Add symlink/junction support for bundle installs with versioned directories

### DIFF
--- a/localhive.ps1
+++ b/localhive.ps1
@@ -7,8 +7,8 @@
 .DESCRIPTION
   Mirrors localhive.sh behavior on Windows. Packs the repo, creates a symlink from
   $HOME/.aspire/hives/<HiveName> to artifacts/packages/<Config>/Shipping (or copies .nupkg files),
-  installs the locally-built Aspire CLI to $HOME/.aspire/bin, and builds/installs the bundle
-  (aspire-managed + DCP) to $HOME/.aspire so the CLI can auto-discover it.
+  installs the locally-built Aspire CLI to $HOME/.aspire/bin, and embeds the bundle
+  payload (aspire-managed + DCP) in the CLI binary so it self-extracts on first run.
 
 .PARAMETER Configuration
   Build configuration: Release or Debug (positional parameter 0). If omitted, the script tries Release then falls back to Debug.
@@ -26,7 +26,8 @@
   Skip installing the locally-built CLI to $HOME/.aspire/bin.
 
 .PARAMETER SkipBundle
-  Skip building and installing the bundle (aspire-managed + DCP) to $HOME/.aspire.
+  Skip building the bundle payload. Without it the CLI binary will not have an embedded
+  bundle and will require externally-provided managed/ and dcp/ directories.
 
 .PARAMETER NativeAot
   Build and install the native AOT CLI (self-extracting binary with embedded bundle) instead of the dotnet tool version.
@@ -303,7 +304,7 @@ else {
   }
 }
 
-# Build the bundle (aspire-managed + DCP, and optionally native AOT CLI)
+# Build the bundle payload (aspire-managed + DCP tar.gz archive, and optionally native AOT CLI)
 if (-not $SkipBundle) {
   $bundleProjPath = Join-Path $RepoRoot "eng" "Bundle.proj"
   $skipNativeArg = if ($NativeAot) { '' } else { '/p:SkipNativeBuild=true' }
@@ -326,29 +327,16 @@ if (-not $SkipBundle) {
     exit 1
   }
 
-  $bundleLayoutDir = Join-Path $RepoRoot "artifacts" "bundle" $bundleRid
-
-  if (-not (Test-Path -LiteralPath $bundleLayoutDir)) {
-    Write-Err "Bundle layout not found at $bundleLayoutDir"
+  # Locate the bundle payload archive produced by Bundle.proj / CreateLayout.
+  # The archive is embedded in the CLI binary so EnsureExtractedAsync handles
+  # versioned layout creation, symlink/junction management, and cleanup at runtime.
+  $bundlePayloadArchive = Get-ChildItem -Path (Join-Path $RepoRoot "artifacts" "bundle") -Filter "aspire-*-$bundleRid.tar.gz" -File |
+    Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+  if (-not $bundlePayloadArchive) {
+    Write-Err "Bundle payload archive not found in artifacts/bundle/ for RID $bundleRid"
     exit 1
   }
-
-  # Copy managed/ and dcp/ to $HOME/.aspire so the CLI auto-discovers them
-  foreach ($component in @('managed', 'dcp')) {
-    $sourceDir = Join-Path $bundleLayoutDir $component
-    $destDir = Join-Path $aspireRoot $component
-    if (Test-Path -LiteralPath $sourceDir) {
-      if (Test-Path -LiteralPath $destDir) {
-        Remove-Item -LiteralPath $destDir -Force -Recurse
-      }
-      Write-Log "Copying $component/ to $destDir"
-      Copy-Item -LiteralPath $sourceDir -Destination $destDir -Recurse -Force
-    } else {
-      Write-Warn "$component/ not found in bundle layout at $sourceDir"
-    }
-  }
-
-  Write-Log "Bundle installed to $aspireRoot (managed/ + dcp/)"
+  Write-Log "Bundle payload archive: $($bundlePayloadArchive.FullName) ($([math]::Round($bundlePayloadArchive.Length / 1MB, 1)) MB)"
 }
 
 # Install the CLI to $aspireRoot/bin
@@ -357,24 +345,37 @@ if (-not $SkipCli) {
 
   if ($NativeAot) {
     # Native AOT CLI is produced by Bundle.proj's _PublishNativeCli target
+    # (already has embedded bundle payload)
     $cliPublishDir = Join-Path $RepoRoot "artifacts" "bin" "Aspire.Cli" $effectiveConfig "net10.0" $bundleRid "native"
     if (-not (Test-Path -LiteralPath $cliPublishDir)) {
       $cliPublishDir = Join-Path $RepoRoot "artifacts" "bin" "Aspire.Cli" $effectiveConfig "net10.0" $bundleRid "publish"
     }
   } elseif ($Rid) {
-    # Cross-RID: publish CLI for the target platform
+    # Cross-RID: publish CLI for the target platform with embedded bundle payload
     Write-Log "Publishing Aspire CLI for target RID: $Rid"
     $cliProj = Join-Path $RepoRoot "src" "Aspire.Cli" "Aspire.Cli.csproj"
     $cliPublishDir = Join-Path $RepoRoot "artifacts" "bin" "Aspire.Cli" $effectiveConfig "net10.0" $Rid "publish"
-    & dotnet publish $cliProj -c $effectiveConfig -r $Rid --self-contained /p:PublishAot=false /p:PublishSingleFile=true "/p:VersionSuffix=$VersionSuffix"
+    $publishArgs = @($cliProj, '-c', $effectiveConfig, '-r', $Rid, '--self-contained', '/p:PublishAot=false', '/p:PublishSingleFile=true', "/p:VersionSuffix=$VersionSuffix")
+    if ($bundlePayloadArchive) {
+      $publishArgs += "/p:BundlePayloadPath=$($bundlePayloadArchive.FullName)"
+    }
+    & dotnet publish @publishArgs
     if ($LASTEXITCODE -ne 0) {
       Write-Err "CLI publish for RID $Rid failed."
       exit 1
     }
   } else {
-    # Framework-dependent CLI from dotnet tool build
+    # Framework-dependent CLI with embedded bundle payload
+    $cliProj = Join-Path $RepoRoot "src" "Aspire.Cli" "Aspire.Cli.Tool.csproj"
     $cliPublishDir = Join-Path $RepoRoot "artifacts" "bin" "Aspire.Cli.Tool" $effectiveConfig "net10.0" "publish"
-    if (-not (Test-Path -LiteralPath $cliPublishDir)) {
+    if ($bundlePayloadArchive) {
+      Write-Log "Publishing Aspire CLI (dotnet tool) with embedded bundle payload..."
+      & dotnet publish $cliProj -c $effectiveConfig "/p:VersionSuffix=$VersionSuffix" "/p:BundlePayloadPath=$($bundlePayloadArchive.FullName)"
+      if ($LASTEXITCODE -ne 0) {
+        Write-Err "CLI publish with embedded bundle failed."
+        exit 1
+      }
+    } elseif (-not (Test-Path -LiteralPath $cliPublishDir)) {
       $cliPublishDir = Join-Path $RepoRoot "artifacts" "bin" "Aspire.Cli.Tool" $effectiveConfig "net10.0"
     }
   }
@@ -494,8 +495,8 @@ if ($Output) {
     Write-Host
   }
   if (-not $SkipBundle) {
-    Write-Log "Bundle (aspire-managed + DCP) installed to: $aspireRoot"
-    Write-Log "  The CLI at ~/.aspire/bin/ will auto-discover managed/ and dcp/ in the parent directory."
+    Write-Log "Bundle payload embedded in CLI binary. The CLI will extract and"
+    Write-Log "  create the versioned layout (bundle/ -> versions/<id>/) on first run."
     Write-Host
   }
   Write-Log 'The Aspire CLI discovers channels automatically from the hives directory; no extra flags are required.'

--- a/localhive.sh
+++ b/localhive.sh
@@ -15,7 +15,7 @@
 #       --archive         Create a .tar.gz (or .zip for win-* RIDs) archive of the output. Requires --output.
 #       --copy            Copy .nupkg files instead of creating a symlink
 #       --skip-cli        Skip installing the locally-built CLI to $HOME/.aspire/bin
-#       --skip-bundle     Skip building and installing the bundle (aspire-managed + DCP)
+#       --skip-bundle     Skip building the bundle payload (CLI won't have embedded bundle)
 #       --native-aot      Build native AOT CLI (self-extracting with embedded bundle)
 #   -h, --help            Show this help and exit
 #
@@ -23,6 +23,7 @@
 # - If no configuration is specified, the script tries Release then Debug.
 # - The hive is created at $HOME/.aspire/hives/<HiveName> so the Aspire CLI can discover a channel.
 # - The CLI is installed to $HOME/.aspire/bin so it can be used directly.
+# - The bundle payload is embedded in the CLI binary and self-extracts on first run.
 
 set -euo pipefail
 
@@ -41,7 +42,7 @@ Options:
       --archive         Create a .tar.gz (or .zip for win-* RIDs) archive of the output. Requires --output.
       --copy            Copy .nupkg files instead of creating a symlink
       --skip-cli        Skip installing the locally-built CLI to \$HOME/.aspire/bin
-      --skip-bundle     Skip building and installing the bundle (aspire-managed + DCP)
+      --skip-bundle     Skip building the bundle payload (CLI won't have embedded bundle)
       --native-aot      Build native AOT CLI (self-extracting with embedded bundle)
   -h, --help            Show this help and exit
 
@@ -311,7 +312,7 @@ else
   fi
 fi
 
-# Build the bundle (aspire-managed + DCP, and optionally native AOT CLI)
+# Build the bundle payload (aspire-managed + DCP tar.gz archive, and optionally native AOT CLI)
 if [[ $SKIP_BUNDLE -eq 0 ]]; then
   BUNDLE_PROJ="$REPO_ROOT/eng/Bundle.proj"
 
@@ -334,54 +335,52 @@ if [[ $SKIP_BUNDLE -eq 0 ]]; then
     exit 1
   fi
 
-  BUNDLE_LAYOUT_DIR="$REPO_ROOT/artifacts/bundle/$BUNDLE_RID"
-
-  if [[ ! -d "$BUNDLE_LAYOUT_DIR" ]]; then
-    error "Bundle layout not found at $BUNDLE_LAYOUT_DIR"
+  # Locate the bundle payload archive produced by Bundle.proj / CreateLayout.
+  # The archive is embedded in the CLI binary so EnsureExtractedAsync handles
+  # versioned layout creation, symlink management, and cleanup at runtime.
+  BUNDLE_PAYLOAD_ARCHIVE="$(ls -t "$REPO_ROOT/artifacts/bundle/"aspire-*-"$BUNDLE_RID".tar.gz 2>/dev/null | head -1)"
+  if [[ -z "$BUNDLE_PAYLOAD_ARCHIVE" ]]; then
+    error "Bundle payload archive not found in artifacts/bundle/ for RID $BUNDLE_RID"
     exit 1
   fi
-
-  # Copy managed/ and dcp/ to $HOME/.aspire so the CLI auto-discovers them
-  for component in managed dcp; do
-    SOURCE_DIR="$BUNDLE_LAYOUT_DIR/$component"
-    DEST_DIR="$ASPIRE_ROOT/$component"
-    if [[ -d "$SOURCE_DIR" ]]; then
-      rm -rf "$DEST_DIR"
-      log "Copying $component/ to $DEST_DIR"
-      cp -r "$SOURCE_DIR" "$DEST_DIR"
-      # Ensure executables are executable
-      if [[ "$component" == "managed" ]]; then
-        chmod +x "$DEST_DIR/aspire-managed" 2>/dev/null || true
-      elif [[ "$component" == "dcp" ]]; then
-        find "$DEST_DIR" -type f -name "dcp" -exec chmod +x {} \; 2>/dev/null || true
-      fi
-    else
-      warn "$component/ not found in bundle layout at $SOURCE_DIR"
-    fi
-  done
-
-  log "Bundle installed to $ASPIRE_ROOT (managed/ + dcp/)"
+  PAYLOAD_SIZE_MB="$(du -m "$BUNDLE_PAYLOAD_ARCHIVE" | cut -f1)"
+  log "Bundle payload archive: $BUNDLE_PAYLOAD_ARCHIVE ($PAYLOAD_SIZE_MB MB)"
 fi
 
 # Install the CLI to $ASPIRE_ROOT/bin
 if [[ $SKIP_CLI -eq 0 ]]; then
   if [[ $NATIVE_AOT -eq 1 ]]; then
-    # Native AOT CLI from Bundle.proj publish
+    # Native AOT CLI from Bundle.proj publish (already has embedded bundle payload)
     CLI_PUBLISH_DIR="$REPO_ROOT/artifacts/bin/Aspire.Cli/$EFFECTIVE_CONFIG/net10.0/$BUNDLE_RID/native"
     if [[ ! -d "$CLI_PUBLISH_DIR" ]]; then
       CLI_PUBLISH_DIR="$REPO_ROOT/artifacts/bin/Aspire.Cli/$EFFECTIVE_CONFIG/net10.0/$BUNDLE_RID/publish"
     fi
   elif [[ -n "$TARGET_RID" ]]; then
-    # Cross-RID: publish CLI for the target platform
+    # Cross-RID: publish CLI for the target platform with embedded bundle payload
     log "Publishing Aspire CLI for target RID: $TARGET_RID"
     CLI_PROJ="$REPO_ROOT/src/Aspire.Cli/Aspire.Cli.csproj"
     CLI_PUBLISH_DIR="$REPO_ROOT/artifacts/bin/Aspire.Cli/$EFFECTIVE_CONFIG/net10.0/$TARGET_RID/publish"
-    dotnet publish "$CLI_PROJ" -c "$EFFECTIVE_CONFIG" -r "$TARGET_RID" --self-contained \
-      /p:PublishAot=false /p:PublishSingleFile=true "/p:VersionSuffix=$VERSION_SUFFIX"
+    PUBLISH_ARGS=(-c "$EFFECTIVE_CONFIG" -r "$TARGET_RID" --self-contained /p:PublishAot=false /p:PublishSingleFile=true "/p:VersionSuffix=$VERSION_SUFFIX")
+    if [[ -n "$BUNDLE_PAYLOAD_ARCHIVE" ]]; then
+      PUBLISH_ARGS+=("/p:BundlePayloadPath=$BUNDLE_PAYLOAD_ARCHIVE")
+    fi
+    dotnet publish "$CLI_PROJ" "${PUBLISH_ARGS[@]}"
+    if [[ $? -ne 0 ]]; then
+      error "CLI publish for RID $TARGET_RID failed."
+      exit 1
+    fi
   else
-    # Framework-dependent CLI from dotnet tool build
+    # Framework-dependent CLI with embedded bundle payload
+    CLI_PROJ="$REPO_ROOT/src/Aspire.Cli/Aspire.Cli.Tool.csproj"
     CLI_PUBLISH_DIR="$REPO_ROOT/artifacts/bin/Aspire.Cli.Tool/$EFFECTIVE_CONFIG/net10.0/publish"
-    if [[ ! -d "$CLI_PUBLISH_DIR" ]]; then
+    if [[ -n "$BUNDLE_PAYLOAD_ARCHIVE" ]]; then
+      log "Publishing Aspire CLI (dotnet tool) with embedded bundle payload..."
+      dotnet publish "$CLI_PROJ" -c "$EFFECTIVE_CONFIG" "/p:VersionSuffix=$VERSION_SUFFIX" "/p:BundlePayloadPath=$BUNDLE_PAYLOAD_ARCHIVE"
+      if [[ $? -ne 0 ]]; then
+        error "CLI publish with embedded bundle failed."
+        exit 1
+      fi
+    elif [[ ! -d "$CLI_PUBLISH_DIR" ]]; then
       CLI_PUBLISH_DIR="$REPO_ROOT/artifacts/bin/Aspire.Cli.Tool/$EFFECTIVE_CONFIG/net10.0"
     fi
   fi
@@ -462,8 +461,8 @@ else
     echo
   fi
   if [[ $SKIP_BUNDLE -eq 0 ]]; then
-    log "Bundle (aspire-managed + DCP) installed to: $ASPIRE_ROOT"
-    log "  The CLI at ~/.aspire/bin/ will auto-discover managed/ and dcp/ in the parent directory."
+    log "Bundle payload embedded in CLI binary. The CLI will extract and"
+    log "  create the versioned layout (bundle/ -> versions/<id>/) on first run."
     echo
   fi
   log "The Aspire CLI discovers channels automatically from the hives directory; no extra flags are required."

--- a/localhive.sh
+++ b/localhive.sh
@@ -89,6 +89,7 @@ VERSION_SUFFIX=""
 OUTPUT_DIR=""
 TARGET_RID=""
 ARCHIVE=0
+BUNDLE_PAYLOAD_ARCHIVE=""
 is_valid_versionsuffix() {
   local s="$1"
   # Must be dot-separated identifiers containing only 0-9A-Za-z- per SemVer2.

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -201,6 +201,13 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
         // .tmp.*, .bad.*, .old.* siblings.
         TryCleanupStaleVersions(versionsRoot, versionId);
 
+        // Best-effort cleanup of .old legacy directories created during this
+        // migration. These are safe to remove now that post-flip validation passed.
+        foreach (var dir in s_linkedLayoutDirectories)
+        {
+            FileDeleteHelper.TryCleanupOldItems(destinationPath, dir);
+        }
+
         logger.LogDebug("Bundle extraction verified successfully.");
         return BundleExtractResult.Extracted;
     }
@@ -338,11 +345,22 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
             FileDeleteHelper.TryCleanupOldItems(layoutPath, dir);
 
             // If a legacy real directory is sitting at the public path (pre-migration
-            // layout), move it aside so we can install a reparse point in its place.
+            // layout), rename it to a .old sibling so a reparse point can be created.
+            // The .old sibling is preserved until after post-flip validation succeeds,
+            // ensuring a working layout is never lost if link creation fails.
             if (Directory.Exists(linkPath) && !ReparsePoint.IsReparsePoint(linkPath))
             {
-                logger.LogDebug("Migrating legacy directory at {Path} to .old sibling.", linkPath);
-                FileDeleteHelper.TryDeleteDirectory(linkPath);
+                var renamedPath = $"{linkPath}.old.{Environment.TickCount64}";
+                logger.LogDebug("Migrating legacy directory at {Path} to {Renamed}.", linkPath, renamedPath);
+                try
+                {
+                    Directory.Move(linkPath, renamedPath);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    logger.LogError(ex, "Failed to rename legacy directory {Path}.", linkPath);
+                    return false;
+                }
             }
 
             try

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -4,6 +4,8 @@
 using System.Diagnostics;
 using System.Formats.Tar;
 using System.IO.Compression;
+using System.IO.Hashing;
+using System.Text;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
@@ -23,6 +25,25 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     /// </summary>
     internal const string VersionMarkerFileName = ".aspire-bundle-version";
 
+    /// <summary>
+    /// Directory under the layout root containing per-version bundle installations.
+    /// </summary>
+    internal const string VersionsDirectoryName = "versions";
+
+    /// <summary>
+    /// Suffix appended to an in-progress extraction directory so it is ignored by
+    /// layout discovery and can be atomically renamed to its final name only after
+    /// extraction completes.
+    /// </summary>
+    internal const string TempSuffixPrefix = ".tmp.";
+
+    /// <summary>
+    /// Suffix appended to a versioned directory that failed verification. Retained
+    /// on disk (with the version-id fingerprint) so the fingerprint-match
+    /// short-circuit cannot accidentally promote a known-bad payload on a later run.
+    /// </summary>
+    internal const string BadSuffixPrefix = ".bad.";
+
     private static readonly bool s_isBundle =
         typeof(BundleService).Assembly.GetManifestResourceInfo(PayloadResourceName) is not null;
 
@@ -37,10 +58,11 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
         typeof(BundleService).Assembly.GetManifestResourceStream(PayloadResourceName);
 
     /// <summary>
-    /// Well-known layout subdirectories that are cleaned before re-extraction.
-    /// The bin/ directory is intentionally excluded since it contains the running CLI binary.
+    /// Well-known layout subdirectories that are exposed as reparse points pointing
+    /// at the active versioned bundle directory. The bin/ directory is intentionally
+    /// excluded since it contains the running CLI binary itself.
     /// </summary>
-    internal static readonly string[] s_layoutDirectories = [
+    internal static readonly string[] s_linkedLayoutDirectories = [
         BundleDiscovery.ManagedDirectoryName,
         BundleDiscovery.DcpDirectoryName
     ];
@@ -129,29 +151,149 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     {
         logger.LogInformation("Extracting embedded bundle to {Path}...", destinationPath);
 
-        // Clean existing layout directories before extraction to avoid file conflicts
-        logger.LogDebug("Cleaning existing layout directories in {Path}.", destinationPath);
-        CleanLayoutDirectories(destinationPath);
+        Directory.CreateDirectory(destinationPath);
+        var versionsRoot = Path.Combine(destinationPath, VersionsDirectoryName);
+        Directory.CreateDirectory(versionsRoot);
 
-        var sw = Stopwatch.StartNew();
-        await ExtractPayloadAsync(destinationPath, cancellationToken);
-        sw.Stop();
-        logger.LogDebug("Payload extraction completed in {ElapsedMs}ms.", sw.ElapsedMilliseconds);
-
-        // Write version marker so subsequent runs skip extraction
         var currentVersion = GetCurrentVersion();
-        WriteVersionMarker(destinationPath, currentVersion);
-        logger.LogDebug("Version marker written (version: {Version}).", currentVersion);
+        var versionId = ComputeVersionId(currentVersion);
+        var activeVersionDir = Path.Combine(versionsRoot, versionId);
 
-        // Verify extraction produced a valid layout
-        if (layoutDiscovery.DiscoverLayout() is null)
+        // Reuse an already-extracted versioned directory if it passes validation.
+        // This handles the case where the marker / links were deleted but the
+        // payload is still intact on disk.
+        if (!IsVersionedLayoutValid(activeVersionDir))
         {
-            logger.LogError("Extraction completed but no valid layout found in {Path}.", destinationPath);
+            logger.LogDebug("Versioned layout {Path} not valid or missing; extracting fresh.", activeVersionDir);
+            if (!await ExtractVersionedLayoutAsync(versionsRoot, versionId, activeVersionDir, cancellationToken).ConfigureAwait(false))
+            {
+                return BundleExtractResult.ExtractionFailed;
+            }
+        }
+        else
+        {
+            logger.LogDebug("Reusing existing versioned layout at {Path}.", activeVersionDir);
+        }
+
+        // Capture prior link targets before flipping so we can roll back if the
+        // post-flip sanity check fails.
+        var priorTargets = CaptureLinkTargets(destinationPath);
+
+        // Migrate any legacy real directories (managed/, dcp/) and flip the public
+        // reparse points to point at the new versioned directory.
+        if (!TryFlipLinks(destinationPath, activeVersionDir))
+        {
+            logger.LogError("Failed to flip bundle links to {VersionDir}.", activeVersionDir);
             return BundleExtractResult.ExtractionFailed;
         }
 
+        // Post-flip sanity check: confirm layout discovery resolves through the
+        // new reparse points. Roll back to the prior targets on failure.
+        if (layoutDiscovery.DiscoverLayout() is null)
+        {
+            logger.LogError("Post-flip layout validation failed; attempting rollback.");
+            if (!TryRestoreLinks(destinationPath, priorTargets))
+            {
+                logger.LogError("Rollback of bundle links failed; layout is in an inconsistent state.");
+            }
+            return BundleExtractResult.ExtractionFailed;
+        }
+
+        // Write version marker so subsequent runs can short-circuit.
+        WriteVersionMarker(destinationPath, currentVersion);
+        logger.LogDebug("Version marker written (version: {Version}).", currentVersion);
+
+        // Best-effort cleanup of non-active versioned directories and any stale
+        // .tmp.*, .bad.*, .old.* siblings.
+        TryCleanupStaleVersions(versionsRoot, versionId);
+
         logger.LogDebug("Bundle extraction verified successfully.");
         return BundleExtractResult.Extracted;
+    }
+
+    /// <summary>
+    /// Extracts the payload into a <c>.tmp.*</c> sibling of the target versioned
+    /// directory, validates the result, and atomically renames it to
+    /// <paramref name="activeVersionDir"/>. Returns <see langword="false"/> if
+    /// verification fails (in which case the failed directory has been renamed
+    /// to <c>.bad.&lt;tick&gt;</c> and logged).
+    /// </summary>
+    private async Task<bool> ExtractVersionedLayoutAsync(
+        string versionsRoot,
+        string versionId,
+        string activeVersionDir,
+        CancellationToken cancellationToken)
+    {
+        var tempDir = Path.Combine(versionsRoot, $"{versionId}{TempSuffixPrefix}{Guid.NewGuid():N}");
+
+        // Clean up if a previous attempt left a dir with this exact name.
+        FileDeleteHelper.TryDeleteDirectory(tempDir);
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            await ExtractPayloadAsync(tempDir, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            FileDeleteHelper.TryDeleteDirectory(tempDir);
+            throw;
+        }
+        sw.Stop();
+        logger.LogDebug("Payload extraction into {Path} completed in {ElapsedMs}ms.", tempDir, sw.ElapsedMilliseconds);
+
+        // Pre-flip verification: validate the freshly-unpacked bundle before it
+        // can become the active version.
+        if (!IsVersionedLayoutValid(tempDir))
+        {
+            var badPath = $"{activeVersionDir}{BadSuffixPrefix}{Environment.TickCount64}";
+            logger.LogError("Extracted bundle at {Path} failed verification; renaming to {BadPath}.", tempDir, badPath);
+            try
+            {
+                Directory.Move(tempDir, badPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogWarning(ex, "Unable to preserve failed bundle at {BadPath}; deleting instead.", badPath);
+                FileDeleteHelper.TryDeleteDirectory(tempDir);
+            }
+            return false;
+        }
+
+        // If a stale activeVersionDir exists (partial prior install), move it aside.
+        if (Directory.Exists(activeVersionDir))
+        {
+            FileDeleteHelper.TryDeleteDirectory(activeVersionDir);
+        }
+
+        try
+        {
+            Directory.Move(tempDir, activeVersionDir);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogError(ex, "Failed to promote {TempDir} to {ActiveDir}.", tempDir, activeVersionDir);
+            FileDeleteHelper.TryDeleteDirectory(tempDir);
+            return false;
+        }
+
+        // Re-validate after rename.
+        if (!IsVersionedLayoutValid(activeVersionDir))
+        {
+            var badPath = $"{activeVersionDir}{BadSuffixPrefix}{Environment.TickCount64}";
+            logger.LogError("Post-rename validation failed for {Path}; renaming to {BadPath}.", activeVersionDir, badPath);
+            try
+            {
+                Directory.Move(activeVersionDir, badPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogWarning(ex, "Unable to preserve failed bundle at {BadPath}.", badPath);
+            }
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -171,30 +313,200 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     }
 
     /// <summary>
-    /// Removes well-known layout subdirectories before re-extraction.
-    /// Preserves the bin/ directory (which contains the CLI binary itself).
-    /// If a directory cannot be deleted (e.g. a process is still using files
-    /// inside it), it is renamed to {dir}.old.{timestamp} so extraction can
-    /// proceed. The stale directory will be cleaned up on the next successful
-    /// extraction.
+    /// Captures the current reparse-point targets for the public link paths so
+    /// they can be restored if the post-flip sanity check fails.
+    /// A non-reparse-point path (or missing path) is captured as <see langword="null"/>
+    /// meaning "no link to restore".
     /// </summary>
-    internal static void CleanLayoutDirectories(string layoutPath)
+    internal static IReadOnlyDictionary<string, string?> CaptureLinkTargets(string layoutPath)
     {
-        foreach (var dir in s_layoutDirectories)
+        var targets = new Dictionary<string, string?>(s_linkedLayoutDirectories.Length, StringComparer.Ordinal);
+        foreach (var dir in s_linkedLayoutDirectories)
         {
-            // Clean up stale .old directories from previous runs first
+            var linkPath = Path.Combine(layoutPath, dir);
+            targets[dir] = ReparsePoint.IsReparsePoint(linkPath) ? ReparsePoint.GetTarget(linkPath) : null;
+        }
+        return targets;
+    }
+
+    /// <summary>
+    /// Points the public link paths (<c>managed/</c>, <c>dcp/</c>) at the active
+    /// versioned directory, replacing any existing link or legacy real directory.
+    /// </summary>
+    private bool TryFlipLinks(string layoutPath, string activeVersionDir)
+    {
+        foreach (var dir in s_linkedLayoutDirectories)
+        {
+            var linkPath = Path.Combine(layoutPath, dir);
+            var target = Path.Combine(activeVersionDir, dir);
+
+            // Clear out legacy stale siblings from prior runs first.
             FileDeleteHelper.TryCleanupOldItems(layoutPath, dir);
 
-            var fullPath = Path.Combine(layoutPath, dir);
-            FileDeleteHelper.TryDeleteDirectory(fullPath);
+            // If a legacy real directory is sitting at the public path (pre-migration
+            // layout), move it aside so we can install a reparse point in its place.
+            if (Directory.Exists(linkPath) && !ReparsePoint.IsReparsePoint(linkPath))
+            {
+                logger.LogDebug("Migrating legacy directory at {Path} to .old sibling.", linkPath);
+                FileDeleteHelper.TryDeleteDirectory(linkPath);
+            }
+
+            try
+            {
+                ReparsePoint.CreateOrReplace(linkPath, target);
+                logger.LogDebug("Linked {Link} -> {Target}", linkPath, target);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogError(ex, "Failed to create reparse point at {Path} -> {Target}.", linkPath, target);
+                return false;
+            }
         }
 
-        // Remove version marker so it's rewritten after extraction
-        var markerPath = Path.Combine(layoutPath, VersionMarkerFileName);
-        if (File.Exists(markerPath))
+        return true;
+    }
+
+    /// <summary>
+    /// Best-effort restore of link targets captured before a failed flip. Entries
+    /// whose prior value was <see langword="null"/> (no previous link) are removed.
+    /// </summary>
+    private bool TryRestoreLinks(string layoutPath, IReadOnlyDictionary<string, string?> priorTargets)
+    {
+        var allOk = true;
+        foreach (var (dir, priorTarget) in priorTargets)
         {
-            File.Delete(markerPath);
+            var linkPath = Path.Combine(layoutPath, dir);
+            try
+            {
+                if (priorTarget is null)
+                {
+                    ReparsePoint.RemoveIfExists(linkPath);
+                }
+                else
+                {
+                    ReparsePoint.CreateOrReplace(linkPath, priorTarget);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogError(ex, "Rollback failed for link {Path}.", linkPath);
+                allOk = false;
+            }
         }
+        return allOk;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="versionDir"/> contains the
+    /// essential bundle components (<c>managed/aspire-managed</c> and a DCP directory).
+    /// </summary>
+    internal static bool IsVersionedLayoutValid(string versionDir)
+    {
+        if (!Directory.Exists(versionDir))
+        {
+            return false;
+        }
+
+        var managedDir = Path.Combine(versionDir, BundleDiscovery.ManagedDirectoryName);
+        var managedExe = Path.Combine(managedDir, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+
+        if (!Directory.Exists(managedDir) || !File.Exists(managedExe))
+        {
+            return false;
+        }
+
+        try
+        {
+            var info = new FileInfo(managedExe);
+            if (info.Length == 0)
+            {
+                return false;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        var dcpDir = Path.Combine(versionDir, BundleDiscovery.DcpDirectoryName);
+        if (!Directory.Exists(dcpDir))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Best-effort sweep of the <c>versions/</c> directory, removing anything other
+    /// than the active version plus any <c>.tmp.*</c>, <c>.bad.*</c>, <c>.old.*</c>
+    /// leftovers. Locked items are softly renamed so they can be reaped next run.
+    /// </summary>
+    internal static void TryCleanupStaleVersions(string versionsRoot, string activeVersionId)
+    {
+        if (!Directory.Exists(versionsRoot))
+        {
+            return;
+        }
+
+        foreach (var entry in Directory.EnumerateDirectories(versionsRoot))
+        {
+            var name = Path.GetFileName(entry);
+
+            // Keep the active version.
+            if (string.Equals(name, activeVersionId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            try
+            {
+                Directory.Delete(entry, recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Still in use — rename so it is out of the way and will be reaped next run.
+                try
+                {
+                    Directory.Move(entry, $"{entry}.old.{Environment.TickCount64}");
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Computes a deterministic, filesystem-safe directory name for a given
+    /// current-version fingerprint. The fingerprint already captures the CLI
+    /// binary's size and timestamp, so the resulting id changes whenever the
+    /// payload would change.
+    /// </summary>
+    /// <remarks>
+    /// Format: <c>&lt;sanitized-version&gt;-&lt;64-bit-xxhash-hex&gt;</c>. Version
+    /// characters outside <c>[A-Za-z0-9._-]</c> are replaced with <c>_</c>.
+    /// </remarks>
+    internal static string ComputeVersionId(string currentVersion)
+    {
+        var hashBytes = XxHash3.Hash(Encoding.UTF8.GetBytes(currentVersion));
+        var hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+
+        // Extract the human-readable prefix (everything before the first '|') for
+        // readability in the on-disk layout, and sanitize for filesystem safety.
+        var separatorIndex = currentVersion.IndexOf('|');
+        var versionPart = separatorIndex >= 0 ? currentVersion[..separatorIndex] : currentVersion;
+
+        var sb = new StringBuilder(versionPart.Length);
+        foreach (var ch in versionPart)
+        {
+            sb.Append(ch is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '.' or '-' or '_'
+                ? ch
+                : '_');
+        }
+
+        var prefix = sb.Length == 0 ? "bundle" : sb.ToString();
+        return $"{prefix}-{hash}";
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -16,10 +16,8 @@ namespace Aspire.Cli.Bundles;
 /// <summary>
 /// Manages extraction of the embedded bundle payload from self-extracting CLI binaries.
 /// </summary>
-internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<BundleService> logger) : IBundleService
+internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILayoutDiscovery layoutDiscovery, ILogger<BundleService> logger) : IBundleService
 {
-    private const string PayloadResourceName = "bundle.tar.gz";
-
     /// <summary>
     /// Name of the marker file written after successful extraction.
     /// </summary>
@@ -44,18 +42,14 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     /// </summary>
     internal const string BadSuffixPrefix = ".bad.";
 
-    private static readonly bool s_isBundle =
-        typeof(BundleService).Assembly.GetManifestResourceInfo(PayloadResourceName) is not null;
-
     /// <inheritdoc/>
-    public bool IsBundle => s_isBundle;
+    public bool IsBundle => payloadProvider.HasPayload;
 
     /// <summary>
-    /// Opens a read-only stream over the embedded bundle payload.
-    /// Returns <see langword="null"/> if no payload is embedded.
+    /// Overrides <see cref="Environment.ProcessPath"/> for version fingerprinting.
+    /// Used in tests to simulate different CLI binaries.
     /// </summary>
-    public static Stream? OpenPayload() =>
-        typeof(BundleService).Assembly.GetManifestResourceStream(PayloadResourceName);
+    internal string? ProcessPathOverride { get; init; }
 
     /// <summary>
     /// Well-known layout subdirectories that are exposed as reparse points pointing
@@ -76,7 +70,7 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
             return;
         }
 
-        var processPath = Environment.ProcessPath;
+        var processPath = ProcessPathOverride ?? Environment.ProcessPath;
         if (string.IsNullOrEmpty(processPath))
         {
             logger.LogDebug("ProcessPath is null or empty, skipping bundle extraction.");
@@ -128,7 +122,7 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
             if (!force && layoutDiscovery.DiscoverLayout() is not null)
             {
                 var existingVersion = ReadVersionMarker(destinationPath);
-                var currentVersion = GetCurrentVersion();
+                var currentVersion = GetCurrentVersion(ProcessPathOverride);
                 if (existingVersion == currentVersion)
                 {
                     logger.LogDebug("Bundle already extracted and up to date (version: {Version}).", existingVersion);
@@ -155,7 +149,7 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
         var versionsRoot = Path.Combine(destinationPath, VersionsDirectoryName);
         Directory.CreateDirectory(versionsRoot);
 
-        var currentVersion = GetCurrentVersion();
+        var currentVersion = GetCurrentVersion(ProcessPathOverride);
         var versionId = ComputeVersionId(currentVersion);
         var activeVersionDir = Path.Combine(versionsRoot, versionId);
 
@@ -575,11 +569,19 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     /// <summary>
     /// Extracts the embedded tar.gz payload to the specified directory using .NET TarReader.
     /// </summary>
-    internal static async Task ExtractPayloadAsync(string destinationPath, CancellationToken cancellationToken)
+    internal async Task ExtractPayloadAsync(string destinationPath, CancellationToken cancellationToken)
+    {
+        using var payloadStream = payloadProvider.OpenPayload() ?? throw new InvalidOperationException("No bundle payload available.");
+        await ExtractPayloadAsync(payloadStream, destinationPath, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Extracts a tar.gz payload stream to the specified directory.
+    /// </summary>
+    internal static async Task ExtractPayloadAsync(Stream payloadStream, string destinationPath, CancellationToken cancellationToken)
     {
         Directory.CreateDirectory(destinationPath);
 
-        using var payloadStream = OpenPayload() ?? throw new InvalidOperationException("No embedded bundle payload.");
         await using var gzipStream = new GZipStream(payloadStream, CompressionMode.Decompress);
         await using var tarReader = new TarReader(gzipStream);
 

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -52,13 +52,12 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
     internal string? ProcessPathOverride { get; init; }
 
     /// <summary>
-    /// Well-known layout subdirectories that are exposed as reparse points pointing
-    /// at the active versioned bundle directory. The bin/ directory is intentionally
-    /// excluded since it contains the running CLI binary itself.
+    /// Well-known layout subdirectory that is exposed as a reparse point pointing
+    /// at the active versioned bundle directory. Components (<c>managed/</c> and
+    /// <c>dcp/</c>) are resolved as subdirectories of this link target.
     /// </summary>
     internal static readonly string[] s_linkedLayoutDirectories = [
-        BundleDiscovery.ManagedDirectoryName,
-        BundleDiscovery.DcpDirectoryName
+        BundleDiscovery.BundleDirectoryName,
     ];
 
     /// <inheritdoc/>
@@ -208,6 +207,11 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
             FileDeleteHelper.TryCleanupOldItems(destinationPath, dir);
         }
 
+        // Best-effort cleanup of legacy top-level managed/ and dcp/ paths from
+        // the old layout (before the single bundle/ link was introduced). These
+        // are no longer needed now that layout discovery resolves through bundle/.
+        TryCleanupLegacyLayoutPaths(destinationPath);
+
         logger.LogDebug("Bundle extraction verified successfully.");
         return BundleExtractResult.Extracted;
     }
@@ -331,23 +335,26 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
     }
 
     /// <summary>
-    /// Points the public link paths (<c>managed/</c>, <c>dcp/</c>) at the active
-    /// versioned directory, replacing any existing link or legacy real directory.
+    /// Points the public <c>bundle/</c> link at the active versioned directory.
+    /// Migrates any legacy real directory sitting at the link path by renaming it
+    /// to a <c>.old</c> sibling (preserved until post-flip validation succeeds).
     /// </summary>
     private bool TryFlipLinks(string layoutPath, string activeVersionDir)
     {
         foreach (var dir in s_linkedLayoutDirectories)
         {
             var linkPath = Path.Combine(layoutPath, dir);
-            var target = Path.Combine(activeVersionDir, dir);
+
+            // The bundle link points directly at the active version directory —
+            // components (managed/, dcp/) are subdirectories of the target.
+            var target = activeVersionDir;
 
             // Clear out legacy stale siblings from prior runs first.
             FileDeleteHelper.TryCleanupOldItems(layoutPath, dir);
 
-            // If a legacy real directory is sitting at the public path (pre-migration
-            // layout), rename it to a .old sibling so a reparse point can be created.
-            // The .old sibling is preserved until after post-flip validation succeeds,
-            // ensuring a working layout is never lost if link creation fails.
+            // If a legacy real directory is sitting at the public path, rename it
+            // to a .old sibling so a reparse point can be created. The .old sibling
+            // is preserved until after post-flip validation succeeds.
             if (Directory.Exists(linkPath) && !ReparsePoint.IsReparsePoint(linkPath))
             {
                 var renamedPath = $"{linkPath}.old.{Environment.TickCount64}";
@@ -485,6 +492,36 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
                 catch
                 {
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Best-effort removal of legacy top-level <c>managed/</c> and <c>dcp/</c>
+    /// directories from the old layout shape (before the single <c>bundle/</c> link
+    /// was introduced). Failures are silently ignored since the new layout via
+    /// <c>bundle/</c> is already functional.
+    /// </summary>
+    private void TryCleanupLegacyLayoutPaths(string layoutPath)
+    {
+        string[] legacyDirs = [BundleDiscovery.ManagedDirectoryName, BundleDiscovery.DcpDirectoryName];
+
+        foreach (var dir in legacyDirs)
+        {
+            var legacyPath = Path.Combine(layoutPath, dir);
+            if (!Directory.Exists(legacyPath))
+            {
+                continue;
+            }
+
+            try
+            {
+                FileDeleteHelper.TryDeleteDirectory(legacyPath);
+                logger.LogDebug("Removed legacy directory at {Path}.", legacyPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogDebug(ex, "Could not remove legacy path {Path}; will retry next run.", legacyPath);
             }
         }
     }

--- a/src/Aspire.Cli/Bundles/EmbeddedBundlePayloadProvider.cs
+++ b/src/Aspire.Cli/Bundles/EmbeddedBundlePayloadProvider.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Bundles;
+
+/// <summary>
+/// Reads the bundle payload from an embedded assembly resource.
+/// </summary>
+internal sealed class EmbeddedBundlePayloadProvider : IBundlePayloadProvider
+{
+    private const string PayloadResourceName = "bundle.tar.gz";
+
+    /// <inheritdoc/>
+    public bool HasPayload { get; } =
+        typeof(BundleService).Assembly.GetManifestResourceInfo(PayloadResourceName) is not null;
+
+    /// <inheritdoc/>
+    public Stream? OpenPayload() =>
+        typeof(BundleService).Assembly.GetManifestResourceStream(PayloadResourceName);
+}

--- a/src/Aspire.Cli/Bundles/IBundlePayloadProvider.cs
+++ b/src/Aspire.Cli/Bundles/IBundlePayloadProvider.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Bundles;
+
+/// <summary>
+/// Provides access to the bundle payload stream for extraction.
+/// </summary>
+internal interface IBundlePayloadProvider
+{
+    /// <summary>
+    /// Gets whether a bundle payload is available.
+    /// </summary>
+    bool HasPayload { get; }
+
+    /// <summary>
+    /// Opens a read-only stream over the bundle payload.
+    /// Returns <see langword="null"/> if no payload is available.
+    /// Each call must return a fresh, independently consumable stream.
+    /// </summary>
+    Stream? OpenPayload();
+}

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -157,7 +157,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
 
         // Check if CLI is in a bundle layout
         // First, check if components are siblings of the CLI (flat layout):
-        //   {layout}/aspire + {layout}/managed/ + {layout}/dcp/
+        //   {layout}/aspire + {layout}/bundle/ -> {layout}/versions/{id}/
         var layout = TryInferLayout(cliDir);
         if (layout is not null)
         {
@@ -165,7 +165,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         }
 
         // Next, check the parent directory (bin/ layout where CLI is in a subdirectory):
-        //   {layout}/bin/aspire + {layout}/managed/ + {layout}/dcp/
+        //   {layout}/bin/aspire + {layout}/bundle/ -> {layout}/versions/{id}/
         var parentDir = Path.GetDirectoryName(cliDir);
         if (!string.IsNullOrEmpty(parentDir))
         {
@@ -182,11 +182,40 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
 
     private LayoutConfiguration? TryInferLayout(string layoutPath)
     {
-        // Check for essential directories
+        // New layout: a single bundle/ link whose target contains managed/ and dcp/.
+        var bundlePath = Path.Combine(layoutPath, BundleDiscovery.BundleDirectoryName);
+        var bundleManagedPath = Path.Combine(bundlePath, BundleDiscovery.ManagedDirectoryName);
+        var bundleDcpPath = Path.Combine(bundlePath, BundleDiscovery.DcpDirectoryName);
+        var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
+
+        _logger.LogDebug("TryInferLayout: Checking layout at {Path}", layoutPath);
+        _logger.LogDebug("  {Dir}/{Managed}/: {Exists}", BundleDiscovery.BundleDirectoryName, BundleDiscovery.ManagedDirectoryName, Directory.Exists(bundleManagedPath) ? "exists" : "MISSING");
+        _logger.LogDebug("  {Dir}/{Dcp}/: {Exists}", BundleDiscovery.BundleDirectoryName, BundleDiscovery.DcpDirectoryName, Directory.Exists(bundleDcpPath) ? "exists" : "MISSING");
+
+        if (Directory.Exists(bundleManagedPath) && Directory.Exists(bundleDcpPath))
+        {
+            var bundleManagedExe = Path.Combine(bundleManagedPath, managedExeName);
+            _logger.LogDebug("  {Dir}/{Managed}/{Exe}: {Exists}", BundleDiscovery.BundleDirectoryName, BundleDiscovery.ManagedDirectoryName, managedExeName, File.Exists(bundleManagedExe) ? "exists" : "MISSING");
+
+            if (File.Exists(bundleManagedExe))
+            {
+                _logger.LogDebug("TryInferLayout: New bundle/ layout is valid");
+                return new LayoutConfiguration
+                {
+                    LayoutPath = layoutPath,
+                    Components = new LayoutComponents
+                    {
+                        Dcp = Path.Combine(BundleDiscovery.BundleDirectoryName, BundleDiscovery.DcpDirectoryName),
+                        Managed = Path.Combine(BundleDiscovery.BundleDirectoryName, BundleDiscovery.ManagedDirectoryName),
+                    }
+                };
+            }
+        }
+
+        // Legacy layout: top-level managed/ and dcp/ directories (or reparse points).
         var managedPath = Path.Combine(layoutPath, BundleDiscovery.ManagedDirectoryName);
         var dcpPath = Path.Combine(layoutPath, BundleDiscovery.DcpDirectoryName);
 
-        _logger.LogDebug("TryInferLayout: Checking layout at {Path}", layoutPath);
         _logger.LogDebug("  {Dir}/: {Exists}", BundleDiscovery.ManagedDirectoryName, Directory.Exists(managedPath) ? "exists" : "MISSING");
         _logger.LogDebug("  {Dir}/: {Exists}", BundleDiscovery.DcpDirectoryName, Directory.Exists(dcpPath) ? "exists" : "MISSING");
 
@@ -197,7 +226,6 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         }
 
         // Check for aspire-managed executable
-        var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
         var managedExePath = Path.Combine(managedPath, managedExeName);
         _logger.LogDebug("  managed/{ManagedExe}: {Exists}", managedExeName, File.Exists(managedExePath) ? "exists" : "MISSING");
 
@@ -207,7 +235,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
             return null;
         }
 
-        _logger.LogDebug("TryInferLayout: Layout is valid");
+        _logger.LogDebug("TryInferLayout: Legacy layout is valid");
 
         // Infer a basic layout configuration
         return new LayoutConfiguration

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -369,6 +369,7 @@ public class Program
         builder.Services.AddHostedService(sp => sp.GetRequiredService<AuxiliaryBackchannelMonitor>());
         builder.Services.AddSingleton<ICliUpdateNotifier, CliUpdateNotifier>();
         builder.Services.AddSingleton<IPackagingService, PackagingService>();
+        builder.Services.AddSingleton<IBundlePayloadProvider, EmbeddedBundlePayloadProvider>();
         builder.Services.AddSingleton<IBundleService, BundleService>();
         builder.Services.AddSingleton<IAppHostServerProjectFactory, AppHostServerProjectFactory>();
         builder.Services.AddSingleton<ICliDownloader, CliDownloader>();

--- a/src/Aspire.Cli/Utils/ReparsePoint.cs
+++ b/src/Aspire.Cli/Utils/ReparsePoint.cs
@@ -376,9 +376,56 @@ internal static partial class ReparsePoint
             out uint lpBytesReturned,
             IntPtr lpOverlapped);
 
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool DeviceIoControl(
+            SafeFileHandle hDevice,
+            uint dwIoControlCode,
+            IntPtr lpInBuffer,
+            uint nInBufferSize,
+            byte[] lpOutBuffer,
+            uint nOutBufferSize,
+            out uint lpBytesReturned,
+            IntPtr lpOverlapped);
+
         // POSIX rename(2): atomic on a single filesystem, overwrites destination if it
         // exists and is of a compatible kind (symlink/file replacing symlink/file).
         [LibraryImport("libc", SetLastError = true, StringMarshalling = StringMarshalling.Utf8, EntryPoint = "rename")]
         internal static partial int rename(string oldpath, string newpath);
+    }
+
+    /// <summary>
+    /// Reads the reparse tag (e.g. <see cref="Win32Constants.IO_REPARSE_TAG_MOUNT_POINT"/>
+    /// or <see cref="Win32Constants.IO_REPARSE_TAG_SYMLINK"/>) from an existing reparse
+    /// point. Returns <see langword="null"/> if <paramref name="path"/> is not a reparse
+    /// point or the tag cannot be read.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    internal static uint? GetReparseTag(string path)
+    {
+        if (!IsReparsePoint(path))
+        {
+            return null;
+        }
+
+        using var handle = OpenReparsePointHandle(path, write: false);
+
+        // REPARSE_DATA_BUFFER starts with a DWORD ReparseTag; we only need the
+        // first 4 bytes but must supply a buffer large enough for the ioctl.
+        var buffer = new byte[16 * 1024];
+        if (!NativeMethods.DeviceIoControl(
+                handle,
+                Win32Constants.FSCTL_GET_REPARSE_POINT,
+                IntPtr.Zero,
+                0,
+                buffer,
+                (uint)buffer.Length,
+                out _,
+                IntPtr.Zero))
+        {
+            return null;
+        }
+
+        return System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buffer.AsSpan(0, 4));
     }
 }

--- a/src/Aspire.Cli/Utils/ReparsePoint.cs
+++ b/src/Aspire.Cli/Utils/ReparsePoint.cs
@@ -67,6 +67,13 @@ internal static partial class ReparsePoint
                 // caller's bundle lock.
                 if (Exists(linkPath))
                 {
+                    if (!IsReparsePoint(linkPath))
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot replace '{linkPath}': it is a real directory, not a reparse point. " +
+                            "Callers must remove or migrate existing directories before creating a reparse point.");
+                    }
+
                     RemoveIfExists(linkPath);
                 }
 
@@ -291,6 +298,11 @@ internal static partial class ReparsePoint
         return handle;
     }
 
+    /// <summary>
+    /// Maximum size of a reparse data buffer (defined by MAXIMUM_REPARSE_DATA_BUFFER_SIZE in the Windows SDK).
+    /// </summary>
+    private const int MaxReparseDataBufferSize = 16 * 1024; // 16 KB
+
     [SupportedOSPlatform("windows")]
     private static void WriteMountPointReparseData(SafeFileHandle handle, string substituteName, string printName)
     {
@@ -314,6 +326,20 @@ internal static partial class ReparsePoint
         var pathBufferSize = subNameBytes.Length + 2 + printNameBytes.Length + 2;
         var reparseDataLength = mountPointInfoSize + pathBufferSize;
         var totalSize = headerSize + reparseDataLength;
+
+        if (reparseDataLength > ushort.MaxValue)
+        {
+            throw new PathTooLongException(
+                $"Junction target path is too long. The reparse data ({reparseDataLength} bytes) exceeds the " +
+                $"maximum of {ushort.MaxValue} bytes. Use a shorter target path.");
+        }
+
+        if (totalSize > MaxReparseDataBufferSize)
+        {
+            throw new PathTooLongException(
+                $"Junction target path is too long. The reparse buffer ({totalSize} bytes) exceeds the " +
+                $"maximum of {MaxReparseDataBufferSize} bytes. Use a shorter target path.");
+        }
 
         var buffer = new byte[totalSize];
         var span = buffer.AsSpan();

--- a/src/Aspire.Cli/Utils/ReparsePoint.cs
+++ b/src/Aspire.Cli/Utils/ReparsePoint.cs
@@ -60,23 +60,21 @@ internal static partial class ReparsePoint
 
         try
         {
+            // Guard against replacing a real directory on any platform. Callers must
+            // remove or migrate existing real directories before calling this method.
+            if (Exists(linkPath) && !IsReparsePoint(linkPath))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot replace '{linkPath}': it is a real directory, not a reparse point. " +
+                    "Callers must remove or migrate existing directories before creating a reparse point.");
+            }
+
             if (OperatingSystem.IsWindows())
             {
                 // Windows has no native overwriting rename for directory reparse points,
                 // so remove the existing link then rename. The window is guarded by the
                 // caller's bundle lock.
-                if (Exists(linkPath))
-                {
-                    if (!IsReparsePoint(linkPath))
-                    {
-                        throw new InvalidOperationException(
-                            $"Cannot replace '{linkPath}': it is a real directory, not a reparse point. " +
-                            "Callers must remove or migrate existing directories before creating a reparse point.");
-                    }
-
-                    RemoveIfExists(linkPath);
-                }
-
+                RemoveIfExists(linkPath);
                 Directory.Move(tempLinkPath, linkPath);
             }
             else

--- a/src/Aspire.Cli/Utils/ReparsePoint.cs
+++ b/src/Aspire.Cli/Utils/ReparsePoint.cs
@@ -1,0 +1,384 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32.SafeHandles;
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Helpers for creating reparse points (symlinks on Unix, symlinks-or-junctions on
+/// Windows) used to point stable public paths at versioned bundle directories.
+/// </summary>
+/// <remarks>
+/// Windows strategy: prefer a symbolic link (<see cref="Directory.CreateSymbolicLink"/>)
+/// — available to users with Developer Mode or admin — and fall back to a directory
+/// junction (created via <c>DeviceIoControl</c> + <c>FSCTL_SET_REPARSE_POINT</c>)
+/// when symlink creation is denied. Junctions need no elevation, work for local
+/// directory targets, and are transparent to <see cref="Directory.Exists(string)"/>
+/// and file enumeration.
+///
+/// Unix strategy: symbolic link via <see cref="Directory.CreateSymbolicLink"/>.
+/// </remarks>
+internal static partial class ReparsePoint
+{
+    /// <summary>
+    /// Creates (or replaces) a directory reparse point at <paramref name="linkPath"/>
+    /// whose target is <paramref name="target"/>.
+    /// </summary>
+    /// <remarks>
+    /// The target must be a local directory path. On Windows, if symbolic-link
+    /// creation is denied (for example, the user does not have Developer Mode
+    /// enabled and is not running as admin), this method falls back to creating
+    /// a directory junction. The public behavior is otherwise identical: the
+    /// resulting path resolves to <paramref name="target"/> for I/O purposes.
+    /// </remarks>
+    /// <param name="linkPath">The path to create the reparse point at.</param>
+    /// <param name="target">Absolute path to the target directory.</param>
+    public static void CreateOrReplace(string linkPath, string target)
+    {
+        if (string.IsNullOrEmpty(linkPath))
+        {
+            throw new ArgumentException("Link path is required.", nameof(linkPath));
+        }
+
+        if (string.IsNullOrEmpty(target))
+        {
+            throw new ArgumentException("Target path is required.", nameof(target));
+        }
+
+        var absoluteTarget = Path.GetFullPath(target);
+
+        // Create the new reparse point under a temporary name adjacent to the
+        // final link, then atomically rename over the existing link. This avoids
+        // any window where the public name does not exist.
+        var tempLinkPath = GetTempLinkPath(linkPath);
+        RemoveIfExists(tempLinkPath);
+
+        CreateSymlinkOrJunction(tempLinkPath, absoluteTarget);
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                // Windows has no native overwriting rename for directory reparse points,
+                // so remove the existing link then rename. The window is guarded by the
+                // caller's bundle lock.
+                if (Exists(linkPath))
+                {
+                    RemoveIfExists(linkPath);
+                }
+
+                Directory.Move(tempLinkPath, linkPath);
+            }
+            else
+            {
+                // On Unix, rename(2) atomically replaces an existing symlink with the
+                // source symlink (both are treated as links, not directories, by the
+                // kernel). This avoids any window where the public path is missing.
+                if (NativeMethods.rename(tempLinkPath, linkPath) != 0)
+                {
+                    var errno = Marshal.GetLastPInvokeError();
+                    throw new IOException(
+                        $"rename('{tempLinkPath}', '{linkPath}') failed with errno {errno}.");
+                }
+            }
+        }
+        catch
+        {
+            // If replacement fails, clean up the temporary link so the next attempt starts fresh.
+            RemoveIfExists(tempLinkPath);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="path"/> exists as a file
+    /// or directory (resolving through reparse points).
+    /// </summary>
+    public static bool Exists(string path)
+    {
+        return Directory.Exists(path) || File.Exists(path);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="path"/> is a reparse
+    /// point (symlink or junction).
+    /// </summary>
+    public static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            var info = new FileInfo(path);
+            if (info.Exists)
+            {
+                return (info.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            }
+
+            var dirInfo = new DirectoryInfo(path);
+            if (dirInfo.Exists)
+            {
+                return (dirInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves the immediate target of a reparse point. Returns <see langword="null"/>
+    /// if <paramref name="path"/> is not a reparse point or the target cannot be read.
+    /// </summary>
+    public static string? GetTarget(string path)
+    {
+        try
+        {
+            var dirInfo = new DirectoryInfo(path);
+            if (dirInfo.Exists && (dirInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
+            {
+                return dirInfo.LinkTarget;
+            }
+
+            var fileInfo = new FileInfo(path);
+            if (fileInfo.Exists && (fileInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
+            {
+                return fileInfo.LinkTarget;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Removes <paramref name="path"/> if it exists. Handles both regular directories,
+    /// reparse points, and files. A reparse point is removed without following through
+    /// to its target.
+    /// </summary>
+    public static void RemoveIfExists(string path)
+    {
+        try
+        {
+            var dirInfo = new DirectoryInfo(path);
+            if (dirInfo.Exists)
+            {
+                if ((dirInfo.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
+                {
+                    // Deleting a directory reparse point removes the link without touching its target.
+                    dirInfo.Delete(recursive: false);
+                }
+                else
+                {
+                    dirInfo.Delete(recursive: true);
+                }
+
+                return;
+            }
+
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+        catch (FileNotFoundException)
+        {
+        }
+    }
+
+    private static void CreateSymlinkOrJunction(string linkPath, string target)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Directory.CreateSymbolicLink(linkPath, target);
+            return;
+        }
+
+        // Windows: try symbolic link first; fall back to a junction if creation is denied.
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, target);
+            return;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            // Fall through to junction creation below.
+        }
+
+        CreateWindowsJunction(linkPath, target);
+    }
+
+    private static string GetTempLinkPath(string linkPath)
+    {
+        // Use an adjacent path under the same parent so the rename stays on-volume
+        // and is effectively atomic.
+        var parent = Path.GetDirectoryName(linkPath) ?? ".";
+        var name = Path.GetFileName(linkPath);
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        return Path.Combine(parent, $"{name}.new.{suffix}");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Windows junction fallback (no admin / dev-mode required)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Directly creates a Windows directory junction at <paramref name="linkPath"/>
+    /// pointing to <paramref name="target"/>, bypassing the symbolic-link preference.
+    /// Exposed for testing so the junction code path can be exercised even on
+    /// systems where <see cref="Directory.CreateSymbolicLink"/> would succeed
+    /// (e.g. Windows with Developer Mode enabled).
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    internal static void CreateWindowsJunction(string linkPath, string target)
+    {
+        Directory.CreateDirectory(linkPath);
+
+        try
+        {
+            // The substitute name for a mount-point junction must be an NT path
+            // prefixed with "\??\" and target an absolute local directory.
+            var substituteName = @"\??\" + target.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var printName = target;
+
+            using var handle = OpenReparsePointHandle(linkPath, write: true);
+            WriteMountPointReparseData(handle, substituteName, printName);
+        }
+        catch
+        {
+            // If we failed mid-way, clean up the empty directory we just created
+            // so subsequent attempts can start fresh.
+            try
+            {
+                Directory.Delete(linkPath);
+            }
+            catch
+            {
+            }
+            throw;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static SafeFileHandle OpenReparsePointHandle(string path, bool write)
+    {
+        var access = write
+            ? Win32Constants.GENERIC_READ | Win32Constants.GENERIC_WRITE
+            : Win32Constants.GENERIC_READ;
+        var handle = NativeMethods.CreateFileW(
+            path,
+            access,
+            Win32Constants.FILE_SHARE_READ | Win32Constants.FILE_SHARE_WRITE | Win32Constants.FILE_SHARE_DELETE,
+            IntPtr.Zero,
+            Win32Constants.OPEN_EXISTING,
+            Win32Constants.FILE_FLAG_BACKUP_SEMANTICS | Win32Constants.FILE_FLAG_OPEN_REPARSE_POINT,
+            IntPtr.Zero);
+
+        if (handle.IsInvalid)
+        {
+            throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(),
+                $"Failed to open reparse point handle for '{path}'.");
+        }
+
+        return handle;
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void WriteMountPointReparseData(SafeFileHandle handle, string substituteName, string printName)
+    {
+        var subNameBytes = System.Text.Encoding.Unicode.GetBytes(substituteName);
+        var printNameBytes = System.Text.Encoding.Unicode.GetBytes(printName);
+
+        // Layout (mount-point reparse buffer):
+        //   DWORD ReparseTag
+        //   WORD  ReparseDataLength
+        //   WORD  Reserved
+        //   WORD  SubstituteNameOffset
+        //   WORD  SubstituteNameLength
+        //   WORD  PrintNameOffset
+        //   WORD  PrintNameLength
+        //   WCHAR PathBuffer[...]
+        //     - SubstituteName, NUL
+        //     - PrintName, NUL
+
+        var headerSize = 8; // tag + length + reserved
+        var mountPointInfoSize = 8; // four WORDs
+        var pathBufferSize = subNameBytes.Length + 2 + printNameBytes.Length + 2;
+        var reparseDataLength = mountPointInfoSize + pathBufferSize;
+        var totalSize = headerSize + reparseDataLength;
+
+        var buffer = new byte[totalSize];
+        var span = buffer.AsSpan();
+
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(span[..4], Win32Constants.IO_REPARSE_TAG_MOUNT_POINT);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(4, 2), (ushort)reparseDataLength);
+        // Reserved remains zero.
+
+        var pathOffset = headerSize + mountPointInfoSize;
+        var subNameOffset = 0;
+        var subNameLength = subNameBytes.Length;
+        var printNameOffset = subNameLength + 2;
+        var printNameLength = printNameBytes.Length;
+
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(8, 2), (ushort)subNameOffset);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(10, 2), (ushort)subNameLength);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(12, 2), (ushort)printNameOffset);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(14, 2), (ushort)printNameLength);
+
+        subNameBytes.CopyTo(span[pathOffset..]);
+        // 2 NUL bytes after substitute name already zero in buffer.
+        printNameBytes.CopyTo(span[(pathOffset + printNameOffset)..]);
+
+        if (!NativeMethods.DeviceIoControl(
+                handle,
+                Win32Constants.FSCTL_SET_REPARSE_POINT,
+                buffer,
+                (uint)totalSize,
+                IntPtr.Zero,
+                0,
+                out _,
+                IntPtr.Zero))
+        {
+            throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(),
+                "FSCTL_SET_REPARSE_POINT failed while creating directory junction.");
+        }
+    }
+
+    private static partial class NativeMethods
+    {
+        [LibraryImport("kernel32.dll", SetLastError = true, EntryPoint = "CreateFileW", StringMarshalling = StringMarshalling.Utf16)]
+        internal static partial SafeFileHandle CreateFileW(
+            string lpFileName,
+            uint dwDesiredAccess,
+            uint dwShareMode,
+            IntPtr lpSecurityAttributes,
+            uint dwCreationDisposition,
+            uint dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool DeviceIoControl(
+            SafeFileHandle hDevice,
+            uint dwIoControlCode,
+            byte[] lpInBuffer,
+            uint nInBufferSize,
+            IntPtr lpOutBuffer,
+            uint nOutBufferSize,
+            out uint lpBytesReturned,
+            IntPtr lpOverlapped);
+
+        // POSIX rename(2): atomic on a single filesystem, overwrites destination if it
+        // exists and is of a compatible kind (symlink/file replacing symlink/file).
+        [LibraryImport("libc", SetLastError = true, StringMarshalling = StringMarshalling.Utf8, EntryPoint = "rename")]
+        internal static partial int rename(string oldpath, string newpath);
+    }
+}

--- a/src/Aspire.Cli/Utils/Win32Constants.cs
+++ b/src/Aspire.Cli/Utils/Win32Constants.cs
@@ -33,7 +33,9 @@ internal static class Win32Constants
 
     // DeviceIoControl - dwIoControlCode
     public const uint FSCTL_SET_REPARSE_POINT = 0x000900A4;
+    public const uint FSCTL_GET_REPARSE_POINT = 0x000900A8;
 
     // Reparse-point tags (winnt.h)
     public const uint IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003u;
+    public const uint IO_REPARSE_TAG_SYMLINK = 0xA000000Cu;
 }

--- a/src/Aspire.Cli/Utils/Win32Constants.cs
+++ b/src/Aspire.Cli/Utils/Win32Constants.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Win32 constants used by P/Invoke call sites in the CLI.
+/// </summary>
+/// <remarks>
+/// The .NET BCL hides these constants behind <c>internal</c> partial classes
+/// (e.g. <c>Interop.Kernel32</c>), so consumers outside the runtime have to
+/// declare their own. Centralising them here keeps magic numbers out of
+/// individual call sites and makes them easier to share when new interop
+/// is added.
+/// </remarks>
+internal static class Win32Constants
+{
+    // CreateFile - dwDesiredAccess
+    public const uint GENERIC_READ = 0x80000000;
+    public const uint GENERIC_WRITE = 0x40000000;
+
+    // CreateFile - dwShareMode
+    public const uint FILE_SHARE_READ = 0x1;
+    public const uint FILE_SHARE_WRITE = 0x2;
+    public const uint FILE_SHARE_DELETE = 0x4;
+
+    // CreateFile - dwCreationDisposition
+    public const uint OPEN_EXISTING = 3;
+
+    // CreateFile - dwFlagsAndAttributes
+    public const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+    public const uint FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
+
+    // DeviceIoControl - dwIoControlCode
+    public const uint FSCTL_SET_REPARSE_POINT = 0x000900A4;
+
+    // Reparse-point tags (winnt.h)
+    public const uint IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003u;
+}

--- a/src/Shared/BundleDiscovery.cs
+++ b/src/Shared/BundleDiscovery.cs
@@ -65,6 +65,13 @@ internal static class BundleDiscovery
     /// </summary>
     public const string ManagedDirectoryName = "managed";
 
+    /// <summary>
+    /// Directory name for the single top-level reparse point that links to the
+    /// active versioned bundle directory. Components (<c>managed/</c> and <c>dcp/</c>)
+    /// are resolved as subdirectories of this link target.
+    /// </summary>
+    public const string BundleDirectoryName = "bundle";
+
     // ═══════════════════════════════════════════════════════════════════════
     // EXECUTABLE NAMES (without path, just the file name)
     // ═══════════════════════════════════════════════════════════════════════

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -45,17 +45,16 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
         var versions = Directory.GetDirectories(versionsDir);
         Assert.Single(versions);
 
-        // managed/ and dcp/ should be reparse points pointing into versions/.
-        var managedLink = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
-        var dcpLink = Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName);
+        // bundle/ should be a reparse point pointing into versions/.
+        var bundleLink = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);
 
         try
         {
-            Assert.True(ReparsePoint.IsReparsePoint(managedLink), "managed/ should be a reparse point");
-            Assert.True(ReparsePoint.IsReparsePoint(dcpLink), "dcp/ should be a reparse point");
+            Assert.True(ReparsePoint.IsReparsePoint(bundleLink), "bundle/ should be a reparse point");
 
-            // Verify the managed exe is reachable through the reparse point.
-            var managedExe = Path.Combine(managedLink,
+            // Verify the managed exe is reachable through the bundle reparse point.
+            var managedExe = Path.Combine(bundleLink,
+                BundleDiscovery.ManagedDirectoryName,
                 BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
             Assert.True(File.Exists(managedExe), $"managed exe should exist at {managedExe}");
         }
@@ -143,7 +142,8 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
             Assert.NotEqual(v1VersionDir, v2Dirs[0]);
 
             // The managed exe should be reachable and contain v2 content.
-            var managedExe = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName,
+            var managedExe = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName,
+                BundleDiscovery.ManagedDirectoryName,
                 BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
             var content = File.ReadAllText(managedExe);
             Assert.Contains("v2-content", content);
@@ -236,8 +236,8 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
         var v1Service = CreateService(new TestBundlePayloadProvider(v1Payload), layoutDiscovery, v1BinaryPath);
         await v1Service.ExtractAsync(layoutRoot, force: true);
 
-        var managedLink = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
-        var v1Target = ReparsePoint.GetTarget(managedLink);
+        var bundleLink = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);
+        var v1Target = ReparsePoint.GetTarget(bundleLink);
         Assert.NotNull(v1Target);
 
         try
@@ -247,7 +247,7 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
             var v2Service = CreateService(new TestBundlePayloadProvider(v2Payload), layoutDiscovery, v2BinaryPath);
             await v2Service.ExtractAsync(layoutRoot, force: true);
 
-            var v2Target = ReparsePoint.GetTarget(managedLink);
+            var v2Target = ReparsePoint.GetTarget(bundleLink);
             Assert.NotNull(v2Target);
             Assert.NotEqual(v1Target, v2Target);
         }
@@ -330,14 +330,15 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
 
     /// <summary>
     /// A layout discovery implementation that discovers from a specific root path,
-    /// checking for managed/ and dcp/ subdirectories.
+    /// checking for bundle/managed/ and bundle/dcp/ subdirectories.
     /// </summary>
     private sealed class TestLayoutDiscovery(string layoutRoot) : ILayoutDiscovery
     {
         public LayoutConfiguration? DiscoverLayout(string? projectDirectory = null)
         {
-            var managedDir = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
-            var dcpDir = Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName);
+            var bundleDir = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);
+            var managedDir = Path.Combine(bundleDir, BundleDiscovery.ManagedDirectoryName);
+            var dcpDir = Path.Combine(bundleDir, BundleDiscovery.DcpDirectoryName);
             var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
             var managedExe = Path.Combine(managedDir, managedExeName);
 
@@ -351,19 +352,20 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
                 LayoutPath = layoutRoot,
                 Components = new LayoutComponents
                 {
-                    Managed = Path.Combine(BundleDiscovery.ManagedDirectoryName, managedExeName),
-                    Dcp = BundleDiscovery.DcpDirectoryName,
+                    Managed = Path.Combine(BundleDiscovery.BundleDirectoryName, BundleDiscovery.ManagedDirectoryName),
+                    Dcp = Path.Combine(BundleDiscovery.BundleDirectoryName, BundleDiscovery.DcpDirectoryName),
                 }
             };
         }
 
         public string? GetComponentPath(LayoutComponent component, string? projectDirectory = null)
         {
+            var bundleDir = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);
             return component switch
             {
-                LayoutComponent.Managed => Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName,
+                LayoutComponent.Managed => Path.Combine(bundleDir, BundleDiscovery.ManagedDirectoryName,
                     BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
-                LayoutComponent.Dcp => Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName),
+                LayoutComponent.Dcp => Path.Combine(bundleDir, BundleDiscovery.DcpDirectoryName),
                 _ => null,
             };
         }

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -1,0 +1,373 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Formats.Tar;
+using System.IO.Compression;
+using Aspire.Cli.Bundles;
+using Aspire.Cli.Layout;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
+using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests;
+
+public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
+{
+    /// <summary>
+    /// Verifies that a fresh extraction with a synthetic payload creates a
+    /// versioned directory, writes a version marker, and establishes reparse
+    /// points for managed/ and dcp/.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_FreshExtraction_CreatesVersionedLayoutAndLinks()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var payload = CreateFakeBundlePayload();
+        var provider = new TestBundlePayloadProvider(payload);
+
+        var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
+        var service = CreateService(provider, layoutDiscovery);
+
+        var result = await service.ExtractAsync(layoutRoot, force: true);
+
+        Assert.Equal(BundleExtractResult.Extracted, result);
+
+        // Version marker should exist.
+        var marker = BundleService.ReadVersionMarker(layoutRoot);
+        Assert.NotNull(marker);
+
+        // versions/ directory should contain exactly one version.
+        var versionsDir = Path.Combine(layoutRoot, BundleService.VersionsDirectoryName);
+        Assert.True(Directory.Exists(versionsDir));
+        var versions = Directory.GetDirectories(versionsDir);
+        Assert.Single(versions);
+
+        // managed/ and dcp/ should be reparse points pointing into versions/.
+        var managedLink = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
+        var dcpLink = Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName);
+
+        try
+        {
+            Assert.True(ReparsePoint.IsReparsePoint(managedLink), "managed/ should be a reparse point");
+            Assert.True(ReparsePoint.IsReparsePoint(dcpLink), "dcp/ should be a reparse point");
+
+            // Verify the managed exe is reachable through the reparse point.
+            var managedExe = Path.Combine(managedLink,
+                BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+            Assert.True(File.Exists(managedExe), $"managed exe should exist at {managedExe}");
+        }
+        finally
+        {
+            CleanupReparsePoints(layoutRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that when an already-extracted layout is up to date, extraction
+    /// is skipped and returns <see cref="BundleExtractResult.AlreadyUpToDate"/>.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_AlreadyUpToDate_SkipsExtraction()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var payload = CreateFakeBundlePayload();
+        var provider = new TestBundlePayloadProvider(payload);
+
+        var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
+        var service = CreateService(provider, layoutDiscovery);
+
+        // First extraction.
+        var result1 = await service.ExtractAsync(layoutRoot, force: true);
+        Assert.Equal(BundleExtractResult.Extracted, result1);
+
+        try
+        {
+            // Second extraction without force — should be up to date.
+            var result2 = await service.ExtractAsync(layoutRoot, force: false);
+            Assert.Equal(BundleExtractResult.AlreadyUpToDate, result2);
+        }
+        finally
+        {
+            CleanupReparsePoints(layoutRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that upgrading from v1 to v2 flips the reparse points to the
+    /// new versioned directory and cleans up the old one.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_Upgrade_FlipsLinksAndCleansUpOldVersion()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
+
+        // Create fake CLI binaries with different content to produce different version IDs.
+        var v1BinaryPath = CreateFakeCliBinary(Path.Combine(layoutRoot, ".fake-bins"), "aspire-v1", "cli-v1");
+        var v2BinaryPath = CreateFakeCliBinary(Path.Combine(layoutRoot, ".fake-bins"), "aspire-v2", "cli-v2-longer");
+        // Ensure different timestamps.
+        File.SetLastWriteTimeUtc(v2BinaryPath, File.GetLastWriteTimeUtc(v1BinaryPath).AddHours(1));
+
+        // Install v1.
+        var v1Payload = CreateFakeBundlePayload("v1-content");
+        var v1Provider = new TestBundlePayloadProvider(v1Payload);
+        var v1Service = CreateService(v1Provider, layoutDiscovery, v1BinaryPath);
+
+        var result1 = await v1Service.ExtractAsync(layoutRoot, force: true);
+        Assert.Equal(BundleExtractResult.Extracted, result1);
+
+        // Capture the v1 version directory.
+        var versionsDir = Path.Combine(layoutRoot, BundleService.VersionsDirectoryName);
+        var v1Dirs = Directory.GetDirectories(versionsDir);
+        Assert.Single(v1Dirs);
+        var v1VersionDir = v1Dirs[0];
+
+        try
+        {
+            // Install v2 with a different payload and different binary fingerprint.
+            var v2Payload = CreateFakeBundlePayload("v2-content");
+            var v2Provider = new TestBundlePayloadProvider(v2Payload);
+            var v2Service = CreateService(v2Provider, layoutDiscovery, v2BinaryPath);
+
+            var result2 = await v2Service.ExtractAsync(layoutRoot, force: true);
+            Assert.Equal(BundleExtractResult.Extracted, result2);
+
+            // Verify we now have a new version directory (old one cleaned up).
+            var v2Dirs = Directory.GetDirectories(versionsDir);
+            Assert.Single(v2Dirs);
+            Assert.NotEqual(v1VersionDir, v2Dirs[0]);
+
+            // The managed exe should be reachable and contain v2 content.
+            var managedExe = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName,
+                BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+            var content = File.ReadAllText(managedExe);
+            Assert.Contains("v2-content", content);
+        }
+        finally
+        {
+            CleanupReparsePoints(layoutRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that stale version directories are cleaned up after extraction.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_CleansUpStaleVersionDirectories()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var versionsDir = Path.Combine(layoutRoot, BundleService.VersionsDirectoryName);
+        Directory.CreateDirectory(versionsDir);
+
+        // Pre-populate with stale directories.
+        Directory.CreateDirectory(Path.Combine(versionsDir, "stale-aaaaaaaaaaaaaaaa"));
+        Directory.CreateDirectory(Path.Combine(versionsDir, $"stale{BundleService.TempSuffixPrefix}deadbeef"));
+        Directory.CreateDirectory(Path.Combine(versionsDir, $"stale{BundleService.BadSuffixPrefix}99999"));
+
+        var payload = CreateFakeBundlePayload();
+        var provider = new TestBundlePayloadProvider(payload);
+        var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
+        var service = CreateService(provider, layoutDiscovery);
+
+        var result = await service.ExtractAsync(layoutRoot, force: true);
+        Assert.Equal(BundleExtractResult.Extracted, result);
+
+        try
+        {
+            // Only the active version should remain.
+            var remaining = Directory.GetDirectories(versionsDir);
+            Assert.Single(remaining);
+        }
+        finally
+        {
+            CleanupReparsePoints(layoutRoot);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the static <see cref="BundleService.ExtractPayloadAsync(Stream, string, CancellationToken)"/>
+    /// overload correctly extracts a tar.gz stream with strip-components=1 behavior.
+    /// </summary>
+    [Fact]
+    public async Task ExtractPayloadAsync_Static_ExtractsTarGzWithStripComponents()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dest = workspace.WorkspaceRoot.FullName;
+        var payload = CreateFakeBundlePayload("test-content");
+
+        using var stream = new MemoryStream(payload);
+        await BundleService.ExtractPayloadAsync(stream, dest, CancellationToken.None);
+
+        // Verify strip-components=1 removed the wrapper directory.
+        var managedExe = Path.Combine(dest, BundleDiscovery.ManagedDirectoryName,
+            BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        Assert.True(File.Exists(managedExe));
+
+        var content = File.ReadAllText(managedExe);
+        Assert.Contains("test-content", content);
+
+        Assert.True(Directory.Exists(Path.Combine(dest, BundleDiscovery.DcpDirectoryName)));
+    }
+
+    /// <summary>
+    /// On Windows, verifies that upgrading replaces existing reparse points with
+    /// new targets pointing at the updated versioned directory.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_ReplacesReparsePointsOnUpgrade()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
+
+        // Create fake CLI binaries with different fingerprints.
+        var v1BinaryPath = CreateFakeCliBinary(Path.Combine(layoutRoot, ".fake-bins"), "aspire-v1", "cli-v1");
+        var v2BinaryPath = CreateFakeCliBinary(Path.Combine(layoutRoot, ".fake-bins"), "aspire-v2", "cli-v2-longer");
+        File.SetLastWriteTimeUtc(v2BinaryPath, File.GetLastWriteTimeUtc(v1BinaryPath).AddHours(1));
+
+        // Install v1.
+        var v1Payload = CreateFakeBundlePayload("v1");
+        var v1Service = CreateService(new TestBundlePayloadProvider(v1Payload), layoutDiscovery, v1BinaryPath);
+        await v1Service.ExtractAsync(layoutRoot, force: true);
+
+        var managedLink = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
+        var v1Target = ReparsePoint.GetTarget(managedLink);
+        Assert.NotNull(v1Target);
+
+        try
+        {
+            // Install v2.
+            var v2Payload = CreateFakeBundlePayload("v2");
+            var v2Service = CreateService(new TestBundlePayloadProvider(v2Payload), layoutDiscovery, v2BinaryPath);
+            await v2Service.ExtractAsync(layoutRoot, force: true);
+
+            var v2Target = ReparsePoint.GetTarget(managedLink);
+            Assert.NotNull(v2Target);
+            Assert.NotEqual(v1Target, v2Target);
+        }
+        finally
+        {
+            CleanupReparsePoints(layoutRoot);
+        }
+    }
+
+    /// <summary>
+    /// Creates a tar.gz byte array containing a fake bundle layout with the
+    /// required wrapper directory for strip-components=1 extraction.
+    /// </summary>
+    internal static byte[] CreateFakeBundlePayload(string contentMarker = "fake-bundle")
+    {
+        using var ms = new MemoryStream();
+
+        using (var gzip = new GZipStream(ms, CompressionLevel.Fastest, leaveOpen: true))
+        using (var tar = new TarWriter(gzip, leaveOpen: true))
+        {
+            // Top-level wrapper directory (stripped during extraction).
+            tar.WriteEntry(new PaxTarEntry(TarEntryType.Directory, "aspire-payload/"));
+
+            // managed/ directory and executable.
+            tar.WriteEntry(new PaxTarEntry(TarEntryType.Directory, $"aspire-payload/{BundleDiscovery.ManagedDirectoryName}/"));
+
+            var exeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
+            var managedEntry = new PaxTarEntry(TarEntryType.RegularFile, $"aspire-payload/{BundleDiscovery.ManagedDirectoryName}/{exeName}")
+            {
+                DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"#!/bin/sh\necho {contentMarker}\n"))
+            };
+            tar.WriteEntry(managedEntry);
+
+            // dcp/ directory with a placeholder file.
+            tar.WriteEntry(new PaxTarEntry(TarEntryType.Directory, $"aspire-payload/{BundleDiscovery.DcpDirectoryName}/"));
+
+            var dcpEntry = new PaxTarEntry(TarEntryType.RegularFile, $"aspire-payload/{BundleDiscovery.DcpDirectoryName}/dcp-placeholder")
+            {
+                DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"dcp-{contentMarker}\n"))
+            };
+            tar.WriteEntry(dcpEntry);
+        }
+
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Removes reparse points created during tests to prevent
+    /// <see cref="TemporaryWorkspace.Dispose"/> from following them
+    /// and deleting target contents.
+    /// </summary>
+    private static void CleanupReparsePoints(string layoutRoot)
+    {
+        foreach (var dir in BundleService.s_linkedLayoutDirectories)
+        {
+            var linkPath = Path.Combine(layoutRoot, dir);
+            ReparsePoint.RemoveIfExists(linkPath);
+        }
+    }
+
+    private static BundleService CreateService(TestBundlePayloadProvider provider, ILayoutDiscovery layoutDiscovery, string? processPathOverride = null)
+    {
+        return new BundleService(provider, layoutDiscovery, NullLogger<BundleService>.Instance)
+        {
+            ProcessPathOverride = processPathOverride
+        };
+    }
+
+    /// <summary>
+    /// Creates a fake CLI binary file with the given content and returns its path.
+    /// Different content produces different version fingerprints.
+    /// </summary>
+    private static string CreateFakeCliBinary(string directory, string name, string content)
+    {
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    /// <summary>
+    /// A layout discovery implementation that discovers from a specific root path,
+    /// checking for managed/ and dcp/ subdirectories.
+    /// </summary>
+    private sealed class TestLayoutDiscovery(string layoutRoot) : ILayoutDiscovery
+    {
+        public LayoutConfiguration? DiscoverLayout(string? projectDirectory = null)
+        {
+            var managedDir = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
+            var dcpDir = Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName);
+            var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
+            var managedExe = Path.Combine(managedDir, managedExeName);
+
+            if (!Directory.Exists(managedDir) || !File.Exists(managedExe) || !Directory.Exists(dcpDir))
+            {
+                return null;
+            }
+
+            return new LayoutConfiguration
+            {
+                LayoutPath = layoutRoot,
+                Components = new LayoutComponents
+                {
+                    Managed = Path.Combine(BundleDiscovery.ManagedDirectoryName, managedExeName),
+                    Dcp = BundleDiscovery.DcpDirectoryName,
+                }
+            };
+        }
+
+        public string? GetComponentPath(LayoutComponent component, string? projectDirectory = null)
+        {
+            return component switch
+            {
+                LayoutComponent.Managed => Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName,
+                    BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
+                LayoutComponent.Dcp => Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName),
+                _ => null,
+            };
+        }
+
+        public bool IsBundleModeAvailable(string? projectDirectory = null) => true;
+    }
+}

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -171,13 +171,14 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var dir = workspace.WorkspaceRoot.FullName;
 
-        // managed/ does not exist → null entry.
-        // dcp/ is a real (non-reparse) directory → null entry.
-        Directory.CreateDirectory(Path.Combine(dir, BundleDiscovery.DcpDirectoryName));
-
+        // bundle/ does not exist → null entry.
         var captured = BundleService.CaptureLinkTargets(dir);
-        Assert.Null(captured[BundleDiscovery.ManagedDirectoryName]);
-        Assert.Null(captured[BundleDiscovery.DcpDirectoryName]);
+        Assert.Null(captured[BundleDiscovery.BundleDirectoryName]);
+
+        // bundle/ is a real (non-reparse) directory → also null entry.
+        Directory.CreateDirectory(Path.Combine(dir, BundleDiscovery.BundleDirectoryName));
+        captured = BundleService.CaptureLinkTargets(dir);
+        Assert.Null(captured[BundleDiscovery.BundleDirectoryName]);
     }
 
     private static void CreateFakeBundleLayout(string root)

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Bundles;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Shared;
 
 namespace Aspire.Cli.Tests;
 
-public class BundleServiceTests
+public class BundleServiceTests(ITestOutputHelper outputHelper)
 {
     [Fact]
     public void IsBundle_ReturnsFalse_WhenNoEmbeddedResource()
@@ -23,33 +25,19 @@ public class BundleServiceTests
     [Fact]
     public void VersionMarker_WriteAndRead_Roundtrips()
     {
-        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
-        try
-        {
-            BundleService.WriteVersionMarker(tempDir.FullName, "13.2.0-dev");
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
 
-            var readVersion = BundleService.ReadVersionMarker(tempDir.FullName);
-            Assert.Equal("13.2.0-dev", readVersion);
-        }
-        finally
-        {
-            tempDir.Delete(recursive: true);
-        }
+        BundleService.WriteVersionMarker(dir, "13.2.0-dev");
+
+        Assert.Equal("13.2.0-dev", BundleService.ReadVersionMarker(dir));
     }
 
     [Fact]
     public void VersionMarker_ReturnsNull_WhenMissing()
     {
-        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
-        try
-        {
-            var readVersion = BundleService.ReadVersionMarker(tempDir.FullName);
-            Assert.Null(readVersion);
-        }
-        finally
-        {
-            tempDir.Delete(recursive: true);
-        }
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        Assert.Null(BundleService.ReadVersionMarker(workspace.WorkspaceRoot.FullName));
     }
 
     [Fact]
@@ -78,25 +66,128 @@ public class BundleServiceTests
     [Fact]
     public void GetCurrentVersion_ChangesWhenCliBinaryChanges()
     {
-        var tempDir = Directory.CreateTempSubdirectory("aspire-test");
-        try
-        {
-            var processPath = Path.Combine(tempDir.FullName, "aspire");
-            File.WriteAllText(processPath, "old");
-            File.SetLastWriteTimeUtc(processPath, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var processPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire");
+        File.WriteAllText(processPath, "old");
+        File.SetLastWriteTimeUtc(processPath, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
-            var firstVersion = BundleService.GetCurrentVersion(processPath);
+        var firstVersion = BundleService.GetCurrentVersion(processPath);
 
-            File.WriteAllText(processPath, "new-content");
-            File.SetLastWriteTimeUtc(processPath, new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+        File.WriteAllText(processPath, "new-content");
+        File.SetLastWriteTimeUtc(processPath, new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
 
-            var secondVersion = BundleService.GetCurrentVersion(processPath);
+        var secondVersion = BundleService.GetCurrentVersion(processPath);
 
-            Assert.NotEqual(firstVersion, secondVersion);
-        }
-        finally
-        {
-            tempDir.Delete(recursive: true);
-        }
+        Assert.NotEqual(firstVersion, secondVersion);
+    }
+
+    [Fact]
+    public void ComputeVersionId_IsDeterministic()
+    {
+        var a = BundleService.ComputeVersionId("1.2.3|1234|56789");
+        var b = BundleService.ComputeVersionId("1.2.3|1234|56789");
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void ComputeVersionId_DiffersWhenFingerprintDiffers()
+    {
+        var a = BundleService.ComputeVersionId("1.2.3|1234|56789");
+        var b = BundleService.ComputeVersionId("1.2.3|1235|56789");
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void ComputeVersionId_IsFilesystemSafe()
+    {
+        var id = BundleService.ComputeVersionId("1.2.3+ci/branch?name|1234|56789");
+        Assert.DoesNotContain('/', id);
+        Assert.DoesNotContain('\\', id);
+        Assert.DoesNotContain('+', id);
+        Assert.DoesNotContain('?', id);
+        Assert.DoesNotContain('|', id);
+        Assert.StartsWith("1.2.3_ci_branch_name-", id, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IsVersionedLayoutValid_RequiresManagedExecutableAndDcpDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
+
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+
+        CreateFakeBundleLayout(dir);
+        Assert.True(BundleService.IsVersionedLayoutValid(dir));
+
+        // Removing the managed exe invalidates the layout.
+        var managedExe = Path.Combine(dir, BundleDiscovery.ManagedDirectoryName,
+            BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        File.Delete(managedExe);
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+
+        // A zero-length managed exe is also invalid.
+        File.WriteAllBytes(managedExe, []);
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+    }
+
+    [Fact]
+    public void IsVersionedLayoutValid_RequiresDcpDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
+        CreateFakeBundleLayout(dir);
+
+        Directory.Delete(Path.Combine(dir, BundleDiscovery.DcpDirectoryName), recursive: true);
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+    }
+
+    [Fact]
+    public void TryCleanupStaleVersions_RemovesNonActiveVersionsAndStaleTempDirs()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var versionsRoot = Path.Combine(workspace.WorkspaceRoot.FullName, BundleService.VersionsDirectoryName);
+        Directory.CreateDirectory(versionsRoot);
+
+        var active = "active-aaaaaaaaaaaaaaaa";
+        Directory.CreateDirectory(Path.Combine(versionsRoot, active));
+        Directory.CreateDirectory(Path.Combine(versionsRoot, "stale-bbbbbbbbbbbbbbbb"));
+        Directory.CreateDirectory(Path.Combine(versionsRoot, $"active{BundleService.TempSuffixPrefix}deadbeef"));
+        Directory.CreateDirectory(Path.Combine(versionsRoot, $"active{BundleService.BadSuffixPrefix}99999"));
+
+        BundleService.TryCleanupStaleVersions(versionsRoot, active);
+
+        Assert.True(Directory.Exists(Path.Combine(versionsRoot, active)));
+        var remaining = Directory.EnumerateDirectories(versionsRoot).Select(Path.GetFileName).ToArray();
+        Assert.Single(remaining);
+        Assert.Equal(active, remaining[0]);
+    }
+
+    [Fact]
+    public void CaptureLinkTargets_ReturnsNullForMissingAndRealDirectories()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
+
+        // managed/ does not exist → null entry.
+        // dcp/ is a real (non-reparse) directory → null entry.
+        Directory.CreateDirectory(Path.Combine(dir, BundleDiscovery.DcpDirectoryName));
+
+        var captured = BundleService.CaptureLinkTargets(dir);
+        Assert.Null(captured[BundleDiscovery.ManagedDirectoryName]);
+        Assert.Null(captured[BundleDiscovery.DcpDirectoryName]);
+    }
+
+    private static void CreateFakeBundleLayout(string root)
+    {
+        var managedDir = Path.Combine(root, BundleDiscovery.ManagedDirectoryName);
+        Directory.CreateDirectory(managedDir);
+        File.WriteAllText(
+            Path.Combine(managedDir, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
+            "#!/bin/sh\necho aspire-managed\n");
+
+        var dcpDir = Path.Combine(root, BundleDiscovery.DcpDirectoryName);
+        Directory.CreateDirectory(dcpDir);
+        File.WriteAllText(Path.Combine(dcpDir, "placeholder"), "dcp");
     }
 }

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -12,14 +12,16 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
     [Fact]
     public void IsBundle_ReturnsFalse_WhenNoEmbeddedResource()
     {
-        // Test assembly has no embedded bundle.tar.gz resource — verify via OpenPayload
-        Assert.Null(BundleService.OpenPayload());
+        // Test assembly has no embedded bundle.tar.gz resource — verify via provider
+        var provider = new EmbeddedBundlePayloadProvider();
+        Assert.False(provider.HasPayload);
     }
 
     [Fact]
     public void OpenPayload_ReturnsNull_WhenNoEmbeddedResource()
     {
-        Assert.Null(BundleService.OpenPayload());
+        var provider = new EmbeddedBundlePayloadProvider();
+        Assert.Null(provider.OpenPayload());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
@@ -11,8 +11,8 @@ namespace Aspire.Cli.Tests.LayoutTests;
 
 /// <summary>
 /// Verifies that <see cref="LayoutDiscovery"/> successfully discovers a bundle layout
-/// whose <c>managed/</c> and <c>dcp/</c> entries are reparse points pointing into a
-/// versioned subdirectory (the new on-disk shape introduced for transactional installs).
+/// whose <c>bundle/</c> entry is a reparse point pointing at a versioned subdirectory
+/// (the new on-disk shape introduced for transactional installs).
 /// </summary>
 public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
 {
@@ -31,13 +31,11 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
             Path.Combine(versionedManaged, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
             "stub");
 
-        var topManaged = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
-        var topDcp = Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName);
-        ReparsePoint.CreateOrReplace(topManaged, versionedManaged);
-        ReparsePoint.CreateOrReplace(topDcp, versionedDcp);
+        // Create a single bundle/ link pointing at the versioned directory.
+        var bundleLink = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);
+        ReparsePoint.CreateOrReplace(bundleLink, versionsDir);
 
-        Assert.True(ReparsePoint.IsReparsePoint(topManaged));
-        Assert.True(ReparsePoint.IsReparsePoint(topDcp));
+        Assert.True(ReparsePoint.IsReparsePoint(bundleLink));
 
         var originalEnv = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
         try
@@ -53,6 +51,7 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         finally
         {
             Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, originalEnv);
+            ReparsePoint.RemoveIfExists(bundleLink);
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Layout;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
+using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.LayoutTests;
+
+/// <summary>
+/// Verifies that <see cref="LayoutDiscovery"/> successfully discovers a bundle layout
+/// whose <c>managed/</c> and <c>dcp/</c> entries are reparse points pointing into a
+/// versioned subdirectory (the new on-disk shape introduced for transactional installs).
+/// </summary>
+public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void DiscoverLayout_ResolvesThroughReparsePoints()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+
+        var versionsDir = Path.Combine(layoutRoot, "versions", "v1");
+        var versionedManaged = Path.Combine(versionsDir, BundleDiscovery.ManagedDirectoryName);
+        var versionedDcp = Path.Combine(versionsDir, BundleDiscovery.DcpDirectoryName);
+        Directory.CreateDirectory(versionedManaged);
+        Directory.CreateDirectory(versionedDcp);
+        File.WriteAllText(
+            Path.Combine(versionedManaged, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
+            "stub");
+
+        var topManaged = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
+        var topDcp = Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName);
+        ReparsePoint.CreateOrReplace(topManaged, versionedManaged);
+        ReparsePoint.CreateOrReplace(topDcp, versionedDcp);
+
+        Assert.True(ReparsePoint.IsReparsePoint(topManaged));
+        Assert.True(ReparsePoint.IsReparsePoint(topDcp));
+
+        var originalEnv = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, layoutRoot);
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
+            var layout = discovery.DiscoverLayout();
+
+            Assert.NotNull(layout);
+            Assert.Equal(layoutRoot, layout!.LayoutPath);
+            Assert.True(discovery.IsBundleModeAvailable());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, originalEnv);
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestBundlePayloadProvider.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestBundlePayloadProvider.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Bundles;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+/// <summary>
+/// A test payload provider that returns a fresh <see cref="MemoryStream"/> from
+/// a pre-built <c>byte[]</c> on each call to <see cref="OpenPayload"/>.
+/// </summary>
+internal sealed class TestBundlePayloadProvider : IBundlePayloadProvider
+{
+    private readonly byte[] _payload;
+
+    public TestBundlePayloadProvider(byte[] payload)
+    {
+        _payload = payload;
+    }
+
+    public bool HasPayload => _payload.Length > 0;
+
+    public Stream? OpenPayload() => HasPayload ? new MemoryStream(_payload) : null;
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -149,6 +149,7 @@ internal static class CliTestHelper
         // This ensures backward compatibility: no layout found = use legacy SDK mode
         services.AddSingleton(options.LayoutDiscoveryFactory);
         services.AddTransient<LayoutProcessRunner>();
+        services.AddSingleton(options.BundlePayloadProviderFactory);
         services.AddSingleton(options.BundleServiceFactory);
         services.AddSingleton<BundleNuGetService>();
 
@@ -583,6 +584,9 @@ internal sealed class CliServiceCollectionTestOptions
     // Bundle service - returns no-op implementation by default (no embedded bundle)
     public Func<IServiceProvider, IBundleService> BundleServiceFactory { get; set; } = _ => new NullBundleService();
 
+    // Bundle payload provider - returns no-payload provider by default
+    public Func<IServiceProvider, IBundlePayloadProvider> BundlePayloadProviderFactory { get; set; } = _ => new NullBundlePayloadProvider();
+
     public Func<IServiceProvider, IMcpTransportFactory> McpServerTransportFactory { get; set; } = (IServiceProvider serviceProvider) =>
     {
         var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
@@ -643,6 +647,16 @@ internal sealed class NullBundleService : IBundleService
 
     public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<Layout.LayoutConfiguration?>(null);
+}
+
+/// <summary>
+/// A no-op payload provider that reports no payload available.
+/// </summary>
+internal sealed class NullBundlePayloadProvider : IBundlePayloadProvider
+{
+    public bool HasPayload => false;
+
+    public Stream? OpenPayload() => null;
 }
 
 /// <summary>

--- a/tests/Aspire.Cli.Tests/Utils/ReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ReparsePointTests.cs
@@ -155,9 +155,18 @@ public class ReparsePointTests(ITestOutputHelper outputHelper)
         ReparsePoint.CreateWindowsJunction(link, target);
 #pragma warning restore CA1416
 
-        Assert.True(ReparsePoint.IsReparsePoint(link));
-        Assert.True(Directory.Exists(link));
-        Assert.Equal("hello", File.ReadAllText(Path.Combine(link, "marker")));
+        try
+        {
+            Assert.True(ReparsePoint.IsReparsePoint(link));
+            Assert.True(Directory.Exists(link));
+            Assert.Equal("hello", File.ReadAllText(Path.Combine(link, "marker")));
+        }
+        finally
+        {
+            // Remove the junction before workspace disposal — Directory.Delete(recursive: true)
+            // follows through junctions on Windows and would try to delete the target contents.
+            ReparsePoint.RemoveIfExists(link);
+        }
     }
 
     [Fact]
@@ -178,16 +187,25 @@ public class ReparsePointTests(ITestOutputHelper outputHelper)
         ReparsePoint.CreateWindowsJunction(link, target);
 #pragma warning restore CA1416
 
-        // Directory enumeration through the junction should see the real content.
-        var nestedThroughLink = Path.Combine(link, "nested");
-        Assert.True(Directory.Exists(nestedThroughLink));
-        Assert.Equal("payload", File.ReadAllText(Path.Combine(nestedThroughLink, "data.txt")));
+        try
+        {
+            // Directory enumeration through the junction should see the real content.
+            var nestedThroughLink = Path.Combine(link, "nested");
+            Assert.True(Directory.Exists(nestedThroughLink));
+            Assert.Equal("payload", File.ReadAllText(Path.Combine(nestedThroughLink, "data.txt")));
 
-        // Enumerating files through the junction should surface the nested tree.
-        var enumerated = Directory.EnumerateFiles(link, "*", SearchOption.AllDirectories)
-            .Select(p => Path.GetFileName(p))
-            .ToArray();
-        Assert.Contains("data.txt", enumerated);
+            // Enumerating files through the junction should surface the nested tree.
+            var enumerated = Directory.EnumerateFiles(link, "*", SearchOption.AllDirectories)
+                .Select(p => Path.GetFileName(p))
+                .ToArray();
+            Assert.Contains("data.txt", enumerated);
+        }
+        finally
+        {
+            // Remove the junction before workspace disposal — Directory.Delete(recursive: true)
+            // follows through junctions on Windows and would try to delete the target contents.
+            ReparsePoint.RemoveIfExists(link);
+        }
     }
 
     [Fact]
@@ -230,11 +248,150 @@ public class ReparsePointTests(ITestOutputHelper outputHelper)
         ReparsePoint.CreateWindowsJunction(link, target);
 #pragma warning restore CA1416
 
-        // DirectoryInfo.LinkTarget on a junction surfaces the resolved target.
-        var linkTarget = ReparsePoint.GetTarget(link);
-        Assert.NotNull(linkTarget);
-        Assert.Equal(
-            Path.GetFullPath(target).TrimEnd(Path.DirectorySeparatorChar),
-            Path.GetFullPath(linkTarget!).TrimEnd(Path.DirectorySeparatorChar));
+        try
+        {
+            // DirectoryInfo.LinkTarget on a junction surfaces the resolved target.
+            var linkTarget = ReparsePoint.GetTarget(link);
+            Assert.NotNull(linkTarget);
+            Assert.Equal(
+                Path.GetFullPath(target).TrimEnd(Path.DirectorySeparatorChar),
+                Path.GetFullPath(linkTarget!).TrimEnd(Path.DirectorySeparatorChar));
+        }
+        finally
+        {
+            // Remove the junction before workspace disposal — Directory.Delete(recursive: true)
+            // follows through junctions on Windows and would try to delete the target contents.
+            ReparsePoint.RemoveIfExists(link);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Windows-specific: junction → symlink migration tests.
+    //
+    // When a CLI install was originally created without Developer Mode (so
+    // junctions were used), and the user later enables Developer Mode, a
+    // subsequent CreateOrReplace call should transparently replace the
+    // junction with a symlink. These tests verify:
+    //   1) CreateOrReplace can replace an existing junction (deterministic)
+    //   2) The replacement is a symlink when symlink creation is available
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CreateOrReplace_ReplacesExistingJunction()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Directory junctions are Windows-only.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var targetV1 = Path.Combine(root, "v1");
+        var targetV2 = Path.Combine(root, "v2");
+        Directory.CreateDirectory(targetV1);
+        Directory.CreateDirectory(targetV2);
+        File.WriteAllText(Path.Combine(targetV1, "id"), "one");
+        File.WriteAllText(Path.Combine(targetV2, "id"), "two");
+
+        var link = Path.Combine(root, "link");
+
+        // Simulate a pre-dev-mode install that created a junction.
+#pragma warning disable CA1416
+        ReparsePoint.CreateWindowsJunction(link, targetV1);
+        Assert.Equal(Win32Constants.IO_REPARSE_TAG_MOUNT_POINT, ReparsePoint.GetReparseTag(link));
+#pragma warning restore CA1416
+        Assert.Equal("one", File.ReadAllText(Path.Combine(link, "id")));
+
+        try
+        {
+            // Act: CreateOrReplace should replace the junction regardless of
+            // whether the new link is a symlink or another junction.
+            ReparsePoint.CreateOrReplace(link, targetV2);
+
+            // Assert: link now resolves to v2.
+            Assert.True(ReparsePoint.IsReparsePoint(link));
+            Assert.Equal("two", File.ReadAllText(Path.Combine(link, "id")));
+
+            var resolvedTarget = ReparsePoint.GetTarget(link);
+            Assert.NotNull(resolvedTarget);
+            Assert.Equal(
+                Path.GetFullPath(targetV2).TrimEnd(Path.DirectorySeparatorChar),
+                Path.GetFullPath(resolvedTarget!).TrimEnd(Path.DirectorySeparatorChar));
+
+            // v1 directory must still be intact — removing a reparse point must
+            // never delete the target directory's contents.
+            Assert.True(File.Exists(Path.Combine(targetV1, "id")));
+        }
+        finally
+        {
+            // Remove the reparse point before workspace disposal — if CreateOrReplace
+            // failed, the original junction is still live and Directory.Delete(recursive: true)
+            // would follow through it.
+            ReparsePoint.RemoveIfExists(link);
+        }
+    }
+
+    [Fact]
+    public void CreateOrReplace_MigratesJunctionToSymlink_WhenSymlinksAreAvailable()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Directory junctions are Windows-only.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        // Probe: can we create symlinks on this machine? If not, skip —
+        // we cannot assert a symlink was created.
+        var probe = Path.Combine(root, "symlink-probe");
+        var probeTarget = Path.Combine(root, "probe-target");
+        Directory.CreateDirectory(probeTarget);
+        try
+        {
+            Directory.CreateSymbolicLink(probe, probeTarget);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            Assert.Skip("Symlink creation is not available (Developer Mode not enabled or not running as admin).");
+            return;
+        }
+        finally
+        {
+            ReparsePoint.RemoveIfExists(probe);
+            Directory.Delete(probeTarget);
+        }
+
+        // Arrange: create targets for the old and new version.
+        var targetV1 = Path.Combine(root, "v1");
+        var targetV2 = Path.Combine(root, "v2");
+        Directory.CreateDirectory(targetV1);
+        Directory.CreateDirectory(targetV2);
+        File.WriteAllText(Path.Combine(targetV1, "id"), "one");
+        File.WriteAllText(Path.Combine(targetV2, "id"), "two");
+
+        var link = Path.Combine(root, "link");
+
+        // Create the initial junction (simulating a pre-dev-mode install).
+#pragma warning disable CA1416
+        ReparsePoint.CreateWindowsJunction(link, targetV1);
+        Assert.Equal(Win32Constants.IO_REPARSE_TAG_MOUNT_POINT, ReparsePoint.GetReparseTag(link));
+#pragma warning restore CA1416
+
+        try
+        {
+            // Act: CreateOrReplace with symlinks available should produce a symlink.
+            ReparsePoint.CreateOrReplace(link, targetV2);
+
+            // Assert: the reparse point was migrated from junction to symlink.
+            Assert.True(ReparsePoint.IsReparsePoint(link));
+#pragma warning disable CA1416
+            Assert.Equal(Win32Constants.IO_REPARSE_TAG_SYMLINK, ReparsePoint.GetReparseTag(link));
+#pragma warning restore CA1416
+            Assert.Equal("two", File.ReadAllText(Path.Combine(link, "id")));
+
+            // v1 contents remain intact.
+            Assert.True(File.Exists(Path.Combine(targetV1, "id")));
+        }
+        finally
+        {
+            // Remove the reparse point before workspace disposal.
+            ReparsePoint.RemoveIfExists(link);
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/ReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ReparsePointTests.cs
@@ -1,0 +1,240 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class ReparsePointTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void CreateOrReplace_CreatesReparsePointToTargetDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var target = Path.Combine(root, "real");
+        Directory.CreateDirectory(target);
+        File.WriteAllText(Path.Combine(target, "marker"), "hello");
+
+        var link = Path.Combine(root, "link");
+        ReparsePoint.CreateOrReplace(link, target);
+
+        Assert.True(ReparsePoint.IsReparsePoint(link));
+        Assert.True(Directory.Exists(link));
+        Assert.Equal("hello", File.ReadAllText(Path.Combine(link, "marker")));
+    }
+
+    [Fact]
+    public void CreateOrReplace_ReplacesExistingReparsePoint()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var target1 = Path.Combine(root, "t1");
+        var target2 = Path.Combine(root, "t2");
+        Directory.CreateDirectory(target1);
+        Directory.CreateDirectory(target2);
+        File.WriteAllText(Path.Combine(target1, "id"), "one");
+        File.WriteAllText(Path.Combine(target2, "id"), "two");
+
+        var link = Path.Combine(root, "link");
+        ReparsePoint.CreateOrReplace(link, target1);
+        Assert.Equal("one", File.ReadAllText(Path.Combine(link, "id")));
+
+        ReparsePoint.CreateOrReplace(link, target2);
+        Assert.Equal("two", File.ReadAllText(Path.Combine(link, "id")));
+        Assert.True(ReparsePoint.IsReparsePoint(link));
+    }
+
+    [Fact]
+    public void CreateOrReplace_ReplacesExistingRealDirectoryWhenRemovedFirst()
+    {
+        // CreateOrReplace expects the caller to have removed any conflicting
+        // non-reparse-point entry. Verify it does not follow a real directory.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var real = Path.Combine(root, "link");
+        Directory.CreateDirectory(real);
+        File.WriteAllText(Path.Combine(real, "legacy"), "legacy");
+
+        var target = Path.Combine(root, "target");
+        Directory.CreateDirectory(target);
+
+        // A real directory in the way should prevent the atomic rename-over on
+        // most platforms. Callers must delete it first; simulate that.
+        Directory.Delete(real, recursive: true);
+        ReparsePoint.CreateOrReplace(real, target);
+
+        Assert.True(ReparsePoint.IsReparsePoint(real));
+    }
+
+    [Fact]
+    public void IsReparsePoint_ReturnsFalseForRegularDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = Path.Combine(workspace.WorkspaceRoot.FullName, "plain");
+        Directory.CreateDirectory(dir);
+
+        Assert.False(ReparsePoint.IsReparsePoint(dir));
+    }
+
+    [Fact]
+    public void IsReparsePoint_ReturnsFalseForMissingPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        Assert.False(ReparsePoint.IsReparsePoint(Path.Combine(workspace.WorkspaceRoot.FullName, "nope")));
+    }
+
+    [Fact]
+    public void RemoveIfExists_RemovesReparsePointWithoutTouchingTarget()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var target = Path.Combine(root, "target");
+        Directory.CreateDirectory(target);
+        var markerPath = Path.Combine(target, "keep");
+        File.WriteAllText(markerPath, "still here");
+
+        var link = Path.Combine(root, "link");
+        ReparsePoint.CreateOrReplace(link, target);
+
+        ReparsePoint.RemoveIfExists(link);
+
+        Assert.False(Directory.Exists(link));
+        Assert.True(File.Exists(markerPath));
+    }
+
+    [Fact]
+    public void RemoveIfExists_RemovesRegularDirectoryRecursively()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = Path.Combine(workspace.WorkspaceRoot.FullName, "plain");
+        Directory.CreateDirectory(Path.Combine(dir, "nested"));
+        File.WriteAllText(Path.Combine(dir, "nested", "f"), "x");
+
+        ReparsePoint.RemoveIfExists(dir);
+
+        Assert.False(Directory.Exists(dir));
+    }
+
+    [Fact]
+    public void RemoveIfExists_DoesNothingForMissingPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        ReparsePoint.RemoveIfExists(Path.Combine(workspace.WorkspaceRoot.FullName, "missing"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Windows-specific: explicitly exercise the junction code path.
+    //
+    // On a Windows machine with Developer Mode enabled (or when running
+    // elevated) Directory.CreateSymbolicLink succeeds, so the junction
+    // fallback inside CreateOrReplace never executes. These tests call
+    // CreateWindowsJunction directly to ensure the reparse-buffer
+    // layout and FSCTL_SET_REPARSE_POINT path remain correct regardless
+    // of dev-mode state on the build/test machine.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CreateWindowsJunction_CreatesReparsePointToTargetDirectory()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Directory junctions are Windows-only.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var target = Path.Combine(root, "real");
+        Directory.CreateDirectory(target);
+        File.WriteAllText(Path.Combine(target, "marker"), "hello");
+
+        var link = Path.Combine(root, "junction");
+#pragma warning disable CA1416
+        ReparsePoint.CreateWindowsJunction(link, target);
+#pragma warning restore CA1416
+
+        Assert.True(ReparsePoint.IsReparsePoint(link));
+        Assert.True(Directory.Exists(link));
+        Assert.Equal("hello", File.ReadAllText(Path.Combine(link, "marker")));
+    }
+
+    [Fact]
+    public void CreateWindowsJunction_TargetIsReachableThroughLink()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Directory junctions are Windows-only.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var target = Path.Combine(root, "real");
+        var nestedDir = Path.Combine(target, "nested");
+        Directory.CreateDirectory(nestedDir);
+        File.WriteAllText(Path.Combine(nestedDir, "data.txt"), "payload");
+
+        var link = Path.Combine(root, "junction");
+#pragma warning disable CA1416
+        ReparsePoint.CreateWindowsJunction(link, target);
+#pragma warning restore CA1416
+
+        // Directory enumeration through the junction should see the real content.
+        var nestedThroughLink = Path.Combine(link, "nested");
+        Assert.True(Directory.Exists(nestedThroughLink));
+        Assert.Equal("payload", File.ReadAllText(Path.Combine(nestedThroughLink, "data.txt")));
+
+        // Enumerating files through the junction should surface the nested tree.
+        var enumerated = Directory.EnumerateFiles(link, "*", SearchOption.AllDirectories)
+            .Select(p => Path.GetFileName(p))
+            .ToArray();
+        Assert.Contains("data.txt", enumerated);
+    }
+
+    [Fact]
+    public void CreateWindowsJunction_CanBeRemovedWithoutTouchingTarget()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Directory junctions are Windows-only.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var target = Path.Combine(root, "real");
+        Directory.CreateDirectory(target);
+        var markerPath = Path.Combine(target, "keep");
+        File.WriteAllText(markerPath, "still here");
+
+        var link = Path.Combine(root, "junction");
+#pragma warning disable CA1416
+        ReparsePoint.CreateWindowsJunction(link, target);
+#pragma warning restore CA1416
+
+        ReparsePoint.RemoveIfExists(link);
+
+        Assert.False(Directory.Exists(link));
+        Assert.True(File.Exists(markerPath));
+    }
+
+    [Fact]
+    public void CreateWindowsJunction_ReportsCorrectTarget()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Directory junctions are Windows-only.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var target = Path.Combine(root, "real");
+        Directory.CreateDirectory(target);
+
+        var link = Path.Combine(root, "junction");
+#pragma warning disable CA1416
+        ReparsePoint.CreateWindowsJunction(link, target);
+#pragma warning restore CA1416
+
+        // DirectoryInfo.LinkTarget on a junction surfaces the resolved target.
+        var linkTarget = ReparsePoint.GetTarget(link);
+        Assert.NotNull(linkTarget);
+        Assert.Equal(
+            Path.GetFullPath(target).TrimEnd(Path.DirectorySeparatorChar),
+            Path.GetFullPath(linkTarget!).TrimEnd(Path.DirectorySeparatorChar));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/ReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ReparsePointTests.cs
@@ -48,10 +48,10 @@ public class ReparsePointTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void CreateOrReplace_ReplacesExistingRealDirectoryWhenRemovedFirst()
+    public void CreateOrReplace_ThrowsWhenExistingPathIsRealDirectory()
     {
-        // CreateOrReplace expects the caller to have removed any conflicting
-        // non-reparse-point entry. Verify it does not follow a real directory.
+        // CreateOrReplace must refuse to remove a real directory to prevent
+        // accidental data loss. Callers must handle migration explicitly.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var root = workspace.WorkspaceRoot.FullName;
 
@@ -62,12 +62,13 @@ public class ReparsePointTests(ITestOutputHelper outputHelper)
         var target = Path.Combine(root, "target");
         Directory.CreateDirectory(target);
 
-        // A real directory in the way should prevent the atomic rename-over on
-        // most platforms. Callers must delete it first; simulate that.
-        Directory.Delete(real, recursive: true);
-        ReparsePoint.CreateOrReplace(real, target);
+        // A real directory at the link path should throw — callers must remove
+        // or migrate it before calling CreateOrReplace.
+        Assert.Throws<InvalidOperationException>(() => ReparsePoint.CreateOrReplace(real, target));
 
-        Assert.True(ReparsePoint.IsReparsePoint(real));
+        // The real directory and its contents must be preserved.
+        Assert.True(Directory.Exists(real));
+        Assert.True(File.Exists(Path.Combine(real, "legacy")));
     }
 
     [Fact]

--- a/tools/CreateLayout/Program.cs
+++ b/tools/CreateLayout/Program.cs
@@ -302,9 +302,9 @@ internal sealed class LayoutBuilder : IDisposable
     private string? FindDcpPath()
     {
         // DCP is in NuGet packages as Microsoft.DeveloperControlPlane.{os}-{arch}
-        var nugetPackages = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".nuget", "packages");
+        // Respect the NUGET_PACKAGES environment variable, then fall back to the default location.
+        var nugetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
 
         // Map RID to DCP package name format
         // win-x64 -> windows-amd64, linux-x64 -> linux-amd64, osx-arm64 -> darwin-arm64


### PR DESCRIPTION
## Description

This PR adds support for using symlinks and junctions (reparse points) for managing bundle asset directories (`managed/`, `dcp/`) during CLI install and upgrade, replacing the previous in-place update approach with versioned directories and atomic link flipping.

### Key changes

**Bundle install/upgrade architecture:**
- Bundle payloads are now extracted into versioned directories under `versions/<version-id>/`
- Public directories (`managed/`, `dcp/`) become reparse points (symlinks preferred, junctions as fallback on Windows without Developer Mode) pointing at the active versioned directory
- Upgrades atomically flip the reparse points to the new version, enabling safe updates even while the current version's executables are in use
- Stale versioned directories are cleaned up after successful upgrade; locked directories are renamed for cleanup on the next run

**Reparse point infrastructure (`ReparsePoint.cs`, `Win32Constants.cs`):**
- New `ReparsePoint` utility class for creating, replacing, and removing directory symlinks/junctions cross-platform
- Symlink-preferred strategy with junction fallback on Windows when `SeCreateSymbolicLinkPrivilege` is not available
- `GetReparseTag()` method for distinguishing symlinks from junctions via `FSCTL_GET_REPARSE_POINT`
- Full P/Invoke layer for Windows junction creation/removal using `DeviceIoControl`

**Testability refactor (`IBundlePayloadProvider`):**
- Extracted the static `OpenPayload()` and `s_isBundle` from `BundleService` into an injectable `IBundlePayloadProvider` interface
- `EmbeddedBundlePayloadProvider` preserves existing behavior (reads from assembly manifest resource)
- `ProcessPathOverride` property enables tests to simulate different CLI binary versions
- `ExtractPayloadAsync` split into instance method (uses provider) and static `Stream` overload (pure extraction logic)

**Comprehensive test coverage:**
- `ReparsePointTests`: 14 tests covering symlink/junction creation, replacement, removal, migration from junction→symlink, and capability-gated scenarios
- `LayoutDiscoveryReparsePointTests`: Validates layout discovery resolves through reparse points
- `BundleServiceIntegrationTests`: 6 in-process integration tests exercising the full extract→link→upgrade→cleanup pipeline with synthetic tar.gz payloads
- `BundleServiceTests`: Updated existing tests for the new provider-based architecture
- All junction tests use `try/finally` cleanup to prevent `Directory.Delete(recursive: true)` from following junctions and deleting target contents

### Validation

- All 35 bundle-related tests pass locally on Windows (14 unit + 6 integration + 14 reparse point + 1 layout discovery)
- Manually verified v1→v2 upgrade flow with symlink flipping
- Manually verified concurrent update while app-host session holds file locks on current version executables
- Manually verified junction→symlink migration when Developer Mode is enabled after initial install

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
