### PR TITLE
Fix interactive C# aspire init config collision

### DIFF
--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -138,7 +138,8 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         // template will write aspire.config.json (including appHost.language) and a
         // pre-create write would cause a file-collision that makes dotnet new fail.
         var explicitLanguage = parseResult.GetValue(_languageOption);
-        var selectedProject = await _languageService.GetOrPromptForProjectAsync(explicitLanguage, saveSelection: false, cancellationToken);
+        var projectSelection = await _languageService.GetOrPromptForProjectSelectionAsync(explicitLanguage, saveSelection: false, cancellationToken);
+        var selectedProject = projectSelection.Project;
 
         // For non-C# languages, skip solution detection and create polyglot apphost.
         if (selectedProject.LanguageId != KnownLanguageId.CSharp)
@@ -161,8 +162,11 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 return polyglotResult;
             }
 
-            // Persist language selection after scaffolding succeeds.
-            await _languageService.SetLanguageAsync(selectedProject, cancellationToken: cancellationToken);
+            if (projectSelection.ShouldPersistSelection)
+            {
+                await _languageService.SetLanguageAsync(selectedProject, cancellationToken: cancellationToken);
+            }
+
             return await _agentInitCommand.PromptAndChainAsync(InteractionService, polyglotResult, _executionContext.WorkingDirectory, agentInitBinding, cancellationToken);
         }
 
@@ -203,11 +207,11 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return initResult;
         }
 
-        // For the solution-based path, persist the language selection now that creation
-        // succeeded. The no-solution (single-file) path skips this because the
+        // For the solution-based path, persist prompted language selections now that
+        // creation succeeded. The no-solution (single-file) path skips this because the
         // aspire-apphost-singlefile template writes aspire.config.json (including
         // appHost.language) so no separate write is needed.
-        if (initContext.SelectedSolutionFile is not null)
+        if (initContext.SelectedSolutionFile is not null && projectSelection.ShouldPersistSelection)
         {
             await _languageService.SetLanguageAsync(selectedProject, cancellationToken: cancellationToken);
         }

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -135,10 +135,10 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         // Get the language selection (from command line, config, or prompt).
         // Do not save yet – for the no-solution C# path the aspire-apphost-singlefile
-        // template will write aspire.config.json (including appHost.language) and a
+        // template will write aspire.config.json and a
         // pre-create write would cause a file-collision that makes dotnet new fail.
         var explicitLanguage = parseResult.GetValue(_languageOption);
-        var projectSelection = await _languageService.GetOrPromptForProjectSelectionAsync(explicitLanguage, saveSelection: false, cancellationToken);
+        var projectSelection = await _languageService.GetOrPromptForProjectSelectionAsync(explicitLanguage, saveLanguageSelection: false, cancellationToken);
         var selectedProject = projectSelection.Project;
 
         // For non-C# languages, skip solution detection and create polyglot apphost.
@@ -207,11 +207,9 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return initResult;
         }
 
-        // For the solution-based path, persist prompted language selections now that
-        // creation succeeded. The no-solution (single-file) path skips this because the
-        // aspire-apphost-singlefile template writes aspire.config.json (including
-        // appHost.language) so no separate write is needed.
-        if (initContext.SelectedSolutionFile is not null && projectSelection.ShouldPersistSelection)
+        // Persist prompted language selections after creation succeeds. This is delayed so
+        // the single-file C# template can create aspire.config.json before the language is merged.
+        if (projectSelection.ShouldPersistSelection)
         {
             await _languageService.SetLanguageAsync(selectedProject, cancellationToken: cancellationToken);
         }

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -134,8 +134,11 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         var agentInitBinding = PromptBinding.CreateInvertedBoolConfirm(parseResult, NewCommand.s_suppressAgentInitOption, defaultValue: true);
 
         // Get the language selection (from command line, config, or prompt).
+        // Do not save yet – for the no-solution C# path the aspire-apphost-singlefile
+        // template will write aspire.config.json (including appHost.language) and a
+        // pre-create write would cause a file-collision that makes dotnet new fail.
         var explicitLanguage = parseResult.GetValue(_languageOption);
