### PR TITLE
Improve CLI docs markdown rendering and simplify DocsGetCommand

### DIFF
--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.Globalization;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Documentation.Docs;
@@ -18,7 +17,7 @@ namespace Aspire.Cli.Commands;
 /// <summary>
 /// Command to get the full content of a documentation page by its slug.
 /// </summary>
-internal sealed partial class DocsGetCommand : BaseCommand
+internal sealed class DocsGetCommand : BaseCommand
 {
     private readonly IDocsIndexService _docsIndexService;
     private readonly ILogger<DocsGetCommand> _logger;
@@ -87,163 +86,9 @@ internal sealed partial class DocsGetCommand : BaseCommand
         }
         else
         {
-            var markdown = WrapMarkdownForConsole(doc.Content);
-            var wroteBlock = false;
-
-            foreach (var block in SplitMarkdownBlocks(markdown))
-            {
-                if (wroteBlock)
-                {
-                    InteractionService.DisplayEmptyLine();
-                }
-
-                InteractionService.DisplayMarkdown(block);
-                wroteBlock = true;
-            }
+            InteractionService.DisplayMarkdown(doc.Content, maxWidth: 100);
         }
 
         return ExitCodeConstants.Success;
     }
-
-    internal static string WrapMarkdownForConsole(string markdown, int width = 100)
-    {
-        var wrappedLines = new List<string>();
-        var inCodeFence = false;
-
-        foreach (var line in markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal).Split('\n'))
-        {
-            var trimmedLine = line.TrimEnd();
-
-            if (trimmedLine.StartsWith("```", StringComparison.Ordinal))
-            {
-                wrappedLines.Add(trimmedLine);
-                inCodeFence = !inCodeFence;
-                continue;
-            }
-
-            if (inCodeFence || string.IsNullOrWhiteSpace(trimmedLine) || IsHeading(trimmedLine) || IsTableLine(trimmedLine))
-            {
-                wrappedLines.Add(trimmedLine);
-                continue;
-            }
-
-            WrapLine(trimmedLine, width, wrappedLines);
-        }
-
-        return string.Join("\n", wrappedLines);
-    }
-
-    internal static IReadOnlyList<string> SplitMarkdownBlocks(string markdown)
-    {
-        var blocks = new List<string>();
-        var currentBlock = new List<string>();
-        var inCodeFence = false;
-
-        foreach (var line in markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal).Split('\n'))
-        {
-            var trimmedLine = line.TrimEnd();
-
-            if (!inCodeFence && string.IsNullOrWhiteSpace(trimmedLine))
-            {
-                AppendBlock(blocks, currentBlock);
-                continue;
-            }
-
-            currentBlock.Add(trimmedLine);
-
-            if (trimmedLine.StartsWith("```", StringComparison.Ordinal))
-            {
-                inCodeFence = !inCodeFence;
-            }
-        }
-
-        AppendBlock(blocks, currentBlock);
-        return blocks;
-    }
-
-    private static void WrapLine(string line, int width, List<string> wrappedLines)
-    {
-        var prefixLength = GetPrefixLength(line);
-        var prefix = line[..prefixLength];
-        var remaining = line[prefixLength..].TrimStart();
-        var continuationPrefix = new string(' ', prefixLength);
-        var currentLine = prefix;
-
-        foreach (Match token in MarkdownTokenRegex().Matches(remaining))
-        {
-            var value = token.Value;
-            var trailingPunctuation = IsTrailingPunctuation(value);
-            var separator = currentLine.Length == prefix.Length || trailingPunctuation ? string.Empty : " ";
-            var candidate = $"{currentLine}{separator}{value}";
-
-            if (candidate.Length <= width || currentLine.Length == prefix.Length || trailingPunctuation)
-            {
-                currentLine = candidate;
-                continue;
-            }
-
-            wrappedLines.Add(currentLine);
-            currentLine = continuationPrefix + value;
-        }
-
-        wrappedLines.Add(currentLine);
-    }
-
-    private static int GetPrefixLength(string line)
-    {
-        if (line.StartsWith("> ", StringComparison.Ordinal))
-        {
-            return 2;
-        }
-
-        if (line.StartsWith("* ", StringComparison.Ordinal))
-        {
-            return 2;
-        }
-
-        var index = 0;
-        while (index < line.Length && char.IsDigit(line[index]))
-        {
-            index++;
-        }
-
-        if (index > 0 &&
-            index + 1 < line.Length &&
-            line[index] == '.' &&
-            line[index + 1] == ' ')
-        {
-            return index + 2;
-        }
-
-        return 0;
-    }
-
-    private static bool IsHeading(string line)
-    {
-        return line.StartsWith('#');
-    }
-
-    private static bool IsTableLine(string line)
-    {
-        return line.StartsWith("|", StringComparison.Ordinal) && line.Count(static character => character == '|') >= 2;
-    }
-
-    private static bool IsTrailingPunctuation(string value)
-    {
-        return value.All(static character => character is ',' or '.' or ':' or ';' or '!' or '?' or ')' or ']');
-    }
-
-    private static void AppendBlock(List<string> blocks, List<string> currentBlock)
-    {
-        if (currentBlock.Count == 0)
-        {
-            return;
-        }
-
-        blocks.Add(string.Join("\n", currentBlock));
-        currentBlock.Clear();
-    }
-
-    [GeneratedRegex(@"(\[((?:[^\[\]]|\[[^\[\]]*\])*)\]\([^)]+\)|`[^`]+`|\*\*[^*]+\*\*|__[^_]+__|\*[^*\n]+\*|_[^_\n]+_|\S+)")]
-    private static partial Regex MarkdownTokenRegex();
 }

