### PR TITLE
Tighten WithOrigin generic constraint for Front Door

### DIFF
--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
@@ -192,7 +192,7 @@ public static class AzureFrontDoorExtensions
     [AspireExport(Description = "Adds an origin (backend) to the Azure Front Door resource")]
     public static IResourceBuilder<AzureFrontDoorResource> WithOrigin<T>(
         this IResourceBuilder<AzureFrontDoorResource> builder,
-        IResourceBuilder<T> resource) where T : IResourceWithEndpoints
+        IResourceBuilder<T> resource) where T : IComputeResource, IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(resource);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFrontDoorTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFrontDoorTests.cs
@@ -158,7 +158,7 @@ public class AzureFrontDoorTests
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var frontDoor = builder.AddAzureFrontDoor("frontdoor");
 
-        Assert.Throws<ArgumentNullException>(() => frontDoor.WithOrigin((IResourceBuilder<IResourceWithEndpoints>)null!));
+        Assert.Throws<ArgumentNullException>(() => frontDoor.WithOrigin((IResourceBuilder<ProjectResource>)null!));
     }
 
     [Fact]


### PR DESCRIPTION
Update WithOrigin to require T : IComputeResource, IResourceWithEndpoints, making the constraint more restrictive. WithOrigin needs to accept an IComputeResource that has endpoints.