-        var selectedProject = await _languageService.GetOrPromptForProjectAsync(explicitLanguage, saveSelection: true, cancellationToken);
+        var selectedProject = await _languageService.GetOrPromptForProjectAsync(explicitLanguage, saveSelection: false, cancellationToken);
 
         // For non-C# languages, skip solution detection and create polyglot apphost.
         if (selectedProject.LanguageId != KnownLanguageId.CSharp)
@@ -158,6 +161,8 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 return polyglotResult;
             }
 
+            // Persist language selection after scaffolding succeeds.
+            await _languageService.SetLanguageAsync(selectedProject, cancellationToken: cancellationToken);
             return await _agentInitCommand.PromptAndChainAsync(InteractionService, polyglotResult, _executionContext.WorkingDirectory, agentInitBinding, cancellationToken);
         }
 
@@ -196,6 +201,15 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         {
             InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
             return initResult;
+        }
+
+        // For the solution-based path, persist the language selection now that creation
+        // succeeded. The no-solution (single-file) path skips this because the
+        // aspire-apphost-singlefile template writes aspire.config.json (including
+        // appHost.language) so no separate write is needed.
+        if (initContext.SelectedSolutionFile is not null)
+        {
+            await _languageService.SetLanguageAsync(selectedProject, cancellationToken: cancellationToken);
         }
 
         return await _agentInitCommand.PromptAndChainAsync(InteractionService, initResult, workspaceRoot, agentInitBinding, cancellationToken);

--- a/src/Aspire.Cli/Projects/ILanguageService.cs
+++ b/src/Aspire.Cli/Projects/ILanguageService.cs
@@ -38,4 +38,18 @@ internal interface ILanguageService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The project handler to use.</returns>
     Task<IAppHostProject> GetOrPromptForProjectAsync(string? explicitLanguageId = null, bool saveSelection = true, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the configured project or prompts, validating explicit language ID, and returns whether the prompted selection still needs to be persisted.
+    /// </summary>
+    /// <param name="explicitLanguageId">An explicitly specified language ID (e.g., from command line).</param>
+    /// <param name="saveSelection">Whether to save the selection to config if prompted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The project handler to use and whether the selection should be saved after the caller completes its work.</returns>
+    Task<AppHostProjectSelection> GetOrPromptForProjectSelectionAsync(string? explicitLanguageId = null, bool saveSelection = true, CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Represents the selected AppHost project and whether that selection still needs to be persisted.
+/// </summary>
+internal sealed record AppHostProjectSelection(IAppHostProject Project, bool ShouldPersistSelection);

--- a/src/Aspire.Cli/Projects/ILanguageService.cs
+++ b/src/Aspire.Cli/Projects/ILanguageService.cs
@@ -34,19 +34,19 @@ internal interface ILanguageService
     /// Gets the configured project or prompts, validating explicit language ID.
     /// </summary>
     /// <param name="explicitLanguageId">An explicitly specified language ID (e.g., from command line).</param>
-    /// <param name="saveSelection">Whether to save the selection to config if prompted.</param>
+    /// <param name="saveLanguageSelection">Whether to save the language selection to config if prompted.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The project handler to use.</returns>
-    Task<IAppHostProject> GetOrPromptForProjectAsync(string? explicitLanguageId = null, bool saveSelection = true, CancellationToken cancellationToken = default);
+    Task<IAppHostProject> GetOrPromptForProjectAsync(string? explicitLanguageId = null, bool saveLanguageSelection = true, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the configured project or prompts, validating explicit language ID, and returns whether the prompted selection still needs to be persisted.
     /// </summary>
     /// <param name="explicitLanguageId">An explicitly specified language ID (e.g., from command line).</param>
-    /// <param name="saveSelection">Whether to save the selection to config if prompted.</param>
+    /// <param name="saveLanguageSelection">Whether to save the language selection to config if prompted.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The project handler to use and whether the selection should be saved after the caller completes its work.</returns>
-    Task<AppHostProjectSelection> GetOrPromptForProjectSelectionAsync(string? explicitLanguageId = null, bool saveSelection = true, CancellationToken cancellationToken = default);
+    Task<AppHostProjectSelection> GetOrPromptForProjectSelectionAsync(string? explicitLanguageId = null, bool saveLanguageSelection = true, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -109,6 +109,17 @@ internal sealed class LanguageService : ILanguageService
         bool saveSelection = true,
         CancellationToken cancellationToken = default)
     {
+        var selection = await GetOrPromptForProjectSelectionAsync(explicitLanguageId, saveSelection, cancellationToken);
+
+        return selection.Project;
+    }
+
+    /// <inheritdoc />
+    public async Task<AppHostProjectSelection> GetOrPromptForProjectSelectionAsync(
+        string? explicitLanguageId = null,
+        bool saveSelection = true,
+        CancellationToken cancellationToken = default)
+    {
         // If explicitly specified, use that
         if (!string.IsNullOrWhiteSpace(explicitLanguageId))
         {
@@ -118,14 +129,15 @@ internal sealed class LanguageService : ILanguageService
                 _interactionService.DisplayError($"Unknown language: '{explicitLanguageId}'");
                 throw new ArgumentException($"Unknown language: '{explicitLanguageId}'", nameof(explicitLanguageId));
             }
-            return _projectFactory.GetProject(language);
+
+            return new AppHostProjectSelection(_projectFactory.GetProject(language), ShouldPersistSelection: false);
         }
 
         // Check if configured
         var configuredProject = await GetConfiguredProjectAsync(cancellationToken);
         if (configuredProject is not null)
         {
-            return configuredProject;
+            return new AppHostProjectSelection(configuredProject, ShouldPersistSelection: false);
         }
 
         // Prompt for selection
@@ -138,6 +150,6 @@ internal sealed class LanguageService : ILanguageService
             _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Language preference saved to local configuration: {selectedProject.DisplayName}");
         }
 
-        return selectedProject;
+        return new AppHostProjectSelection(selectedProject, ShouldPersistSelection: !saveSelection);
     }
 }

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -106,10 +106,10 @@ internal sealed class LanguageService : ILanguageService
     /// <inheritdoc />
     public async Task<IAppHostProject> GetOrPromptForProjectAsync(
         string? explicitLanguageId = null,
-        bool saveSelection = true,
+        bool saveLanguageSelection = true,
         CancellationToken cancellationToken = default)
     {
-        var selection = await GetOrPromptForProjectSelectionAsync(explicitLanguageId, saveSelection, cancellationToken);
+        var selection = await GetOrPromptForProjectSelectionAsync(explicitLanguageId, saveLanguageSelection, cancellationToken);
 
         return selection.Project;
     }
