### PR TITLE
Add env support to Aspire debug launch configuration

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -7,6 +7,9 @@
     <trans-unit id="command.add">
       <source xml:lang="en">Add an integration</source>
     </trans-unit>
+    <trans-unit id="extension.debug.args">
+      <source xml:lang="en">Additional arguments to pass to the Aspire CLI command</source>
+    </trans-unit>
     <trans-unit id="mcpServerDefinitionProviders.aspire.label">
       <source xml:lang="en">Aspire</source>
     </trans-unit>
@@ -177,6 +180,9 @@
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.enterPipelineStep">
       <source xml:lang="en">Enter the pipeline step to execute</source>
+    </trans-unit>
+    <trans-unit id="extension.debug.env">
+      <source xml:lang="en">Environment variables to set when launching the Aspire AppHost</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.errorGettingConfigInfo">
       <source xml:lang="en">Error getting Aspire config info: {0}. Try updating the Aspire CLI with: aspire update</source>

--- a/extension/package.json
+++ b/extension/package.json
@@ -127,6 +127,22 @@
               "step": {
                 "type": "string",
                 "description": "%extension.debug.step%"
+              },
+              "args": {
+                "type": "array",
+                "description": "%extension.debug.args%",
+                "items": {
+                  "type": "string"
+                },
+                "default": []
+              },
+              "env": {
+                "type": "object",
+                "description": "%extension.debug.env%",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "default": {}
               }
             }
           }

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -1,10 +1,13 @@
 {
 	"extension.title": "Aspire VSCode",
 	"extension.description": "Official Aspire extension for Visual Studio Code",
-	"extension.debug.program": "Path to the AppHost to run",
+  "extension.debug.program": "Path to the AppHost to run",
   "extension.debug.debuggers": "Configuration to apply when launching resources of specific types",
 	"extension.debug.command": "The Aspire CLI command to execute (run, deploy, publish, or do)",
 	"extension.debug.step": "The pipeline step name to execute when command is 'do'",
+	"extension.debug.args": "Additional arguments to pass to the Aspire CLI command",
+	"extension.debug.env": "Environment variables to set when launching the Aspire AppHost",
+
 	"extension.debug.defaultConfiguration.name": "Aspire: Launch default AppHost",
 	"extension.debug.defaultConfiguration.description": "Launch the effective Aspire AppHost in your workspace",
 	"command.add": "Add an integration",

--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -163,6 +163,7 @@ export interface AspireExtendedDebugConfiguration extends vscode.DebugConfigurat
     command?: AspireCommandType;
     args?: string[];
     step?: string;
+    env?: { [key: string]: string };
 }
 
 interface AspireDebuggersConfiguration {

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -168,6 +168,11 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       }
     });
 
+    const configuredEnv = this.configuration.env;
+    const env = configuredEnv
+      ? Object.entries(configuredEnv).map(([name, value]) => ({ name, value: String(value) }))
+      : undefined;
+
     spawnCliProcess(
       this._terminalProvider,
       await this._terminalProvider.getAspireCliExecutablePath(),
@@ -194,7 +199,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
         },
         workingDirectory: workingDirectory,
         debugSessionId: this.debugSessionId,
-        noDebug: noDebug
+        noDebug: noDebug,
+        env: env
       },
     );
 