--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -86,19 +86,6 @@ internal sealed class DocsGetCommand : BaseCommand
         }
         else
         {
-            InteractionService.DisplayMarkdown(
-                """
-                ## API
-
-                The API section configures authentication for the dashboard’s HTTP API endpoints.
-                | Option | Description |
-                | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-                | `Dashboard:Api:Enabled` Default: `false` | Enables the Telemetry HTTP API (`/api/telemetry/*`) endpoints. When `false`, the endpoints are not registered. |
-                | `Dashboard:Api:AuthMode` Default: `Unsecured` | Can be set to `ApiKey` or `Unsecured`. `Unsecured` should only be used during local development. If an API key is configured and no auth mode is specified, defaults to `ApiKey`. |
-                | `Dashboard:Api:PrimaryApiKey` Default: `null` | Specifies the primary API key. The API key can be any text, but a value with at least 128 bits of entropy is recommended. This value is required if auth mode is API key. |
-                | `Dashboard:Api:SecondaryApiKey` Default: `null` | Specifies the secondary API key. The API key can be any text, but a value with at least 128 bits of entropy is recommended. This value is optional. |
-                """, maxWidth: 100);
-
             InteractionService.DisplayMarkdown(doc.Content, maxWidth: 100);
         }
 

--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -59,6 +59,8 @@ internal sealed class DocsGetCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        System.Diagnostics.Debugger.Launch();
+
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
         var slug = parseResult.GetValue(s_slugArgument)!;
@@ -86,6 +88,19 @@ internal sealed class DocsGetCommand : BaseCommand
         }
         else
         {
+            InteractionService.DisplayMarkdown(
+                """
+                ## API
+
+                The API section configures authentication for the dashboard’s HTTP API endpoints.
+                | Option | Description |
+                | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+                | `Dashboard:Api:Enabled` Default: `false` | Enables the Telemetry HTTP API (`/api/telemetry/*`) endpoints. When `false`, the endpoints are not registered. |
+                | `Dashboard:Api:AuthMode` Default: `Unsecured` | Can be set to `ApiKey` or `Unsecured`. `Unsecured` should only be used during local development. If an API key is configured and no auth mode is specified, defaults to `ApiKey`. |
+                | `Dashboard:Api:PrimaryApiKey` Default: `null` | Specifies the primary API key. The API key can be any text, but a value with at least 128 bits of entropy is recommended. This value is required if auth mode is API key. |
+                | `Dashboard:Api:SecondaryApiKey` Default: `null` | Specifies the secondary API key. The API key can be any text, but a value with at least 128 bits of entropy is recommended. This value is optional. |
+                """, maxWidth: 100);
+
             InteractionService.DisplayMarkdown(doc.Content, maxWidth: 100);
         }
 

