### PR TITLE
Enforce explicit compute environment binding

### DIFF
--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -617,21 +617,24 @@ public class DistributedApplication : IHost, IAsyncDisposable
     }
 
     /// <summary>
-    /// When the model contains exactly one compute environment, applies a
-    /// <see cref="ComputeEnvironmentAnnotation"/> pointing to that environment to every
-    /// <see cref="IComputeResource"/> that doesn't already have one.
+    /// Validates and applies <see cref="ComputeEnvironmentAnnotation"/> to compute resources based on
+    /// the number of compute environments in the model:
     /// </summary>
     /// <remarks>
-    /// This implements the "single compute environment is the default" convention: when only one
-    /// compute environment is present (e.g., a single <c>AzureContainerAppEnvironmentResource</c>),
-    /// developers don't need to call <c>WithComputeEnvironment(...)</c> on every compute resource —
-    /// the unique environment is auto-assigned here. Resources that have been explicitly bound to a
-    /// compute environment (via <c>WithComputeEnvironment</c> or otherwise) are left untouched.
+    /// - When exactly one compute environment is present (e.g., a single
+    /// <c>AzureContainerAppEnvironmentResource</c>), it is auto-assigned to every <see cref="IComputeResource"/>
+    /// that doesn't already have an explicit binding. Developers don't need to call
+    /// <c>WithComputeEnvironment(...)</c> on every compute resource — the unique environment is the default.
+    /// Resources that have been explicitly bound to a compute environment (via <c>WithComputeEnvironment</c>
+    /// or otherwise) are left untouched.
     ///
-    /// When zero or more than one compute environment is present we deliberately do nothing.
-    /// - With zero compute environments there is no default to apply.
-    /// - With multiple compute environments there is no unambiguous default; the developer must pick one explicitly per
-    /// resource.
+    /// - When more than one compute environment is present there is no unambiguous default. Any
+    /// <see cref="IComputeResource"/> without an explicit <see cref="ComputeEnvironmentAnnotation"/>
+    /// causes an <see cref="InvalidOperationException"/> so the developer is forced to disambiguate via
+    /// <c>WithComputeEnvironment</c> rather than silently producing a model where some resources are
+    /// never deployed (because per-environment prepare steps would skip resources not bound to their env).
+    ///
+    /// - When zero compute environments are present nothing is done.
     ///
     /// Doing this once here, before the before-start pipeline runs, guarantees downstream
     /// consumers (per-environment prepare steps, deployment-target inspection helpers, etc.) see
@@ -653,6 +656,26 @@ public class DistributedApplication : IHost, IAsyncDisposable
                 {
                     computeResource.Annotations.Add(new ComputeEnvironmentAnnotation(environment));
                 }
+            }
+        }
+        else if (computeEnvironments.Count > 1)
+        {
+            // With multiple compute environments there is no unambiguous default. Surface a clear
+            // error for any compute resource that hasn't been explicitly bound, rather than letting
+            // the environments' steps silently skip it (which would result in the resource
+            // never being deployed).
+            var unboundResources = appModel.Resources
+                .OfType<IComputeResource>()
+                .Where(r => r.GetComputeEnvironment() is null)
+                .ToList();
+
+            if (unboundResources.Count > 0)
+            {
+                var resourceNames = string.Join("', '", unboundResources.Select(r => r.Name));
+                var environmentNames = string.Join("', '", computeEnvironments.Select(e => e.Name));
+                throw new InvalidOperationException(
+                    $"Compute resource(s) '{resourceNames}' are not assigned to a compute environment, but the model contains multiple compute environments ('{environmentNames}'). " +
+                    $"Specify which environment each resource should target by calling 'WithComputeEnvironment' on the resource builder.");
             }
         }
     }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -617,24 +617,19 @@ public class DistributedApplication : IHost, IAsyncDisposable
     }
 
     /// <summary>
-    /// Validates and applies <see cref="ComputeEnvironmentAnnotation"/> to compute resources based on
-    /// the number of compute environments in the model:
+    /// Applies a default <see cref="ComputeEnvironmentAnnotation"/> when the model contains exactly one
+    /// compute environment.
     /// </summary>
     /// <remarks>