@@ -117,7 +117,7 @@ internal sealed class LanguageService : ILanguageService
     /// <inheritdoc />
     public async Task<AppHostProjectSelection> GetOrPromptForProjectSelectionAsync(
         string? explicitLanguageId = null,
-        bool saveSelection = true,
+        bool saveLanguageSelection = true,
         CancellationToken cancellationToken = default)
     {
         // If explicitly specified, use that
@@ -144,12 +144,12 @@ internal sealed class LanguageService : ILanguageService
         var (selectedProject, selectedLanguage) = await PromptForProjectWithLanguageAsync(cancellationToken);
 
         // Save the language ID
-        if (saveSelection)
+        if (saveLanguageSelection)
         {
             await SetLanguageAsync(selectedLanguage.LanguageId, isGlobal: false, cancellationToken);
             _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Language preference saved to local configuration: {selectedProject.DisplayName}");
         }
 
-        return new AppHostProjectSelection(selectedProject, ShouldPersistSelection: !saveSelection);
+        return new AppHostProjectSelection(selectedProject, ShouldPersistSelection: !saveLanguageSelection);
     }
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/aspire.config.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/aspire.config.json
@@ -1,5 +1,6 @@
 {
   "appHost": {
-    "path": "apphost.cs"
+    "path": "apphost.cs",
+    "language": "csharp"
   }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/CSharpInitTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CSharpInitTests.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// Regression test for interactive <c>aspire init</c> with the default C# language selection.
+/// Verifies that accepting the default prompt (rather than passing <c>--language csharp</c>) does not
+/// produce a conflicting-files / overwrite error and that the expected output files are created.
+/// </summary>
+public sealed class CSharpInitTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Runs <c>aspire init</c> interactively, accepts the default <c>&gt; C#</c> selection from the
+    /// language prompt, handles any NuGet.config prompt that may follow, and verifies that both
+    /// <c>apphost.cs</c> and <c>aspire.config.json</c> are created with the expected content.
+    /// </summary>
+    [CaptureWorkspaceOnFailure]
+    [Fact]
+    public async Task InteractiveCSharpInitCreatesExpectedFiles()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect();
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Run aspire init without --language so the interactive language prompt is shown.
+        await auto.TypeAsync("aspire init");
+        await auto.EnterAsync();
+
+        // Wait for the language selection prompt and confirm the default "> C#" choice.
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("> C#").Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(30),
+            description: "language selection prompt with default '> C#'");
+        await auto.EnterAsync();
+
+        // After selecting C#, wait for either a NuGet.config prompt or init completion.
+        var waitingForNuGetConfigPrompt = new CellPatternSearcher().Find("NuGet.config");
+        var waitingForInitComplete = new CellPatternSearcher().Find("Aspire initialization complete");
+
+        await auto.WaitUntilAsync(
+            s => waitingForNuGetConfigPrompt.Search(s).Count > 0
+                || waitingForInitComplete.Search(s).Count > 0,
+            timeout: TimeSpan.FromMinutes(2),
+            description: "NuGet.config prompt or aspire initialization complete");
+
+        // Dismiss NuGet.config prompt if it appeared (pressing Enter is a no-op if init already completed).
+        await auto.EnterAsync();
+
+        await auto.WaitUntilAsync(
+            s => waitingForInitComplete.Search(s).Count > 0,
+            timeout: TimeSpan.FromMinutes(2),
+            description: "aspire initialization complete");
+
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        // --- Host-side file assertions ---
+        var appHostCs = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
+        var aspireConfigJson = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+
+        Assert.True(File.Exists(appHostCs), $"Expected apphost.cs to exist at: {appHostCs}");
+        Assert.True(File.Exists(aspireConfigJson), $"Expected aspire.config.json to exist at: {aspireConfigJson}");
+
+        var configText = await File.ReadAllTextAsync(aspireConfigJson);
+        var config = JsonNode.Parse(configText);
+        Assert.NotNull(config);
+
+        var appHostNode = config["appHost"];
+        Assert.NotNull(appHostNode);
+
+        var path = appHostNode!["path"]?.GetValue<string>();
+        Assert.Equal("apphost.cs", path);
+
+        var language = appHostNode["language"]?.GetValue<string>();
+        Assert.NotNull(language);
+        Assert.Contains("csharp", language, StringComparison.OrdinalIgnoreCase);
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/CSharpInitTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CSharpInitTests.cs
@@ -18,8 +18,8 @@ public sealed class CSharpInitTests(ITestOutputHelper output)
 {
     /// <summary>
     /// Runs <c>aspire init</c> interactively, accepts the default <c>&gt; C#</c> selection from the
-    /// language prompt, handles any NuGet.config prompt that may follow, and verifies that both
-    /// <c>apphost.cs</c> and <c>aspire.config.json</c> are created with the expected content.
+    /// language prompt, accepts the default URL format, handles any NuGet.config prompt that may follow,
+    /// and verifies that both <c>apphost.cs</c> and <c>aspire.config.json</c> are created with the expected content.
     /// </summary>
     [CaptureWorkspaceOnFailure]
     [Fact]
@@ -50,18 +50,28 @@ public sealed class CSharpInitTests(ITestOutputHelper output)
             description: "language selection prompt with default '> C#'");
         await auto.EnterAsync();
 