--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -59,8 +59,6 @@ internal sealed class DocsGetCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        System.Diagnostics.Debugger.Launch();
-
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
         var slug = parseResult.GetValue(s_slugArgument)!;

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -128,7 +128,7 @@ internal static class ResourceCommandHelper
     {
         if (result.Format is CommandResultFormat.Markdown)
         {
-            interactionService.DisplayMarkdown(result.Value, ConsoleOutput.Standard);
+            interactionService.DisplayMarkdown(result.Value, ConsoleOutput.Standard, maxWidth: 100);
         }
         else
         {

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -545,6 +545,9 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         builder.Append(NormalizeMarkdownSegment(content[position..]));
 
         var normalized = TrailingWhitespaceBeforeNewlineRegex().Replace(builder.ToString(), "\n");
+        normalized = BlankLineAfterHeadingRegex().Replace(normalized, "$1\n");
+        normalized = BlankLineAfterTableRegex().Replace(normalized, "$1\n");
+        normalized = BlankLineAfterListRegex().Replace(normalized, "$1\n");
         normalized = ExcessBlankLinesRegex().Replace(normalized, "\n\n");
 
         return normalized.Trim();
@@ -649,6 +652,15 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
     [GeneratedRegex(@"(?m)^[ \t]+")]
     private static partial Regex LeadingWhitespaceRegex();
+
+    [GeneratedRegex(@"(?m)(^#{1,6}\s+[^\n]+\n)(?!\n|#|```)")]
+    private static partial Regex BlankLineAfterHeadingRegex();
+
+    [GeneratedRegex(@"(?m)(^\|[^\n]*\|[^\n]*\n)(?!\n|\||```)")]
+    private static partial Regex BlankLineAfterTableRegex();
+
+    [GeneratedRegex(@"(?m)(^(?:\*\s|\d+\.\s)[^\n]*\n)(?!\n|\*\s|\d+\.\s|```)")]
+    private static partial Regex BlankLineAfterListRegex();
 
     /// <summary>
     /// Pre-indexed document with lowercase text for faster searching.

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -523,7 +523,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         return score;
     }
 
-    private static string NormalizeContent(string content)
+    internal static string NormalizeContent(string content)
     {
         if (string.IsNullOrWhiteSpace(content))
         {

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -523,6 +523,12 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         return score;
     }
 
+    /// <summary>
+    /// Normalizes markdown content from llms.txt sources.
+    /// The llms.txt format strips most whitespace from markdown, collapsing headings,
+    /// lists, tables, and code blocks onto fewer lines. This method re-introduces
+    /// the blank lines and line breaks needed so the text parses as valid markdown.
+    /// </summary>
     internal static string NormalizeContent(string content)
     {
         if (string.IsNullOrWhiteSpace(content))

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -370,7 +370,7 @@ internal class ConsoleInteractionService : IInteractionService
         target.Profile.Out.Writer.WriteLine(text);
     }
 
-    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null)
+    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null)
     {
         var effectiveConsole = consoleOverride ?? Console;
         if (ShouldDisplayMarkdownAsPlainText(effectiveConsole))
@@ -381,9 +381,25 @@ internal class ConsoleInteractionService : IInteractionService
         }
 
         var target = effectiveConsole == ConsoleOutput.Error ? _errorConsole : _outConsole;
-        var renderable = MarkdownToSpectreConverter.ConvertToRenderable(markdown);
-        target.Write(renderable);
-        target.WriteLine();
+        var originalWidth = target.Profile.Width;
+        if (maxWidth is not null)
+        {
+            target.Profile.Width = Math.Min(originalWidth, maxWidth.Value);
+        }
+
+        try
+        {
+            var renderable = MarkdownToSpectreConverter.ConvertToRenderable(markdown);
+            target.Write(renderable);
+            target.WriteLine();
+        }
+        finally
+        {
+            if (maxWidth is not null)
+            {
+                target.Profile.Width = originalWidth;
+            }
+        }
     }
 
     private bool ShouldDisplayMarkdownAsPlainText(ConsoleOutput effectiveConsole)

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -431,7 +431,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         // Convert to Spectre markup for console display
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, markdown, _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayMarkdown(markdown, consoleOverride);
+        _consoleInteractionService.DisplayMarkdown(markdown, consoleOverride, maxWidth);
     }
 
     public void DisplayMarkupLine(string markup)

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -425,7 +425,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayRawText(text, consoleOverride);
     }
 