-    /// - When exactly one compute environment is present (e.g., a single
-    /// <c>AzureContainerAppEnvironmentResource</c>), it is auto-assigned to every <see cref="IComputeResource"/>
-    /// that doesn't already have an explicit binding. Developers don't need to call
-    /// <c>WithComputeEnvironment(...)</c> on every compute resource — the unique environment is the default.
-    /// Resources that have been explicitly bound to a compute environment (via <c>WithComputeEnvironment</c>
-    /// or otherwise) are left untouched.
+    /// This implements the "single compute environment is the default" convention: when exactly one
+    /// compute environment is present (for example, a single <c>AzureContainerAppEnvironmentResource</c>),
+    /// it is auto-assigned to every <see cref="IComputeResource"/> that does not already have an explicit
+    /// binding. Resources explicitly bound via <c>WithComputeEnvironment(...)</c> or otherwise are left
+    /// untouched.
     ///
-    /// - When more than one compute environment is present there is no unambiguous default. Any
-    /// <see cref="IComputeResource"/> without an explicit <see cref="ComputeEnvironmentAnnotation"/>
-    /// causes an <see cref="InvalidOperationException"/> so the developer is forced to disambiguate via
-    /// <c>WithComputeEnvironment</c> rather than silently producing a model where some resources are
-    /// never deployed (because per-environment prepare steps would skip resources not bound to their env).
-    ///
-    /// - When zero compute environments are present nothing is done.
+    /// When zero or multiple compute environments are present, this method deliberately does nothing.
+    /// Validation for ambiguous multi-environment models is handled by a required before-start pipeline
+    /// step.
     ///
     /// Doing this once here, before the before-start pipeline runs, guarantees downstream
     /// consumers (per-environment prepare steps, deployment-target inspection helpers, etc.) see
@@ -656,26 +651,6 @@ public class DistributedApplication : IHost, IAsyncDisposable
                 {
                     computeResource.Annotations.Add(new ComputeEnvironmentAnnotation(environment));
                 }
-            }
-        }
-        else if (computeEnvironments.Count > 1)
-        {
-            // With multiple compute environments there is no unambiguous default. Surface a clear
-            // error for any compute resource that hasn't been explicitly bound, rather than letting
-            // the environments' steps silently skip it (which would result in the resource
-            // never being deployed).
-            var unboundResources = appModel.Resources
-                .OfType<IComputeResource>()
-                .Where(r => r.GetComputeEnvironment() is null)
-                .ToList();
-
-            if (unboundResources.Count > 0)
-            {
-                var resourceNames = string.Join("', '", unboundResources.Select(r => r.Name));
-                var environmentNames = string.Join("', '", computeEnvironments.Select(e => e.Name));
-                throw new InvalidOperationException(
-                    $"Compute resource(s) '{resourceNames}' are not assigned to a compute environment, but the model contains multiple compute environments ('{environmentNames}'). " +
-                    $"Specify which environment each resource should target by calling 'WithComputeEnvironment' on the resource builder.");
             }
         }
     }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -617,19 +617,21 @@ public class DistributedApplication : IHost, IAsyncDisposable
     }
 
     /// <summary>
-    /// Applies a default <see cref="ComputeEnvironmentAnnotation"/> when the model contains exactly one
-    /// compute environment.
+    /// When the model contains exactly one compute environment, applies a
+    /// <see cref="ComputeEnvironmentAnnotation"/> pointing to that environment to every
+    /// <see cref="IComputeResource"/> that doesn't already have one.
     /// </summary>
     /// <remarks>
-    /// This implements the "single compute environment is the default" convention: when exactly one
-    /// compute environment is present (for example, a single <c>AzureContainerAppEnvironmentResource</c>),
-    /// it is auto-assigned to every <see cref="IComputeResource"/> that does not already have an explicit
-    /// binding. Resources explicitly bound via <c>WithComputeEnvironment(...)</c> or otherwise are left
-    /// untouched.
+    /// This implements the "single compute environment is the default" convention: when only one
+    /// compute environment is present (e.g., a single <c>AzureContainerAppEnvironmentResource</c>),
+    /// developers don't need to call <c>WithComputeEnvironment(...)</c> on every compute resource —
+    /// the unique environment is auto-assigned here. Resources that have been explicitly bound to a
+    /// compute environment (via <c>WithComputeEnvironment</c> or otherwise) are left untouched.
     ///
-    /// When zero or multiple compute environments are present, this method deliberately does nothing.
-    /// Validation for ambiguous multi-environment models is handled by a required before-start pipeline
-    /// step.
+    /// When zero or more than one compute environment is present we deliberately do nothing.
+    /// - With zero compute environments there is no default to apply.
+    /// - With multiple compute environments there is no unambiguous default; the developer must pick one explicitly per
+    /// resource.
     ///
     /// Doing this once here, before the before-start pipeline runs, guarantees downstream
     /// consumers (per-environment prepare steps, deployment-target inspection helpers, etc.) see

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -334,6 +334,18 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
             Action = _ => Task.CompletedTask
         });
 