-        // After selecting C#, wait for either a NuGet.config prompt or init completion.
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("Use *.dev.localhost URLs").Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(10),
+            description: "URLs prompt");
+        await auto.EnterAsync();
+
         var waitingForNuGetConfigPrompt = new CellPatternSearcher().Find("NuGet.config");
         var waitingForInitComplete = new CellPatternSearcher().Find("Aspire initialization complete");
+        var sawNuGetConfigPrompt = false;
 
-        await auto.WaitUntilAsync(
-            s => waitingForNuGetConfigPrompt.Search(s).Count > 0
-                || waitingForInitComplete.Search(s).Count > 0,
+        await auto.WaitUntilAsync(s =>
+        {
+            sawNuGetConfigPrompt = waitingForNuGetConfigPrompt.Search(s).Count > 0;
+            return sawNuGetConfigPrompt || waitingForInitComplete.Search(s).Count > 0;
+        },
             timeout: TimeSpan.FromMinutes(2),
             description: "NuGet.config prompt or aspire initialization complete");
 
-        // Dismiss NuGet.config prompt if it appeared (pressing Enter is a no-op if init already completed).
-        await auto.EnterAsync();
+        if (sawNuGetConfigPrompt)
+        {
+            await auto.EnterAsync();
+        }
 
         await auto.WaitUntilAsync(
             s => waitingForInitComplete.Search(s).Count > 0,

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -413,6 +413,13 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 return new TestLanguageService
                 {
                     DefaultProject = defaultCsharpProject,
+                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveSelection, ct) =>
+                    {
+                        Assert.Null(explicitLanguage);
+                        Assert.False(saveSelection);
+
+                        return Task.FromResult(new AppHostProjectSelection(defaultCsharpProject, ShouldPersistSelection: true));
+                    },
                     GetOrPromptForProjectAsyncCallback = async (explicitLanguage, saveSelection, ct) =>
                     {
                         if (string.IsNullOrWhiteSpace(explicitLanguage) && saveSelection)
@@ -451,9 +458,6 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                     }
 
                     // No collision: create the files the template would produce.
-                    // After the production fix (tasks 2 and 3) the final config retains
-                    // both the template-written path and the language that was persisted
-                    // before (or merged back after) dotnet new runs.
                     File.WriteAllText(Path.Combine(outputDir, "apphost.cs"), "// apphost");
                     File.WriteAllText(configFilePath, """{"appHost":{"path":"apphost.cs","language":"csharp"}}""");
                     return 0;
@@ -482,6 +486,156 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var configJson = await File.ReadAllTextAsync(configPath);
         Assert.Contains("apphost.cs", configJson);
         Assert.Contains("csharp", configJson);
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenLanguageIsExplicit_DoesNotPersistLanguageAgain()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var scaffolded = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.LanguageServiceFactory = (sp) =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(CreateTypeScriptLanguageInfo());
+
+                return new TestLanguageService
+                {
+                    DefaultProject = tsProject,
+                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveSelection, ct) =>
+                    {
+                        Assert.Equal(KnownLanguageId.TypeScript, explicitLanguage);
+                        Assert.False(saveSelection);
+
+                        return Task.FromResult(new AppHostProjectSelection(tsProject, ShouldPersistSelection: false));
+                    },
+                    SetLanguageAsyncCallback = (_, _, _) => throw new InvalidOperationException("Explicit language selection should not be persisted again.")
+                };
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                scaffolded = true;
+                return Task.FromResult(true);
+            }
+        });
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse($"init --language {KnownLanguageId.TypeScript} --suppress-agent-init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(scaffolded);
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenLanguageIsConfigured_DoesNotPersistLanguageAgain()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var scaffolded = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.LanguageServiceFactory = (sp) =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(CreateTypeScriptLanguageInfo());
+
+                return new TestLanguageService
+                {
+                    DefaultProject = tsProject,
+                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveSelection, ct) =>
+                    {
+                        Assert.Null(explicitLanguage);
+                        Assert.False(saveSelection);
+
+                        return Task.FromResult(new AppHostProjectSelection(tsProject, ShouldPersistSelection: false));
+                    },
+                    SetLanguageAsyncCallback = (_, _, _) => throw new InvalidOperationException("Configured language selection should not be persisted again.")
+                };
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                scaffolded = true;
+                return Task.FromResult(true);
+            }
+        });
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init --suppress-agent-init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(scaffolded);
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenLanguageIsPrompted_PersistsLanguageAfterScaffoldingSucceeds()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var scaffolded = false;
+        var persistedLanguage = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.LanguageServiceFactory = (sp) =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(CreateTypeScriptLanguageInfo());
+
+                return new TestLanguageService
+                {
+                    DefaultProject = tsProject,
+                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveSelection, ct) =>
+                    {
+                        Assert.Null(explicitLanguage);
+                        Assert.False(saveSelection);
+
+                        return Task.FromResult(new AppHostProjectSelection(tsProject, ShouldPersistSelection: true));
+                    },
+                    SetLanguageAsyncCallback = (project, isGlobal, ct) =>
+                    {
+                        Assert.Same(tsProject, project);
+                        Assert.False(isGlobal);
+
+                        persistedLanguage = true;
+                        return Task.CompletedTask;
+                    }
+                };
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                scaffolded = true;
+                return Task.FromResult(true);
+            }
+        });
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init --suppress-agent-init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(scaffolded);
+        Assert.True(persistedLanguage);
     }
 
     private static TestPackagingService CreatePackagingServiceWithTemplatePackages() => new()