--- a/extension/src/test/launchProfiles.test.ts
+++ b/extension/src/test/launchProfiles.test.ts
@@ -442,17 +442,19 @@ suite('Launch Profile Tests', () => {
     });
 
     suite('determineWorkingDirectory', () => {
-        const projectPath = path.join('C:', 'project', 'MyApp.csproj');
+        const projectDir = path.resolve(path.sep, 'project');
+        const projectPath = path.join(projectDir, 'MyApp.csproj');
+        const absoluteWorkingDir = path.resolve(path.sep, 'custom', 'working', 'dir');
 
         test('uses absolute working directory from launch profile', () => {
             const baseProfile: LaunchProfile = {
                 commandName: 'Project',
-                workingDirectory: path.join('C:', 'custom', 'working', 'dir')
+                workingDirectory: absoluteWorkingDir
             };
 
             const result = determineWorkingDirectory(projectPath, baseProfile);
 
-            assert.strictEqual(result, path.join('C:', 'custom', 'working', 'dir'));
+            assert.strictEqual(result, absoluteWorkingDir);
         });
 
         test('resolves relative working directory from launch profile', () => {
@@ -463,7 +465,7 @@ suite('Launch Profile Tests', () => {
 
             const result = determineWorkingDirectory(projectPath, baseProfile);
 
-            assert.strictEqual(result, path.join('C:', 'project', 'custom'));
+            assert.strictEqual(result, path.join(projectDir, 'custom'));
         });
 
         test('uses project directory when no working directory specified', () => {
@@ -473,13 +475,13 @@ suite('Launch Profile Tests', () => {
 
             const result = determineWorkingDirectory(projectPath, baseProfile);
 
-            assert.strictEqual(result, path.join('C:', 'project'));
+            assert.strictEqual(result, projectDir);
         });
 
         test('uses project directory when base profile is null', () => {
             const result = determineWorkingDirectory(projectPath, null);
 
-            assert.strictEqual(result, path.join('C:', 'project'));
+            assert.strictEqual(result, projectDir);
         });
 
         test('expands environment variables in working directory before resolving', () => {

--- a/extension/src/test/packageManifest.test.ts
+++ b/extension/src/test/packageManifest.test.ts
@@ -7,12 +7,30 @@ type ManifestMenuItem = {
     when?: string;
 };
 
+type DebuggerProperty = {
+    type?: string | string[];
+    description?: string;
+    additionalProperties?: { type?: string };
+    items?: { type?: string };
+    default?: unknown;
+};
+
+type DebuggerContribution = {
+    type?: string;
+    configurationAttributes?: {
+        launch?: {
+            properties?: { [key: string]: DebuggerProperty };
+        };
+    };
+};
+
 type ExtensionManifest = {
     contributes: {
         viewsWelcome?: Array<{ view?: string; contents?: string; when?: string }>;
         menus?: {
             'view/title'?: ManifestMenuItem[];
         };
+        debuggers?: DebuggerContribution[];
     };
 };
 
@@ -50,5 +68,31 @@ suite('extension/package.json', () => {
         assertContains(switchToWorkspace?.when, "view == 'aspire-vscode.runningAppHosts'");
         assertContains(switchToWorkspace?.when, "aspire.viewMode == 'global'");
         assertContains(refreshRunningAppHosts?.when, "view == 'aspire-vscode.runningAppHosts'");
+    });
+
+    test('aspire launch configuration declares an env property as a string-valued object', () => {
+        const manifest = readManifest();
+        const aspireDebugger = manifest.contributes.debuggers?.find(d => d.type === 'aspire');
+        const properties = aspireDebugger?.configurationAttributes?.launch?.properties;
+
+        assert.ok(properties, 'Expected aspire debugger to declare launch configuration properties');
+        const envProperty = properties.env;
+        assert.ok(envProperty, 'Expected aspire launch configuration to declare an env property');
+        assert.strictEqual(envProperty.type, 'object');
+        assert.strictEqual(envProperty.additionalProperties?.type, 'string');
+        assert.strictEqual(envProperty.description, '%extension.debug.env%');
+    });
+
+    test('aspire launch configuration declares an args property as a string array', () => {
+        const manifest = readManifest();
+        const aspireDebugger = manifest.contributes.debuggers?.find(d => d.type === 'aspire');
+        const properties = aspireDebugger?.configurationAttributes?.launch?.properties;
+
+        assert.ok(properties, 'Expected aspire debugger to declare launch configuration properties');
+        const argsProperty = properties.args;
+        assert.ok(argsProperty, 'Expected aspire launch configuration to declare an args property');
+        assert.strictEqual(argsProperty.type, 'array');
+        assert.strictEqual(argsProperty.items?.type, 'string');
+        assert.strictEqual(argsProperty.description, '%extension.debug.args%');
     });
 });


### PR DESCRIPTION
## Description

Adds launch configuration schema support for `env` and `args` on Aspire debug configurations so VS Code recognizes the existing launch settings without warnings.

The `env` configuration is now wired into the Aspire CLI spawn options when launching an AppHost. The existing `args` setting is also declared in the schema. This change includes package manifest coverage for both schema entries and fixes the related launch profile working-directory tests to use platform-correct absolute paths.

Validation:

- `cd extension && npx tsc --noEmit -p tsconfig.json`
- `cd extension && npm run compile-tests`
- `cd extension && npm run lint`
- `cd extension && npm test` (324 passing)

Fixes https://github.com/microsoft/aspire/issues/16445

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No