### PR TITLE
feat(ci): add test failure retry support to auto-rerun workflow

### DIFF
--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -728,6 +728,11 @@ async function getLatestRunAttempt({ github, owner, repo, runId }) {
     }
 }
 
+function sanitizeMarkdown(text) {
+    // Escape backticks and pipe characters to prevent markdown injection
+    return String(text).replace(/[`|]/g, ch => `\\${ch}`);
+}
+
 function buildPullRequestCommentBody({
     failedAttemptUrl,
     rerunAttemptUrl,
@@ -754,7 +759,7 @@ function buildPullRequestCommentBody({
             '',
             `<details><summary>Matched test failure patterns (${testPatternMatchedTests.length} test${testPatternMatchedTests.length === 1 ? '' : 's'})</summary>`,
             '',
-            ...displayedTests.map(test => `- \`${test.testName}\` — ${test.reason}`),
+            ...displayedTests.map(test => `- \`${sanitizeMarkdown(test.testName)}\` — ${test.reason}`),
         );
 
         if (testPatternMatchedTests.length > 10) {
@@ -1205,9 +1210,9 @@ function decodeXmlEntities(text) {
     return text
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
-        .replace(/&amp;/g, '&')
         .replace(/&quot;/g, '"')
-        .replace(/&apos;/g, "'");
+        .replace(/&apos;/g, "'")
+        .replace(/&amp;/g, '&');
 }
 
 function analyzeTrxFiles(trxFileContents, testFailurePatterns) {

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -909,11 +909,37 @@ function loadRetryPatternsConfig(configPath) {
             return { config: null, errors: validation.errors };
         }
 
-        return { config, errors: [] };
+        const warnings = compileRetryPatterns(config);
+
+        return { config, errors: [], warnings };
     }
     catch (error) {
         return { config: null, errors: [`Failed to load config: ${error.message}`] };
     }
+}
+
+function compileRetryPatterns(config) {
+    const warnings = [];
+    const allRules = [
+        ...(config.testFailurePatterns || []),
+        ...(config.jobFailurePatterns || []),
+    ];
+
+    for (const rule of allRules) {
+        for (const value of Object.values(rule)) {
+            if (value && typeof value === 'object' && typeof value.regex === 'string') {
+                try {
+                    value._compiledRegex = new RegExp(value.regex, 'i');
+                }
+                catch (error) {
+                    warnings.push(`Invalid regex '${value.regex}': ${error.message} — rule will be skipped.`);
+                    rule.enabled = false;
+                }
+            }
+        }
+    }
+
+    return warnings;
 }
 
 function validateRetryPatternsConfig(config) {
@@ -1040,12 +1066,18 @@ function matchesRetryPattern(text, patternValue) {
         return text.toLowerCase().includes(patternValue.toLowerCase());
     }
 
-    if (patternValue && typeof patternValue === 'object' && typeof patternValue.regex === 'string') {
-        try {
-            return new RegExp(patternValue.regex, 'i').test(text);
+    if (patternValue && typeof patternValue === 'object') {
+        if (patternValue._compiledRegex) {
+            return patternValue._compiledRegex.test(text);
         }
-        catch {
-            return false;
+
+        if (typeof patternValue.regex === 'string') {
+            try {
+                return new RegExp(patternValue.regex, 'i').test(text);
+            }
+            catch {
+                return false;
+            }
         }
     }
 
@@ -1298,6 +1330,7 @@ module.exports = {
     annotationText,
     buildPullRequestCommentBody,
     classifyFailedJob,
+    compileRetryPatterns,
     computeRerunEligibility,
     computeRerunExecutionEligibility,
     decodeXmlEntities,

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -1,4 +1,6 @@
 // Shared matcher, summary, and rerun helpers for the transient CI rerun workflow.
+const fs = require('node:fs');
+
 const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure']);
 const ignoredJobs = new Set(['Final Results', 'Tests / Final Test Results']);
 const defaultMaxRetryableJobs = 5;
@@ -826,6 +828,326 @@ async function rerunMatchedJobs({
     await summaryBuilder.write();
 }
 
+// --- Test failure retry pattern matching ---
+
+const maxTestOutputLength = 10 * 1024; // 10KB cap for test output to prevent ReDoS
+
+function loadRetryPatternsConfig(configPath) {
+    try {
+        const content = fs.readFileSync(configPath, 'utf8');
+        const config = JSON.parse(content);
+        const validation = validateRetryPatternsConfig(config);
+
+        if (!validation.valid) {
+            return { config: null, errors: validation.errors };
+        }
+
+        return { config, errors: [] };
+    }
+    catch (error) {
+        return { config: null, errors: [`Failed to load config: ${error.message}`] };
+    }
+}
+
+function validateRetryPatternsConfig(config) {
+    const errors = [];
+
+    if (!config || typeof config !== 'object' || Array.isArray(config)) {
+        errors.push('Config must be a non-null object.');
+        return { valid: false, errors };
+    }
+
+    const allowedTopLevel = new Set(['version', 'testFailurePatterns', 'jobFailurePatterns']);
+    for (const key of Object.keys(config)) {
+        if (!allowedTopLevel.has(key)) {
+            errors.push(`Unknown top-level property '${key}'.`);
+        }
+    }
+
+    if (config.version !== 1) {
+        errors.push(`Expected version 1, got ${JSON.stringify(config.version)}.`);
+    }
+
+    const testPatternAllowedFields = new Set(['testName', 'testProject', 'output', 'reason', 'enabled']);
+    const jobPatternAllowedFields = new Set(['jobName', 'output', 'reason', 'enabled']);
+    const testPatternMatcherFields = ['testName', 'testProject', 'output'];
+    const jobPatternMatcherFields = ['jobName', 'output'];
+
+    if (config.testFailurePatterns !== undefined) {
+        if (!Array.isArray(config.testFailurePatterns)) {
+            errors.push('testFailurePatterns must be an array.');
+        }
+        else {
+            config.testFailurePatterns.forEach((rule, i) => {
+                validatePatternRule(rule, `testFailurePatterns[${i}]`, testPatternAllowedFields, testPatternMatcherFields, errors);
+            });
+        }
+    }
+
+    if (config.jobFailurePatterns !== undefined) {
+        if (!Array.isArray(config.jobFailurePatterns)) {
+            errors.push('jobFailurePatterns must be an array.');
+        }
+        else {
+            config.jobFailurePatterns.forEach((rule, i) => {
+                validatePatternRule(rule, `jobFailurePatterns[${i}]`, jobPatternAllowedFields, jobPatternMatcherFields, errors);
+            });
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+function validatePatternRule(rule, path, allowedFields, matcherFields, errors) {
+    if (!rule || typeof rule !== 'object' || Array.isArray(rule)) {
+        errors.push(`${path}: must be a non-null object.`);
+        return;
+    }
+
+    for (const key of Object.keys(rule)) {
+        if (!allowedFields.has(key)) {
+            errors.push(`${path}: unknown field '${key}'.`);
+        }
+    }
+
+    if (typeof rule.reason !== 'string' || rule.reason.trim().length === 0) {
+        errors.push(`${path}: 'reason' must be a non-empty string.`);
+    }
+
+    if (rule.enabled !== undefined && typeof rule.enabled !== 'boolean') {
+        errors.push(`${path}: 'enabled' must be a boolean.`);
+    }
+
+    const hasMatcherField = matcherFields.some(field => rule[field] !== undefined);
+    if (!hasMatcherField) {
+        errors.push(`${path}: must contain at least one matcher field (${matcherFields.join(', ')}).`);
+    }
+
+    for (const field of matcherFields) {
+        if (rule[field] !== undefined) {
+            validatePatternValue(rule[field], `${path}.${field}`, errors);
+        }
+    }
+}
+
+function validatePatternValue(value, path, errors) {
+    if (typeof value === 'string') {
+        if (value.length === 0) {
+            errors.push(`${path}: string pattern must be non-empty.`);
+        }
+        return;
+    }
+
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+        if (typeof value.regex !== 'string' || value.regex.length === 0) {
+            errors.push(`${path}: regex pattern must have a non-empty 'regex' string.`);
+            return;
+        }
+
+        const allowedRegexKeys = new Set(['regex']);
+        for (const key of Object.keys(value)) {
+            if (!allowedRegexKeys.has(key)) {
+                errors.push(`${path}: unknown regex property '${key}'.`);
+            }
+        }
+
+        try {
+            new RegExp(value.regex, 'i');
+        }
+        catch (regexError) {
+            errors.push(`${path}: invalid regex '${value.regex}': ${regexError.message}`);
+        }
+
+        return;
+    }
+
+    errors.push(`${path}: must be a string or { "regex": "..." } object.`);
+}
+
+function matchesRetryPattern(text, patternValue) {
+    if (!text || !patternValue) {
+        return false;
+    }
+
+    if (typeof patternValue === 'string') {
+        return text.toLowerCase().includes(patternValue.toLowerCase());
+    }
+
+    if (patternValue && typeof patternValue === 'object' && typeof patternValue.regex === 'string') {
+        try {
+            return new RegExp(patternValue.regex, 'i').test(text);
+        }
+        catch {
+            return false;
+        }
+    }
+
+    return false;
+}
+
+function isPatternEnabled(rule) {
+    return rule.enabled !== false;
+}
+
+function matchTestFailurePatterns(failedTests, testProject, patterns) {
+    if (!Array.isArray(failedTests) || failedTests.length === 0 || !Array.isArray(patterns) || patterns.length === 0) {
+        return { shouldRetry: false, matchedTests: [] };
+    }
+
+    const enabledPatterns = patterns.filter(isPatternEnabled);
+    if (enabledPatterns.length === 0) {
+        return { shouldRetry: false, matchedTests: [] };
+    }
+
+    const matchedTests = [];
+
+    for (const test of failedTests) {
+        for (const pattern of enabledPatterns) {
+            if (matchesSingleTestPattern(test, testProject, pattern)) {
+                const matchedSnippet = extractMatchedSnippet(test.output, pattern.output);
+                matchedTests.push({
+                    testName: test.testName,
+                    reason: pattern.reason,
+                    matchedSnippet,
+                });
+                break; // first matching rule wins per test
+            }
+        }
+    }
+
+    return { shouldRetry: matchedTests.length > 0, matchedTests };
+}
+
+function matchesSingleTestPattern(test, testProject, pattern) {
+    if (pattern.testName !== undefined && !matchesRetryPattern(test.testName, pattern.testName)) {
+        return false;
+    }
+
+    if (pattern.testProject !== undefined && !matchesRetryPattern(testProject, pattern.testProject)) {
+        return false;
+    }
+
+    if (pattern.output !== undefined && !matchesRetryPattern(test.output, pattern.output)) {
+        return false;
+    }
+
+    return true;
+}
+
+function extractMatchedSnippet(output, patternOutput) {
+    if (!output || !patternOutput) {
+        return '';
+    }
+
+    const maxSnippetLength = 200;
+    const searchTerm = typeof patternOutput === 'string' ? patternOutput : null;
+
+    if (searchTerm) {
+        const lowerOutput = output.toLowerCase();
+        const lowerSearch = searchTerm.toLowerCase();
+        const index = lowerOutput.indexOf(lowerSearch);
+
+        if (index >= 0) {
+            const start = Math.max(0, index - 40);
+            const end = Math.min(output.length, index + searchTerm.length + 40);
+            let snippet = output.slice(start, end);
+
+            if (start > 0) {
+                snippet = '...' + snippet;
+            }
+
+            if (end < output.length) {
+                snippet = snippet + '...';
+            }
+
+            return snippet.length > maxSnippetLength
+                ? snippet.slice(0, maxSnippetLength - 3) + '...'
+                : snippet;
+        }
+    }
+
+    return output.length > maxSnippetLength
+        ? output.slice(0, maxSnippetLength - 3) + '...'
+        : output;
+}
+
+function matchJobLogPattern(jobName, jobLogText, patterns) {
+    if (!Array.isArray(patterns) || patterns.length === 0) {
+        return null;
+    }
+
+    const enabledPatterns = patterns.filter(isPatternEnabled);
+
+    for (const pattern of enabledPatterns) {
+        if (pattern.jobName !== undefined && !matchesRetryPattern(jobName, pattern.jobName)) {
+            continue;
+        }
+
+        if (pattern.output !== undefined && !matchesRetryPattern(jobLogText, pattern.output)) {
+            continue;
+        }
+
+        return { matched: true, reason: pattern.reason };
+    }
+
+    return null;
+}
+
+function extractFailedTestsFromTrx(trxContent) {
+    if (!trxContent || typeof trxContent !== 'string') {
+        return [];
+    }
+
+    const failedTests = [];
+
+    // Match UnitTestResult elements with outcome="Failed" (handles attribute order variation)
+    const resultRegex = /<UnitTestResult\b[^>]*\boutcome\s*=\s*"Failed"[^>]*>[\s\S]*?<\/UnitTestResult>/gi;
+    let resultMatch;
+
+    while ((resultMatch = resultRegex.exec(trxContent)) !== null) {
+        const block = resultMatch[0];
+        const testNameMatch = block.match(/\btestName\s*=\s*"([^"]*)"/i);
+
+        if (!testNameMatch) {
+            continue;
+        }
+
+        const testName = decodeXmlEntities(testNameMatch[1]);
+        const message = extractXmlElementContent(block, 'Message');
+        const stackTrace = extractXmlElementContent(block, 'StackTrace');
+        const stdOut = extractXmlElementContent(block, 'StdOut');
+
+        let output = [message, stackTrace, stdOut].filter(Boolean).join('\n');
+
+        if (output.length > maxTestOutputLength) {
+            output = output.slice(0, maxTestOutputLength);
+        }
+
+        failedTests.push({ testName, output });
+    }
+
+    return failedTests;
+}
+
+function extractXmlElementContent(xml, elementName) {
+    const regex = new RegExp(`<${elementName}>([\\s\\S]*?)</${elementName}>`, 'i');
+    const match = xml.match(regex);
+    return match ? decodeXmlEntities(match[1].trim()) : '';
+}
+
+function decodeXmlEntities(text) {
+    if (!text) {
+        return '';
+    }
+
+    return text
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&amp;/g, '&')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'");
+}
+
 module.exports = {
     addPullRequestComments,
     analyzeFailedJobs,
@@ -834,7 +1156,10 @@ module.exports = {
     classifyFailedJob,
     computeRerunEligibility,
     computeRerunExecutionEligibility,
+    decodeXmlEntities,
     defaultMaxRetryableJobs,
+    extractFailedTestsFromTrx,
+    extractMatchedSnippet,
     formatMatchedPatternForMarkdown,
     findInfrastructureNetworkLogOverridePattern,
     getAssociatedPullRequestNumbers,
@@ -842,6 +1167,12 @@ module.exports = {
     getOpenPullRequestNumbers,
     getLatestRunAttempt,
     listPullRequestsByHead,
+    loadRetryPatternsConfig,
+    matchesRetryPattern,
+    matchJobLogPattern,
+    matchTestFailurePatterns,
     rerunMatchedJobs,
+    testExecutionFailureStepPatterns,
+    validateRetryPatternsConfig,
     writeAnalysisSummary,
 };

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -261,6 +261,10 @@ function canUseInfrastructureNetworkLogOverride(failedSteps) {
     return failedSteps.length > 0 && !failedSteps.some(step => matchesAny(step, testExecutionFailureStepPatterns));
 }
 
+function hasTestExecutionFailureStep(failedSteps) {
+    return failedSteps.some(step => matchesAny(step, testExecutionFailureStepPatterns));
+}
+
 function formatFailedStepLabel(failedSteps, failedStepText) {
     const label = failedSteps.length === 1 ? 'Failed step' : 'Failed steps';
     return `${label} '${failedStepText}'`;
@@ -430,6 +434,7 @@ async function analyzeFailedJobs({
     getAnnotationsForJob,
     getJobLogTextForJob,
     maxRetryableJobs = defaultMaxRetryableJobs,
+    retryPatternsConfig = null,
 }) {
     const normalizedMaxRetryableJobs =
         Number.isInteger(maxRetryableJobs) && maxRetryableJobs >= 0
@@ -438,6 +443,7 @@ async function analyzeFailedJobs({
     const failedJobs = (jobs || []).filter(job => failureConclusions.has(job.conclusion) && !ignoredJobs.has(job.name));
     const retryableJobs = [];
     const skippedJobs = [];
+    const jobFailurePatterns = retryPatternsConfig?.jobFailurePatterns;
 
     for (const job of failedJobs) {
         const failedSteps = getFailedSteps(job);
@@ -466,6 +472,27 @@ async function analyzeFailedJobs({
                 jobLogText,
                 { matchedInfrastructureNetworkLogOverridePattern }
             );
+        }
+
+        // Third classification pass: configurable job log patterns for test execution failures
+        if (
+            !classification.retryable &&
+            getJobLogTextForJob &&
+            Array.isArray(jobFailurePatterns) &&
+            jobFailurePatterns.length > 0 &&
+            hasTestExecutionFailureStep(failedSteps)
+        ) {
+            const jobLogText = await getJobLogTextForJob(job);
+            const match = matchJobLogPattern(job.name, jobLogText, jobFailurePatterns);
+
+            if (match) {
+                const failedStepText = failedSteps.join(' | ');
+                classification = {
+                    retryable: true,
+                    failedSteps,
+                    reason: `${formatFailedStepLabel(failedSteps, failedStepText)} will be retried because the job log matched a configurable test-retry pattern: ${match.reason}`,
+                };
+            }
         }
 
         const jobResult = {
@@ -566,6 +593,7 @@ async function writeAnalysisSummary({
     rerunEligible,
     sourceRunUrl,
     sourceRunAttempt,
+    testPatternMatchedTests = [],
 }) {
     const analyzedRunReference = buildSummaryReference(
         buildWorkflowRunAttemptUrl(sourceRunUrl, sourceRunAttempt),
@@ -609,6 +637,19 @@ async function writeAnalysisSummary({
             [{ data: 'Job', header: true }, { data: 'Reason', header: true }],
             ...retryableJobs.map(job => [job.name, job.reason]),
         ]);
+    }
+
+    if (testPatternMatchedTests.length > 0) {
+        await summary.addHeading('Matched test failure patterns', 2);
+        const displayedTests = testPatternMatchedTests.slice(0, 25);
+        await summary.addTable([
+            [{ data: 'Test', header: true }, { data: 'Reason', header: true }],
+            ...displayedTests.map(test => [test.testName, test.reason]),
+        ]);
+
+        if (testPatternMatchedTests.length > 25) {
+            summary.addRaw(`...and ${testPatternMatchedTests.length - 25} more matched test(s).`).addBreak();
+        }
     }
 
     if (skippedJobs.length > 0) {
@@ -691,8 +732,9 @@ function buildPullRequestCommentBody({
     failedAttemptUrl,
     rerunAttemptUrl,
     retryableJobs,
+    testPatternMatchedTests = [],
 }) {
-    return [
+    const lines = [
         `Re-running the failed jobs in the CI workflow for this pull request because ${retryableJobs.length} job${retryableJobs.length === 1 ? ' was' : 's were'} identified as retry-safe transient failures in ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)}.`,
         `GitHub was asked to rerun all failed jobs for that attempt, and the rerun is being tracked in ${formatMarkdownLink('the rerun attempt', rerunAttemptUrl)}.`,
         'The job links below point to the failed attempt jobs that matched the retry-safe transient failure rules.',
@@ -704,7 +746,25 @@ function buildPullRequestCommentBody({
 
             return `- ${jobReference} - ${job.reason}`;
         }),
-    ].join('\n');
+    ];
+
+    if (testPatternMatchedTests.length > 0) {
+        const displayedTests = testPatternMatchedTests.slice(0, 10);
+        lines.push(
+            '',
+            `<details><summary>Matched test failure patterns (${testPatternMatchedTests.length} test${testPatternMatchedTests.length === 1 ? '' : 's'})</summary>`,
+            '',
+            ...displayedTests.map(test => `- \`${test.testName}\` — ${test.reason}`),
+        );
+
+        if (testPatternMatchedTests.length > 10) {
+            lines.push(`- ...and ${testPatternMatchedTests.length - 10} more`);
+        }
+
+        lines.push('', '</details>');
+    }
+
+    return lines.join('\n');
 }
 
 async function addPullRequestComments({ github, owner, repo, pullRequestNumbers, body }) {
@@ -737,6 +797,7 @@ async function rerunMatchedJobs({
     sourceRunId,
     sourceRunUrl,
     sourceRunAttempt,
+    testPatternMatchedTests = [],
 }) {
     if (retryableJobs.length === 0) {
         return;
@@ -803,6 +864,7 @@ async function rerunMatchedJobs({
                 failedAttemptUrl: failedAttemptReference.url,
                 rerunAttemptUrl: rerunAttemptReference.url,
                 retryableJobs,
+                testPatternMatchedTests,
             }),
         });
     }
@@ -1148,9 +1210,86 @@ function decodeXmlEntities(text) {
         .replace(/&apos;/g, "'");
 }
 
+function analyzeTrxFiles(trxFileContents, testFailurePatterns) {
+    if (!Array.isArray(trxFileContents) || trxFileContents.length === 0 || !Array.isArray(testFailurePatterns) || testFailurePatterns.length === 0) {
+        return { allMatchedTests: [] };
+    }
+
+    const allMatchedTests = [];
+    const seenTestNames = new Set();
+
+    for (const { fileName, content } of trxFileContents) {
+        const failedTests = extractFailedTestsFromTrx(content);
+        const testProject = String(fileName || '').replace(/\.trx$/i, '');
+        const { matchedTests } = matchTestFailurePatterns(failedTests, testProject, testFailurePatterns);
+
+        for (const match of matchedTests) {
+            if (!seenTestNames.has(match.testName)) {
+                seenTestNames.add(match.testName);
+                allMatchedTests.push({ ...match, testProject });
+            }
+        }
+    }
+
+    return { allMatchedTests };
+}
+
+function promoteTestExecutionFailureJobs(retryableJobs, skippedJobs, allMatchedTests) {
+    if (!Array.isArray(allMatchedTests) || allMatchedTests.length === 0) {
+        return { retryableJobs, skippedJobs, promotedJobs: [] };
+    }
+
+    const matchSummary = [...new Set(allMatchedTests.map(m => m.reason))].join(', ');
+    const promotedJobs = [];
+    const remainingSkippedJobs = [];
+
+    for (const job of skippedJobs) {
+        if (hasTestExecutionFailureStep(job.failedSteps)) {
+            promotedJobs.push({
+                ...job,
+                reason: `Test execution failure will be retried because ${allMatchedTests.length} failed test(s) matched transient test failure patterns (${matchSummary}).`,
+                matchedTests: allMatchedTests,
+            });
+        }
+        else {
+            remainingSkippedJobs.push(job);
+        }
+    }
+
+    return {
+        retryableJobs: [...retryableJobs, ...promotedJobs],
+        skippedJobs: remainingSkippedJobs,
+        promotedJobs,
+    };
+}
+
+function selectTestResultsArtifact(artifacts) {
+    if (!Array.isArray(artifacts) || artifacts.length === 0) {
+        return null;
+    }
+
+    const maxArtifactBytes = 100 * 1024 * 1024; // 100MB cap
+    const candidates = artifacts
+        .filter(a => a.name === 'All-TestResults' && !a.expired)
+        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+    if (candidates.length === 0) {
+        return null;
+    }
+
+    const selected = candidates[0];
+
+    if (selected.size_in_bytes > maxArtifactBytes) {
+        return null;
+    }
+
+    return selected;
+}
+
 module.exports = {
     addPullRequestComments,
     analyzeFailedJobs,
+    analyzeTrxFiles,
     annotationText,
     buildPullRequestCommentBody,
     classifyFailedJob,
@@ -1166,12 +1305,15 @@ module.exports = {
     getCheckRunIdForJob,
     getOpenPullRequestNumbers,
     getLatestRunAttempt,
+    hasTestExecutionFailureStep,
     listPullRequestsByHead,
     loadRetryPatternsConfig,
     matchesRetryPattern,
     matchJobLogPattern,
     matchTestFailurePatterns,
+    promoteTestExecutionFailureJobs,
     rerunMatchedJobs,
+    selectTestResultsArtifact,
     testExecutionFailureStepPatterns,
     validateRetryPatternsConfig,
     writeAnalysisSummary,

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -283,9 +283,17 @@ jobs:
                     const trxFileContents = [];
                     const maxTrxFiles = 200;
                     const maxTrxFileBytes = 50 * 1024 * 1024; // 50MB per file cap
+                    const resolvedTrxDir = fs.realpathSync(trxDir);
                     const findTrxFiles = (dir) => {
                       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                        if (entry.isSymbolicLink()) {
+                          continue;
+                        }
                         const fullPath = path.join(dir, entry.name);
+                        const resolvedPath = fs.realpathSync(fullPath);
+                        if (!resolvedPath.startsWith(resolvedTrxDir + path.sep) && resolvedPath !== resolvedTrxDir) {
+                          continue;
+                        }
                         if (entry.isDirectory()) {
                           findTrxFiles(fullPath);
                         } else if (entry.name.endsWith('.trx') && trxFileContents.length < maxTrxFiles) {
@@ -342,10 +350,9 @@ jobs:
             });
             core.setOutput('rerun_eligible', String(rerunEligible));
             core.setOutput('rerun_execution_eligible', String(rerunExecutionEligible));
-            core.setOutput('test_pattern_matched_tests', JSON.stringify(testPatternMatchedTests.map(t => ({
+            core.setOutput('test_pattern_matched_tests', JSON.stringify(testPatternMatchedTests.slice(0, 50).map(t => ({
               testName: t.testName,
               reason: t.reason,
-              testProject: t.testProject || '',
             }))));
 
             await rerunWorkflow.writeAnalysisSummary({

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -53,6 +53,7 @@ jobs:
       rerun_execution_eligible: ${{ steps.analyze.outputs.rerun_execution_eligible }}
       dry_run: ${{ steps.analyze.outputs.dry_run }}
       max_retryable_jobs: ${{ steps.analyze.outputs.max_retryable_jobs }}
+      test_pattern_matched_tests: ${{ steps.analyze.outputs.test_pattern_matched_tests }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -67,6 +68,10 @@ jobs:
         with:
           script: |
             const rerunWorkflow = require('./.github/workflows/auto-rerun-transient-ci-failures.js');
+            const path = require('node:path');
+            const fs = require('node:fs');
+            const { execSync } = require('node:child_process');
+            const os = require('node:os');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const isWorkflowDispatch = context.eventName === 'workflow_dispatch';
@@ -203,6 +208,7 @@ jobs:
             core.setOutput('skipped_count', '0');
             core.setOutput('rerun_eligible', 'false');
             core.setOutput('rerun_execution_eligible', 'false');
+            core.setOutput('test_pattern_matched_tests', '[]');
 
             if (workflowRun.name && workflowRun.name !== 'CI') {
               console.log(`Workflow run ${workflowRun.id} is '${workflowRun.name}', not 'CI'. Skipping.`);
@@ -226,12 +232,93 @@ jobs:
             const runId = workflowRun.id;
             const runAttempt = workflowRun.run_attempt;
             const jobs = await listJobsForAttempt(runId, runAttempt);
-            const { failedJobs, retryableJobs, skippedJobs } = await rerunWorkflow.analyzeFailedJobs({
+
+            // Load test retry patterns config
+            const configPath = path.join(process.env.GITHUB_WORKSPACE, 'eng', 'test-retry-patterns.json');
+            const { config: retryPatternsConfig, errors: configErrors } = rerunWorkflow.loadRetryPatternsConfig(configPath);
+            if (configErrors.length > 0) {
+              core.warning(`Test retry patterns config has errors: ${configErrors.join('; ')}`);
+            }
+
+            let { failedJobs, retryableJobs, skippedJobs } = await rerunWorkflow.analyzeFailedJobs({
               jobs,
               getAnnotationsForJob: async job => listAnnotations(job),
               getJobLogTextForJob: async job => getJobLogText(job.id),
               maxRetryableJobs,
+              retryPatternsConfig,
             });
+
+            // TRX-based analysis: check test output for transient patterns
+            let testPatternMatchedTests = [];
+            const hasSkippedTestExecJobs = skippedJobs.some(job =>
+              rerunWorkflow.hasTestExecutionFailureStep(job.failedSteps)
+            );
+            const testFailurePatterns = retryPatternsConfig?.testFailurePatterns;
+
+            if (hasSkippedTestExecJobs && Array.isArray(testFailurePatterns) && testFailurePatterns.length > 0) {
+              try {
+                const artifacts = await paginate(
+                  'GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts',
+                  { owner, repo, run_id: runId },
+                  data => data.artifacts || []);
+                const testArtifact = rerunWorkflow.selectTestResultsArtifact(artifacts);
+
+                if (testArtifact) {
+                  console.log(`Downloading test results artifact '${testArtifact.name}' (${testArtifact.size_in_bytes} bytes)...`);
+                  const download = await github.rest.actions.downloadArtifact({
+                    owner,
+                    repo,
+                    artifact_id: testArtifact.id,
+                    archive_format: 'zip',
+                  });
+
+                  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-results-'));
+                  try {
+                    const zipPath = path.join(tmpDir, 'test-results.zip');
+                    fs.writeFileSync(zipPath, Buffer.from(download.data));
+                    const trxDir = path.join(tmpDir, 'trx');
+                    fs.mkdirSync(trxDir, { recursive: true });
+                    execSync(`unzip -qo "${zipPath}" -d "${trxDir}"`, { timeout: 30_000 });
+
+                    const trxFileContents = [];
+                    const maxTrxFiles = 200;
+                    const maxTrxFileBytes = 50 * 1024 * 1024; // 50MB per file cap
+                    const findTrxFiles = (dir) => {
+                      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                        const fullPath = path.join(dir, entry.name);
+                        if (entry.isDirectory()) {
+                          findTrxFiles(fullPath);
+                        } else if (entry.name.endsWith('.trx') && trxFileContents.length < maxTrxFiles) {
+                          const stat = fs.statSync(fullPath);
+                          if (stat.size <= maxTrxFileBytes) {
+                            trxFileContents.push({
+                              fileName: entry.name,
+                              content: fs.readFileSync(fullPath, 'utf8'),
+                            });
+                          }
+                        }
+                      }
+                    };
+                    findTrxFiles(trxDir);
+
+                    if (trxFileContents.length > 0) {
+                      const { allMatchedTests } = rerunWorkflow.analyzeTrxFiles(trxFileContents, testFailurePatterns);
+                      if (allMatchedTests.length > 0) {
+                        console.log(`Found ${allMatchedTests.length} test(s) matching transient failure patterns.`);
+                        const promoted = rerunWorkflow.promoteTestExecutionFailureJobs(retryableJobs, skippedJobs, allMatchedTests);
+                        retryableJobs = promoted.retryableJobs;
+                        skippedJobs = promoted.skippedJobs;
+                        testPatternMatchedTests = allMatchedTests;
+                      }
+                    }
+                  } finally {
+                    fs.rmSync(tmpDir, { recursive: true, force: true });
+                  }
+                }
+              } catch (trxError) {
+                core.warning(`TRX analysis failed (non-fatal): ${trxError.message}`);
+              }
+            }
 
             core.setOutput('retryable_jobs', JSON.stringify(retryableJobs.map(job => ({
               id: job.id,
@@ -255,6 +342,11 @@ jobs:
             });
             core.setOutput('rerun_eligible', String(rerunEligible));
             core.setOutput('rerun_execution_eligible', String(rerunExecutionEligible));
+            core.setOutput('test_pattern_matched_tests', JSON.stringify(testPatternMatchedTests.map(t => ({
+              testName: t.testName,
+              reason: t.reason,
+              testProject: t.testProject || '',
+            }))));
 
             await rerunWorkflow.writeAnalysisSummary({
               summary: core.summary,
@@ -266,6 +358,7 @@ jobs:
               rerunEligible,
               sourceRunUrl,
               sourceRunAttempt: runAttempt,
+              testPatternMatchedTests,
             });
 
             if (retryableJobs.length === 0) {
@@ -295,6 +388,7 @@ jobs:
           SOURCE_RUN_ID: ${{ needs.analyze-transient-failures.outputs.source_run_id }}
           SOURCE_RUN_ATTEMPT: ${{ needs.analyze-transient-failures.outputs.source_run_attempt }}
           SOURCE_RUN_URL: ${{ needs.analyze-transient-failures.outputs.source_run_url }}
+          TEST_PATTERN_MATCHED_TESTS: ${{ needs.analyze-transient-failures.outputs.test_pattern_matched_tests }}
         with:
           script: |
             const rerunWorkflow = require('./.github/workflows/auto-rerun-transient-ci-failures.js');
@@ -305,6 +399,7 @@ jobs:
             const sourceRunId = Number(process.env.SOURCE_RUN_ID);
             const sourceRunAttempt = Number(process.env.SOURCE_RUN_ATTEMPT);
             const sourceRunUrl = process.env.SOURCE_RUN_URL;
+            const testPatternMatchedTests = JSON.parse(process.env.TEST_PATTERN_MATCHED_TESTS || '[]');
 
             if (retryableJobs.length === 0) {
               console.log('No retryable jobs were provided to the rerun job.');
@@ -321,4 +416,5 @@ jobs:
               sourceRunId,
               sourceRunAttempt,
               sourceRunUrl,
+              testPatternMatchedTests,
             });

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -1,63 +1,105 @@
 # Auto-rerun transient CI failures
 
-This document describes the current behavior contract for `.github/workflows/auto-rerun-transient-ci-failures.yml`.
+This document explains how the automatic CI rerun system works and how to configure it.
 
-## Overview
+## How it works at a glance
 
-The workflow analyzes failed `CI` pull request runs, identifies retry-safe transient infrastructure failures, uses those matched jobs as the eligibility signal, requests GitHub to rerun all failed jobs for the failed attempt through the run-level failed-job rerun API, and comments on the open pull request with the rerun details.
+When a `CI` pull request run fails on GitHub Actions, a companion workflow automatically analyzes the failure, determines whether it was caused by transient infrastructure or test issues, and — if safe — requests GitHub to rerun the failed jobs. It also posts a comment on the PR explaining what it did and why.
 
-GitHub does not provide an API for atomically rerunning multiple arbitrary failed jobs within the same workflow run. Once the matcher finds one or more retry-safe jobs and all safety rails pass, the workflow sends a single run-level `rerun-failed-jobs` request for the source run. That rerun attempt includes all failed jobs for that attempt, not only the matched jobs.
+```text
+CI run fails on PR
+       │
+       ▼
+┌──────────────────────────────────┐
+│  Analyze failed jobs             │
+│  1. Infrastructure matchers      │  ← hardcoded in JS
+│  2. Infrastructure log override  │  ← hardcoded in JS
+│  3. Job log pattern matching     │  ← eng/test-retry-patterns.json (jobFailurePatterns)
+│  4. TRX test output matching     │  ← eng/test-retry-patterns.json (testFailurePatterns)
+└──────────────┬───────────────────┘
+               │
+               ▼
+┌──────────────────────────────────┐
+│  Safety rails                    │
+│  • ≤ 3 total attempts            │
+│  • ≤ 5 retryable jobs (default)  │
+│  • PR must still be open         │
+└──────────────┬───────────────────┘
+               │
+               ▼
+   Rerun all failed jobs for the attempt
+   + Post PR comment with matched jobs and reasons
+```
 
-When GitHub's `workflow_run` payload omits `pull_requests` for a failed PR run, the workflow falls back to resolving the source pull request from the CI run's `head_repository.owner.login` and `head_branch`. The fallback proceeds only when that lookup yields exactly one matching pull request, so ambiguous branch reuse still results in a skip. When the `workflow_run` payload also includes a `head_sha`, the fallback further filters candidate pull requests to those whose head SHA matches that value, which can also cause the lookup to skip if the branch still matches but the pull request head has advanced since the analyzed run.
+The full analysis runs in four passes:
 
-It is intentionally conservative:
+1. **Infrastructure annotation check** — Hardcoded patterns match runner failures, action download failures, and other known infrastructure errors from job annotations.
+2. **Infrastructure log override** — For non-test-execution failures, job logs are checked against a hardcoded list of high-confidence network failure patterns (NuGet feed timeouts, GitHub API errors, etc.).
+3. **Job log pattern matching** — For test execution failures (`Run tests*` step), the job log is matched against configurable `jobFailurePatterns` from [`eng/test-retry-patterns.json`](../../eng/test-retry-patterns.json).
+4. **TRX test output matching** — If any test execution failures remain unmatched, the workflow downloads the `All-TestResults` artifact, parses the `.trx` files, and matches individual failed test output against configurable `testFailurePatterns` from the same config file.
 
-- it does not treat every failed run as rerun-eligible; a rerun is requested only when at least one matched job satisfies the retry-safe rules and the safety rails pass
-- it treats mixed deterministic failures plus transient post-step noise as non-retryable by default
-- it keeps `workflow_dispatch` behind the same matcher and safety rails as automatic execution, with an optional dry-run mode for inspection-only runs
+Passes 1–2 are hardcoded because they target well-known infrastructure signatures that rarely change. Passes 3–4 are configurable because transient test failure patterns evolve as integrations are added or CI environments change.
 
-## Matcher behavior
+## When does it trigger?
 
-### Infrastructure matchers (hardcoded)
+| Trigger | Behavior |
+|---------|----------|
+| **Automatic** (`workflow_run` on `CI` completion) | Runs whenever a `CI` pull request workflow concludes with failure. No manual action needed. |
+| **Manual** (`workflow_dispatch`) | Enter a `CI` run ID to analyze. Supports a `dry_run` option that produces the analysis summary without actually requesting a rerun. |
 
-- Retry jobs with no failed steps only when their annotations contain an explicit job-level infrastructure signature.
-- Retry jobs whose failed step is on the retry-safe allowlist only when their annotations also contain a transient infrastructure signature.
-- Ignore aggregator jobs such as `Final Results` and `Tests / Final Test Results`.
-- Skip jobs whose failed steps are outside the retry-safe allowlist, even if their annotations contain generic failure text.
-- Keep the mixed-failure veto: if an ignored step such as `Run tests*` failed, do not rerun the job based only on unrelated transient post-step noise.
-- Allow a narrow override when an ignored failed step is paired with a high-confidence job-level infrastructure annotation such as runner loss or action-download failure.
-- Allow a narrow override for Windows jobs whose failures are limited to post-test cleanup or upload steps when the annotations report process initialization failure `-1073741502` (`0xC0000142`).
-- Allow a narrow log-based override for non-test-execution failures when the job log shows high-confidence infrastructure network failures against approved `dnceng` public feeds, `builds.dotnet.microsoft.com`, `api.github.com`, or `github.com`.
+Both trigger paths use the same analysis and safety rails. The only difference is how the source run is identified.
 
-### Test failure retry patterns (configurable)
+## Configuring test failure retry patterns
 
-In addition to the hardcoded infrastructure matchers, the workflow supports configurable test failure retry patterns defined in `eng/test-retry-patterns.json`. These patterns catch transient test failures that are not infrastructure-level but are still retry-worthy (e.g., network resets, DNS failures, connection timeouts in test output).
+The file [`eng/test-retry-patterns.json`](../../eng/test-retry-patterns.json) defines patterns for identifying transient test failures that should trigger a rerun. Changes to this file go through normal PR review — the patterns are not user-supplied at runtime.
 
-Two matching paths:
-
-1. **Job log pattern matching**: For jobs that fail on a test execution step (`Run tests*`), the job log text is matched against `jobFailurePatterns` rules. This happens as a third classification pass inside `analyzeFailedJobs`, after the infrastructure matchers.
-
-2. **TRX-based pattern matching**: After job classification, if there are still-skipped test execution failure jobs, the workflow downloads the `All-TestResults` artifact from the analyzed CI run, extracts `.trx` files, and matches failed test output against `testFailurePatterns` rules. If any test matches, all skipped test execution failure jobs are promoted to retryable.
-
-Both matching paths share the same attempt budget (max 3 attempts) and retryable job cap.
-
-#### Config file schema (`eng/test-retry-patterns.json`)
+### File structure
 
 ```json
 {
   "version": 1,
+  "testFailurePatterns": [ ... ],
+  "jobFailurePatterns": [ ... ]
+}
+```
+
+- **`version`**: Schema version. Currently `1`. Reserved for future schema migrations.
+- **`testFailurePatterns`**: Rules matched against individual failed test output from TRX files (pass 4).
+- **`jobFailurePatterns`**: Rules matched against the full job log text for test execution failure jobs (pass 3).
+
+### Adding a new pattern
+
+**Example**: Tests in the Redis integration project occasionally fail with `ECONNRESET` due to container startup races. To automatically retry these:
+
+```json
+{
   "testFailurePatterns": [
     {
       "output": "ECONNRESET",
       "reason": "Transient network connection reset"
-    },
-    {
-      "testName": { "regex": ".*Redis.*" },
-      "testProject": "Aspire.Hosting.Redis.Tests",
-      "output": "connection refused",
-      "reason": "Redis container startup race"
     }
-  ],
+  ]
+}
+```
+
+If the pattern should only apply to a specific test project or test name:
+
+```json
+{
+  "testFailurePatterns": [
+    {
+      "testProject": "Aspire.Hosting.Redis.Tests",
+      "output": "ECONNRESET",
+      "reason": "Redis container transient connection reset"
+    }
+  ]
+}
+```
+
+For job-level log matching (e.g., a Windows-specific process init failure):
+
+```json
+{
   "jobFailurePatterns": [
     {
       "jobName": { "regex": ".*windows.*" },
@@ -68,49 +110,102 @@ Both matching paths share the same attempt budget (max 3 attempts) and retryable
 }
 ```
 
-#### Rule semantics
+### Rule fields
 
-- **Within a rule**: All specified fields must match (AND logic).
-- **Across rules**: Any matching rule is sufficient (OR logic).
-- **Plain string value**: Case-insensitive substring match.
-- **`{"regex": "..."}`**: Case-insensitive regex match.
-- **`enabled`**: Optional, defaults to `true`. Set `false` to temporarily disable without deleting.
-- **`reason`**: Required. Human-readable reason shown in PR comments and workflow summary.
+#### Common to both rule types
 
-#### Matchable fields
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `reason` | **Yes** | string | Human-readable explanation shown in PR comments and workflow summary |
+| `output` | No | string or `{"regex": "..."}` | Matched against the relevant text (test output or job log) |
+| `enabled` | No | boolean | Defaults to `true`. Set `false` to temporarily disable a rule without deleting it |
 
-- **testFailurePatterns**: `testName` (FQN from TRX), `testProject` (derived from TRX filename), `output` (ErrorMessage + StackTrace + StdOut concatenated, capped at 10KB per test).
-- **jobFailurePatterns**: `jobName` (GitHub Actions job name), `output` (job log text, capped at 256KB).
+#### `testFailurePatterns` fields
 
-#### Safety measures
+| Field | Type | Matched against |
+|-------|------|-----------------|
+| `testName` | string or `{"regex": "..."}` | Fully qualified test name from TRX (e.g., `Aspire.Hosting.Redis.Tests.RedisFunctionalTests.TestMethod`) |
+| `testProject` | string or `{"regex": "..."}` | Test project name derived from TRX filename (e.g., `Aspire.Hosting.Redis.Tests`) |
+| `output` | string or `{"regex": "..."}` | Concatenation of ErrorMessage + StackTrace + StdOut from the TRX test result (capped at 10KB per test) |
 
-- Test output is capped at 10KB per test; job logs at 256KB (existing cap). This prevents regex performance issues.
-- The config file is committed to the repo and reviewed via PR — not user-supplied at runtime.
-- Regex compilation errors are caught and logged as warnings.
-- Missing, expired, or corrupt `All-TestResults` artifacts result in a non-fatal skip — the workflow falls through without blocking.
-- Artifact downloads are capped at 100MB.
+#### `jobFailurePatterns` fields
+
+| Field | Type | Matched against |
+|-------|------|-----------------|
+| `jobName` | string or `{"regex": "..."}` | GitHub Actions job name (e.g., `Tests / Run ubuntu-latest Aspire.Hosting.Redis.Tests`) |
+| `output` | string or `{"regex": "..."}` | Full job log text (capped at 256KB) |
+
+### Matching semantics
+
+- **Plain string**: Case-insensitive substring match (e.g., `"ECONNRESET"` matches `"Error: socket hang up: ECONNRESET"`).
+- **`{"regex": "..."}`**: JavaScript (V8) regular expression, case-insensitive. Compiled once per run; compilation errors are logged as warnings and the rule is skipped.
+- **Within a rule**: All specified fields must match (**AND** logic). A rule with `testProject` + `output` requires both to match.
+- **Across rules**: Any matching rule is sufficient (**OR** logic). A test that matches rule 1 or rule 2 is considered matched.
+- **Deduplication**: If the same test (by fully qualified name) matches multiple rules, it appears once in the results with the first matching reason.
+
+### What happens when a pattern matches
+
+**Job log patterns (pass 3)**: The matched job is moved from "skipped" to "retryable" immediately during job classification.
+
+**Test output patterns (pass 4)**: After TRX analysis, if *any* test matches a `testFailurePatterns` rule, *all* skipped test execution failure jobs are promoted to retryable. This is intentional — TRX files are a shared artifact that doesn't map 1:1 to individual jobs, and the existing `maxRetryableJobs` cap prevents runaway retries.
+
+### Tips for writing good patterns
+
+1. **Start specific, broaden if needed.** A pattern with `testProject` + `output` is safer than `output` alone. If the pattern is too broad, it may retry deterministic failures.
+2. **Use `reason` to document the known transient failure.** The reason text appears in PR comments, so make it descriptive enough that a reviewer can understand *why* this pattern is retry-worthy.
+3. **Prefer plain strings over regex.** Substring matching is simpler, easier to review, and less prone to surprising matches. Use regex only when you need anchoring, alternation, or wildcards.
+4. **Temporarily disable before deleting.** Set `"enabled": false` rather than removing a rule. This preserves the pattern for future reference if the same transient issue recurs.
+5. **Test your patterns locally.** The test suite validates config structure and regex compilation. Run the tests after modifying the config:
+   ```bash
+   dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- \
+     --filter-class "*.AutoRerunTransientCiFailuresTests" \
+     --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
+   ```
+
+### Verifying with dry run
+
+To test how the workflow would analyze a specific failed CI run without triggering a rerun:
+
+1. Go to **Actions** → **Auto-rerun transient CI failures** → **Run workflow**
+2. Enter the failed CI run ID
+3. Check **dry_run**
+4. Inspect the workflow summary for matched jobs, matched tests, and whether a rerun would have been requested
 
 ## Safety rails
 
-- `workflow_dispatch` can inspect any `CI` workflow run by ID and request reruns when the same retry-safety rules are satisfied.
-- `workflow_dispatch` also exposes an optional `dry_run` input so manual runs can produce the analysis summary without sending rerun requests.
-- Dry-run summaries still report whether the analyzed run would be eligible to rerun if dry run were disabled; the execution gate remains suppressed separately.
-- Automatic rerun triggers only when the run attempt is 3 or fewer (`run_attempt <= 3`), allowing up to 2 automatic reruns (3 total attempts) per PR run.
-- Automatic rerun requires at least one retryable job.
-- Automatic rerun is suppressed when matched jobs exceed the configured cap (default: 5).
-- For attempts after the first (`run_attempt > 1`), a stricter cap applies: rerun is suppressed unless the matched job count is strictly less than the configured cap (for example, fewer than 5 jobs by default). Aggregator jobs such as `Final Results` and `Tests / Final Test Results` are excluded from this count.
-- Before issuing reruns, the workflow confirms that at least one associated pull request is still open.
-- When a rerun is requested, the workflow sends one run-level failed-job rerun request for the analyzed source run rather than one request per matched job.
-- The matched-job count limits remain an eligibility gate: once the run is eligible, GitHub reruns all failed jobs for that attempt.
-- The workflow summary clearly states whether reruns were skipped, are eligible, or were requested, and links to the analyzed workflow run.
-- When reruns are requested, the rerun summary also links to both the failed attempt and the rerun attempt, plus any posted pull request comments.
-- After successful rerun requests, the workflow comments on the open associated pull request that the failed jobs in the CI workflow are being rerun, with links to the failed attempt, the rerun attempt, and the matched failed-attempt jobs and retry reasons that made the run eligible.
+The workflow is intentionally conservative. All of these conditions must be met for a rerun to be requested:
+
+| Rail | Detail |
+|------|--------|
+| **Attempt limit** | The source run must be on attempt ≤ 3 (allowing up to 2 automatic reruns, 3 total attempts). |
+| **Retryable job cap** | At least 1 but no more than 5 retryable jobs (default). On attempts > 1, the cap is stricter: the count must be *strictly less than* 5. |
+| **Open PR** | At least one associated pull request must still be open. |
+| **Non-aggregator** | Aggregator jobs (`Final Results`, `Tests / Final Test Results`) are excluded from analysis. |
+| **Mixed-failure veto** | A job with both a test execution failure (`Run tests*`) and unrelated transient post-step noise is *not* retried on infrastructure grounds alone — the test execution failure must match a pattern (pass 3 or 4) to qualify. |
+
+When a rerun is requested, GitHub reruns **all** failed jobs for that attempt — not just the matched ones. This is a GitHub API constraint (there is no API for atomically rerunning a subset of failed jobs). The matched-job count and safety rails are the eligibility gate; once eligible, the rerun covers the full failed set.
+
+### PR association
+
+The workflow identifies the associated PR from the `workflow_run` event payload. When GitHub's payload omits `pull_requests` (which can happen for fork-based PRs), the workflow falls back to matching by `head_repository.owner.login`, `head_branch`, and optionally `head_sha`. The fallback requires exactly one matching PR to proceed — ambiguous matches are skipped.
+
+## Architecture and file layout
+
+| File | Role |
+|------|------|
+| [`.github/workflows/auto-rerun-transient-ci-failures.yml`](../../.github/workflows/auto-rerun-transient-ci-failures.yml) | YAML workflow: orchestration, GitHub API calls, artifact download, TRX file I/O |
+| [`.github/workflows/auto-rerun-transient-ci-failures.js`](../../.github/workflows/auto-rerun-transient-ci-failures.js) | JavaScript module: all testable logic — pattern matching, job classification, TRX parsing, promotion, summary formatting |
+| [`eng/test-retry-patterns.json`](../../eng/test-retry-patterns.json) | Configuration: test failure and job failure patterns |
+| [`tests/.../auto-rerun-transient-ci-failures.harness.js`](../../tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js) | Node.js test harness: bridges C# xUnit tests to the JS module functions |
+| [`tests/.../AutoRerunTransientCiFailuresTests.cs`](../../tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs) | C# test class: behavior-focused tests covering all matcher logic |
+
+The JS module is intentionally separated from the YAML workflow so that all classification, matching, and formatting logic can be tested via the Node.js harness without mocking GitHub APIs. The YAML workflow only handles orchestration: fetching jobs, downloading artifacts, and calling the GitHub rerun API.
 
 ## Tests
 
-The automated tests for this workflow live in `tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs`.
+The automated tests live in `tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs`.
 
-Those tests are intentionally behavior-focused rather than regex-focused:
+They are intentionally behavior-focused rather than regex-focused:
 
 - they use representative fixtures for each supported behavior
 - they keep representative job and step fixtures anchored to the current CI workflow names so matcher coverage does not drift from the implementation
@@ -121,3 +216,13 @@ Those tests are intentionally behavior-focused rather than regex-focused:
 - they test TRX parsing, output capping, XML entity decoding, and the `analyzeTrxFiles` deduplication
 - they test the `promoteTestExecutionFailureJobs` promotion logic and `selectTestResultsArtifact` selection
 - they test the `analyzeFailedJobs` integration with `retryPatternsConfig` for job log pattern matching
+
+### Running the tests
+
+```bash
+dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- \
+  --filter-class "*.AutoRerunTransientCiFailuresTests" \
+  --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
+```
+
+These tests require Node.js to be installed (the harness invokes `node` to run the JS module).

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -18,6 +18,8 @@ It is intentionally conservative:
 
 ## Matcher behavior
 
+### Infrastructure matchers (hardcoded)
+
 - Retry jobs with no failed steps only when their annotations contain an explicit job-level infrastructure signature.
 - Retry jobs whose failed step is on the retry-safe allowlist only when their annotations also contain a transient infrastructure signature.
 - Ignore aggregator jobs such as `Final Results` and `Tests / Final Test Results`.
@@ -26,6 +28,67 @@ It is intentionally conservative:
 - Allow a narrow override when an ignored failed step is paired with a high-confidence job-level infrastructure annotation such as runner loss or action-download failure.
 - Allow a narrow override for Windows jobs whose failures are limited to post-test cleanup or upload steps when the annotations report process initialization failure `-1073741502` (`0xC0000142`).
 - Allow a narrow log-based override for non-test-execution failures when the job log shows high-confidence infrastructure network failures against approved `dnceng` public feeds, `builds.dotnet.microsoft.com`, `api.github.com`, or `github.com`.
+
+### Test failure retry patterns (configurable)
+
+In addition to the hardcoded infrastructure matchers, the workflow supports configurable test failure retry patterns defined in `eng/test-retry-patterns.json`. These patterns catch transient test failures that are not infrastructure-level but are still retry-worthy (e.g., network resets, DNS failures, connection timeouts in test output).
+
+Two matching paths:
+
+1. **Job log pattern matching**: For jobs that fail on a test execution step (`Run tests*`), the job log text is matched against `jobFailurePatterns` rules. This happens as a third classification pass inside `analyzeFailedJobs`, after the infrastructure matchers.
+
+2. **TRX-based pattern matching**: After job classification, if there are still-skipped test execution failure jobs, the workflow downloads the `All-TestResults` artifact from the analyzed CI run, extracts `.trx` files, and matches failed test output against `testFailurePatterns` rules. If any test matches, all skipped test execution failure jobs are promoted to retryable.
+
+Both matching paths share the same attempt budget (max 3 attempts) and retryable job cap.
+
+#### Config file schema (`eng/test-retry-patterns.json`)
+
+```json
+{
+  "version": 1,
+  "testFailurePatterns": [
+    {
+      "output": "ECONNRESET",
+      "reason": "Transient network connection reset"
+    },
+    {
+      "testName": { "regex": ".*Redis.*" },
+      "testProject": "Aspire.Hosting.Redis.Tests",
+      "output": "connection refused",
+      "reason": "Redis container startup race"
+    }
+  ],
+  "jobFailurePatterns": [
+    {
+      "jobName": { "regex": ".*windows.*" },
+      "output": "0xC0000142",
+      "reason": "Windows process initialization failure"
+    }
+  ]
+}
+```
+
+#### Rule semantics
+
+- **Within a rule**: All specified fields must match (AND logic).
+- **Across rules**: Any matching rule is sufficient (OR logic).
+- **Plain string value**: Case-insensitive substring match.
+- **`{"regex": "..."}`**: Case-insensitive regex match.
+- **`enabled`**: Optional, defaults to `true`. Set `false` to temporarily disable without deleting.
+- **`reason`**: Required. Human-readable reason shown in PR comments and workflow summary.
+
+#### Matchable fields
+
+- **testFailurePatterns**: `testName` (FQN from TRX), `testProject` (derived from TRX filename), `output` (ErrorMessage + StackTrace + StdOut concatenated, capped at 10KB per test).
+- **jobFailurePatterns**: `jobName` (GitHub Actions job name), `output` (job log text, capped at 256KB).
+
+#### Safety measures
+
+- Test output is capped at 10KB per test; job logs at 256KB (existing cap). This prevents regex performance issues.
+- The config file is committed to the repo and reviewed via PR — not user-supplied at runtime.
+- Regex compilation errors are caught and logged as warnings.
+- Missing, expired, or corrupt `All-TestResults` artifacts result in a non-fatal skip — the workflow falls through without blocking.
+- Artifact downloads are capped at 100MB.
 
 ## Safety rails
 
@@ -53,3 +116,8 @@ Those tests are intentionally behavior-focused rather than regex-focused:
 - they keep representative job and step fixtures anchored to the current CI workflow names so matcher coverage does not drift from the implementation
 - they cover the mixed-failure veto and ignored-step override explicitly
 - they keep only a minimal set of YAML contract checks for safety rails such as the optional manual `dry_run` override, up-to-three-attempt automatic reruns, enabling manual reruns through `workflow_dispatch`, and gating the rerun job on `rerun_execution_eligible`
+- they validate the `eng/test-retry-patterns.json` config structure and regex compilation in Node.js (V8)
+- they test pattern matching functions (substring, regex, AND/OR logic, disabled rules)
+- they test TRX parsing, output capping, XML entity decoding, and the `analyzeTrxFiles` deduplication
+- they test the `promoteTestExecutionFailureJobs` promotion logic and `selectTestResultsArtifact` selection
+- they test the `analyzeFailedJobs` integration with `retryPatternsConfig` for job log pattern matching

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -69,6 +69,8 @@ The file [`eng/test-retry-patterns.json`](../../eng/test-retry-patterns.json) de
 
 ### Adding a new pattern
 
+> **Note**: The snippets below show only the relevant pattern entry. Add the pattern to the corresponding array (`testFailurePatterns` or `jobFailurePatterns`) in the full config file shown above.
+
 **Example**: Tests in the Redis integration project occasionally fail with `ECONNRESET` due to container startup races. To automatically retry these:
 
 ```json
@@ -138,7 +140,7 @@ For job-level log matching (e.g., a Windows-specific process init failure):
 ### Matching semantics
 
 - **Plain string**: Case-insensitive substring match (e.g., `"ECONNRESET"` matches `"Error: socket hang up: ECONNRESET"`).
-- **`{"regex": "..."}`**: JavaScript (V8) regular expression, case-insensitive. Compiled once per run; compilation errors are logged as warnings and the rule is skipped.
+- **`{"regex": "..."}`**: JavaScript (V8) regular expression, case-insensitive. Regex patterns are precompiled when the config is loaded; invalid patterns log a warning and the rule is disabled.
 - **Within a rule**: All specified fields must match (**AND** logic). A rule with `testProject` + `output` requires both to match.
 - **Across rules**: Any matching rule is sufficient (**OR** logic). A test that matches rule 1 or rule 2 is considered matched.
 - **Deduplication**: If the same test (by fully qualified name) matches multiple rules, it appears once in the results with the first matching reason.

--- a/eng/test-retry-patterns.json
+++ b/eng/test-retry-patterns.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "testFailurePatterns": [
+    {
+      "output": "ECONNRESET",
+      "reason": "Transient network connection reset"
+    },
+    {
+      "output": "ECONNREFUSED",
+      "reason": "Transient connection refused"
+    },
+    {
+      "output": "Could not resolve host",
+      "reason": "Transient DNS resolution failure"
+    },
+    {
+      "output": "The SSL connection could not be established",
+      "reason": "Transient SSL connection failure"
+    },
+    {
+      "output": "A connection attempt failed because the connected party did not properly respond after a period of time",
+      "reason": "Transient TCP connection timeout"
+    },
+    {
+      "output": "Operation timed out",
+      "reason": "Transient operation timeout"
+    }
+  ],
+  "jobFailurePatterns": [
+    {
+      "jobName": { "regex": ".*windows.*" },
+      "output": "0xC0000142",
+      "reason": "Windows process initialization failure (0xC0000142)"
+    },
+    {
+      "output": "Could not resolve host",
+      "reason": "Transient DNS resolution failure in job log"
+    }
+  ]
+}

--- a/eng/test-retry-patterns.json
+++ b/eng/test-retry-patterns.json
@@ -24,6 +24,22 @@
     {
       "output": "Operation timed out",
       "reason": "Transient operation timeout"
+    },
+    {
+      "output": { "regex": "mcr\\.microsoft\\.com[\\s\\S]{0,500}403 Forbidden" },
+      "reason": "MCR registry rate limiting (HTTP 403)"
+    },
+    {
+      "output": { "regex": "mcr\\.microsoft\\.com[\\s\\S]{0,500}The request is blocked" },
+      "reason": "MCR registry request blocked (rate limiting)"
+    },
+    {
+      "output": "CONTAINER1016",
+      "reason": "Unable to access container registry during publish"
+    },
+    {
+      "output": "pull access denied for mcr.microsoft.com",
+      "reason": "MCR container pull denied (rate limiting)"
     }
   ],
   "jobFailurePatterns": [
@@ -35,6 +51,14 @@
     {
       "output": "Could not resolve host",
       "reason": "Transient DNS resolution failure in job log"
+    },
+    {
+      "output": { "regex": "mcr\\.microsoft\\.com[\\s\\S]{0,500}403 Forbidden" },
+      "reason": "MCR registry rate limiting (HTTP 403)"
+    },
+    {
+      "output": { "regex": "mcr\\.microsoft\\.com[\\s\\S]{0,500}The request is blocked" },
+      "reason": "MCR registry request blocked (rate limiting)"
     }
   ]
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -1371,6 +1371,288 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Equal("DNS failure", result.Reason);
     }
 
+    // --- analyzeFailedJobs with retryPatternsConfig tests ---
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AnalyzeFailedJobsWithConfigRetriesTestExecFailureViaJobLogPattern()
+    {
+        WorkflowJob job = CreateJob(id: 1, failedSteps: ["Run tests"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeJobsAsync(
+            [job],
+            new Dictionary<string, string> { ["1"] = "Process completed with exit code 1." },
+            new Dictionary<string, string> { ["1"] = "Process failed with 0xC0000142" },
+            retryPatternsConfig: new
+            {
+                version = 1,
+                testFailurePatterns = Array.Empty<object>(),
+                jobFailurePatterns = new object[]
+                {
+                    new { jobName = new { regex = ".*" }, output = "0xC0000142", reason = "Windows init failure" }
+                }
+            });
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("configurable test-retry pattern", result.RetryableJobs[0].Reason);
+        Assert.Contains("Windows init failure", result.RetryableJobs[0].Reason);
+        Assert.Empty(result.SkippedJobs);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AnalyzeFailedJobsWithConfigSkipsWhenJobLogDoesNotMatchPattern()
+    {
+        WorkflowJob job = CreateJob(id: 1, failedSteps: ["Run tests"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeJobsAsync(
+            [job],
+            new Dictionary<string, string> { ["1"] = "Process completed with exit code 1." },
+            new Dictionary<string, string> { ["1"] = "Some unrelated failure" },
+            retryPatternsConfig: new
+            {
+                version = 1,
+                testFailurePatterns = Array.Empty<object>(),
+                jobFailurePatterns = new object[]
+                {
+                    new { output = "0xC0000142", reason = "Windows init failure" }
+                }
+            });
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AnalyzeFailedJobsWithConfigDoesNotApplyJobLogPatternToNonTestExecFailures()
+    {
+        // A job that fails on a non-test step should NOT use jobFailurePatterns
+        WorkflowJob job = CreateJob(id: 1, failedSteps: ["Compile project"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeJobsAsync(
+            [job],
+            new Dictionary<string, string> { ["1"] = "Process completed with exit code 1." },
+            new Dictionary<string, string> { ["1"] = "0xC0000142" },
+            retryPatternsConfig: new
+            {
+                version = 1,
+                testFailurePatterns = Array.Empty<object>(),
+                jobFailurePatterns = new object[]
+                {
+                    new { output = "0xC0000142", reason = "Windows init failure" }
+                }
+            });
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+    }
+
+    // --- analyzeTrxFiles tests ---
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AnalyzeTrxFilesFindsMatchedTests()
+    {
+        string trxContent = BuildTrxContent(
+            new TrxTestResult("Aspire.Tests.FailingTest", "Failed", ErrorMessage: "ECONNRESET: connection reset"),
+            new TrxTestResult("Aspire.Tests.PassingTest", "Passed"));
+
+        var patterns = new object[]
+        {
+            new { output = "ECONNRESET", reason = "Network reset" }
+        };
+
+        AnalyzeTrxFilesResult result = await InvokeHarnessAsync<AnalyzeTrxFilesResult>(
+            "analyzeTrxFiles",
+            new
+            {
+                trxFileContents = new[] { new { fileName = "Aspire.Tests.trx", content = trxContent } },
+                testFailurePatterns = patterns
+            });
+
+        Assert.Single(result.AllMatchedTests);
+        Assert.Equal("Aspire.Tests.FailingTest", result.AllMatchedTests[0].TestName);
+        Assert.Equal("Network reset", result.AllMatchedTests[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AnalyzeTrxFilesDedupesByTestName()
+    {
+        string trxContent = BuildTrxContent(
+            new TrxTestResult("Aspire.Tests.Flaky", "Failed", ErrorMessage: "ECONNRESET"));
+
+        var patterns = new object[]
+        {
+            new { output = "ECONNRESET", reason = "Network reset" }
+        };
+
+        // Same test in two TRX files
+        AnalyzeTrxFilesResult result = await InvokeHarnessAsync<AnalyzeTrxFilesResult>(
+            "analyzeTrxFiles",
+            new
+            {
+                trxFileContents = new[]
+                {
+                    new { fileName = "Aspire.Tests.trx", content = trxContent },
+                    new { fileName = "Aspire.Tests.retry.trx", content = trxContent }
+                },
+                testFailurePatterns = patterns
+            });
+
+        Assert.Single(result.AllMatchedTests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AnalyzeTrxFilesReturnsEmptyWhenNoMatches()
+    {
+        string trxContent = BuildTrxContent(
+            new TrxTestResult("Aspire.Tests.LogicError", "Failed", ErrorMessage: "Assert.True() Failure"));
+
+        var patterns = new object[]
+        {
+            new { output = "ECONNRESET", reason = "Network reset" }
+        };
+
+        AnalyzeTrxFilesResult result = await InvokeHarnessAsync<AnalyzeTrxFilesResult>(
+            "analyzeTrxFiles",
+            new
+            {
+                trxFileContents = new[] { new { fileName = "Aspire.Tests.trx", content = trxContent } },
+                testFailurePatterns = patterns
+            });
+
+        Assert.Empty(result.AllMatchedTests);
+    }
+
+    // --- promoteTestExecutionFailureJobs tests ---
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task PromoteTestExecutionFailureJobsMovesTestExecJobsToRetryable()
+    {
+        var skippedJobs = new[]
+        {
+            new { id = 1, name = "Tests / Build (ubuntu-latest)", htmlUrl = (string?)null, failedSteps = new[] { "Run tests" }, reason = "Not retryable." },
+            new { id = 2, name = "Build / Compile", htmlUrl = (string?)null, failedSteps = new[] { "Compile project" }, reason = "Not retryable." }
+        };
+        var allMatchedTests = new[]
+        {
+            new { testName = "Aspire.Tests.Flaky", reason = "Network reset", testProject = "Aspire.Tests" }
+        };
+
+        PromoteTestExecutionFailureJobsResult result = await InvokeHarnessAsync<PromoteTestExecutionFailureJobsResult>(
+            "promoteTestExecutionFailureJobs",
+            new { retryableJobs = Array.Empty<object>(), skippedJobs, allMatchedTests });
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal("Tests / Build (ubuntu-latest)", result.RetryableJobs[0].Name);
+        Assert.Contains("transient test failure patterns", result.RetryableJobs[0].Reason);
+
+        // Non-test-exec job stays skipped
+        Assert.Single(result.SkippedJobs);
+        Assert.Equal("Build / Compile", result.SkippedJobs[0].Name);
+
+        Assert.Single(result.PromotedJobs);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task PromoteTestExecutionFailureJobsDoesNothingWhenNoMatchedTests()
+    {
+        var skippedJobs = new[]
+        {
+            new { id = 1, name = "Tests / Build (ubuntu-latest)", htmlUrl = (string?)null, failedSteps = new[] { "Run tests" }, reason = "Not retryable." }
+        };
+
+        PromoteTestExecutionFailureJobsResult result = await InvokeHarnessAsync<PromoteTestExecutionFailureJobsResult>(
+            "promoteTestExecutionFailureJobs",
+            new { retryableJobs = Array.Empty<object>(), skippedJobs, allMatchedTests = Array.Empty<object>() });
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+        Assert.Empty(result.PromotedJobs);
+    }
+
+    // --- selectTestResultsArtifact tests ---
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task SelectTestResultsArtifactReturnsNewestNonExpired()
+    {
+        var artifacts = new object[]
+        {
+            new { name = "All-TestResults", size_in_bytes = 1000, expired = false, created_at = "2024-01-01T00:00:00Z", id = 1 },
+            new { name = "All-TestResults", size_in_bytes = 2000, expired = false, created_at = "2024-01-02T00:00:00Z", id = 2 },
+            new { name = "Other-Artifact", size_in_bytes = 500, expired = false, created_at = "2024-01-03T00:00:00Z", id = 3 }
+        };
+
+        SelectTestResultsArtifactResult? result = await InvokeHarnessAsync<SelectTestResultsArtifactResult?>(
+            "selectTestResultsArtifact",
+            new { artifacts });
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Id);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task SelectTestResultsArtifactReturnsNullForExpired()
+    {
+        var artifacts = new object[]
+        {
+            new { name = "All-TestResults", size_in_bytes = 1000, expired = true, created_at = "2024-01-01T00:00:00Z", id = 1 }
+        };
+
+        SelectTestResultsArtifactResult? result = await InvokeHarnessAsync<SelectTestResultsArtifactResult?>(
+            "selectTestResultsArtifact",
+            new { artifacts });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task SelectTestResultsArtifactReturnsNullForOversized()
+    {
+        var artifacts = new object[]
+        {
+            new { name = "All-TestResults", size_in_bytes = 200 * 1024 * 1024, expired = false, created_at = "2024-01-01T00:00:00Z", id = 1 }
+        };
+
+        SelectTestResultsArtifactResult? result = await InvokeHarnessAsync<SelectTestResultsArtifactResult?>(
+            "selectTestResultsArtifact",
+            new { artifacts });
+
+        Assert.Null(result);
+    }
+
+    // --- hasTestExecutionFailureStep tests ---
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task HasTestExecutionFailureStepReturnsTrueForRunTests()
+    {
+        bool result = await InvokeHarnessAsync<bool>(
+            "hasTestExecutionFailureStep",
+            new { failedSteps = new[] { "Run tests (ubuntu-latest)" } });
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task HasTestExecutionFailureStepReturnsFalseForNonTestSteps()
+    {
+        bool result = await InvokeHarnessAsync<bool>(
+            "hasTestExecutionFailureStep",
+            new { failedSteps = new[] { "Checkout code" } });
+
+        Assert.False(result);
+    }
+
     // --- TRX parsing tests ---
 
     [Fact]
@@ -1720,7 +2002,8 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         WorkflowJob[] jobs,
         Dictionary<string, string> annotationTextByJobId,
         Dictionary<string, string>? jobLogTextByJobId = null,
-        int? maxRetryableJobs = null)
+        int? maxRetryableJobs = null,
+        object? retryPatternsConfig = null)
         => InvokeHarnessAsync<AnalyzeFailedJobsResult>(
             "analyzeFailedJobs",
             new AnalyzeFailedJobsRequest
@@ -1728,7 +2011,8 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
                 Jobs = jobs,
                 AnnotationTextByJobId = annotationTextByJobId,
                 JobLogTextByJobId = jobLogTextByJobId,
-                MaxRetryableJobs = maxRetryableJobs
+                MaxRetryableJobs = maxRetryableJobs,
+                RetryPatternsConfig = retryPatternsConfig
             });
 
     private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
@@ -1804,6 +2088,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         public Dictionary<string, string> AnnotationTextByJobId { get; init; } = [];
         public Dictionary<string, string>? JobLogTextByJobId { get; init; }
         public int? MaxRetryableJobs { get; init; }
+        public object? RetryPatternsConfig { get; init; }
     }
 
     private sealed class AnalyzeFailedJobsResult
@@ -1923,5 +2208,34 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
     {
         public string TestName { get; init; } = string.Empty;
         public string Output { get; init; } = string.Empty;
+    }
+
+    private sealed class AnalyzeTrxFilesResult
+    {
+        public AnalyzedTrxMatch[] AllMatchedTests { get; init; } = [];
+    }
+
+    private sealed class AnalyzedTrxMatch
+    {
+        public string TestName { get; init; } = string.Empty;
+        public string Reason { get; init; } = string.Empty;
+        public string? MatchedSnippet { get; init; }
+        public string TestProject { get; init; } = string.Empty;
+    }
+
+    private sealed class PromoteTestExecutionFailureJobsResult
+    {
+        public AnalyzedJob[] RetryableJobs { get; init; } = [];
+        public AnalyzedJob[] SkippedJobs { get; init; } = [];
+        public AnalyzedJob[] PromotedJobs { get; init; } = [];
+    }
+
+    private sealed class SelectTestResultsArtifactResult
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("size_in_bytes")]
+        public long SizeInBytes { get; init; }
     }
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -1052,6 +1052,658 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Contains(result.Events, e => e.Type == "raw" && e.Text == "PR #15110 comment");
     }
 
+    // --- Test retry pattern config validation tests ---
+
+    [Fact]
+    public async Task TestRetryPatternsJsonIsValidAndWellFormed()
+    {
+        string configJson = await ReadRepoFileAsync("eng/test-retry-patterns.json");
+
+        JsonDocument doc = JsonDocument.Parse(configJson);
+        JsonElement root = doc.RootElement;
+
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.True(root.TryGetProperty("version", out JsonElement version));
+        Assert.Equal(1, version.GetInt32());
+        Assert.True(root.TryGetProperty("testFailurePatterns", out JsonElement testPatterns));
+        Assert.Equal(JsonValueKind.Array, testPatterns.ValueKind);
+        Assert.True(root.TryGetProperty("jobFailurePatterns", out JsonElement jobPatterns));
+        Assert.Equal(JsonValueKind.Array, jobPatterns.ValueKind);
+
+        // Validate no unknown top-level properties
+        HashSet<string> allowedTopLevel = ["version", "testFailurePatterns", "jobFailurePatterns"];
+        foreach (JsonProperty prop in root.EnumerateObject())
+        {
+            Assert.Contains(prop.Name, allowedTopLevel);
+        }
+    }
+
+    [Fact]
+    public async Task TestRetryPatternsJsonHasValidRuleStructure()
+    {
+        string configJson = await ReadRepoFileAsync("eng/test-retry-patterns.json");
+
+        JsonDocument doc = JsonDocument.Parse(configJson);
+        JsonElement root = doc.RootElement;
+
+        HashSet<string> testPatternAllowedFields = ["testName", "testProject", "output", "reason", "enabled"];
+        HashSet<string> jobPatternAllowedFields = ["jobName", "output", "reason", "enabled"];
+        HashSet<string> testPatternMatcherFields = ["testName", "testProject", "output"];
+        HashSet<string> jobPatternMatcherFields = ["jobName", "output"];
+
+        foreach (JsonElement rule in root.GetProperty("testFailurePatterns").EnumerateArray())
+        {
+            ValidatePatternRule(rule, testPatternAllowedFields, testPatternMatcherFields);
+        }
+
+        foreach (JsonElement rule in root.GetProperty("jobFailurePatterns").EnumerateArray())
+        {
+            ValidatePatternRule(rule, jobPatternAllowedFields, jobPatternMatcherFields);
+        }
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task TestRetryPatternsJsonPassesJavaScriptValidation()
+    {
+        string configPath = Path.Combine(_repoRoot, "eng", "test-retry-patterns.json");
+
+        LoadRetryPatternsConfigResult result = await InvokeHarnessAsync<LoadRetryPatternsConfigResult>(
+            "validateRetryPatternsConfigFromFile",
+            new { configPath });
+
+        Assert.NotNull(result.Config);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task TestRetryPatternsJsonRegexesCompileInJavaScript()
+    {
+        string configJson = await ReadRepoFileAsync("eng/test-retry-patterns.json");
+        JsonDocument doc = JsonDocument.Parse(configJson);
+        JsonElement root = doc.RootElement;
+
+        List<string> regexPatterns = [];
+        ExtractRegexPatterns(root.GetProperty("testFailurePatterns"), regexPatterns);
+        ExtractRegexPatterns(root.GetProperty("jobFailurePatterns"), regexPatterns);
+
+        foreach (string pattern in regexPatterns)
+        {
+            bool matches = await InvokeHarnessAsync<bool>(
+                "matchesRetryPattern",
+                new { text = "test-input", patternValue = new { regex = pattern } });
+
+            // We don't care about the result, just that it didn't throw.
+            // The harness would fail if the regex was invalid.
+            Assert.IsType<bool>(matches);
+        }
+    }
+
+    // --- Pattern matching function tests ---
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchesRetryPatternMatchesSubstringCaseInsensitively()
+    {
+        bool result = await InvokeHarnessAsync<bool>(
+            "matchesRetryPattern",
+            new { text = "Error: ECONNRESET detected", patternValue = "econnreset" });
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchesRetryPatternReturnsFalseWhenSubstringNotPresent()
+    {
+        bool result = await InvokeHarnessAsync<bool>(
+            "matchesRetryPattern",
+            new { text = "Some other error", patternValue = "ECONNRESET" });
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchesRetryPatternMatchesRegexCaseInsensitively()
+    {
+        bool result = await InvokeHarnessAsync<bool>(
+            "matchesRetryPattern",
+            new { text = "Aspire.Hosting.Redis.Tests.ConnectionTest", patternValue = new { regex = ".*redis.*" } });
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchesRetryPatternReturnsFalseForNonMatchingRegex()
+    {
+        bool result = await InvokeHarnessAsync<bool>(
+            "matchesRetryPattern",
+            new { text = "Aspire.Hosting.Kafka.Tests", patternValue = new { regex = "^Redis" } });
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchesRetryPatternHandlesInvalidRegexGracefully()
+    {
+        bool result = await InvokeHarnessAsync<bool>(
+            "matchesRetryPattern",
+            new { text = "some text", patternValue = new { regex = "[invalid" } });
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchTestFailurePatternsReturnsShouldRetryWhenOutputMatches()
+    {
+        var failedTests = new[]
+        {
+            new { testName = "Aspire.Redis.Tests.ConnectAsync", output = "Error: ECONNRESET: connection reset" }
+        };
+        var patterns = new[]
+        {
+            new { output = "ECONNRESET", reason = "Transient network reset", enabled = true }
+        };
+
+        MatchTestFailurePatternsResult result = await InvokeHarnessAsync<MatchTestFailurePatternsResult>(
+            "matchTestFailurePatterns",
+            new { failedTests, testProject = "Aspire.Redis.Tests", patterns });
+
+        Assert.True(result.ShouldRetry);
+        Assert.Single(result.MatchedTests);
+        Assert.Equal("Transient network reset", result.MatchedTests[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchTestFailurePatternsReturnsFalseWhenNoPatternMatches()
+    {
+        var failedTests = new[]
+        {
+            new { testName = "Aspire.Tests.SomeTest", output = "Assertion failed: expected true" }
+        };
+        var patterns = new[]
+        {
+            new { output = "ECONNRESET", reason = "Transient network reset", enabled = true }
+        };
+
+        MatchTestFailurePatternsResult result = await InvokeHarnessAsync<MatchTestFailurePatternsResult>(
+            "matchTestFailurePatterns",
+            new { failedTests, testProject = "Aspire.Tests", patterns });
+
+        Assert.False(result.ShouldRetry);
+        Assert.Empty(result.MatchedTests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchTestFailurePatternsSkipsDisabledPatterns()
+    {
+        var failedTests = new[]
+        {
+            new { testName = "Aspire.Tests.Flaky", output = "ECONNRESET" }
+        };
+        var patterns = new object[]
+        {
+            new { output = "ECONNRESET", reason = "Disabled pattern", enabled = false },
+            new { output = "ECONNREFUSED", reason = "Enabled pattern", enabled = true }
+        };
+
+        MatchTestFailurePatternsResult result = await InvokeHarnessAsync<MatchTestFailurePatternsResult>(
+            "matchTestFailurePatterns",
+            new { failedTests, testProject = "Aspire.Tests", patterns });
+
+        Assert.False(result.ShouldRetry);
+        Assert.Empty(result.MatchedTests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchTestFailurePatternsUsesAndLogicWithinRules()
+    {
+        var failedTests = new[]
+        {
+            new { testName = "Aspire.Kafka.Tests.ProducerTest", output = "ECONNRESET" }
+        };
+        var patterns = new object[]
+        {
+            new { testName = new { regex = ".*Redis.*" }, output = "ECONNRESET", reason = "Redis ECONNRESET" }
+        };
+
+        MatchTestFailurePatternsResult result = await InvokeHarnessAsync<MatchTestFailurePatternsResult>(
+            "matchTestFailurePatterns",
+            new { failedTests, testProject = "Aspire.Kafka.Tests", patterns });
+
+        // testName doesn't match (Kafka, not Redis), so AND fails
+        Assert.False(result.ShouldRetry);
+        Assert.Empty(result.MatchedTests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchTestFailurePatternsUsesOrLogicAcrossRules()
+    {
+        var failedTests = new[]
+        {
+            new { testName = "Aspire.Tests.Timeout", output = "Operation timed out" }
+        };
+        var patterns = new object[]
+        {
+            new { output = "ECONNRESET", reason = "Network reset" },
+            new { output = "timed out", reason = "Timeout" }
+        };
+
+        MatchTestFailurePatternsResult result = await InvokeHarnessAsync<MatchTestFailurePatternsResult>(
+            "matchTestFailurePatterns",
+            new { failedTests, testProject = "Aspire.Tests", patterns });
+
+        Assert.True(result.ShouldRetry);
+        Assert.Single(result.MatchedTests);
+        Assert.Equal("Timeout", result.MatchedTests[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchTestFailurePatternsReturnsEmptyForNullInputs()
+    {
+        MatchTestFailurePatternsResult result = await InvokeHarnessAsync<MatchTestFailurePatternsResult>(
+            "matchTestFailurePatterns",
+            new { failedTests = Array.Empty<object>(), testProject = "", patterns = Array.Empty<object>() });
+
+        Assert.False(result.ShouldRetry);
+        Assert.Empty(result.MatchedTests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchJobLogPatternMatchesJobNameAndOutput()
+    {
+        var patterns = new object[]
+        {
+            new { jobName = new { regex = ".*windows.*" }, output = "0xC0000142", reason = "Windows init failure" }
+        };
+
+        MatchJobLogPatternResult? result = await InvokeHarnessAsync<MatchJobLogPatternResult?>(
+            "matchJobLogPattern",
+            new { jobName = "Tests / Build (windows-latest)", jobLogText = "Process failed with 0xC0000142", patterns });
+
+        Assert.NotNull(result);
+        Assert.True(result.Matched);
+        Assert.Equal("Windows init failure", result.Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchJobLogPatternReturnsNullWhenJobNameDoesNotMatch()
+    {
+        var patterns = new object[]
+        {
+            new { jobName = new { regex = ".*windows.*" }, output = "0xC0000142", reason = "Windows init failure" }
+        };
+
+        MatchJobLogPatternResult? result = await InvokeHarnessAsync<MatchJobLogPatternResult?>(
+            "matchJobLogPattern",
+            new { jobName = "Tests / Build (ubuntu-latest)", jobLogText = "Process failed with 0xC0000142", patterns });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MatchJobLogPatternMatchesOutputOnlyPatterns()
+    {
+        var patterns = new object[]
+        {
+            new { output = "Could not resolve host", reason = "DNS failure" }
+        };
+
+        MatchJobLogPatternResult? result = await InvokeHarnessAsync<MatchJobLogPatternResult?>(
+            "matchJobLogPattern",
+            new { jobName = "Tests / Any", jobLogText = "Error: Could not resolve host github.com", patterns });
+
+        Assert.NotNull(result);
+        Assert.True(result.Matched);
+        Assert.Equal("DNS failure", result.Reason);
+    }
+
+    // --- TRX parsing tests ---
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractFailedTestsFromTrxExtractsFailedTests()
+    {
+        string trxContent = BuildTrxContent(
+            new TrxTestResult("Aspire.Tests.PassingTest", "Passed"),
+            new TrxTestResult("Aspire.Tests.FailingTest", "Failed", ErrorMessage: "ECONNRESET", StackTrace: "at Line 42"));
+
+        ExtractFailedTestsFromTrxResult[] results = await InvokeHarnessAsync<ExtractFailedTestsFromTrxResult[]>(
+            "extractFailedTestsFromTrx",
+            new { trxContent });
+
+        Assert.Single(results);
+        Assert.Equal("Aspire.Tests.FailingTest", results[0].TestName);
+        Assert.Contains("ECONNRESET", results[0].Output);
+        Assert.Contains("at Line 42", results[0].Output);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractFailedTestsFromTrxReturnsEmptyForNoFailures()
+    {
+        string trxContent = BuildTrxContent(
+            new TrxTestResult("Aspire.Tests.PassingTest", "Passed"));
+
+        ExtractFailedTestsFromTrxResult[] results = await InvokeHarnessAsync<ExtractFailedTestsFromTrxResult[]>(
+            "extractFailedTestsFromTrx",
+            new { trxContent });
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractFailedTestsFromTrxReturnsEmptyForEmptyInput()
+    {
+        ExtractFailedTestsFromTrxResult[] results = await InvokeHarnessAsync<ExtractFailedTestsFromTrxResult[]>(
+            "extractFailedTestsFromTrx",
+            new { trxContent = "" });
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractFailedTestsFromTrxHandlesMalformedXml()
+    {
+        ExtractFailedTestsFromTrxResult[] results = await InvokeHarnessAsync<ExtractFailedTestsFromTrxResult[]>(
+            "extractFailedTestsFromTrx",
+            new { trxContent = "<not valid xml" });
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractFailedTestsFromTrxCapsOutputAt10KB()
+    {
+        string longMessage = new('x', 12_000);
+        string trxContent = BuildTrxContent(
+            new TrxTestResult("Aspire.Tests.BigOutput", "Failed", ErrorMessage: longMessage));
+
+        ExtractFailedTestsFromTrxResult[] results = await InvokeHarnessAsync<ExtractFailedTestsFromTrxResult[]>(
+            "extractFailedTestsFromTrx",
+            new { trxContent });
+
+        Assert.Single(results);
+        Assert.True(results[0].Output.Length <= 10 * 1024, $"Output length {results[0].Output.Length} exceeds 10KB cap");
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractFailedTestsFromTrxDecodesXmlEntities()
+    {
+        string trxContent = BuildTrxContent(
+            new TrxTestResult("Aspire.Tests.EntityTest", "Failed", ErrorMessage: "Expected &lt;value&gt; but got &amp;null"));
+
+        ExtractFailedTestsFromTrxResult[] results = await InvokeHarnessAsync<ExtractFailedTestsFromTrxResult[]>(
+            "extractFailedTestsFromTrx",
+            new { trxContent });
+
+        Assert.Single(results);
+        Assert.Contains("<value>", results[0].Output);
+        Assert.Contains("&null", results[0].Output);
+    }
+
+    // --- Config validation edge case tests ---
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ValidateRetryPatternsConfigRejectsUnknownTopLevelProperties()
+    {
+        var config = new
+        {
+            version = 1,
+            testFailurePatterns = Array.Empty<object>(),
+            jobFailurePatterns = Array.Empty<object>(),
+            unknownProp = "bad"
+        };
+
+        ValidationResult result = await InvokeHarnessAsync<ValidationResult>(
+            "validateRetryPatternsConfig",
+            new { config });
+
+        Assert.False(result.Valid);
+        Assert.Contains(result.Errors, e => e.Contains("unknownProp"));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ValidateRetryPatternsConfigRejectsWrongVersion()
+    {
+        var config = new
+        {
+            version = 2,
+            testFailurePatterns = Array.Empty<object>(),
+            jobFailurePatterns = Array.Empty<object>()
+        };
+
+        ValidationResult result = await InvokeHarnessAsync<ValidationResult>(
+            "validateRetryPatternsConfig",
+            new { config });
+
+        Assert.False(result.Valid);
+        Assert.Contains(result.Errors, e => e.Contains("version"));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ValidateRetryPatternsConfigRejectsMissingReason()
+    {
+        var config = new
+        {
+            version = 1,
+            testFailurePatterns = new object[]
+            {
+                new { output = "ECONNRESET" }
+            },
+            jobFailurePatterns = Array.Empty<object>()
+        };
+
+        ValidationResult result = await InvokeHarnessAsync<ValidationResult>(
+            "validateRetryPatternsConfig",
+            new { config });
+
+        Assert.False(result.Valid);
+        Assert.Contains(result.Errors, e => e.Contains("reason"));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ValidateRetryPatternsConfigRejectsRuleWithNoMatcherFields()
+    {
+        var config = new
+        {
+            version = 1,
+            testFailurePatterns = new object[]
+            {
+                new { reason = "No matchers here" }
+            },
+            jobFailurePatterns = Array.Empty<object>()
+        };
+
+        ValidationResult result = await InvokeHarnessAsync<ValidationResult>(
+            "validateRetryPatternsConfig",
+            new { config });
+
+        Assert.False(result.Valid);
+        Assert.Contains(result.Errors, e => e.Contains("matcher field"));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ValidateRetryPatternsConfigRejectsInvalidRegex()
+    {
+        var config = new
+        {
+            version = 1,
+            testFailurePatterns = new object[]
+            {
+                new { testName = new { regex = "[invalid" }, reason = "Bad regex" }
+            },
+            jobFailurePatterns = Array.Empty<object>()
+        };
+
+        ValidationResult result = await InvokeHarnessAsync<ValidationResult>(
+            "validateRetryPatternsConfig",
+            new { config });
+
+        Assert.False(result.Valid);
+        Assert.Contains(result.Errors, e => e.Contains("invalid regex") || e.Contains("Invalid"));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ValidateRetryPatternsConfigAcceptsValidConfig()
+    {
+        var config = new
+        {
+            version = 1,
+            testFailurePatterns = new object[]
+            {
+                new { output = "ECONNRESET", reason = "Network reset" },
+                new { testName = new { regex = ".*Redis.*" }, output = "refused", reason = "Redis race" }
+            },
+            jobFailurePatterns = new object[]
+            {
+                new { jobName = new { regex = ".*windows.*" }, output = "0xC0000142", reason = "Win init" }
+            }
+        };
+
+        ValidationResult result = await InvokeHarnessAsync<ValidationResult>(
+            "validateRetryPatternsConfig",
+            new { config });
+
+        Assert.True(result.Valid);
+        Assert.Empty(result.Errors);
+    }
+
+    private static void ValidatePatternRule(JsonElement rule, HashSet<string> allowedFields, HashSet<string> matcherFields)
+    {
+        Assert.Equal(JsonValueKind.Object, rule.ValueKind);
+
+        foreach (JsonProperty prop in rule.EnumerateObject())
+        {
+            Assert.Contains(prop.Name, allowedFields);
+        }
+
+        Assert.True(
+            rule.TryGetProperty("reason", out JsonElement reason) && reason.ValueKind == JsonValueKind.String && reason.GetString()!.Length > 0,
+            "Each rule must have a non-empty 'reason' string.");
+
+        if (rule.TryGetProperty("enabled", out JsonElement enabled))
+        {
+            Assert.True(
+                enabled.ValueKind is JsonValueKind.True or JsonValueKind.False,
+                "'enabled' must be a boolean.");
+        }
+
+        bool hasMatcherField = false;
+        foreach (string field in matcherFields)
+        {
+            if (rule.TryGetProperty(field, out JsonElement fieldValue))
+            {
+                hasMatcherField = true;
+                ValidatePatternValue(fieldValue, $"{field}");
+            }
+        }
+
+        Assert.True(hasMatcherField, $"Rule must contain at least one matcher field ({string.Join(", ", matcherFields)}).");
+    }
+
+    private static void ValidatePatternValue(JsonElement value, string fieldName)
+    {
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            Assert.True(value.GetString()!.Length > 0, $"{fieldName}: string pattern must be non-empty.");
+            return;
+        }
+
+        if (value.ValueKind == JsonValueKind.Object)
+        {
+            Assert.True(
+                value.TryGetProperty("regex", out JsonElement regex) && regex.ValueKind == JsonValueKind.String && regex.GetString()!.Length > 0,
+                $"{fieldName}: regex pattern must have a non-empty 'regex' string.");
+            return;
+        }
+
+        Assert.Fail($"{fieldName}: must be a string or {{ \"regex\": \"...\" }} object.");
+    }
+
+    private static void ExtractRegexPatterns(JsonElement patternsArray, List<string> regexPatterns)
+    {
+        foreach (JsonElement rule in patternsArray.EnumerateArray())
+        {
+            foreach (JsonProperty prop in rule.EnumerateObject())
+            {
+                if (prop.Value.ValueKind == JsonValueKind.Object &&
+                    prop.Value.TryGetProperty("regex", out JsonElement regex) &&
+                    regex.ValueKind == JsonValueKind.String)
+                {
+                    regexPatterns.Add(regex.GetString()!);
+                }
+            }
+        }
+    }
+
+    private static string BuildTrxContent(params TrxTestResult[] results)
+    {
+        List<string> resultElements = [];
+
+        foreach (TrxTestResult test in results)
+        {
+            string outputElement = "";
+
+            if (!string.IsNullOrEmpty(test.ErrorMessage) || !string.IsNullOrEmpty(test.StackTrace) || !string.IsNullOrEmpty(test.StdOut))
+            {
+                string errorInfo = "";
+                if (!string.IsNullOrEmpty(test.ErrorMessage) || !string.IsNullOrEmpty(test.StackTrace))
+                {
+                    errorInfo = "<ErrorInfo>" +
+                        (string.IsNullOrEmpty(test.ErrorMessage) ? "" : $"<Message>{test.ErrorMessage}</Message>") +
+                        (string.IsNullOrEmpty(test.StackTrace) ? "" : $"<StackTrace>{test.StackTrace}</StackTrace>") +
+                        "</ErrorInfo>";
+                }
+
+                string stdOut = string.IsNullOrEmpty(test.StdOut) ? "" : $"<StdOut>{test.StdOut}</StdOut>";
+                outputElement = $"<Output>{errorInfo}{stdOut}</Output>";
+            }
+
+            resultElements.Add(
+                $"""<UnitTestResult testName="{test.TestName}" outcome="{test.Outcome}">{outputElement}</UnitTestResult>""");
+        }
+
+        return $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <TestRun>
+              <Results>
+                {string.Join("\n    ", resultElements)}
+              </Results>
+            </TestRun>
+            """;
+    }
+
+    private sealed record TrxTestResult(
+        string TestName,
+        string Outcome,
+        string ErrorMessage = "",
+        string StackTrace = "",
+        string StdOut = "");
+
     private async Task<AnalyzeFailedJobsResult> AnalyzeSingleJobAsync(WorkflowJob job, string annotationsOrText, string jobLogText = "")
     {
         Dictionary<string, string>? jobLogTextByJobId = string.IsNullOrEmpty(jobLogText)
@@ -1234,5 +1886,42 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
     {
         public string Route { get; init; } = string.Empty;
         public JsonElement Payload { get; init; }
+    }
+
+    private sealed class LoadRetryPatternsConfigResult
+    {
+        public JsonElement? Config { get; init; }
+        public string[] Errors { get; init; } = [];
+    }
+
+    private sealed class ValidationResult
+    {
+        public bool Valid { get; init; }
+        public string[] Errors { get; init; } = [];
+    }
+
+    private sealed class MatchTestFailurePatternsResult
+    {
+        public bool ShouldRetry { get; init; }
+        public MatchedTest[] MatchedTests { get; init; } = [];
+    }
+
+    private sealed class MatchedTest
+    {
+        public string TestName { get; init; } = string.Empty;
+        public string Reason { get; init; } = string.Empty;
+        public string? MatchedSnippet { get; init; }
+    }
+
+    private sealed class MatchJobLogPatternResult
+    {
+        public bool Matched { get; init; }
+        public string Reason { get; init; } = string.Empty;
+    }
+
+    private sealed class ExtractFailedTestsFromTrxResult
+    {
+        public string TestName { get; init; } = string.Empty;
+        public string Output { get; init; } = string.Empty;
     }
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -1059,7 +1059,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
     {
         string configJson = await ReadRepoFileAsync("eng/test-retry-patterns.json");
 
-        JsonDocument doc = JsonDocument.Parse(configJson);
+        using JsonDocument doc = JsonDocument.Parse(configJson);
         JsonElement root = doc.RootElement;
 
         Assert.Equal(JsonValueKind.Object, root.ValueKind);
@@ -1083,7 +1083,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
     {
         string configJson = await ReadRepoFileAsync("eng/test-retry-patterns.json");
 
-        JsonDocument doc = JsonDocument.Parse(configJson);
+        using JsonDocument doc = JsonDocument.Parse(configJson);
         JsonElement root = doc.RootElement;
 
         HashSet<string> testPatternAllowedFields = ["testName", "testProject", "output", "reason", "enabled"];
@@ -1121,7 +1121,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
     public async Task TestRetryPatternsJsonRegexesCompileInJavaScript()
     {
         string configJson = await ReadRepoFileAsync("eng/test-retry-patterns.json");
-        JsonDocument doc = JsonDocument.Parse(configJson);
+        using JsonDocument doc = JsonDocument.Parse(configJson);
         JsonElement root = doc.RootElement;
 
         List<string> regexPatterns = [];

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -1741,6 +1741,22 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Contains("&null", results[0].Output);
     }
 
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractFailedTestsFromTrxDecodesDoubleEncodedXmlEntities()
+    {
+        string trxContent = BuildTrxContent(
+            new TrxTestResult("Aspire.Tests.QuoteTest", "Failed", ErrorMessage: "Expected &amp;quot;hello&amp;quot; but got &amp;apos;world&amp;apos;"));
+
+        ExtractFailedTestsFromTrxResult[] results = await InvokeHarnessAsync<ExtractFailedTestsFromTrxResult[]>(
+            "extractFailedTestsFromTrx",
+            new { trxContent });
+
+        Assert.Single(results);
+        Assert.Contains("&quot;hello&quot;", results[0].Output);
+        Assert.Contains("&apos;world&apos;", results[0].Output);
+    }
+
     // --- Config validation edge case tests ---
 
     [Fact]

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -62,6 +62,7 @@ async function dispatch(operation, payload) {
                         return payload.jobLogTextByJobId?.[String(job.id)] ?? '';
                     },
                     maxRetryableJobs: payload.maxRetryableJobs,
+                    retryPatternsConfig: payload.retryPatternsConfig ?? null,
                 });
 
                 return { ...result, logRequestJobIds };
@@ -118,6 +119,23 @@ async function dispatch(operation, payload) {
                 payload.jobName,
                 payload.jobLogText,
                 payload.patterns);
+
+        case 'analyzeTrxFiles':
+            return rerunWorkflow.analyzeTrxFiles(
+                payload.trxFileContents,
+                payload.testFailurePatterns);
+
+        case 'promoteTestExecutionFailureJobs':
+            return rerunWorkflow.promoteTestExecutionFailureJobs(
+                payload.retryableJobs ?? [],
+                payload.skippedJobs ?? [],
+                payload.allMatchedTests ?? []);
+
+        case 'selectTestResultsArtifact':
+            return rerunWorkflow.selectTestResultsArtifact(payload.artifacts);
+
+        case 'hasTestExecutionFailureStep':
+            return rerunWorkflow.hasTestExecutionFailureStep(payload.failedSteps ?? []);
 
         case 'validateRetryPatternsConfigFromFile': {
             const configPath = path.resolve(payload.configPath);

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -1,4 +1,5 @@
 const fs = require('node:fs/promises');
+const path = require('node:path');
 const rerunWorkflow = require('../../../.github/workflows/auto-rerun-transient-ci-failures.js');
 
 class SummaryRecorder {
@@ -93,6 +94,36 @@ async function dispatch(operation, payload) {
 
         case 'computeRerunExecutionEligibility':
             return rerunWorkflow.computeRerunExecutionEligibility(payload);
+
+        case 'validateRetryPatternsConfig':
+            return rerunWorkflow.validateRetryPatternsConfig(payload.config);
+
+        case 'loadRetryPatternsConfig':
+            return rerunWorkflow.loadRetryPatternsConfig(payload.configPath);
+
+        case 'extractFailedTestsFromTrx':
+            return rerunWorkflow.extractFailedTestsFromTrx(payload.trxContent);
+
+        case 'matchesRetryPattern':
+            return rerunWorkflow.matchesRetryPattern(payload.text, payload.patternValue);
+
+        case 'matchTestFailurePatterns':
+            return rerunWorkflow.matchTestFailurePatterns(
+                payload.failedTests,
+                payload.testProject,
+                payload.patterns);
+
+        case 'matchJobLogPattern':
+            return rerunWorkflow.matchJobLogPattern(
+                payload.jobName,
+                payload.jobLogText,
+                payload.patterns);
+
+        case 'validateRetryPatternsConfigFromFile': {
+            const configPath = path.resolve(payload.configPath);
+            const result = rerunWorkflow.loadRetryPatternsConfig(configPath);
+            return result;
+        }
 
         case 'writeAnalysisSummary': {
             const summary = new SummaryRecorder();


### PR DESCRIPTION
## Description

Adds test failure retry support to the auto-rerun transient CI failures workflow. When a CI job fails due to test execution failures, the workflow now downloads TRX test result artifacts, parses them, and matches individual test failures against configurable retry-safe patterns (e.g., network errors, MCR rate limiting).

The design of the retry patterns configuration was inspired by [arcade's test configuration JSON schema](https://github.com/dotnet/arcade/blob/main/Documentation/DevWorkflow/Design/Dev-Design-Test-Configuration-Json.md?plain=1#L48-L54).

## Retry Patterns Config (`eng/test-retry-patterns.json`)

The new `eng/test-retry-patterns.json` file defines which test and job failures are safe to automatically retry. It uses a declarative JSON format with two pattern arrays:

### Structure

```json
{
  "version": 1,
  "testFailurePatterns": [ ... ],
  "jobFailurePatterns": [ ... ]
}
```

Each pattern has:
- **`output`** — a substring or `{ "regex": "..." }` matched against test output or job logs
- **`reason`** — human-readable explanation shown in PR comments and workflow summaries
- **`testName`** *(optional, test patterns only)* — filter by test name (substring or regex)
- **`testProject`** *(optional, test patterns only)* — filter by test project/assembly name
- **`jobName`** *(optional, job patterns only)* — filter by job name (substring or regex)

### Example: Simple substring match

Match any test whose output contains `ECONNRESET`:

```json
{
  "output": "ECONNRESET",
  "reason": "Transient network connection reset"
}
```

### Example: Regex pattern

Match MCR rate-limiting responses (403 within ~500 chars of the MCR URL):

```json
{
  "output": { "regex": "mcr\\.microsoft\\.com[\\s\\S]{0,500}403 Forbidden" },
  "reason": "MCR registry rate limiting (HTTP 403)"
}
```

### Example: Job-scoped pattern with job name filter

Match the Windows process init failure only on Windows jobs:

```json
{
  "jobName": { "regex": ".*windows.*" },
  "output": "0xC0000142",
  "reason": "Windows process initialization failure (0xC0000142)"
}
```

### Example: Test-scoped pattern with test name filter

Match a specific flaky test by name and output:

```json
{
  "testName": { "regex": ".*MyFlakyTest.*" },
  "output": "Connection refused",
  "reason": "Known transient failure in MyFlakyTest"
}
```

### Adding new patterns

1. Edit `eng/test-retry-patterns.json`
2. Add a new entry to `testFailurePatterns` or `jobFailurePatterns`
3. The config is validated at runtime — unknown properties, missing `reason`, or invalid regex will produce clear error messages
4. Run the Infrastructure.Tests to verify: `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