@@ -522,6 +676,14 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
             }
         };
     }
+
+    private static LanguageInfo CreateTypeScriptLanguageInfo() => new(
+        LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+        DisplayName: "TypeScript (Node.js)",
+        PackageName: "@aspire/app-host",
+        DetectionPatterns: ["apphost.ts"],
+        CodeGenerator: "typescript",
+        AppHostFileName: "apphost.ts");
 
     [Fact]
     public async Task InitCommandWithChannelOptionUsesSpecifiedChannel()

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -382,6 +382,108 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         Assert.False(promptedForOutputPath, "Should not have prompted for output path");
     }
 
+    [Fact]
+    public async Task InitCommand_WhenCSharpLanguageIsPromptedAndSaved_DoesNotFailDueToPrecedingConfigFileWrite_Regression15750()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/15750
+        //
+        // Bug: LanguageService.GetOrPromptForProjectAsync persists appHost.language to
+        // aspire.config.json BEFORE CreateEmptyAppHostAsync invokes
+        // dotnet new aspire-apphost-singlefile.  The dotnet new template also emits
+        // aspire.config.json into the same working directory, so the pre-existing file
+        // causes a collision and dotnet new fails.
+        //
+        // This test drives the interactive prompt path (no --language flag) so the
+        // language-save happens, mirrors the collision by failing NewProjectAsync when
+        // aspire.config.json already exists, and then asserts the command succeeds with
+        // a final config containing both appHost.path and appHost.language.
+        // Against the current buggy code the test will fail because the command returns
+        // a non-zero exit code due to the collision.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            // Override the language service to mirror the real LanguageService behaviour:
+            // when GetOrPromptForProjectAsync is called without an explicit language id and
+            // saveSelection is true, it persists the selection to aspire.config.json via
+            // ConfigurationService before returning the C# project.
+            options.LanguageServiceFactory = (sp) =>
+            {
+                var defaultCsharpProject = sp.GetRequiredService<DotNetAppHostProject>();
+                return new TestLanguageService
+                {
+                    DefaultProject = defaultCsharpProject,
+                    GetOrPromptForProjectAsyncCallback = async (explicitLanguage, saveSelection, ct) =>
+                    {
+                        if (string.IsNullOrWhiteSpace(explicitLanguage) && saveSelection)
+                        {
+                            // Reproduce the exact write that real LanguageService performs via
+                            // ConfigurationService.SetConfigurationAsync("appHost.language", "csharp").
+                            var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+                            await File.WriteAllTextAsync(configPath,
+                                """{"appHost":{"language":"csharp"}}""", ct);
+                        }
+
+                        return defaultCsharpProject;
+                    }
+                };
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                    (ExitCode: 0, TemplateVersion: "10.0.0");
+
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    // Simulate dotnet new aspire-apphost-singlefile running in the working
+                    // directory (UseWorkingDirectory = true).  The real dotnet new tool fails
+                    // with a non-zero exit code when aspire.config.json already exists there.
+                    var outputDir = Path.GetFullPath(outputPath);
+                    var configFilePath = Path.Combine(outputDir, "aspire.config.json");
+
+                    if (File.Exists(configFilePath))
+                    {
+                        // Collision: aspire.config.json was written by the language save.
+                        return 1;
+                    }
+
+                    // No collision: create the files the template would produce.
+                    // After the production fix (tasks 2 and 3) the final config retains
+                    // both the template-written path and the language that was persisted
+                    // before (or merged back after) dotnet new runs.
+                    File.WriteAllText(Path.Combine(outputDir, "apphost.cs"), "// apphost");
+                    File.WriteAllText(configFilePath, """{"appHost":{"path":"apphost.cs","language":"csharp"}}""");
+                    return 0;
+                };
+
+                return runner;
+            };
+
+            options.PackagingServiceFactory = _ => CreatePackagingServiceWithTemplatePackages();
+        });
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        // Act: run without --language to exercise the interactive prompt+save path.
+        var parseResult = initCommand.Parse("init --suppress-agent-init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        // Assert: the command must succeed and the final aspire.config.json must contain
+        // both the template's appHost.path entry and the language selection.
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+        Assert.True(File.Exists(configPath), "aspire.config.json should exist after init");
+
+        var configJson = await File.ReadAllTextAsync(configPath);
+        Assert.Contains("apphost.cs", configJson);
+        Assert.Contains("csharp", configJson);
+    }
+
     private static TestPackagingService CreatePackagingServiceWithTemplatePackages() => new()
     {
         GetChannelsAsyncCallback = _ =>

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
@@ -403,26 +404,27 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            // Override the language service to mirror the real LanguageService behaviour:
+            // Override the language service to mirror the real LanguageService behavior:
             // when GetOrPromptForProjectAsync is called without an explicit language id and
-            // saveSelection is true, it persists the selection to aspire.config.json via
+            // saveLanguageSelection is true, it persists the selection to aspire.config.json via
             // ConfigurationService before returning the C# project.
             options.LanguageServiceFactory = (sp) =>
             {
                 var defaultCsharpProject = sp.GetRequiredService<DotNetAppHostProject>();
+                var configurationService = sp.GetRequiredService<IConfigurationService>();
                 return new TestLanguageService
                 {
                     DefaultProject = defaultCsharpProject,
-                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveSelection, ct) =>
+                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveLanguageSelection, ct) =>
                     {
                         Assert.Null(explicitLanguage);
-                        Assert.False(saveSelection);
+                        Assert.False(saveLanguageSelection);
 
                         return Task.FromResult(new AppHostProjectSelection(defaultCsharpProject, ShouldPersistSelection: true));
                     },
-                    GetOrPromptForProjectAsyncCallback = async (explicitLanguage, saveSelection, ct) =>
+                    GetOrPromptForProjectAsyncCallback = async (explicitLanguage, saveLanguageSelection, ct) =>
                     {
-                        if (string.IsNullOrWhiteSpace(explicitLanguage) && saveSelection)
+                        if (string.IsNullOrWhiteSpace(explicitLanguage) && saveLanguageSelection)
                         {
                             // Reproduce the exact write that real LanguageService performs via
                             // ConfigurationService.SetConfigurationAsync("appHost.language", "csharp").
@@ -432,6 +434,13 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                         }
 
                         return defaultCsharpProject;
+                    },
+                    SetLanguageAsyncCallback = (project, isGlobal, ct) =>
+                    {
+                        Assert.Same(defaultCsharpProject, project);
+                        Assert.False(isGlobal);
+
+                        return configurationService.SetConfigurationAsync("appHost.language", project.LanguageId, isGlobal, ct);
                     }
                 };
             };
