### PR TITLE
Fix long command names overflowing Commands submenu

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -77,9 +77,9 @@ public partial class AspireMenu : FluentComponentBase
                 .AddStyle("right", $"{right}px", right != 0)
                 .AddStyle("top", $"{top}px", top != 0)
                 .AddStyle("bottom", $"{bottom}px", bottom != 0)
-                // max-width and min-width values come from fluentui-blazor stylesheet
-                // explicitly set to override min-width: fit-content applied by library to some menus
-                .AddStyle("max-width", "368px")
+                // Width values come from fluentui-blazor stylesheet; max-width uses an app CSS variable so nested submenus stay in sync.
+                // Explicitly set to override min-width: fit-content applied by library to some menus.
+                .AddStyle("max-width", "var(--aspire-menu-max-width)")
                 .AddStyle("min-width", "64px")
                 .Build();
 

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -927,9 +927,14 @@ fluent-tooltip[anchor="dialog_close"] > div {
     margin-right: var(--inline-icon-margin);
 }
 
-.aspire-menu-container > fluent-menu > fluent-menu-item::part(content) {
+.aspire-menu-container fluent-menu-item::part(content) {
     width: 100%;
+    overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.aspire-menu-container fluent-menu fluent-menu {
+    max-width: 368px;
 }
 
 .overflow-fluent-menu-item::part(content) {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -927,6 +927,10 @@ fluent-tooltip[anchor="dialog_close"] > div {
     margin-right: var(--inline-icon-margin);
 }
 
+.aspire-menu-container {
+    --aspire-menu-max-width: 368px;
+}
+
 .aspire-menu-container fluent-menu-item::part(content) {
     width: 100%;
     overflow: hidden;
@@ -934,7 +938,7 @@ fluent-tooltip[anchor="dialog_close"] > div {
 }
 
 .aspire-menu-container fluent-menu fluent-menu {
-    max-width: 368px;
+    max-width: var(--aspire-menu-max-width);
 }
 
 .overflow-fluent-menu-item::part(content) {


### PR DESCRIPTION
## Description

Long command names overflow the Commands submenu in the dashboard resource action menu. The CSS selector for menu item text truncation used direct child combinators (`>`) that only matched top-level `fluent-menu-item` elements. When there are more than 5 commands, `ResourceMenuBuilder` groups non-highlighted commands under a nested "Commands" submenu, and those nested items had no width constraint or text truncation.

The fix broadens the CSS selector to target all descendant `fluent-menu-item` elements, adds `overflow: hidden` (required for `text-overflow: ellipsis`), and constrains nested submenus to `max-width: 368px` to match the parent menu.

Fixes #15443

<img width="1730" height="1940" alt="image" src="https://github.com/user-attachments/assets/45195ced-3f47-4efa-a8e1-b6d5daaf43a5" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No