+        _steps.Add(new PipelineStep
+        {
+            Name = "validate-compute-environment-bindings",
+            Description = "Validates compute resource bindings before startup.",
+            Action = static context =>
+            {
+                ValidateComputeEnvironmentBindings(context.Model);
+                return Task.CompletedTask;
+            },
+            RequiredBySteps = [WellKnownPipelineSteps.BeforeStart],
+        });
+
         // Add a "destroy" aggregation step for teardown operations
         _steps.Add(new PipelineStep
         {
@@ -354,6 +366,36 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
             Description = "Prerequisite step that runs before any destroy operations.",
             Action = _ => Task.CompletedTask,
         });
+    }
+
+    private static void ValidateComputeEnvironmentBindings(DistributedApplicationModel model)
+    {
+        // With multiple compute environments there is no unambiguous default. Surface a clear
+        // error for any compute resource that hasn't been explicitly bound, rather than letting
+        // the environments' steps silently skip it (which would result in the resource
+        // never being deployed).
+
+        var computeEnvironments = model.Resources.OfType<IComputeEnvironmentResource>().ToList();
+        if (computeEnvironments.Count <= 1)
+        {
+            return;
+        }
+
+        var unboundResources = model.Resources
+            .OfType<IComputeResource>()
+            .Where(resource => resource.GetComputeEnvironment() is null)
+            .ToList();
+
+        if (unboundResources.Count == 0)
+        {
+            return;
+        }
+
+        var resourceNames = string.Join("', '", unboundResources.Select(resource => resource.Name));
+        var environmentNames = string.Join("', '", computeEnvironments.Select(environment => environment.Name));
+        throw new InvalidOperationException(
+            $"Compute resource(s) '{resourceNames}' are not assigned to a compute environment, but the model contains multiple compute environments ('{environmentNames}'). " +
+            $"Specify which environment each resource should target by calling 'WithComputeEnvironment' on the resource builder.");
     }
 
     public bool HasSteps => _steps.Count > 0;

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -336,7 +336,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
 
         _steps.Add(new PipelineStep
         {
-            Name = "validate-compute-environment-bindings",
+            Name = "validate-compute-environments",
             Description = "Validates compute resource bindings before startup.",
             Action = static context =>
             {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
@@ -1,11 +1,11 @@
-﻿[  
+[  
 PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 =====================================
 
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 36
+Total steps defined: 37
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -17,39 +17,40 @@ Steps with no dependencies run first, followed by steps that depend on them.
   1. azure-prepare-resources
   2. prepare-azure-app-service-env
   3. validate-azure-app-service
-  4. before-start
-  5. process-parameters
-  6. build-prereq
-  7. check-container-runtime
-  8. deploy-prereq
-  9. build-api
- 10. build
- 11. validate-azure-login
- 12. create-provisioning-context
- 13. provision-api-identity
- 14. provision-kv
- 15. provision-api-roles-kv
- 16. provision-env-acr
- 17. provision-env
- 18. login-to-acr-env-acr
- 19. push-prereq
- 20. push-api
- 21. provision-api-website
- 22. print-api-summary
- 23. provision-azure-bicep-resources
- 24. print-dashboard-url-env
- 25. deploy
- 26. deploy-api
- 27. destroy-prereq
- 28. destroy-azure-azure634f9
- 29. destroy
- 30. diagnostics
- 31. publish-prereq
- 32. publish-azure634f9
- 33. validate-appservice-config-env
- 34. publish
- 35. publish-manifest
- 36. push
+  4. validate-compute-environments
+  5. before-start
+  6. process-parameters
+  7. build-prereq
+  8. check-container-runtime
+  9. deploy-prereq
+ 10. build-api
+ 11. build
+ 12. validate-azure-login
+ 13. create-provisioning-context
+ 14. provision-api-identity
+ 15. provision-kv
+ 16. provision-api-roles-kv
+ 17. provision-env-acr
+ 18. provision-env
+ 19. login-to-acr-env-acr
+ 20. push-prereq
+ 21. push-api
+ 22. provision-api-website
+ 23. print-api-summary
+ 24. provision-azure-bicep-resources
+ 25. print-dashboard-url-env
+ 26. deploy
+ 27. deploy-api
+ 28. destroy-prereq
+ 29. destroy-azure-azure634f9
+ 30. destroy
+ 31. diagnostics
+ 32. publish-prereq
+ 33. publish-azure634f9
+ 34. validate-appservice-config-env
+ 35. publish
+ 36. publish-manifest
+ 37. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -63,7 +64,7 @@ Step: azure-prepare-resources
 
 Step: before-start
     Description: Aggregation step for operations that run before the application starts.
-    Dependencies: ✓ azure-prepare-resources, ✓ prepare-azure-app-service-env, ✓ validate-azure-app-service
+    Dependencies: ✓ azure-prepare-resources, ✓ prepare-azure-app-service-env, ✓ validate-azure-app-service, ✓ validate-compute-environments
 
 Step: build
     Description: Aggregation step for all build operations. All build steps should be required by this step.
@@ -230,6 +231,10 @@ Step: validate-azure-login
     Dependencies: ✓ deploy-prereq
     Resource: azure634f9 (AzureEnvironmentResource)
 
+Step: validate-compute-environments
+    Description: Validates compute resource bindings before startup.
+    Dependencies: none
+
 POTENTIAL ISSUES:
 Identifies problems in the pipeline configuration that could prevent execution.
 ─────────────────
@@ -248,10 +253,10 @@ If targeting 'azure-prepare-resources':
     [0] azure-prepare-resources
 
 If targeting 'before-start':
-  Direct dependencies: azure-prepare-resources, prepare-azure-app-service-env, validate-azure-app-service
-  Total steps: 4
+  Direct dependencies: azure-prepare-resources, prepare-azure-app-service-env, validate-azure-app-service, validate-compute-environments
+  Total steps: 5
   Execution order:
-    [0] azure-prepare-resources | validate-azure-app-service (parallel)
+    [0] azure-prepare-resources | validate-azure-app-service | validate-compute-environments (parallel)
     [1] prepare-azure-app-service-env
     [2] before-start
 
@@ -587,6 +592,12 @@ If targeting 'validate-azure-login':
     [0] process-parameters
     [1] deploy-prereq
     [2] validate-azure-login
+
+If targeting 'validate-compute-environments':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] validate-compute-environments
 
 
 ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
@@ -1,11 +1,11 @@
-﻿[  
+[  
 PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 =====================================
 
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 48
+Total steps defined: 49
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -19,49 +19,50 @@ Steps with no dependencies run first, followed by steps that depend on them.
   3. prepare-azure-container-apps-aca-env
   4. validate-azure-app-service
   5. validate-azure-container-apps
-  6. before-start
-  7. process-parameters
-  8. build-prereq
-  9. check-container-runtime
- 10. deploy-prereq
- 11. build-api-service
- 12. build-python-app
- 13. build
- 14. validate-azure-login
- 15. create-provisioning-context
- 16. provision-aas-env-acr
- 17. provision-aas-env
- 18. login-to-acr-aas-env-acr
- 19. provision-aca-env-acr
- 20. login-to-acr-aca-env-acr
- 21. push-prereq
- 22. push-api-service
- 23. provision-api-service-website
- 24. print-api-service-summary
- 25. provision-aca-env
- 26. provision-cache-containerapp
- 27. print-cache-summary
- 28. push-python-app
- 29. provision-python-app-containerapp
- 30. provision-storage
- 31. provision-azure-bicep-resources
- 32. print-dashboard-url-aas-env
- 33. print-dashboard-url-aca-env
- 34. print-python-app-summary
- 35. deploy
- 36. deploy-api-service
- 37. deploy-cache
- 38. deploy-python-app
- 39. destroy-prereq
- 40. destroy-azure-azure634f9
- 41. destroy
- 42. diagnostics
- 43. publish-prereq
- 44. publish-azure634f9
- 45. validate-appservice-config-aas-env
- 46. publish
- 47. publish-manifest
- 48. push
+  6. validate-compute-environments
+  7. before-start
+  8. process-parameters
+  9. build-prereq
+ 10. check-container-runtime
+ 11. deploy-prereq
+ 12. build-api-service
+ 13. build-python-app
+ 14. build
+ 15. validate-azure-login
+ 16. create-provisioning-context
+ 17. provision-aas-env-acr
+ 18. provision-aas-env
+ 19. login-to-acr-aas-env-acr
+ 20. provision-aca-env-acr
+ 21. login-to-acr-aca-env-acr
+ 22. push-prereq
+ 23. push-api-service
+ 24. provision-api-service-website
+ 25. print-api-service-summary
+ 26. provision-aca-env
+ 27. provision-cache-containerapp
+ 28. print-cache-summary
+ 29. push-python-app
+ 30. provision-python-app-containerapp
+ 31. provision-storage
+ 32. provision-azure-bicep-resources
+ 33. print-dashboard-url-aas-env
+ 34. print-dashboard-url-aca-env
+ 35. print-python-app-summary
+ 36. deploy
+ 37. deploy-api-service
+ 38. deploy-cache
+ 39. deploy-python-app
+ 40. destroy-prereq
+ 41. destroy-azure-azure634f9
+ 42. destroy
+ 43. diagnostics
+ 44. publish-prereq
+ 45. publish-azure634f9
+ 46. validate-appservice-config-aas-env
+ 47. publish
+ 48. publish-manifest
+ 49. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -75,7 +76,7 @@ Step: azure-prepare-resources
 
 Step: before-start
     Description: Aggregation step for operations that run before the application starts.
-    Dependencies: ✓ azure-prepare-resources, ✓ prepare-azure-app-service-aas-env, ✓ prepare-azure-container-apps-aca-env, ✓ validate-azure-app-service, ✓ validate-azure-container-apps
+    Dependencies: ✓ azure-prepare-resources, ✓ prepare-azure-app-service-aas-env, ✓ prepare-azure-container-apps-aca-env, ✓ validate-azure-app-service, ✓ validate-azure-container-apps, ✓ validate-compute-environments
 
 Step: build
     Description: Aggregation step for all build operations. All build steps should be required by this step.
@@ -307,6 +308,10 @@ Step: validate-azure-login
     Dependencies: ✓ deploy-prereq
     Resource: azure634f9 (AzureEnvironmentResource)
 
+Step: validate-compute-environments
+    Description: Validates compute resource bindings before startup.
+    Dependencies: none
+
 POTENTIAL ISSUES:
 Identifies problems in the pipeline configuration that could prevent execution.
 ─────────────────
@@ -325,10 +330,10 @@ If targeting 'azure-prepare-resources':
     [0] azure-prepare-resources
 
 If targeting 'before-start':
-  Direct dependencies: azure-prepare-resources, prepare-azure-app-service-aas-env, prepare-azure-container-apps-aca-env, validate-azure-app-service, validate-azure-container-apps
-  Total steps: 6
+  Direct dependencies: azure-prepare-resources, prepare-azure-app-service-aas-env, prepare-azure-container-apps-aca-env, validate-azure-app-service, validate-azure-container-apps, validate-compute-environments
+  Total steps: 7
   Execution order:
-    [0] azure-prepare-resources | validate-azure-app-service | validate-azure-container-apps (parallel)
+    [0] azure-prepare-resources | validate-azure-app-service | validate-azure-container-apps | validate-compute-environments (parallel)
     [1] prepare-azure-app-service-aas-env | prepare-azure-container-apps-aca-env (parallel)
     [2] before-start
 
@@ -809,6 +814,12 @@ If targeting 'validate-azure-login':
     [0] process-parameters
     [1] deploy-prereq
     [2] validate-azure-login
+
+If targeting 'validate-compute-environments':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] validate-compute-environments
 
 
 ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
@@ -1,11 +1,11 @@
-﻿[  
+[  
 PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 =====================================
 
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 48
+Total steps defined: 49
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -17,51 +17,52 @@ Steps with no dependencies run first, followed by steps that depend on them.
   1. azure-prepare-resources
   2. prepare-azure-container-apps-env
   3. validate-azure-container-apps
-  4. before-start
-  5. process-parameters
-  6. build-prereq
-  7. check-container-runtime
-  8. deploy-prereq
-  9. build-api
- 10. build
- 11. validate-azure-login
- 12. create-provisioning-context
- 13. provision-api-identity
- 14. provision-cosmos
- 15. provision-api-roles-cosmos
- 16. provision-sql-nsg
- 17. provision-vnet
- 18. provision-privatelink-file-core-windows-net
- 19. provision-sql-store
- 20. provision-pe-subnet-files-pe
- 21. provision-privatelink-database-windows-net
- 22. provision-sql
- 23. provision-pe-subnet-sql-pe
- 24. provision-api-roles-sql
- 25. provision-env-acr
- 26. provision-env
- 27. provision-privatelink-documents-azure-com
- 28. provision-pe-subnet-cosmos-pe
- 29. login-to-acr-env-acr
- 30. push-prereq
- 31. push-api
- 32. provision-api-containerapp
- 33. print-api-summary
- 34. provision-sql-admin-identity
- 35. provision-sql-admin-identity-roles-sql-store
- 36. provision-azure-bicep-resources
- 37. print-dashboard-url-env
- 38. deploy
- 39. deploy-api
- 40. destroy-prereq
- 41. destroy-azure-azure634f9
- 42. destroy
- 43. diagnostics
- 44. publish-prereq
- 45. publish-azure634f9
- 46. publish
- 47. publish-manifest
- 48. push
+  4. validate-compute-environments
+  5. before-start
+  6. process-parameters
+  7. build-prereq
+  8. check-container-runtime
+  9. deploy-prereq
+ 10. build-api
+ 11. build
+ 12. validate-azure-login
+ 13. create-provisioning-context
+ 14. provision-api-identity
+ 15. provision-cosmos
+ 16. provision-api-roles-cosmos
+ 17. provision-sql-nsg
+ 18. provision-vnet
+ 19. provision-privatelink-file-core-windows-net
+ 20. provision-sql-store
+ 21. provision-pe-subnet-files-pe
+ 22. provision-privatelink-database-windows-net
+ 23. provision-sql
+ 24. provision-pe-subnet-sql-pe
+ 25. provision-api-roles-sql
+ 26. provision-env-acr
+ 27. provision-env
+ 28. provision-privatelink-documents-azure-com
+ 29. provision-pe-subnet-cosmos-pe
+ 30. login-to-acr-env-acr
+ 31. push-prereq
+ 32. push-api
+ 33. provision-api-containerapp
+ 34. print-api-summary
+ 35. provision-sql-admin-identity
+ 36. provision-sql-admin-identity-roles-sql-store
+ 37. provision-azure-bicep-resources
+ 38. print-dashboard-url-env
+ 39. deploy
+ 40. deploy-api
+ 41. destroy-prereq
+ 42. destroy-azure-azure634f9
+ 43. destroy
+ 44. diagnostics
+ 45. publish-prereq
+ 46. publish-azure634f9
+ 47. publish
+ 48. publish-manifest
+ 49. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -75,7 +76,7 @@ Step: azure-prepare-resources
 
 Step: before-start
     Description: Aggregation step for operations that run before the application starts.
-    Dependencies: ✓ azure-prepare-resources, ✓ prepare-azure-container-apps-env, ✓ validate-azure-container-apps
+    Dependencies: ✓ azure-prepare-resources, ✓ prepare-azure-container-apps-env, ✓ validate-azure-container-apps, ✓ validate-compute-environments
 
 Step: build
     Description: Aggregation step for all build operations. All build steps should be required by this step.
@@ -315,6 +316,10 @@ Step: validate-azure-login
     Dependencies: ✓ deploy-prereq
     Resource: azure634f9 (AzureEnvironmentResource)
 
+Step: validate-compute-environments
+    Description: Validates compute resource bindings before startup.
+    Dependencies: none
+
 POTENTIAL ISSUES:
 Identifies problems in the pipeline configuration that could prevent execution.
 ─────────────────
@@ -333,10 +338,10 @@ If targeting 'azure-prepare-resources':
     [0] azure-prepare-resources
 
 If targeting 'before-start':
-  Direct dependencies: azure-prepare-resources, prepare-azure-container-apps-env, validate-azure-container-apps
-  Total steps: 4
+  Direct dependencies: azure-prepare-resources, prepare-azure-container-apps-env, validate-azure-container-apps, validate-compute-environments
+  Total steps: 5
   Execution order:
-    [0] azure-prepare-resources | validate-azure-container-apps (parallel)
+    [0] azure-prepare-resources | validate-azure-container-apps | validate-compute-environments (parallel)
     [1] prepare-azure-container-apps-env
     [2] before-start
 
@@ -823,6 +828,12 @@ If targeting 'validate-azure-login':
     [0] process-parameters
     [1] deploy-prereq
     [2] validate-azure-login
+
+If targeting 'validate-compute-environments':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] validate-compute-environments
 
 
 ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -1,11 +1,11 @@
-﻿[  
+[  
 PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 =====================================
 
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 43
+Total steps defined: 44
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -17,46 +17,47 @@ Steps with no dependencies run first, followed by steps that depend on them.
   1. azure-prepare-resources
   2. prepare-azure-app-service-env
   3. validate-azure-app-service
-  4. before-start
-  5. process-parameters
-  6. build-prereq
-  7. check-container-runtime
-  8. deploy-prereq
-  9. build-api
- 10. build
- 11. validate-azure-login
- 12. create-provisioning-context
- 13. provision-api-identity
- 14. provision-cache-kv
- 15. provision-api-roles-cache-kv
- 16. provision-cosmos-kv
- 17. provision-api-roles-cosmos-kv
- 18. provision-pg-kv
- 19. provision-api-roles-pg-kv
- 20. provision-cache
- 21. provision-cosmos
- 22. provision-env-acr
- 23. provision-env
- 24. provision-pg
- 25. login-to-acr-env-acr
- 26. push-prereq
- 27. push-api
- 28. provision-api-website
- 29. print-api-summary
- 30. provision-azure-bicep-resources
- 31. print-dashboard-url-env
- 32. deploy
- 33. deploy-api
- 34. destroy-prereq
- 35. destroy-azure-azure634f9
- 36. destroy
- 37. diagnostics
- 38. publish-prereq
- 39. publish-azure634f9
- 40. validate-appservice-config-env
- 41. publish
- 42. publish-manifest
- 43. push
+  4. validate-compute-environments
+  5. before-start
+  6. process-parameters
+  7. build-prereq
+  8. check-container-runtime
+  9. deploy-prereq
+ 10. build-api
+ 11. build
+ 12. validate-azure-login
+ 13. create-provisioning-context
+ 14. provision-api-identity
+ 15. provision-cache-kv
+ 16. provision-api-roles-cache-kv
+ 17. provision-cosmos-kv
+ 18. provision-api-roles-cosmos-kv
+ 19. provision-pg-kv
+ 20. provision-api-roles-pg-kv
+ 21. provision-cache
+ 22. provision-cosmos
+ 23. provision-env-acr
+ 24. provision-env
+ 25. provision-pg
+ 26. login-to-acr-env-acr
+ 27. push-prereq
+ 28. push-api
+ 29. provision-api-website
+ 30. print-api-summary
+ 31. provision-azure-bicep-resources
+ 32. print-dashboard-url-env
+ 33. deploy
+ 34. deploy-api
+ 35. destroy-prereq
+ 36. destroy-azure-azure634f9
+ 37. destroy
+ 38. diagnostics
+ 39. publish-prereq
+ 40. publish-azure634f9
+ 41. validate-appservice-config-env
+ 42. publish
+ 43. publish-manifest
+ 44. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -70,7 +71,7 @@ Step: azure-prepare-resources
 
 Step: before-start
     Description: Aggregation step for operations that run before the application starts.
-    Dependencies: ✓ azure-prepare-resources, ✓ prepare-azure-app-service-env, ✓ validate-azure-app-service
+    Dependencies: ✓ azure-prepare-resources, ✓ prepare-azure-app-service-env, ✓ validate-azure-app-service, ✓ validate-compute-environments
 
 Step: build
     Description: Aggregation step for all build operations. All build steps should be required by this step.
@@ -279,6 +280,10 @@ Step: validate-azure-login
     Dependencies: ✓ deploy-prereq
     Resource: azure634f9 (AzureEnvironmentResource)
 
+Step: validate-compute-environments
+    Description: Validates compute resource bindings before startup.
+    Dependencies: none
+
 POTENTIAL ISSUES:
 Identifies problems in the pipeline configuration that could prevent execution.
 ─────────────────
@@ -297,10 +302,10 @@ If targeting 'azure-prepare-resources':
     [0] azure-prepare-resources
 
 If targeting 'before-start':
-  Direct dependencies: azure-prepare-resources, prepare-azure-app-service-env, validate-azure-app-service
-  Total steps: 4
+  Direct dependencies: azure-prepare-resources, prepare-azure-app-service-env, validate-azure-app-service, validate-compute-environments
+  Total steps: 5
   Execution order:
-    [0] azure-prepare-resources | validate-azure-app-service (parallel)
+    [0] azure-prepare-resources | validate-azure-app-service | validate-compute-environments (parallel)
     [1] prepare-azure-app-service-env
     [2] before-start
 
@@ -711,6 +716,12 @@ If targeting 'validate-azure-login':
     [0] process-parameters
     [1] deploy-prereq
     [2] validate-azure-login
+
+If targeting 'validate-compute-environments':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] validate-compute-environments
 
 
 ]

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Hosting.Tests;
 
+[Trait("Partition", "6")]
 public class ComputeEnvironmentValidationTests
 {
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+
+namespace Aspire.Hosting.Tests;
+
+public class ComputeEnvironmentValidationTests
+{
+    [Fact]
+    public async Task MultipleComputeEnvironments_WithUnboundComputeResource_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        builder.AddResource(new TestComputeResource("api"));
+
+        using var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => app.ExecuteBeforeStartHooksAsync(default)).DefaultTimeout();
+
+        Assert.Contains("'api'", ex.Message);
+        Assert.Contains("'env1'", ex.Message);
+        Assert.Contains("'env2'", ex.Message);
+        Assert.Contains("WithComputeEnvironment", ex.Message);
+    }
+
+    [Fact]
+    public async Task MultipleComputeEnvironments_WithAllResourcesBound_DoesNotThrow()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironment(env1);
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task SingleComputeEnvironment_AutoBindsUnboundResources()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var api = builder.AddResource(new TestComputeResource("api"));
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        Assert.Same(env.Resource, api.Resource.GetComputeEnvironment());
+    }
+
+    private sealed class TestComputeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
+    {
+    }
+
+    private sealed class TestComputeResource(string name) : Resource(name), IComputeResource
+    {
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -1558,7 +1558,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         await pipeline.ExecuteAsync(context).DefaultTimeout();
 
         Assert.True(callbackExecuted);
-        Assert.Equal(16, capturedSteps.Count); // Default steps: deploy, deploy-prereq, process-parameters, build, build-prereq, check-container-runtime, push, push-prereq, publish, publish-prereq, diagnostics, before-start, destroy, destroy-prereq + step1, step2
+        Assert.Equal(17, capturedSteps.Count); // Default steps: deploy, deploy-prereq, process-parameters, build, build-prereq, check-container-runtime, push, push-prereq, publish, publish-prereq, diagnostics, validate-compute-environment-bindings, before-start, destroy, destroy-prereq + step1, step2
         Assert.Contains(capturedSteps, s => s.Name == "deploy");
         Assert.Contains(capturedSteps, s => s.Name == "process-parameters");
         Assert.Contains(capturedSteps, s => s.Name == "deploy-prereq");
@@ -1569,6 +1569,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         Assert.Contains(capturedSteps, s => s.Name == "publish");
         Assert.Contains(capturedSteps, s => s.Name == "publish-prereq");
         Assert.Contains(capturedSteps, s => s.Name == "diagnostics");
+        Assert.Contains(capturedSteps, s => s.Name == "validate-compute-environment-bindings");
         Assert.Contains(capturedSteps, s => s.Name == "before-start");
         Assert.Contains(capturedSteps, s => s.Name == "destroy");
         Assert.Contains(capturedSteps, s => s.Name == "destroy-prereq");

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -1558,7 +1558,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         await pipeline.ExecuteAsync(context).DefaultTimeout();
 
         Assert.True(callbackExecuted);
-        Assert.Equal(17, capturedSteps.Count); // Default steps: deploy, deploy-prereq, process-parameters, build, build-prereq, check-container-runtime, push, push-prereq, publish, publish-prereq, diagnostics, validate-compute-environment-bindings, before-start, destroy, destroy-prereq + step1, step2
+        Assert.Equal(17, capturedSteps.Count); // Default steps: deploy, deploy-prereq, process-parameters, build, build-prereq, check-container-runtime, push, push-prereq, publish, publish-prereq, diagnostics, validate-compute-environments, before-start, destroy, destroy-prereq + step1, step2
         Assert.Contains(capturedSteps, s => s.Name == "deploy");
         Assert.Contains(capturedSteps, s => s.Name == "process-parameters");
         Assert.Contains(capturedSteps, s => s.Name == "deploy-prereq");
@@ -1569,7 +1569,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         Assert.Contains(capturedSteps, s => s.Name == "publish");
         Assert.Contains(capturedSteps, s => s.Name == "publish-prereq");
         Assert.Contains(capturedSteps, s => s.Name == "diagnostics");
-        Assert.Contains(capturedSteps, s => s.Name == "validate-compute-environment-bindings");
+        Assert.Contains(capturedSteps, s => s.Name == "validate-compute-environments");
         Assert.Contains(capturedSteps, s => s.Name == "before-start");
         Assert.Contains(capturedSteps, s => s.Name == "destroy");
         Assert.Contains(capturedSteps, s => s.Name == "destroy-prereq");


### PR DESCRIPTION
Throw if compute resources are unbound when multiple compute environments exist, preventing ambiguous deployments. Update summary comments to clarify behavior. Add tests to verify exception is thrown for unbound resources, no exception when all are bound, and auto-binding with a single environment.

This was the behavior originally in [Allow multiple compute environment resources in an app model (microsoft/aspire#8820)](https://github.com/microsoft/aspire/pull/8820). However, [Fix: Skip resources targeted to different compute environments (microsoft/aspire#14177)](https://github.com/microsoft/aspire/pull/14177) broke this behavior to no longer throw - and compute resources silently were ignored.