@@ -457,9 +466,9 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                         return 1;
                     }
 
-                    // No collision: create the files the template would produce.
+                    // No collision: create the files that an older single-file template would produce.
                     File.WriteAllText(Path.Combine(outputDir, "apphost.cs"), "// apphost");
-                    File.WriteAllText(configFilePath, """{"appHost":{"path":"apphost.cs","language":"csharp"}}""");
+                    File.WriteAllText(configFilePath, """{"appHost":{"path":"apphost.cs"}}""");
                     return 0;
                 };
 
@@ -504,10 +513,10 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 return new TestLanguageService
                 {
                     DefaultProject = tsProject,
-                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveSelection, ct) =>
+                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveLanguageSelection, ct) =>
                     {
                         Assert.Equal(KnownLanguageId.TypeScript, explicitLanguage);
-                        Assert.False(saveSelection);
+                        Assert.False(saveLanguageSelection);
 
                         return Task.FromResult(new AppHostProjectSelection(tsProject, ShouldPersistSelection: false));
                     },
@@ -551,10 +560,10 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 return new TestLanguageService
                 {
                     DefaultProject = tsProject,
-                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveSelection, ct) =>
+                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveLanguageSelection, ct) =>
                     {
                         Assert.Null(explicitLanguage);
-                        Assert.False(saveSelection);
+                        Assert.False(saveLanguageSelection);
 
                         return Task.FromResult(new AppHostProjectSelection(tsProject, ShouldPersistSelection: false));
                     },