-    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null)
+    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null)
     {
         // Send raw markdown to extension (it can handle markdown natively)
         // Convert to Spectre markup for console display

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -22,7 +22,7 @@ internal interface IInteractionService
     void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false);
     void DisplayPlainText(string text);
     void DisplayRawText(string text, ConsoleOutput? consoleOverride = null);
-    void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null);
+    void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null);
     void DisplayMarkupLine(string markup);
     void DisplaySuccess(string message, bool allowMarkup = false);
     void DisplaySubtleMessage(string message, bool allowMarkup = false);

--- a/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.Markup.cs
+++ b/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.Markup.cs
@@ -245,6 +245,10 @@ internal partial class MarkdownToSpectreConverter
         {
             case ParagraphBlock paragraph:
                 AppendInlinesToMarkup(builder, paragraph.Inline, markdown);
+                while (builder.Length > start && builder[builder.Length - 1] == '\n')
+                {
+                    builder.Length--;
+                }
                 break;
             case HtmlBlock htmlBlock:
                 AppendEscapedMarkup(builder, StripHtmlTags(GetOriginalMarkdownSpan(htmlBlock.Span, markdown)).AsSpan());

--- a/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
@@ -233,49 +233,6 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void WrapMarkdownForConsole_PreservesMarkdownStructure()
-    {
-        var markdown = """
-            # Certificate configuration
-
-            > Learn how to configure HTTPS endpoints with the [Aspire CLI](https://aspire.dev/get-started/install-cli/) and `aspire run`.
-
-            ### Using the Aspire CLI (recommended)
-
-            * First item with [a link](https://example.com/docs)
-            * Second item
-
-            ```bash
-            aspire docs get certificate-configuration
-            ```
-            """;
-
-        var wrapped = Aspire.Cli.Commands.DocsGetCommand.WrapMarkdownForConsole(markdown, width: 60);
-
-        Assert.Contains("# Certificate configuration", wrapped);
-        Assert.Contains("\n\n### Using the Aspire CLI (recommended)\n\n", wrapped);
-        Assert.Contains("[Aspire CLI](https://aspire.dev/get-started/install-cli/)", wrapped);
-        Assert.Contains("`aspire run`", wrapped);
-        Assert.Contains("```bash\naspire docs get certificate-configuration\n```", wrapped.Replace("\r\n", "\n"));
-    }
-
-    [Fact]
-    public void WrapMarkdownForConsole_DoesNotWrapTableRows()
-    {
-        var markdown = """
-            | Setting | Environment variable | Purpose |
-            | ---------------------- | ----------------------- | ---------------------------------------------- |
-            | `Azure:SubscriptionId` | `Azure__SubscriptionId` | Target Azure subscription |
-            """;
-
-        var wrapped = Aspire.Cli.Commands.DocsGetCommand.WrapMarkdownForConsole(markdown, width: 40);
-
-        Assert.Contains("| Setting | Environment variable | Purpose |", wrapped);
-        Assert.Contains("| ---------------------- | ----------------------- | ---------------------------------------------- |", wrapped);
-        Assert.Contains("| `Azure:SubscriptionId` | `Azure__SubscriptionId` | Target Azure subscription |", wrapped);
-    }
-
-    [Fact]
     public async Task DocsGetCommand_WithInvalidSlug_ReturnsError()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
@@ -222,14 +222,14 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("Azure__SubscriptionId", output);
         Assert.Contains("Target Azure subscription", output);
 
-        var headingIndex = FindLogIndex(outputWriter.Logs, "Docs Smoke Test");
-        var listIndex = FindLogIndex(outputWriter.Logs, "1. First item");
-        var codeIndex = FindLogIndex(outputWriter.Logs, "aspire docs get docs-smoke-test");
-        var tableIndex = FindLogIndex(outputWriter.Logs, "Azure:SubscriptionId");
+        var headingPos = output.IndexOf("Docs Smoke Test", StringComparison.Ordinal);
+        var listPos = output.IndexOf("1. First item", StringComparison.Ordinal);
+        var codePos = output.IndexOf("aspire docs get docs-smoke-test", StringComparison.Ordinal);
+        var tablePos = output.IndexOf("Azure:SubscriptionId", StringComparison.Ordinal);
 
-        Assert.True(headingIndex < listIndex);
-        Assert.True(listIndex < codeIndex);
-        Assert.True(codeIndex < tableIndex);
+        Assert.True(headingPos < listPos);
+        Assert.True(listPos < codePos);
+        Assert.True(codePos < tablePos);
     }
 
     [Fact]
@@ -247,23 +247,6 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.NotEqual(0, exitCode);
-    }
-
-    private static int FindLogIndex(IReadOnlyList<string> logs, string text)
-    {
-        var index = -1;
-
-        for (var i = 0; i < logs.Count; i++)
-        {
-            if (logs[i].Contains(text, StringComparison.Ordinal))
-            {
-                index = i;
-                break;
-            }
-        }
-
-        Assert.True(index >= 0, $"Could not find '{text}' in output.");
-        return index;
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -962,7 +962,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
-    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null) { }
+    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null) { }
     public void DisplayMarkupLine(string markup) { }
 
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1199,7 +1199,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) => _innerService.DisplayMessage(emoji, message, allowMarkup);
     public void DisplayPlainText(string text) => _innerService.DisplayPlainText(text);
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) => _innerService.DisplayRawText(text, consoleOverride);
-    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null) => _innerService.DisplayMarkdown(markdown, consoleOverride);
+    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null) => _innerService.DisplayMarkdown(markdown, consoleOverride, maxWidth);
     public void DisplayMarkupLine(string markup) => _innerService.DisplayMarkupLine(markup);
     public void DisplaySuccess(string message, bool allowMarkup = false) => _innerService.DisplaySuccess(message, allowMarkup);
     public void DisplaySubtleMessage(string message, bool allowMarkup = false) => _innerService.DisplaySubtleMessage(message, allowMarkup);

--- a/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
@@ -1189,6 +1189,206 @@ public class DocsIndexServiceTests
         }
     }
 