@@ -599,10 +608,10 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 return new TestLanguageService
                 {
                     DefaultProject = tsProject,
-                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveSelection, ct) =>
+                    GetOrPromptForProjectSelectionAsyncCallback = (explicitLanguage, saveLanguageSelection, ct) =>
                     {
                         Assert.Null(explicitLanguage);
-                        Assert.False(saveSelection);
+                        Assert.False(saveLanguageSelection);
 
                         return Task.FromResult(new AppHostProjectSelection(tsProject, ShouldPersistSelection: true));
                     },

--- a/tests/Aspire.Cli.Tests/TestServices/TestLanguageService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestLanguageService.cs
@@ -11,6 +11,7 @@ internal sealed class TestLanguageService : ILanguageService
     public Func<IAppHostProject, bool, CancellationToken, Task>? SetLanguageAsyncCallback { get; set; }
     public Func<CancellationToken, Task<IAppHostProject>>? PromptForProjectAsyncCallback { get; set; }
     public Func<string?, bool, CancellationToken, Task<IAppHostProject>>? GetOrPromptForProjectAsyncCallback { get; set; }
+    public Func<string?, bool, CancellationToken, Task<AppHostProjectSelection>>? GetOrPromptForProjectSelectionAsyncCallback { get; set; }
 
     /// <summary>
     /// The default project to return when no callback is set.