+    [Fact]
+    public void NormalizeContent_WithEmptyString_ReturnsEmpty()
+    {
+        var result = DocsIndexService.NormalizeContent("");
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void NormalizeContent_WithWhitespaceOnly_ReturnsWhitespace()
+    {
+        var result = DocsIndexService.NormalizeContent("   ");
+        Assert.Equal("   ", result);
+    }
+
+    [Fact]
+    public void NormalizeContent_NormalizesLineEndings()
+    {
+        var result = DocsIndexService.NormalizeContent("line1\r\nline2\rline3\nline4");
+        Assert.Equal("""
+            line1
+            line2
+            line3
+            line4
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_SplitsInlineHeadings()
+    {
+        var result = DocsIndexService.NormalizeContent("Some text ## Heading");
+        Assert.Equal("""
+            Some text
+
+            ## Heading
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_RemovesSectionTitledBookmarks()
+    {
+        var result = DocsIndexService.NormalizeContent("Before [Section titled Overview](#overview) After");
+        Assert.Equal("""
+            Before
+
+            After
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_SplitsInlineOrderedLists()
+    {
+        var result = DocsIndexService.NormalizeContent("Some text 1. First item");
+        Assert.Equal("""
+            Some text
+            1. First item
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_SplitsInlineUnorderedLists()
+    {
+        var result = DocsIndexService.NormalizeContent("Some text * List item");
+        Assert.Equal("""
+            Some text
+            * List item
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_CollapsesExcessBlankLines()
+    {
+        var result = DocsIndexService.NormalizeContent("""
+            Paragraph 1
+
+
+
+
+            Paragraph 2
+            """);
+        Assert.Equal("""
+            Paragraph 1
+
+            Paragraph 2
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_StripsTrailingWhitespaceBeforeNewlines()
+    {
+        var result = DocsIndexService.NormalizeContent("line1   \nline2\t\nline3");
+        Assert.Equal("""
+            line1
+            line2
+            line3
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_StripsLeadingWhitespace()
+    {
+        var result = DocsIndexService.NormalizeContent("""
+              indented line
+                more indented
+            """);
+        Assert.Equal("""
+            indented line
+            more indented
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_PreservesCodeBlockContent()
+    {
+        var input = """
+            Before
+            ```csharp
+              var x = 1;
+              var y = 2;
+            ```
+            After
+            """;
+        var result = DocsIndexService.NormalizeContent(input);
+        Assert.Equal("""
+            Before
+
+            ```csharp
+              var x = 1;
+              var y = 2;
+            ```
+
+            After
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_ExpandsInlineCodeBlocks()
+    {
+        var result = DocsIndexService.NormalizeContent("""Text ```csharp Console.WriteLine("hello");``` more""");
+        Assert.Equal("""
+            Text
+            ```csharp
+            Console.WriteLine("hello");
+            ```
+            more
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_SplitsInlineTables()
+    {
+        var result = DocsIndexService.NormalizeContent("Text |Col1|Col2|Col3| |---|---|---| |A|B|C|");
+        Assert.Equal("""
+            Text
+            |Col1|Col2|Col3|
+            |---|---|---|
+            |A|B|C|
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_TrimsResult()
+    {
+        var result = DocsIndexService.NormalizeContent("\n\n  Hello world  \n\n");
+        Assert.Equal("Hello world", result);
+    }
+
+    [Fact]
+    public void NormalizeContent_HandlesComplexDocument()
+    {
+        var input = """
+            # Title
+            Some intro text ## Configuration
+            Use `aspire run`. 1. Step one 2. Step two
+
+
+
+            ```bash
+            aspire run
+            ```
+            Done.
+            """;
+        var result = DocsIndexService.NormalizeContent(input);
+
+        Assert.Equal("""
+            # Title
+            Some intro text
+
+            ## Configuration
+            Use `aspire run`.
+            1. Step one
+            2. Step two
+
+            ```bash
+            aspire run
+            ```
+
+            Done.
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
     private sealed class DelayingDocsFetcher(string? content, TimeSpan delay) : IDocsFetcher
     {
         public async Task<string?> FetchDocsAsync(CancellationToken cancellationToken = default)

--- a/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
@@ -1218,11 +1218,13 @@ public class DocsIndexServiceTests
     [Fact]
     public void NormalizeContent_SplitsInlineHeadings()
     {
-        var result = DocsIndexService.NormalizeContent("Some text ## Heading");
+        var result = DocsIndexService.NormalizeContent("Some text ## Heading\nMore text");
         Assert.Equal("""
             Some text
 
             ## Heading
+
+            More text
             """, result, ignoreLineEndingDifferences: true);
     }
 
@@ -1374,9 +1376,11 @@ public class DocsIndexServiceTests
 
         Assert.Equal("""
             # Title
+
             Some intro text
 
             ## Configuration
+
             Use `aspire run`.
             1. Step one
             2. Step two
@@ -1385,6 +1389,79 @@ public class DocsIndexServiceTests
             aspire run
             ```
 
+            Done.
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_AddsBlankLineAfterTable()
+    {
+        var result = DocsIndexService.NormalizeContent("Header text |Col1|Col2| |---|---| |A|B| Footer text");
+        Assert.Equal("""
+            Header text
+            |Col1|Col2|
+            |---|---|
+            |A|B|
+
+            Footer text
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_AddsBlankLineAfterList()
+    {
+        var result = DocsIndexService.NormalizeContent("Intro text 1. First 2. Second\nFollowing paragraph");
+        Assert.Equal("""
+            Intro text
+            1. First
+            2. Second
+
+            Following paragraph
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_AddsBlankLineAfterUnorderedList()
+    {
+        var result = DocsIndexService.NormalizeContent("Intro text * Item one * Item two\nFollowing paragraph");
+        Assert.Equal("""
+            Intro text
+            * Item one
+            * Item two
+
+            Following paragraph
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_AddsBlankLineOnlyAfterRootList()
+    {
+        var result = DocsIndexService.NormalizeContent("Intro 1. First * Sub A * Sub B 2. Second\nFollowing paragraph");
+        Assert.Equal("""
+            Intro
+            1. First
+            * Sub A
+            * Sub B
+            2. Second
+
+            Following paragraph
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void NormalizeContent_NoBlankLineAfterListBeforeCodeBlock()
+    {
+        var result = DocsIndexService.NormalizeContent("Intro * Bash ```bash echo hello``` * PowerShell ```powershell Write-Host hello``` Done.");
+        Assert.Equal("""
+            Intro
+            * Bash
+            ```bash
+            echo hello
+            ```
+            * PowerShell
+            ```powershell
+            Write-Host hello
+            ```
             Done.
             """, result, ignoreLineEndingDifferences: true);
     }

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -173,7 +173,7 @@ public class ExtensionGuestLauncherTests
         public void DisplayEmptyLine() => throw new NotImplementedException();
         public void DisplayPlainText(string text) => throw new NotImplementedException();
         public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) => throw new NotImplementedException();
-        public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null) => throw new NotImplementedException();
+        public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null) => throw new NotImplementedException();
         public void DisplayMarkupLine(string markup) => throw new NotImplementedException();
         public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) => throw new NotImplementedException();
         public void DisplayRenderable(Spectre.Console.Rendering.IRenderable renderable) => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -447,7 +447,7 @@ public class DotNetTemplateFactoryTests
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
         public void DisplayPlainText(string text) { }
         public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
-        public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null) { }
+        public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null) { }
         public void DisplayMarkupLine(string markup) { }
         public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
         public void DisplayEmptyLine() { }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -143,7 +143,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     {
     }
 
-    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null)
+    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -243,7 +243,7 @@ internal sealed class TestInteractionService : IInteractionService
         DisplayRawTextCallback?.Invoke(text);
     }
 
-    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null)
+    public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
@@ -721,7 +721,8 @@ Some ~~strikethrough~~ text with ```inline code block```.
         {
             Ansi = AnsiSupport.No,
             ColorSystem = ColorSystemSupport.NoColors,
-            Out = new AnsiConsoleOutput(writer)
+            Out = new AnsiConsoleOutput(writer),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
         });
 
         console.Profile.Width = int.MaxValue;
@@ -782,5 +783,36 @@ npm install[/]
 
 [italic grey]> That's all![/]".Replace("\r\n", "\n").Replace("\r", "\n");
         Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ConvertToRenderable_WithParagraphBeforeTable_HasSingleBlankLineBetween()
+    {
+        var markdown = """
+            ## API
+
+            The API section configures authentication.
+            | Option | Description |
+            | ------ | ----------- |
+            | `AuthMode` | Can be set to `ApiKey` or `Unsecured`. |
+            """;
+
+        var output = RenderToPlainConsole(MarkdownToSpectreConverter.ConvertToRenderable(markdown));
+
+        var expected = """
+            API
+
+            The API section configures authentication.
+
+            ┌──────────┬────────────────────────────────────┐
+            │ Option   │ Description                        │
+            ├──────────┼────────────────────────────────────┤
+            │ AuthMode │ Can be set to ApiKey or Unsecured. │
+            └──────────┴────────────────────────────────────┘
+
+
+            """;
+
+        Assert.Equal(expected, output, ignoreLineEndingDifferences: true);
     }
 }


### PR DESCRIPTION
## Description

Improve how the CLI renders documentation markdown fetched from aspire.dev.

### Changes

**Simplify `DocsGetCommand`**: Replace the manual `WrapMarkdownForConsole` / `SplitMarkdownBlocks` logic with a single `DisplayMarkdown` call using `maxWidth: 100`. The old code manually word-wrapped, split blocks, and re-assembled markdown — all of which is now handled by the markdown converter and Spectre.Console.

**Add `maxWidth` parameter to `DisplayMarkdown`**: The `IInteractionService.DisplayMarkdown` method now accepts an optional `maxWidth` parameter so callers can cap the rendering width (e.g., for wide tables in docs or resource commands).

**Fix paragraph trailing newline in `MarkdownToSpectreConverter`**: Trim trailing `\n` from paragraph blocks so that a paragraph followed by a table produces exactly one blank line instead of two when rendered via `ConvertToRenderable`.

**Improve `NormalizeContent` in `DocsIndexService`**: The llms.txt format strips most whitespace from markdown. Added regex passes to insert blank lines after headings, tables, and list items so the content parses as valid markdown. Made the method `internal` for testability and added xmldoc explaining its purpose.

**Resource command markdown**: Set `maxWidth: 100` when displaying markdown from resource command results.

**Cleanup**: Removed a leftover `Debugger.Launch()` call from `DocsGetCommand`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