@@ -59,5 +60,16 @@ internal sealed class TestLanguageService : ILanguageService
         }
 
         return Task.FromResult(DefaultProject);
+    }
+
+    public async Task<AppHostProjectSelection> GetOrPromptForProjectSelectionAsync(string? explicitLanguageId = null, bool saveSelection = true, CancellationToken cancellationToken = default)
+    {
+        if (GetOrPromptForProjectSelectionAsyncCallback is not null)
+        {
+            return await GetOrPromptForProjectSelectionAsyncCallback(explicitLanguageId, saveSelection, cancellationToken);
+        }
+
+        var project = await GetOrPromptForProjectAsync(explicitLanguageId, saveSelection, cancellationToken);
+        return new AppHostProjectSelection(project, ShouldPersistSelection: false);
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestLanguageService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestLanguageService.cs
@@ -47,11 +47,11 @@ internal sealed class TestLanguageService : ILanguageService
         return Task.FromResult(DefaultProject);
     }
 
-    public Task<IAppHostProject> GetOrPromptForProjectAsync(string? explicitLanguageId = null, bool saveSelection = true, CancellationToken cancellationToken = default)
+    public Task<IAppHostProject> GetOrPromptForProjectAsync(string? explicitLanguageId = null, bool saveLanguageSelection = true, CancellationToken cancellationToken = default)
     {
         if (GetOrPromptForProjectAsyncCallback is not null)
         {
-            return GetOrPromptForProjectAsyncCallback(explicitLanguageId, saveSelection, cancellationToken);
+            return GetOrPromptForProjectAsyncCallback(explicitLanguageId, saveLanguageSelection, cancellationToken);
         }
 
         if (DefaultProject is null)
@@ -62,14 +62,14 @@ internal sealed class TestLanguageService : ILanguageService
         return Task.FromResult(DefaultProject);
     }
 
-    public async Task<AppHostProjectSelection> GetOrPromptForProjectSelectionAsync(string? explicitLanguageId = null, bool saveSelection = true, CancellationToken cancellationToken = default)
+    public async Task<AppHostProjectSelection> GetOrPromptForProjectSelectionAsync(string? explicitLanguageId = null, bool saveLanguageSelection = true, CancellationToken cancellationToken = default)
     {
         if (GetOrPromptForProjectSelectionAsyncCallback is not null)
         {
-            return await GetOrPromptForProjectSelectionAsyncCallback(explicitLanguageId, saveSelection, cancellationToken);
+            return await GetOrPromptForProjectSelectionAsyncCallback(explicitLanguageId, saveLanguageSelection, cancellationToken);
         }
 
-        var project = await GetOrPromptForProjectAsync(explicitLanguageId, saveSelection, cancellationToken);
+        var project = await GetOrPromptForProjectAsync(explicitLanguageId, saveLanguageSelection, cancellationToken);
         return new AppHostProjectSelection(project, ShouldPersistSelection: false);
     }
 }


### PR DESCRIPTION
## Description

Fixes interactive `aspire init` in an empty folder when the user accepts the default C# AppHost language. The language selection is no longer written to local config before the single-file C# template runs, which avoids the `aspire.config.json` overwrite collision. The single-file AppHost template now records `appHost.language` so the generated config still has complete AppHost metadata.

Fixes #15750

Validation:
- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.InitCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
