### PR TITLE
Add LocalArchive + DotnetTool CLI install modes for E2E tests

### DIFF
--- a/.github/instructions/acquisition-tests.instructions.md
+++ b/.github/instructions/acquisition-tests.instructions.md
@@ -1,0 +1,28 @@
+---
+applyTo: "eng/scripts/get-aspire-cli*.sh,eng/scripts/get-aspire-cli*.ps1"
+---
+
+# CLI Acquisition Script Tests
+
+When modifying `get-aspire-cli-pr.sh`, `get-aspire-cli-pr.ps1`, `get-aspire-cli.sh`, or `get-aspire-cli.ps1`, update the corresponding tests in `tests/Aspire.Acquisition.Tests/Scripts/`.
+
+## Test project layout
+
+| Script | Shell tests | Function tests | PS tests |
+|--------|------------|----------------|----------|
+| `get-aspire-cli-pr.sh` | `PRScriptShellTests.cs` | `PRScriptFunctionTests.cs` | — |
+| `get-aspire-cli-pr.ps1` | `PRScriptPowerShellTests.cs` | `PRScriptPSFunctionTests.cs` | — |
+| `get-aspire-cli.sh` | `ReleaseScriptShellTests.cs` | — | — |
+| `get-aspire-cli.ps1` | `ReleaseScriptPowerShellTests.cs` | — | — |
+
+- **Shell tests** (`*ShellTests.cs`): End-to-end parameter handling tests that invoke the script with `--dry-run` and a mock `gh` CLI.
+- **Function tests** (`*FunctionTests.cs`): Unit tests for individual bash/PowerShell functions (e.g., `get_runtime_identifier`, `extract_version_suffix_from_packages`).
+- **Common helpers**: `tests/Aspire.Acquisition.Tests/Scripts/Common/` contains `TestEnvironment`, `ScriptToolCommand`, `ScriptFunctionCommand`, `FakeArchiveHelper`, and mock `gh` script creation.
+
+## Running tests
+
+```bash
+dotnet test --project tests/Aspire.Acquisition.Tests/Aspire.Acquisition.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
+```
+
+Bash script tests are skipped on Windows (`SkipOnPlatform`). PowerShell tests require `pwsh` (`RequiresTools`).

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -216,38 +216,6 @@ jobs:
             Write-Host "NuGet package source '$source' does not exist — skipping copy"
           }
 
-      - name: Extract expected CLI version from nupkg
-        if: ${{ fromJson(inputs.properties).requiresCliArchive == true }}
-        id: extract_cli_version
-        shell: pwsh
-        run: |
-          # Look for Aspire.Cli.{version}.nupkg in cli-archives or built packages
-          $directories = @(
-            "${{ github.workspace }}/cli-archives",
-            "${{ github.workspace }}/artifacts/packages/Debug/Shipping"
-          )
-
-          foreach ($dir in $directories) {
-            if (Test-Path -Path $dir) {
-              $nupkg = Get-ChildItem -Path $dir -Filter 'Aspire.Cli.*.nupkg' -File -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -notlike '*.symbols.*' -and $_.Name -match '^Aspire\.Cli\.\d' } |
-                Select-Object -First 1
-
-              if ($null -ne $nupkg) {
-                $filename = $nupkg.Name
-                # Strip 'Aspire.Cli.' prefix and '.nupkg' suffix to get version
-                $version = $filename.Substring('Aspire.Cli.'.Length)
-                $version = $version.Substring(0, $version.Length - '.nupkg'.Length)
-                Write-Host "Extracted expected CLI version: $version (from $filename)"
-                "version=$version" >> $env:GITHUB_OUTPUT
-                exit 0
-              }
-            }
-          }
-
-          Write-Host "WARNING: Could not extract CLI version from nupkg files — version check will be skipped"
-          "version=" >> $env:GITHUB_OUTPUT
-
       - name: Install sdk for nuget based testing
         if: ${{ fromJson(inputs.properties).requiresTestSdk == true }}
         run: >
@@ -378,7 +346,6 @@ jobs:
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
           ASPIRE_E2E_CLI_ARCHIVE_DIR: ${{ fromJson(inputs.properties).requiresCliArchive == true && format('{0}/cli-archives', github.workspace) || '' }}
-          ASPIRE_E2E_EXPECTED_CLI_VERSION: ${{ steps.extract_cli_version.outputs.version || '' }}
           GH_TOKEN: ${{ (fromJson(inputs.properties).requiresGitHubToken == true || fromJson(inputs.properties).requiresCliArchive == true) && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (60s interval to reduce log noise)
@@ -419,7 +386,6 @@ jobs:
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
           ASPIRE_E2E_CLI_ARCHIVE_DIR: ${{ fromJson(inputs.properties).requiresCliArchive == true && format('{0}/cli-archives', github.workspace) || '' }}
-          ASPIRE_E2E_EXPECTED_CLI_VERSION: ${{ steps.extract_cli_version.outputs.version || '' }}
           GH_TOKEN: ${{ (fromJson(inputs.properties).requiresGitHubToken == true || fromJson(inputs.properties).requiresCliArchive == true) && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (output goes to console directly)
@@ -466,7 +432,6 @@ jobs:
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
           ASPIRE_E2E_CLI_ARCHIVE_DIR: ${{ fromJson(inputs.properties).requiresCliArchive == true && format('{0}/cli-archives', github.workspace) || '' }}
-          ASPIRE_E2E_EXPECTED_CLI_VERSION: ${{ steps.extract_cli_version.outputs.version || '' }}
           GH_TOKEN: ${{ (fromJson(inputs.properties).requiresGitHubToken == true || fromJson(inputs.properties).requiresCliArchive == true) && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (60s interval to reduce log noise)
@@ -514,7 +479,6 @@ jobs:
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
           ASPIRE_E2E_CLI_ARCHIVE_DIR: ${{ fromJson(inputs.properties).requiresCliArchive == true && format('{0}/cli-archives', github.workspace) || '' }}
-          ASPIRE_E2E_EXPECTED_CLI_VERSION: ${{ steps.extract_cli_version.outputs.version || '' }}
           GH_TOKEN: ${{ (fromJson(inputs.properties).requiresGitHubToken == true || fromJson(inputs.properties).requiresCliArchive == true) && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (output goes to console directly)

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -229,8 +229,8 @@ jobs:
 
           foreach ($dir in $directories) {
             if (Test-Path -Path $dir) {
-              $nupkg = Get-ChildItem -Path $dir -Filter 'Aspire.Cli.[0-9]*.nupkg' -File -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -notlike '*.symbols.*' } |
+              $nupkg = Get-ChildItem -Path $dir -Filter 'Aspire.Cli.*.nupkg' -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -notlike '*.symbols.*' -and $_.Name -match '^Aspire\.Cli\.\d' } |
                 Select-Object -First 1
 
               if ($null -ne $nupkg) {

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -219,25 +219,34 @@ jobs:
       - name: Extract expected CLI version from nupkg
         if: ${{ fromJson(inputs.properties).requiresCliArchive == true }}
         id: extract_cli_version
-        shell: bash
+        shell: pwsh
         run: |
           # Look for Aspire.Cli.{version}.nupkg in cli-archives or built packages
-          for dir in "${{ github.workspace }}/cli-archives" "${{ github.workspace }}/artifacts/packages/Debug/Shipping"; do
-            if [ -d "$dir" ]; then
-              nupkg=$(find "$dir" -maxdepth 1 -name 'Aspire.Cli.[0-9]*.nupkg' ! -name '*.symbols.*' 2>/dev/null | head -1)
-              if [ -n "$nupkg" ]; then
-                filename=$(basename "$nupkg")
+          $directories = @(
+            "${{ github.workspace }}/cli-archives",
+            "${{ github.workspace }}/artifacts/packages/Debug/Shipping"
+          )
+
+          foreach ($dir in $directories) {
+            if (Test-Path -Path $dir) {
+              $nupkg = Get-ChildItem -Path $dir -Filter 'Aspire.Cli.[0-9]*.nupkg' -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -notlike '*.symbols.*' } |
+                Select-Object -First 1
+
+              if ($null -ne $nupkg) {
+                $filename = $nupkg.Name
                 # Strip 'Aspire.Cli.' prefix and '.nupkg' suffix to get version
-                version="${filename#Aspire.Cli.}"
-                version="${version%.nupkg}"
-                echo "Extracted expected CLI version: $version (from $filename)"
-                echo "version=$version" >> "$GITHUB_OUTPUT"
+                $version = $filename.Substring('Aspire.Cli.'.Length)
+                $version = $version.Substring(0, $version.Length - '.nupkg'.Length)
+                Write-Host "Extracted expected CLI version: $version (from $filename)"
+                "version=$version" >> $env:GITHUB_OUTPUT
                 exit 0
-              fi
-            fi
-          done
-          echo "WARNING: Could not extract CLI version from nupkg files — version check will be skipped"
-          echo "version=" >> "$GITHUB_OUTPUT"
+              }
+            }
+          }
+
+          Write-Host "WARNING: Could not extract CLI version from nupkg files — version check will be skipped"
+          "version=" >> $env:GITHUB_OUTPUT
 
       - name: Install sdk for nuget based testing
         if: ${{ fromJson(inputs.properties).requiresTestSdk == true }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -189,6 +189,56 @@ jobs:
             Write-Host "Merged $($nupkgs.Count) arch-specific nugets for RID=$env:RID into $dest"
           }
 
+      - name: Download CLI native archives
+        if: ${{ fromJson(inputs.properties).requiresCliArchive == true }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cli-native-archives-${{ steps.compute_rid.outputs.rid }}
+          path: ${{ github.workspace }}/cli-archives
+
+      - name: Copy NuGet packages into CLI archives directory
+        if: ${{ fromJson(inputs.properties).requiresCliArchive == true && fromJson(inputs.properties).requiresNugets == true }}
+        shell: pwsh
+        run: |
+          $source = "${{ github.workspace }}/artifacts/packages/Debug/Shipping"
+          $dest = "${{ github.workspace }}/cli-archives"
+          if (Test-Path $source) {
+            $nupkgs = Get-ChildItem -Path $source -Filter *.nupkg -ErrorAction SilentlyContinue
+            if ($nupkgs -and $nupkgs.Count -gt 0) {
+              foreach ($pkg in $nupkgs) {
+                Copy-Item -Path $pkg.FullName -Destination $dest -Force
+              }
+              Write-Host "Copied $($nupkgs.Count) NuGet packages into cli-archives for LocalArchive mode"
+            } else {
+              Write-Host "No NuGet packages found in '$source' to copy"
+            }
+          } else {
+            Write-Host "NuGet package source '$source' does not exist — skipping copy"
+          }
+
+      - name: Extract expected CLI version from nupkg
+        if: ${{ fromJson(inputs.properties).requiresCliArchive == true }}
+        id: extract_cli_version
+        shell: bash
+        run: |
+          # Look for Aspire.Cli.{version}.nupkg in cli-archives or built packages
+          for dir in "${{ github.workspace }}/cli-archives" "${{ github.workspace }}/artifacts/packages/Debug/Shipping"; do
+            if [ -d "$dir" ]; then
+              nupkg=$(find "$dir" -maxdepth 1 -name 'Aspire.Cli.[0-9]*.nupkg' ! -name '*.symbols.*' 2>/dev/null | head -1)
+              if [ -n "$nupkg" ]; then
+                filename=$(basename "$nupkg")
+                # Strip 'Aspire.Cli.' prefix and '.nupkg' suffix to get version
+                version="${filename#Aspire.Cli.}"
+                version="${version%.nupkg}"
+                echo "Extracted expected CLI version: $version (from $filename)"
+                echo "version=$version" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          done
+          echo "WARNING: Could not extract CLI version from nupkg files — version check will be skipped"
+          echo "version=" >> "$GITHUB_OUTPUT"
+
       - name: Install sdk for nuget based testing
         if: ${{ fromJson(inputs.properties).requiresTestSdk == true }}
         run: >
@@ -315,10 +365,11 @@ jobs:
           TEST_LOG_PATH: ${{ github.workspace }}/artifacts/log/test-logs
           TestsRunningOutsideOfRepo: true
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
-          # PR metadata and token for CLI E2E tests that download artifacts from a PR
+          # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
-          ASPIRE_CLI_WORKFLOW_RUN_ID: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.run_id || '' }}
+          ASPIRE_E2E_CLI_ARCHIVE_DIR: ${{ fromJson(inputs.properties).requiresCliArchive == true && format('{0}/cli-archives', github.workspace) || '' }}
+          ASPIRE_E2E_EXPECTED_CLI_VERSION: ${{ steps.extract_cli_version.outputs.version || '' }}
           GH_TOKEN: ${{ (fromJson(inputs.properties).requiresGitHubToken == true || fromJson(inputs.properties).requiresCliArchive == true) && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (60s interval to reduce log noise)
@@ -355,10 +406,11 @@ jobs:
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
           # Prevent VBCSCompiler from starting during tests. See #15832
           UseSharedCompilation: false
-          # PR metadata and token for CLI E2E tests that download artifacts from a PR
+          # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
-          ASPIRE_CLI_WORKFLOW_RUN_ID: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.run_id || '' }}
+          ASPIRE_E2E_CLI_ARCHIVE_DIR: ${{ fromJson(inputs.properties).requiresCliArchive == true && format('{0}/cli-archives', github.workspace) || '' }}
+          ASPIRE_E2E_EXPECTED_CLI_VERSION: ${{ steps.extract_cli_version.outputs.version || '' }}
           GH_TOKEN: ${{ (fromJson(inputs.properties).requiresGitHubToken == true || fromJson(inputs.properties).requiresCliArchive == true) && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (output goes to console directly)
@@ -401,10 +453,11 @@ jobs:
           NUGET_PACKAGES: ${{ github.workspace }}/.packages
           PLAYWRIGHT_INSTALLED: ${{ fromJson(inputs.properties).enablePlaywrightInstall != true && 'false' || 'true' }}
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
-          # PR metadata and token for CLI E2E tests that download artifacts from a PR
+          # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
-          ASPIRE_CLI_WORKFLOW_RUN_ID: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.run_id || '' }}
+          ASPIRE_E2E_CLI_ARCHIVE_DIR: ${{ fromJson(inputs.properties).requiresCliArchive == true && format('{0}/cli-archives', github.workspace) || '' }}
+          ASPIRE_E2E_EXPECTED_CLI_VERSION: ${{ steps.extract_cli_version.outputs.version || '' }}
           GH_TOKEN: ${{ (fromJson(inputs.properties).requiresGitHubToken == true || fromJson(inputs.properties).requiresCliArchive == true) && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (60s interval to reduce log noise)
@@ -448,10 +501,11 @@ jobs:
           # so any rebuild triggered by DCP's "dotnet run" should be minimal.
           # See https://github.com/microsoft/aspire/issues/15832
           UseSharedCompilation: false
-          # PR metadata and token for CLI E2E tests that download artifacts from a PR
+          # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
-          ASPIRE_CLI_WORKFLOW_RUN_ID: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.run_id || '' }}
+          ASPIRE_E2E_CLI_ARCHIVE_DIR: ${{ fromJson(inputs.properties).requiresCliArchive == true && format('{0}/cli-archives', github.workspace) || '' }}
+          ASPIRE_E2E_EXPECTED_CLI_VERSION: ${{ steps.extract_cli_version.outputs.version || '' }}
           GH_TOKEN: ${{ (fromJson(inputs.properties).requiresGitHubToken == true || fromJson(inputs.properties).requiresCliArchive == true) && github.token || '' }}
         run: |
           # Start heartbeat monitor in background (output goes to console directly)
@@ -496,6 +550,14 @@ jobs:
           $trxFiles = Get-ChildItem -Path "${{ github.workspace }}/testresults" -Filter *.trx -Recurse -ErrorAction SilentlyContinue
 
           if ($trxFiles.Count -eq 0) {
+            # MTP does not produce .trx files when the test run is aborted (e.g., by --hangdump-timeout).
+            # Check for recordings or other test artifacts that prove tests actually ran before failing.
+            $hasRecordings = Test-Path "${{ github.workspace }}/testresults/recordings/*.cast"
+            $hasHangDumps = Get-ChildItem -Path "${{ github.workspace }}/testresults" -Filter *hangdump* -Recurse -ErrorAction SilentlyContinue
+            if ($hasRecordings -or $hasHangDumps) {
+              Write-Warning "No .trx files found, but test artifacts exist — test run likely aborted by timeout before trx was flushed."
+              exit 0
+            }
             Write-Error "No .trx files found. Tests may not have run due to infrastructure issues."
             exit 1
           }

--- a/.github/workflows/specialized-test-runner.yml
+++ b/.github/workflows/specialized-test-runner.yml
@@ -147,7 +147,17 @@ jobs:
       fail-fast: false
       matrix:
         tests: ${{ fromJson(needs.generate_tests_matrix.outputs.runsheet) }}
-    if: ${{ github.repository_owner == 'microsoft' && !cancelled() && !failure() }}
+    # Allow tests to run even if build_cli_archives partially fails (e.g., one RID
+    # like osx-arm64 has an infra issue but linux-x64 succeeded). Tests that need
+    # a failed RID's archive will fail at the download step.
+    # We still require generate_tests_matrix and build_packages to succeed.
+    if: >-
+      ${{
+        github.repository_owner == 'microsoft' &&
+        !cancelled() &&
+        needs.generate_tests_matrix.result == 'success' &&
+        (needs.build_packages.result == 'success' || needs.build_packages.result == 'skipped')
+      }}
     uses: ./.github/workflows/run-tests.yml
     with:
       testShortName: ${{ matrix.tests.project }}
@@ -223,8 +233,9 @@ jobs:
       - name: Fail if any dependency failed
         # 'skipped' can be when a transitive dependency fails and the dependent job gets 'skipped'.
         # For example, one of setup_* jobs failing and the Integration test jobs getting 'skipped'
-        # Note: build_packages/build_cli_archives being skipped is expected when requiresNugets is false,
-        # so we check them separately.
+        # Note: build_packages being skipped is expected when requiresNugets is false.
+        # Note: build_cli_archives partial failures (e.g. one RID) are tolerated — tests
+        # that need the failed RID will fail individually at the download step.
         if: >-
           ${{
             always() && (
@@ -234,9 +245,7 @@ jobs:
               needs.run_tests.result == 'cancelled' ||
               needs.run_tests.result == 'skipped' ||
               (needs.build_packages.result == 'failure') ||
-              (needs.build_packages.result == 'cancelled') ||
-              (needs.build_cli_archives.result == 'failure') ||
-              (needs.build_cli_archives.result == 'cancelled')
+              (needs.build_packages.result == 'cancelled')
             )
           }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,3 +419,4 @@ Additional instructions are automatically applied when editing files matching sp
 | `src/Components/**/README.md` | `.github/instructions/client-readme.instructions.md` - Client integration READMEs |
 | `tools/QuarantineTools/*` | `.github/instructions/quarantine.instructions.md` - QuarantineTools usage |
 | `tests/**/*.cs` | `.github/instructions/test-review-guidelines.instructions.md` - Flaky test patterns and test review guidelines |
+| `eng/scripts/get-aspire-cli*.sh`, `eng/scripts/get-aspire-cli*.ps1` | `.github/instructions/acquisition-tests.instructions.md` - CLI acquisition script tests |

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -44,7 +44,7 @@
     <ProjectToBuild Include="$(RepoRoot)eng\OuterPreBuild.proj" />
 
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
-    <ProjectToBuild Remove="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.*csproj" Condition="'$(SkipBundleDeps)' == 'true'" />
+    <ProjectToBuild Remove="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.csproj" Condition="'$(SkipBundleDeps)' == 'true'" />
     <ProjectToBuild Remove="$(RepoRoot)src\Aspire.Dashboard\Aspire.Dashboard.csproj" Condition="'$(SkipBundleDeps)' == 'true'" />
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" Condition="'$(SkipBundleDeps)' != 'true'" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" Condition="'$(SkipBundleDeps)' != 'true'" />

--- a/eng/scripts/get-aspire-cli-pr.ps1
+++ b/eng/scripts/get-aspire-cli-pr.ps1
@@ -19,6 +19,13 @@
 .PARAMETER WorkflowRunId
     Workflow run ID to download from (optional)
 
+.PARAMETER LocalDir
+    Use pre-downloaded artifacts from a local directory instead of downloading from GitHub.
+    Mutually exclusive with PRNumber and WorkflowRunId.
+
+.PARAMETER HiveLabel
+    Override the NuGet hive label (default: pr-PRNUMBER, run-RUNID, or run-GITHUB_RUN_ID for LocalDir).
+
 .PARAMETER InstallPath
     Directory prefix to install (default: $HOME/.aspire on Unix, %USERPROFILE%\.aspire on Windows)
     CLI will be installed to InstallPath\bin (or InstallPath/bin on Unix)
@@ -47,6 +54,12 @@
 
 .EXAMPLE
     .\get-aspire-cli-pr.ps1 1234 -WorkflowRunId 12345678
+
+.EXAMPLE
+    .\get-aspire-cli-pr.ps1 -LocalDir "C:\path\to\artifacts"
+
+.EXAMPLE
+    .\get-aspire-cli-pr.ps1 -LocalDir "C:\path\to\artifacts" -HiveLabel my-build
 
 .EXAMPLE
     .\get-aspire-cli-pr.ps1 1234 -InstallPath "C:\my-aspire"
@@ -1421,11 +1434,15 @@ DESCRIPTION:
 
 Usage:
     get-aspire-cli-pr.ps1 <PRNumber> [OPTIONS]
+    get-aspire-cli-pr.ps1 -WorkflowRunId <RunId> [OPTIONS]
+    get-aspire-cli-pr.ps1 -LocalDir <Path> [OPTIONS]
     iex "& { `$(irm <url>/get-aspire-cli-pr.ps1) } <PRNumber> [OPTIONS]"
 
 OPTIONS:
     -PRNumber <int>         Pull request number (required, positional)
     -WorkflowRunId <long>   Workflow run ID to download from (optional)
+    -LocalDir <string>      Use pre-downloaded artifacts from a local directory
+    -HiveLabel <string>     Override the NuGet hive label
     -InstallPath <string>   Directory prefix to install
     -OS <string>            Override OS detection (win, linux, linux-musl, osx)
     -Architecture <string>  Override architecture detection (x64, arm64)

--- a/eng/scripts/get-aspire-cli-pr.ps1
+++ b/eng/scripts/get-aspire-cli-pr.ps1
@@ -93,6 +93,12 @@ param(
     [ValidateRange(1, [long]::MaxValue)]
     [long]$WorkflowRunId,
 
+    [Parameter(HelpMessage = "Use pre-downloaded artifacts from a local directory instead of downloading from GitHub")]
+    [string]$LocalDir = "",
+
+    [Parameter(HelpMessage = "Override the NuGet hive label (default: pr-<PR>, run-<RUN_ID>, or run-<GITHUB_RUN_ID>/run-local)")]
+    [string]$HiveLabel = "",
+
     [Parameter(HelpMessage = "Directory prefix to install")]
     [string]$InstallPath = "",
 
@@ -1230,6 +1236,72 @@ function Install-AspireCliFromDownload {
     Write-Message "Aspire CLI successfully installed to: $cliPath" -Level Success
 }
 
+# Main function to install from a local directory of pre-built artifacts
+function Start-InstallFromLocalDir {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LocalDirPath
+    )
+
+    if (-not (Test-Path $LocalDirPath -PathType Container)) {
+        Write-Message "Local directory does not exist: $LocalDirPath" -Level Error
+        throw "Local directory not found"
+    }
+
+    Write-Message "Installing from local directory: $LocalDirPath" -Level Info
+
+    # Set installation paths
+    $cliBinDir = Join-Path $resolvedInstallPrefix "bin"
+    $resolvedHiveLabel = if ($HiveLabel) {
+        $HiveLabel
+    } elseif ($env:GITHUB_RUN_ID) {
+        "run-$($env:GITHUB_RUN_ID)"
+    } else {
+        "run-local"
+    }
+    $nugetHiveDir = Join-Path $resolvedInstallPrefix "hives" $resolvedHiveLabel "packages"
+
+    Write-Message "Using hive label: $resolvedHiveLabel" -Level Info
+
+    $rid = Get-RuntimeIdentifier $OS $Architecture
+
+    # Install CLI from local directory
+    if ($HiveOnly) {
+        Write-Message "Skipping CLI installation due to -HiveOnly flag" -Level Info
+    } else {
+        Install-AspireCliFromDownload -DownloadDir $LocalDirPath -CliBinDir $cliBinDir
+    }
+
+    # Install NuGet packages from local directory
+    Install-BuiltNugets -DownloadDir $LocalDirPath -NugetHiveDir $nugetHiveDir
+
+    # Extract and print the version suffix from packages
+    try {
+        $versionSuffix = Get-VersionSuffixFromPackages -DownloadDir $LocalDirPath
+        Write-Message "Package version suffix: $versionSuffix" -Level Info
+    }
+    catch {
+        Write-Message "Could not extract version suffix from local packages: $($_.Exception.Message)" -Level Warning
+    }
+
+    # Save the global channel setting
+    if (-not $HiveOnly) {
+        $cliExe = if ($Script:HostOS -eq "win") { "aspire.exe" } else { "aspire" }
+        $cliPath = Join-Path $cliBinDir $cliExe
+        Save-GlobalSettings -CliPath $cliPath -Key "channel" -Value $resolvedHiveLabel
+    }
+
+    # Update PATH environment variables
+    if (-not $HiveOnly) {
+        if ($SkipPath) {
+            Write-Message "Skipping PATH configuration due to -SkipPath flag" -Level Info
+        } else {
+            Update-PathEnvironment -CliBinDir $cliBinDir
+        }
+    }
+}
+
 # Main function to download and install from PR or workflow run ID
 function Start-DownloadAndInstall {
     [CmdletBinding(SupportsShouldProcess)]
@@ -1240,7 +1312,11 @@ function Start-DownloadAndInstall {
 
     if ($WorkflowRunId) {
         # When workflow ID is provided, use it directly
-        Write-Message "Starting download and installation for PR #$PRNumber with workflow run ID: $WorkflowRunId" -Level Info
+        if ($PRNumber -gt 0) {
+            Write-Message "Starting download and installation for PR #$PRNumber with workflow run ID: $WorkflowRunId" -Level Info
+        } else {
+            Write-Message "Starting download and installation for workflow run ID: $WorkflowRunId" -Level Info
+        }
         $runId = $WorkflowRunId.ToString()
     }
     else {
@@ -1258,7 +1334,14 @@ function Start-DownloadAndInstall {
 
     # Set installation paths
     $cliBinDir = Join-Path $resolvedInstallPrefix "bin"
-    $nugetHiveDir = Join-Path $resolvedInstallPrefix "hives" "pr-$PRNumber" "packages"
+    $resolvedHiveLabel = if ($HiveLabel) {
+        $HiveLabel
+    } elseif ($PRNumber -gt 0) {
+        "pr-$PRNumber"
+    } else {
+        "run-$runId"
+    }
+    $nugetHiveDir = Join-Path $resolvedInstallPrefix "hives" $resolvedHiveLabel "packages"
 
     $rid = Get-RuntimeIdentifier $OS $Architecture
 
@@ -1309,7 +1392,7 @@ function Start-DownloadAndInstall {
         # Determine CLI path
         $cliExe = if ($Script:HostOS -eq "win") { "aspire.exe" } else { "aspire" }
         $cliPath = Join-Path $cliBinDir $cliExe
-        Save-GlobalSettings -CliPath $cliPath -Key "channel" -Value "pr-$PRNumber"
+        Save-GlobalSettings -CliPath $cliPath -Key "channel" -Value $resolvedHiveLabel
     }
 
     # Update PATH environment variables
@@ -1356,9 +1439,14 @@ OPTIONS:
         if ($InvokedFromFile) { exit 0 } else { return 0 }
     }
 
-    # Validate PRNumber is provided when not showing help
-    if ($PRNumber -le 0) {
-        Write-Message "Error: PRNumber parameter is required" -Level Error
+    # Validate PRNumber is provided when not showing help or using --local-dir
+    if ($LocalDir) {
+        if ($PRNumber -gt 0 -or $WorkflowRunId -gt 0) {
+            Write-Message "Error: -LocalDir is mutually exclusive with -PRNumber and -WorkflowRunId" -Level Error
+            if ($InvokedFromFile) { exit 1 } else { return 1 }
+        }
+    } elseif ($PRNumber -le 0 -and $WorkflowRunId -le 0) {
+        Write-Message "Error: PRNumber, -WorkflowRunId, or -LocalDir parameter is required" -Level Error
         Write-Message "Use -Help for usage information" -Level Info
         if ($InvokedFromFile) { exit 1 } else { return 1 }
     }
@@ -1366,8 +1454,10 @@ OPTIONS:
     # Set host OS for PATH environment updates
     $script:HostOS = Get-OperatingSystem
 
-    # Check gh dependency
-    Test-GitHubCLIDependency
+    # Check gh dependency (not needed for -LocalDir mode)
+    if (-not $LocalDir) {
+        Test-GitHubCLIDependency
+    }
 
     # Set default install prefix if not provided
     $resolvedInstallPrefix = Get-InstallPrefix -InstallPrefix $InstallPath
@@ -1376,8 +1466,12 @@ OPTIONS:
     $tempDir = New-TempDirectory -Prefix "aspire-cli-pr-download"
 
     try {
-        # Download and install from PR or workflow run ID
-        Start-DownloadAndInstall -TempDir $tempDir
+        # Download and install from PR/workflow run ID, or install from local directory
+        if ($LocalDir) {
+            Start-InstallFromLocalDir -LocalDirPath $LocalDir
+        } else {
+            Start-DownloadAndInstall -TempDir $tempDir
+        }
 
         $exitCode = 0
     }

--- a/eng/scripts/get-aspire-cli-pr.ps1
+++ b/eng/scripts/get-aspire-cli-pr.ps1
@@ -96,7 +96,7 @@ param(
     [Parameter(HelpMessage = "Use pre-downloaded artifacts from a local directory instead of downloading from GitHub")]
     [string]$LocalDir = "",
 
-    [Parameter(HelpMessage = "Override the NuGet hive label (default: pr-<PR>, run-<RUN_ID>, or run-<GITHUB_RUN_ID>/run-local)")]
+    [Parameter(HelpMessage = "Override the NuGet hive label (default: pr-<PR>, run-<RUN_ID>, or run-<GITHUB_RUN_ID> (run-local when GITHUB_RUN_ID is unset))")]
     [string]$HiveLabel = "",
 
     [Parameter(HelpMessage = "Directory prefix to install")]

--- a/eng/scripts/get-aspire-cli-pr.sh
+++ b/eng/scripts/get-aspire-cli-pr.sh
@@ -2,6 +2,8 @@
 
 # get-aspire-cli-pr.sh - Download and unpack the Aspire CLI from a specific PR's build artifacts
 # Usage: ./get-aspire-cli-pr.sh PR_NUMBER [OPTIONS]
+#        ./get-aspire-cli-pr.sh --run-id WORKFLOW_RUN_ID [OPTIONS]
+#        ./get-aspire-cli-pr.sh --local-dir /path/to/artifacts [OPTIONS]
 
 set -euo pipefail
 
@@ -26,6 +28,8 @@ readonly RESET='\033[0m'
 INSTALL_PREFIX=""
 PR_NUMBER=""
 WORKFLOW_RUN_ID=""
+LOCAL_DIR=""
+HIVE_LABEL=""
 OS_ARG=""
 ARCH_ARG=""
 SHOW_HELP=false
@@ -57,12 +61,20 @@ DESCRIPTION:
 USAGE:
     ./get-aspire-cli-pr.sh PR_NUMBER [OPTIONS]
     ./get-aspire-cli-pr.sh PR_NUMBER --run-id WORKFLOW_RUN_ID [OPTIONS]
+    ./get-aspire-cli-pr.sh --run-id WORKFLOW_RUN_ID [OPTIONS]
+    ./get-aspire-cli-pr.sh --local-dir /path/to/artifacts [OPTIONS]
 
-    PR_NUMBER                   Pull request number (required)
-    --run-id, -r WORKFLOW_ID    Workflow run ID to download from (optional)
+    PR_NUMBER                   Pull request number (required unless --run-id or --local-dir is used alone)
+    --run-id, -r WORKFLOW_ID    Workflow run ID to download from (optional with PR, required without)
+    --local-dir PATH            Use pre-downloaded artifacts from a local directory instead of downloading
+                                from GitHub. Mutually exclusive with PR_NUMBER and --run-id.
+                                The directory must contain CLI archive files (aspire-cli-*.tar.gz or .zip)
+                                and optionally NuGet packages (*.nupkg).
+    --hive-label LABEL          Override the NuGet hive label (default: pr-<PR_NUMBER>, run-<RUN_ID>,
+                                or run-<GITHUB_RUN_ID>/run-local for --local-dir)
     -i, --install-path PATH     Directory prefix to install (default: ~/.aspire)
                                 CLI installs to: <install-path>/bin
-                                NuGet hive:      <install-path>/hives/pr-<PR_NUMBER>/packages
+                                NuGet hive:      <install-path>/hives/pr-<PR_NUMBER>/packages (or run-<RUN_ID>)
     --os OS                     Override OS detection (win, linux, linux-musl, osx)
     --arch ARCH                 Override architecture detection (x64, arm64)
     --hive-only                 Only install NuGet packages to the hive, skip CLI download
@@ -77,6 +89,9 @@ USAGE:
 EXAMPLES:
     ./get-aspire-cli-pr.sh 1234
     ./get-aspire-cli-pr.sh 1234 --run-id 12345678
+    ./get-aspire-cli-pr.sh --run-id 12345678
+    ./get-aspire-cli-pr.sh --local-dir /path/to/artifacts
+    ./get-aspire-cli-pr.sh --local-dir /path/to/artifacts --hive-label my-build
     ./get-aspire-cli-pr.sh 1234 --install-path ~/my-aspire
     ./get-aspire-cli-pr.sh 1234 --os linux --arch arm64 --verbose
     ./get-aspire-cli-pr.sh 1234 --hive-only
@@ -88,7 +103,7 @@ EXAMPLES:
     curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s -- <PR_NUMBER>
 
 REQUIREMENTS:
-    - GitHub CLI (gh) must be installed and authenticated
+    - GitHub CLI (gh) must be installed and authenticated (not needed with --local-dir)
     - Permissions to download artifacts from the target repository
     - VS Code extension installation requires VS Code CLI (code) to be available in PATH
 
@@ -111,24 +126,27 @@ parse_args() {
 
     # Check that at least one argument is provided
     if [[ $# -lt 1 ]]; then
-        say_error "At least one argument is required. The first argument must be a PR number."
+        say_error "At least one argument is required. Provide a PR number or --run-id <ID>."
         say_info "Use --help for usage information."
         exit 1
     fi
 
-    # First argument must be the PR number (cannot start with --)
-    if [[ "$1" == --* ]]; then
-        say_error "First argument must be a PR number, not an option. Got: '$1'"
+    # First argument can be a PR number, --run-id, or --local-dir for direct artifact installation
+    if [[ "$1" == "--run-id" || "$1" == "-r" ]]; then
+        # No PR number — install directly from workflow run ID
+        PR_NUMBER=""
+    elif [[ "$1" == "--local-dir" ]]; then
+        # No PR number — install from local directory
+        PR_NUMBER=""
+    elif [[ "$1" == --* ]]; then
+        say_error "First argument must be a PR number, --run-id <ID>, or --local-dir <PATH>. Got: '$1'"
         say_info "Use --help for usage information."
         exit 1
-    fi
-
-    # Validate that the first argument is a valid PR number (positive integer)
-    if [[ "$1" =~ ^[1-9][0-9]*$ ]]; then
+    elif [[ "$1" =~ ^[1-9][0-9]*$ ]]; then
         PR_NUMBER="$1"
         shift
     else
-        say_error "First argument must be a valid PR number"
+        say_error "First argument must be a valid PR number, --run-id <ID>, or --local-dir <PATH>"
         say_info "Use --help for usage information."
         exit 1
     fi
@@ -148,6 +166,24 @@ parse_args() {
                     exit 1
                 fi
                 WORKFLOW_RUN_ID="$2"
+                shift 2
+                ;;
+            --local-dir)
+                if [[ $# -lt 2 || -z "$2" ]]; then
+                    say_error "Option '$1' requires a non-empty value"
+                    say_info "Use --help for usage information."
+                    exit 1
+                fi
+                LOCAL_DIR="$2"
+                shift 2
+                ;;
+            --hive-label)
+                if [[ $# -lt 2 || -z "$2" ]]; then
+                    say_error "Option '$1' requires a non-empty value"
+                    say_info "Use --help for usage information."
+                    exit 1
+                fi
+                HIVE_LABEL="$2"
                 shift 2
                 ;;
             -i|--install-path)
@@ -965,6 +1001,93 @@ install_aspire_cli() {
     return 0
 }
 
+# Main function to install from a local directory of pre-built artifacts
+install_from_local_dir() {
+    local local_dir="$1"
+
+    if [[ ! -d "$local_dir" ]]; then
+        say_error "Local directory does not exist: $local_dir"
+        return 1
+    fi
+
+    say_info "Installing from local directory: $local_dir"
+
+    # Set installation paths
+    local cli_install_dir="$INSTALL_PREFIX/bin"
+    local hive_label
+    if [[ -n "$HIVE_LABEL" ]]; then
+        hive_label="$HIVE_LABEL"
+    elif [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+        hive_label="run-$GITHUB_RUN_ID"
+    else
+        hive_label="run-local"
+    fi
+    local nuget_hive_dir="$INSTALL_PREFIX/hives/$hive_label/packages"
+
+    say_info "Using hive label: $hive_label"
+
+    # Compute RID
+    local rid
+    if ! rid=$(get_runtime_identifier "$OS_ARG" "$ARCH_ARG"); then
+        return 1
+    fi
+    say_verbose "Computed RID: $rid"
+
+    # Find CLI archive in local directory
+    if [[ "$HIVE_ONLY" == true ]]; then
+        say_info "Skipping CLI installation due to --hive-only flag"
+    else
+        local -a cli_files=()
+        while IFS= read -r -d '' f; do
+            cli_files+=("$f")
+        done < <(find "$local_dir" -type f \( -name "${ASPIRE_CLI_ARTIFACT_NAME_PREFIX}-*.tar.gz" -o -name "${ASPIRE_CLI_ARTIFACT_NAME_PREFIX}-*.zip" \) -print0 | sort -z)
+
+        if [[ ${#cli_files[@]} -eq 0 ]]; then
+            say_error "No CLI archive found in local directory. Expected ${ASPIRE_CLI_ARTIFACT_NAME_PREFIX}-*.tar.gz or .zip in: $local_dir"
+            say_info "Showing up to first 25 files under local directory (for debugging):"
+            find "$local_dir" -type f | head -25 | sed 's/^/  /'
+            return 1
+        fi
+        if [[ ${#cli_files[@]} -gt 1 ]]; then
+            say_error "Multiple CLI archives found (expected exactly one). Matches:"
+            printf '  %s\n' "${cli_files[@]}"
+            return 1
+        fi
+
+        local cli_archive_path="${cli_files[0]}"
+        say_verbose "Using CLI archive: $cli_archive_path"
+
+        if ! install_aspire_cli "$cli_archive_path" "$cli_install_dir"; then
+            return 1
+        fi
+    fi
+
+    # Install NuGet packages from local directory
+    if ! install_built_nugets "$local_dir" "$nuget_hive_dir"; then
+        say_error "Failed to install nuget packages from local directory"
+        return 1
+    fi
+
+    # Extract and print the version suffix from packages
+    local version_suffix
+    if version_suffix=$(extract_version_suffix_from_packages "$local_dir"); then
+        say_info "Package version suffix: $version_suffix"
+    else
+        say_warn "Could not extract version suffix from local packages"
+    fi
+
+    # Save the global channel setting
+    if [[ "$HIVE_ONLY" != true ]]; then
+        local cli_path
+        if [[ -f "$cli_install_dir/aspire.exe" ]]; then
+            cli_path="$cli_install_dir/aspire.exe"
+        else
+            cli_path="$cli_install_dir/aspire"
+        fi
+        save_global_settings "$cli_path" "channel" "$hive_label" || true
+    fi
+}
+
 # Main function to download and install from PR or workflow run ID
 download_and_install_from_pr() {
     # Parameters:
@@ -975,9 +1098,17 @@ download_and_install_from_pr() {
     # If a workflow run ID was explicitly provided via arguments, use that directly.
     # (Previously this checked the uninitialized local variable 'workflow_run_id', which was always empty.)
     if [[ -n "$WORKFLOW_RUN_ID" ]]; then
-        say_info "Starting download and installation for PR #$PR_NUMBER with workflow run ID: $WORKFLOW_RUN_ID"
+        if [[ -n "$PR_NUMBER" ]]; then
+            say_info "Starting download and installation for PR #$PR_NUMBER with workflow run ID: $WORKFLOW_RUN_ID"
+        else
+            say_info "Starting download and installation for workflow run ID: $WORKFLOW_RUN_ID"
+        fi
         workflow_run_id="$WORKFLOW_RUN_ID"
     else
+        if [[ -z "$PR_NUMBER" ]]; then
+            say_error "Either a PR number or --run-id <ID> must be provided."
+            return 1
+        fi
         # When only PR number is provided, find the workflow run
         say_info "Starting download and installation for PR #$PR_NUMBER"
 
@@ -995,7 +1126,15 @@ download_and_install_from_pr() {
 
     # Set installation paths
     local cli_install_dir="$INSTALL_PREFIX/bin"
-    local nuget_hive_dir="$INSTALL_PREFIX/hives/pr-$PR_NUMBER/packages"
+    local hive_label
+    if [[ -n "$HIVE_LABEL" ]]; then
+        hive_label="$HIVE_LABEL"
+    elif [[ -n "$PR_NUMBER" ]]; then
+        hive_label="pr-$PR_NUMBER"
+    else
+        hive_label="run-$workflow_run_id"
+    fi
+    local nuget_hive_dir="$INSTALL_PREFIX/hives/$hive_label/packages"
 
     # First, download both artifacts
     local cli_archive_path nuget_download_dir
@@ -1071,7 +1210,7 @@ download_and_install_from_pr() {
             cli_path="$cli_install_dir/aspire"
         fi
         # Non-fatal: channel can be set manually if this fails
-        save_global_settings "$cli_path" "channel" "pr-$PR_NUMBER" || true
+        save_global_settings "$cli_path" "channel" "$hive_label" || true
     fi
 }
 
@@ -1094,8 +1233,18 @@ main() {
         exit 1
     fi
 
-    # Check gh dependency
-    check_gh_dependency
+    # Validate mutually exclusive options
+    if [[ -n "$LOCAL_DIR" ]]; then
+        if [[ -n "$PR_NUMBER" || -n "$WORKFLOW_RUN_ID" ]]; then
+            say_error "--local-dir is mutually exclusive with PR_NUMBER and --run-id"
+            exit 1
+        fi
+    fi
+
+    # Check gh dependency (not needed for --local-dir mode)
+    if [[ -z "$LOCAL_DIR" ]]; then
+        check_gh_dependency
+    fi
 
     # Set default install prefix if not provided
     if [[ -z "$INSTALL_PREFIX" ]]; then
@@ -1123,9 +1272,15 @@ main() {
     }
     trap cleanup EXIT
 
-    # Download and install from PR or workflow run ID
-    if ! download_and_install_from_pr "$temp_dir"; then
-        exit 1
+    # Download and install from PR/workflow run ID, or install from local directory
+    if [[ -n "$LOCAL_DIR" ]]; then
+        if ! install_from_local_dir "$LOCAL_DIR"; then
+            exit 1
+        fi
+    else
+        if ! download_and_install_from_pr "$temp_dir"; then
+            exit 1
+        fi
     fi
 
     # Add to shell profile for persistent PATH

--- a/eng/scripts/get-aspire-cli-pr.sh
+++ b/eng/scripts/get-aspire-cli-pr.sh
@@ -71,7 +71,7 @@ USAGE:
                                 The directory must contain CLI archive files (aspire-cli-*.tar.gz or .zip)
                                 and optionally NuGet packages (*.nupkg).
     --hive-label LABEL          Override the NuGet hive label (default: pr-<PR_NUMBER>, run-<RUN_ID>,
-                                or run-<GITHUB_RUN_ID>/run-local for --local-dir)
+                                or run-<GITHUB_RUN_ID> (or run-local if GITHUB_RUN_ID is unset) for --local-dir)
     -i, --install-path PATH     Directory prefix to install (default: ~/.aspire)
                                 CLI installs to: <install-path>/bin
                                 NuGet hive:      <install-path>/hives/pr-<PR_NUMBER>/packages (or run-<RUN_ID>)

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -217,7 +217,7 @@ internal sealed class AddCommand : BaseCommand
             // WITHOUT package source mapping restrictions, so that transitive deps
             // (including RID-specific and stable-versioned packages) can still resolve
             // from NuGet.org via the normal NuGet source hierarchy.
-            if (string.IsNullOrEmpty(source) && VersionHelper.IsPrChannel(selectedNuGetPackage.Channel.Name))
+            if (string.IsNullOrEmpty(source) && VersionHelper.IsLocalBuildChannel(selectedNuGetPackage.Channel.Name))
             {
                 var mappings = selectedNuGetPackage.Channel.Mappings;
                 if (mappings is { Length: > 0 })
@@ -375,7 +375,7 @@ internal sealed class AddCommand : BaseCommand
         // When PR hives are present, prefer the package that exactly matches the installed
         // CLI/SDK version so template- and add-generated projects stay on the same build.
         var prChannelPackageVersions = packageVersions
-            .Where(p => VersionHelper.IsPrChannel(p.Channel.Name))
+            .Where(p => VersionHelper.IsLocalBuildChannel(p.Channel.Name))
             .ToArray();
 
         if (VersionHelper.TryGetCurrentCliVersionMatch(

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -280,7 +280,7 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         }
 
         var mappings = Mappings;
-        if (!VersionHelper.IsPrChannel(Name) || Type is not PackageChannelType.Explicit || mappings is not { Length: > 0 })
+        if (!VersionHelper.IsLocalBuildChannel(Name) || Type is not PackageChannelType.Explicit || mappings is not { Length: > 0 })
         {
             return this;
         }

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -9,13 +9,19 @@ namespace Aspire.Cli.Utils;
 
 internal static class VersionHelper
 {
-    public static bool IsPrChannel(string? channelName)
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="channelName"/> identifies a
+    /// locally-built channel — either a PR hive (<c>pr-*</c>) or a workflow-run hive (<c>run-*</c>).
+    /// </summary>
+    public static bool IsLocalBuildChannel(string? channelName)
     {
-        return channelName?.StartsWith("pr-", StringComparison.OrdinalIgnoreCase) == true;
+        return channelName is not null &&
+            (channelName.StartsWith("pr-", StringComparison.OrdinalIgnoreCase) ||
+             channelName.StartsWith("run-", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
-    /// Finds the candidate that exactly matches the current CLI/SDK version when running against PR channels or PR hives.
+    /// Finds the candidate that exactly matches the current CLI/SDK version when running against local build channels or hives.
     /// </summary>
     public static bool TryGetCurrentCliVersionMatch<T>(
         IEnumerable<T> candidates,
@@ -27,7 +33,7 @@ internal static class VersionHelper
         ArgumentNullException.ThrowIfNull(candidates);
         ArgumentNullException.ThrowIfNull(versionSelector);
 
-        if (!hasPrHives && !IsPrChannel(channelName))
+        if (!hasPrHives && !IsLocalBuildChannel(channelName))
         {
             match = default;
             return false;

--- a/tests/Aspire.Acquisition.Tests/Scripts/Common/ScriptHostFixture.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/Common/ScriptHostFixture.cs
@@ -97,6 +97,10 @@ public sealed class ScriptHostFixture : IAsyncLifetime
         {
             // Already disposed
         }
+        catch (HttpListenerException)
+        {
+            // The listener may already be torn down while another process has reused the probed port.
+        }
 
         if (_serverTask is not null)
         {
@@ -114,7 +118,19 @@ public sealed class ScriptHostFixture : IAsyncLifetime
             }
         }
 
-        _listener?.Close();
+        try
+        {
+            _listener?.Close();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already disposed
+        }
+        catch (HttpListenerException)
+        {
+            // Closing only releases cleanup state; the server loop has already been canceled.
+        }
+
         _cts?.Dispose();
     }
 

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPowerShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPowerShellTests.cs
@@ -56,6 +56,8 @@ public class PRScriptPowerShellTests(ITestOutputHelper testOutput)
         var normalized = System.Text.RegularExpressions.Regex.Replace(result.Output, @"\r?\n\s*", "");
 
         Assert.Contains("PRNumber", normalized);
+        Assert.Contains("LocalDir", normalized);
+        Assert.Contains("HiveLabel", normalized);
         Assert.Contains("InstallPath", normalized);
         Assert.Contains("OS", normalized);
         Assert.Contains("Architecture", normalized);
@@ -113,6 +115,28 @@ public class PRScriptPowerShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("987654321", result.Output);
+    }
+
+    [Fact]
+    public async Task LocalDir_WhatIf_UsesLocalDirectoryWithoutGh()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptToolCommand(s_scriptPath, env, _testOutput);
+        var localDir = Path.Combine(env.TempDirectory, "local artifacts");
+        Directory.CreateDirectory(localDir);
+        await FakeArchiveHelper.CreateFakeNupkgAsync(localDir, "Aspire.Cli", "13.3.0-preview.1.12345.1");
+
+        var result = await cmd.ExecuteAsync(
+            "-LocalDir", localDir,
+            "-HiveLabel", "test-hive",
+            "-HiveOnly",
+            "-WhatIf");
+
+        result.EnsureSuccessful();
+        Assert.Contains("Installing from local directory", result.Output);
+        Assert.Contains(localDir, result.Output);
+        Assert.Contains("test-hive", result.Output);
+        Assert.DoesNotContain("Downloading CLI from GitHub", result.Output);
     }
 
     [Fact]

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs
@@ -57,7 +57,7 @@ public class PRScriptShellTests(ITestOutputHelper testOutput)
     }
 
     [Fact]
-    public async Task MissingPRNumber_ReturnsError()
+    public async Task MissingPRNumberAndRunId_ReturnsError()
     {
         using var env = new TestEnvironment();
         using var cmd = new ScriptToolCommand(s_scriptPath, env, _testOutput);
@@ -65,6 +65,7 @@ public class PRScriptShellTests(ITestOutputHelper testOutput)
 
         Assert.NotEqual(0, result.ExitCode);
         Assert.Contains("PR number", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--run-id", result.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -100,6 +101,78 @@ public class PRScriptShellTests(ITestOutputHelper testOutput)
         using var cmd = await CreateCommandWithMockGhAsync(env);
 
         var result = await cmd.ExecuteAsync("12345", "--dry-run", "--skip-path", "--run-id", "987654321");
+
+        result.EnsureSuccessful();
+        Assert.Contains("987654321", result.Output);
+    }
+
+    [Fact]
+    public async Task RunIdAsFirstArg_DryRun_Succeeds()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = await CreateCommandWithMockGhAsync(env);
+
+        var result = await cmd.ExecuteAsync("--run-id", "987654321", "--dry-run", "--skip-path");
+
+        result.EnsureSuccessful();
+        Assert.Contains("987654321", result.Output);
+        Assert.Contains("[DRY RUN]", result.Output);
+    }
+
+    [Fact]
+    public async Task RunIdAsFirstArg_DryRun_UsesRunHiveLabel()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = await CreateCommandWithMockGhAsync(env);
+
+        var result = await cmd.ExecuteAsync("--run-id", "987654321", "--dry-run", "--skip-path", "--verbose");
+
+        result.EnsureSuccessful();
+        Assert.Contains("run-987654321", result.Output);
+    }
+
+    [Fact]
+    public async Task RunIdWithPRNumber_DryRun_UsesPrHiveLabel()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = await CreateCommandWithMockGhAsync(env);
+
+        var result = await cmd.ExecuteAsync("12345", "--run-id", "987654321", "--dry-run", "--skip-path", "--verbose");
+
+        result.EnsureSuccessful();
+        Assert.Contains("pr-12345", result.Output);
+    }
+
+    [Fact]
+    public async Task RunIdAsFirstArg_NonNumericValue_ReturnsError()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = await CreateCommandWithMockGhAsync(env);
+
+        var result = await cmd.ExecuteAsync("--run-id", "--dry-run", "--skip-path");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Run ID must be a number", result.Output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunIdAsFirstArg_NoValue_ReturnsError()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptToolCommand(s_scriptPath, env, _testOutput);
+
+        var result = await cmd.ExecuteAsync("--run-id");
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task ShortRunIdFlag_AsFirstArg_DryRun_Succeeds()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = await CreateCommandWithMockGhAsync(env);
+
+        var result = await cmd.ExecuteAsync("-r", "987654321", "--dry-run", "--skip-path");
 
         result.EnsureSuccessful();
         Assert.Contains("987654321", result.Output);
@@ -236,7 +309,7 @@ public class PRScriptShellTests(ITestOutputHelper testOutput)
     }
 
     [Fact]
-    public async Task InvalidPRNumber_OptionAsFirst_ReturnsError()
+    public async Task UnrecognizedOptionAsFirstArg_ReturnsError()
     {
         using var env = new TestEnvironment();
         using var cmd = await CreateCommandWithMockGhAsync(env);

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs
@@ -44,6 +44,8 @@ public class PRScriptShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("--run-id", result.Output);
+        Assert.Contains("--local-dir", result.Output);
+        Assert.Contains("--hive-label", result.Output);
         Assert.Contains("--install-path", result.Output);
         Assert.Contains("--os", result.Output);
         Assert.Contains("--arch", result.Output);
@@ -104,6 +106,28 @@ public class PRScriptShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("987654321", result.Output);
+    }
+
+    [Fact]
+    public async Task LocalDir_DryRun_UsesLocalDirectoryWithoutGh()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptToolCommand(s_scriptPath, env, _testOutput);
+        var localDir = Path.Combine(env.TempDirectory, "local artifacts");
+        Directory.CreateDirectory(localDir);
+        await FakeArchiveHelper.CreateFakeNupkgAsync(localDir, "Aspire.Cli", "13.3.0-preview.1.12345.1");
+
+        var result = await cmd.ExecuteAsync(
+            "--local-dir", localDir,
+            "--hive-label", "test-hive",
+            "--hive-only",
+            "--dry-run");
+
+        result.EnsureSuccessful();
+        Assert.Contains("Installing from local directory", result.Output);
+        Assert.Contains(localDir, result.Output);
+        Assert.Contains("test-hive", result.Output);
+        Assert.DoesNotContain("Downloading CLI from GitHub", result.Output);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -26,7 +26,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     public async Task AgentCommands_AllHelpOutputs_AreCorrect()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -88,7 +88,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     public async Task AgentInitCommand_MigratesDeprecatedConfig()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -163,7 +163,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     public async Task DoctorCommand_DetectsDeprecatedAgentConfig()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -203,7 +203,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     public async Task AgentInitCommand_DefaultSelection_InstallsSkillOnly()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
@@ -19,7 +19,7 @@ public sealed class BannerTests(ITestOutputHelper output)
     public async Task Banner_DisplayedOnFirstRun()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -60,7 +60,7 @@ public sealed class BannerTests(ITestOutputHelper output)
     public async Task Banner_DisplayedWithExplicitFlag()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -92,7 +92,7 @@ public sealed class BannerTests(ITestOutputHelper output)
     public async Task Banner_NotDisplayedWithNoLogoFlag()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
@@ -20,7 +20,7 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
     public async Task CreateAndRunAspireStarterProjectWithBundle()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
@@ -21,7 +21,7 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
     public async Task AspireUpdateRemovesAppHostPackageVersionFromDirectoryPackagesProps()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -124,7 +124,7 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
     public async Task AspireAddPackageVersionToDirectoryPackagesProps()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CertificatesCommandTests.cs
@@ -18,7 +18,7 @@ public sealed class CertificatesCommandTests(ITestOutputHelper output)
     public async Task CertificatesTrust_WithUntrustedCert_TrustsCertificate()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -62,7 +62,7 @@ public sealed class CertificatesCommandTests(ITestOutputHelper output)
     public async Task CertificatesClean_RemovesCertificates()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -105,7 +105,7 @@ public sealed class CertificatesCommandTests(ITestOutputHelper output)
     public async Task CertificatesTrust_WithNoCert_CreatesAndTrustsCertificate()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigDiscoveryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigDiscoveryTests.cs
@@ -31,7 +31,7 @@ public sealed class ConfigDiscoveryTests(ITestOutputHelper output)
     public async Task RunFromParentDirectory_UsesExistingConfigNearAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigHealingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigHealingTests.cs
@@ -25,7 +25,7 @@ public sealed class ConfigHealingTests(ITestOutputHelper output)
     public async Task InvalidAppHostPathWithComments_IsHealedOnRun()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigMigrationTests.cs
@@ -108,7 +108,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     public async Task GlobalSettings_MigratedFromLegacyFormat()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, strategy, workspace);
@@ -173,7 +173,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     public async Task GlobalMigration_SkipsWhenNewConfigExists()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, strategy, workspace);
@@ -223,7 +223,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     public async Task GlobalMigration_HandlesMalformedLegacyJson()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, strategy, workspace);
@@ -282,7 +282,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     public async Task GlobalMigration_HandlesCommentsAndTrailingCommas()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, strategy, workspace);
@@ -352,7 +352,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     public async Task ConfigSetGet_CreatesNestedJsonFormat()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, strategy, workspace);
@@ -436,7 +436,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     public async Task GlobalMigration_PreservesAllValueTypes()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, strategy, workspace);
@@ -522,7 +522,7 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
     public async Task FullUpgrade_LegacyCliToNewCli_MigratesGlobalSettings()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, strategy, workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -19,7 +19,7 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
     public async Task DashboardRunWithOtelTracesReturnsNoTraces()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
@@ -19,7 +19,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
     public async Task DescribeCommandShowsRunningResources()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -89,7 +89,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
     public async Task DescribeCommandResolvesReplicaNames()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
@@ -24,7 +24,7 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
     public async Task CreateAndDeployToDockerCompose()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
@@ -135,7 +135,7 @@ builder.Build().Run();
     public async Task CreateAndDeployToDockerComposeInteractive()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
@@ -37,11 +37,7 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         // Step 1: Create a new Aspire Starter App (no Redis cache)
         await auto.AspireNewAsync(ProjectName, counter, useRedisCache: false);
@@ -148,11 +144,7 @@ builder.Build().Run();
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         // Step 1: Create a new Aspire Starter App (no Redis cache)
         await auto.AspireNewAsync(ProjectName, counter, useRedisCache: false);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DocsCommandE2ETests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DocsCommandE2ETests.cs
@@ -15,7 +15,7 @@ public sealed class DocsCommandE2ETests(ITestOutputHelper output)
     public async Task DocsCommand_RendersInteractiveMarkdownFromLocalSource()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
         var docsFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "llms-small.txt");
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
@@ -25,7 +25,7 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
     public async Task DoctorCommand_WithoutSslCertDir_ShowsPartiallyTrusted()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -64,7 +64,7 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
     public async Task DoctorCommand_WithSslCertDir_ShowsTrusted()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -119,7 +119,7 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
     public async Task DoctorCommand_TypeScriptAppHostReportsMissingConfiguredToolchain(string toolchain)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DotnetToolSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DotnetToolSmokeTests.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end smoke tests for the Aspire CLI installed via <c>dotnet tool install --global Aspire.Cli</c>.
+/// Unlike the general smoke tests that use <see cref="CliInstallStrategy.Detect"/>, these tests
+/// explicitly construct a DotnetTool strategy to validate the dotnet tool distribution channel.
+/// <para>
+/// The strategy is resolved from (in priority order):
+/// <list type="number">
+///   <item><c>ASPIRE_E2E_DOTNET_TOOL_SOURCE</c> + <c>ASPIRE_E2E_VERSION</c> — install from local nupkg directory</item>
+///   <item><c>ASPIRE_E2E_DOTNET_TOOL=true</c> — install from published NuGet feed (optionally with <c>ASPIRE_E2E_VERSION</c>)</item>
+///   <item><c>BUILT_NUGETS_PATH</c> — auto-discover from CI-built nupkgs directory</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class DotnetToolSmokeTests(ITestOutputHelper output)
+{
+    [CaptureWorkspaceOnFailure]
+    [Fact]
+    public async Task DotnetToolInstall_CreateAndRunAspireStarterProject()
+    {
+        var strategy = GetDotnetToolStrategy();
+
+        Assert.True(strategy is not null,
+            "DotnetToolSmokeTests requires one of: ASPIRE_E2E_DOTNET_TOOL_SOURCE + ASPIRE_E2E_VERSION, " +
+            "ASPIRE_E2E_DOTNET_TOOL=true, or BUILT_NUGETS_PATH containing Aspire.Cli nupkg.");
+
+        output.WriteLine($"DotnetTool strategy resolved: {strategy}");
+
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        // Prepare Docker environment (prompt counting, umask, env vars)
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+
+        // Install the Aspire CLI via dotnet tool
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Verify the tool is installed via dotnet tool list
+        await auto.TypeAsync("dotnet tool list -g");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("aspire.cli", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Verify aspire is accessible from the dotnet tools path
+        await auto.TypeAsync("command -v aspire");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync(".dotnet/tools/aspire", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Verify the installed version matches expectations
+        await auto.TypeAsync("aspire --version");
+        await auto.EnterAsync();
+
+        if (strategy.Version is not null)
+        {
+            // When a specific version was requested, verify it was actually installed
+            output.WriteLine($"Verifying installed version matches expected: {strategy.Version}");
+            await auto.WaitUntilTextAsync(strategy.Version, timeout: TimeSpan.FromSeconds(10));
+        }
+
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Create a new project using aspire new
+        await auto.AspireNewAsync("AspireToolApp", counter);
+
+        // Run the project with aspire run
+        await auto.TypeAsync("aspire run");
+        await auto.EnterAsync();
+
+        await auto.WaitUntilAsync(s =>
+        {
+            if (s.ContainsText("Select an AppHost to use:"))
+            {
+                throw new InvalidOperationException(
+                    "Unexpected apphost selection prompt detected! " +
+                    "This indicates multiple apphosts were incorrectly detected.");
+            }
+
+            return s.ContainsText("Press CTRL+C to stop the AppHost and exit.");
+        }, timeout: TimeSpan.FromMinutes(2), description: "Press CTRL+C message (aspire run started)");
+
+        // Stop the running apphost with Ctrl+C
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Exit the shell
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Explicitly constructs a DotnetTool strategy from env vars, bypassing <see cref="CliInstallStrategy.Detect"/>.
+    /// Checks (in order):
+    /// <list type="number">
+    ///   <item><c>ASPIRE_E2E_DOTNET_TOOL_SOURCE</c> + <c>ASPIRE_E2E_VERSION</c> — explicit local nupkg directory</item>
+    ///   <item><c>ASPIRE_E2E_DOTNET_TOOL=true</c> — install from published NuGet feed</item>
+    ///   <item><c>BUILT_NUGETS_PATH</c> — auto-discover from CI-built nupkgs directory</item>
+    /// </list>
+    /// Returns <see langword="null"/> when none of the above are configured — callers should fail with
+    /// a clear message indicating the workflow is misconfigured.
+    /// </summary>
+    private static CliInstallStrategy? GetDotnetToolStrategy()
+    {
+        // 1. Explicit local nupkg source (user-provided)
+        var source = Environment.GetEnvironmentVariable("ASPIRE_E2E_DOTNET_TOOL_SOURCE");
+
+        if (!string.IsNullOrEmpty(source))
+        {
+            var version = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
+
+            if (string.IsNullOrEmpty(version))
+            {
+                throw new InvalidOperationException(
+                    "ASPIRE_E2E_DOTNET_TOOL_SOURCE requires ASPIRE_E2E_VERSION to specify which version to install.");
+            }
+
+            return CliInstallStrategy.FromDotnetToolLocalSource(source, version);
+        }
+
+        // 2. Published NuGet feed
+        var dotnetTool = Environment.GetEnvironmentVariable("ASPIRE_E2E_DOTNET_TOOL");
+
+        if (string.Equals(dotnetTool, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(dotnetTool, "1", StringComparison.OrdinalIgnoreCase))
+        {
+            var version = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
+            return CliInstallStrategy.FromDotnetTool(version);
+        }
+
+        // 3. Auto-discover from CI-built nupkgs (BUILT_NUGETS_PATH contains the tool nupkg
+        //    directly since the dotnet tool is built as part of the normal package build)
+        var builtNugetsPath = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
+
+        if (!string.IsNullOrEmpty(builtNugetsPath) && Directory.Exists(builtNugetsPath))
+        {
+            var nupkgs = Directory.GetFiles(builtNugetsPath, "Aspire.Cli.*.nupkg")
+                .Where(f => !f.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase)
+                         && !f.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            if (nupkgs.Length == 1)
+            {
+                var version = ExtractVersionFromNupkgFilename(nupkgs[0]);
+                return CliInstallStrategy.FromDotnetToolLocalSource(builtNugetsPath, version);
+            }
+
+            if (nupkgs.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Found multiple Aspire.Cli nupkgs in '{builtNugetsPath}': {string.Join(", ", nupkgs.Select(Path.GetFileName))}. Expected exactly one.");
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the NuGet package version from a filename like <c>Aspire.Cli.10.0.0-dev.26223.1.nupkg</c>.
+    /// </summary>
+    private static string ExtractVersionFromNupkgFilename(string nupkgPath)
+    {
+        const string prefix = "Aspire.Cli.";
+        const string suffix = ".nupkg";
+
+        var filename = Path.GetFileName(nupkgPath);
+
+        if (filename.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+            filename.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return filename[prefix.Length..^suffix.Length];
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot extract version from nupkg filename: {filename}. Expected format: Aspire.Cli.{{version}}.nupkg");
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
@@ -19,7 +19,7 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
     public async Task CreateAndRunEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -134,7 +134,7 @@ internal static class CliE2EAutomatorHelpers
                 throw new ArgumentOutOfRangeException(nameof(strategy), strategy.Mode, "Unknown install mode");
         }
 
-        await auto.LogAspireCliVersionAsync(counter);
+        await auto.VerifyAspireCliVersionAsync(strategy, counter);
     }
 
     /// <summary>
@@ -230,7 +230,66 @@ internal static class CliE2EAutomatorHelpers
                 throw new ArgumentOutOfRangeException(nameof(strategy), strategy.Mode, "Unknown install mode");
         }
 
-        await auto.LogAspireCliVersionAsync(counter);
+        await auto.VerifyAspireCliVersionAsync(strategy, counter);
+    }
+
+    /// <summary>
+    /// Verifies the installed Aspire CLI version matches the expected version from the install strategy.
+    /// When <see cref="CliInstallStrategy.ExpectedVersion"/> is set, runs <c>aspire --version</c> and asserts
+    /// an exact match (stripping build metadata like <c>+commit</c>).
+    /// On CI with <see cref="CliInstallMode.LocalArchive"/>, fails hard if no expected version could be determined.
+    /// Otherwise, just logs the installed version for diagnostics.
+    /// </summary>
+    internal static async Task VerifyAspireCliVersionAsync(
+        this Hex1bTerminalAutomator auto,
+        CliInstallStrategy strategy,
+        SequenceCounter counter)
+    {
+        var expectedVersion = strategy.ExpectedVersion;
+
+        if (expectedVersion is null)
+        {
+            if (CliE2ETestHelpers.IsRunningInCI && strategy.Mode is CliInstallMode.LocalArchive)
+            {
+                Assert.Fail(
+                    "Running on CI with LocalArchive mode but could not extract expected CLI version " +
+                    $"from Aspire.Cli.*.nupkg in the archive directory ({strategy.ArchiveDir}). " +
+                    "This may indicate the nupkg was not included in the archive or the copy step failed.");
+            }
+
+            // No version to verify — just log for diagnostics
+            await auto.LogAspireCliVersionAsync(counter);
+            return;
+        }
+
+        // Run bash version comparison: get installed version, strip +commit build metadata, compare
+        await auto.TypeAsync(
+            $"VER=$(aspire --version 2>/dev/null) && BASE_VER=${{VER%%+*}} && " +
+            $"[ \"$BASE_VER\" = \"{expectedVersion}\" ] && " +
+            $"echo \"CLI_VERSION_EXACT:$VER\" || " +
+            $"echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"");
+        await auto.EnterAsync();
+
+        var foundExact = false;
+        await auto.WaitUntilAsync(
+            snapshot =>
+            {
+                if (new CellPatternSearcher().Find("CLI_VERSION_EXACT:").Search(snapshot).Count > 0)
+                {
+                    foundExact = true;
+                    return true;
+                }
+
+                return new CellPatternSearcher().Find("CLI_VERSION_MISMATCH:").Search(snapshot).Count > 0;
+            },
+            timeout: TimeSpan.FromSeconds(30),
+            description: "CLI version verification");
+
+        await auto.WaitForAnyPromptAsync(counter);
+
+        Assert.True(foundExact,
+            $"Aspire CLI version mismatch. Expected '{expectedVersion}' (from {strategy.Mode}) " +
+            "but got a different version. This may indicate the wrong CLI binary was installed.");
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -106,12 +106,28 @@ internal static class CliE2EAutomatorHelpers
                 await auto.SourceAspireBundleEnvironmentAsync(counter);
                 break;
 
+            case CliInstallMode.LocalArchive:
+                await auto.RunCommandFailFastAsync(
+                    AspireCliShellCommandHelpers.GetLocalArchiveInstallCommand("/tmp/aspire-cli-archives", AspireCliShellCommandHelpers.DockerPullRequestInstallCommandPrefix),
+                    counter,
+                    TimeSpan.FromSeconds(120));
+                await auto.SourceAspireBundleEnvironmentAsync(counter);
+                break;
+
             case CliInstallMode.InstallScript:
                 await auto.RunCommandFailFastAsync(
                     AspireCliShellCommandHelpers.GetInstallScriptCommand(strategy, AspireCliShellCommandHelpers.DockerInstallScriptCommandPrefix),
                     counter,
                     TimeSpan.FromSeconds(120));
                 await auto.SourceAspireCliEnvironmentAsync(counter);
+                break;
+
+            case CliInstallMode.DotnetTool:
+                await auto.SourceDotnetToolEnvironmentAsync(counter);
+                await auto.RunCommandFailFastAsync(
+                    AspireCliShellCommandHelpers.GetDotnetToolInstallCommandInDocker(strategy),
+                    counter,
+                    TimeSpan.FromSeconds(120));
                 break;
 
             default:
@@ -186,6 +202,16 @@ internal static class CliE2EAutomatorHelpers
                 await auto.SourceAspireCliEnvironmentAsync(counter);
                 break;
 
+            case CliInstallMode.LocalArchive:
+                var archiveDir = strategy.ArchiveDir ?? throw new InvalidOperationException("LocalArchive strategy is missing the archive directory.");
+                var localDirPrScript = AspireCliShellCommandHelpers.QuoteBashArg(Path.Combine(CliE2ETestHelpers.GetRepoRoot(), "eng", "scripts", "get-aspire-cli-pr.sh"));
+                await auto.RunCommandFailFastAsync(
+                    AspireCliShellCommandHelpers.GetLocalArchiveInstallCommand(archiveDir, $"bash {localDirPrScript}"),
+                    counter,
+                    TimeSpan.FromSeconds(120));
+                await auto.SourceAspireCliEnvironmentAsync(counter);
+                break;
+
             case CliInstallMode.InstallScript:
                 var getAspireCliScript = AspireCliShellCommandHelpers.QuoteBashArg(Path.Combine(CliE2ETestHelpers.GetRepoRoot(), "eng", "scripts", "get-aspire-cli.sh"));
                 await auto.RunCommandFailFastAsync(
@@ -194,6 +220,11 @@ internal static class CliE2EAutomatorHelpers
                     TimeSpan.FromSeconds(120));
                 await auto.SourceAspireCliEnvironmentAsync(counter);
                 break;
+
+            case CliInstallMode.DotnetTool:
+                throw new InvalidOperationException(
+                    "DotnetTool CLI mode is only supported in Docker test environments. " +
+                    "Use CreateDockerTestTerminal instead of CreateTestTerminal to avoid mutating the host machine.");
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(strategy), strategy.Mode, "Unknown install mode");
@@ -303,6 +334,20 @@ internal static class CliE2EAutomatorHelpers
         SequenceCounter counter)
     {
         await auto.SourceAspireEnvironmentAsync(counter, includeBundlePath: true);
+    }
+
+    /// <summary>
+    /// Configures the PATH and environment variables for the Aspire CLI installed via <c>dotnet tool install</c>.
+    /// Adds <c>~/.dotnet/tools</c> to PATH and sets the standard Aspire environment variables.
+    /// </summary>
+    internal static async Task SourceDotnetToolEnvironmentAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        await auto.RunCommandAsync(
+            $"export PATH=~/.dotnet/tools:$PATH {AspireCliShellCommandHelpers.CommonAspireEnvironmentAssignments}",
+            counter,
+            TimeSpan.FromSeconds(30));
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -371,6 +371,16 @@ internal static class CliE2EAutomatorHelpers
         await auto.WaitForSuccessPromptAsync(counter);
     }
 
+    internal static async Task VerifyPullRequestCliVersionAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        if (CliE2ETestHelpers.TryGetPullRequestHeadSha(out var commitSha))
+        {
+            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
+        }
+    }
+
     private static string GetExpectedStableVersionMarker()
     {
         var versionsPropsPath = Path.Combine(CliE2ETestHelpers.GetRepoRoot(), "eng", "Versions.props");

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -172,7 +172,7 @@ internal static class CliE2ETestHelpers
         output.WriteLine($"Creating Docker test terminal:");
         output.WriteLine($"  Test name:      {testName}");
         output.WriteLine($"  Strategy:       {strategy}");
-        output.WriteLine($"  Expected ver:   {Environment.GetEnvironmentVariable("ASPIRE_E2E_EXPECTED_CLI_VERSION") ?? "(not set)"}");
+        output.WriteLine($"  Expected ver:   {strategy.ExpectedVersion ?? "(not available)"}");
         output.WriteLine($"  Variant:        {variant}");
         output.WriteLine($"  Dockerfile:     {dockerfilePath}");
         output.WriteLine($"  Workspace:      {workspace?.WorkspaceRoot.FullName ?? "(none)"}");

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -17,15 +17,14 @@ namespace Aspire.Cli.EndToEnd.Tests.Helpers;
 /// </summary>
 internal static class CliE2ETestHelpers
 {
-    internal const string CliArchiveWorkflowRunIdEnvironmentVariableName = CliInstallStrategy.CliArchiveWorkflowRunIdEnvironmentVariableName;
+    internal const string CliArchiveDirEnvironmentVariableName = CliInstallStrategy.CliArchiveDirEnvironmentVariableName;
 
     /// <summary>
     /// Gets whether the tests are running in CI (GitHub Actions) vs locally.
     /// When running locally, some commands are replaced with echo stubs.
     /// </summary>
     internal static bool IsRunningInCI =>
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER")) &&
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA"));
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
 
     /// <summary>
     /// Gets the PR number from the GITHUB_PR_NUMBER environment variable.
@@ -47,8 +46,8 @@ internal static class CliE2ETestHelpers
     }
 
     /// <summary>
-    /// Gets the commit SHA from the GITHUB_PR_HEAD_SHA environment variable.
-    /// This is the actual PR head commit, not the merge commit (GITHUB_SHA).
+    /// Gets the commit SHA from the GITHUB_PR_HEAD_SHA environment variable,
+    /// falling back to GITHUB_SHA for non-PR CI runs (e.g., schedule-triggered workflows).
     /// When running locally (not in CI), returns a dummy value for testing.
     /// </summary>
     /// <returns>The commit SHA, or a dummy value when running locally.</returns>
@@ -56,22 +55,21 @@ internal static class CliE2ETestHelpers
     {
         var commitSha = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA");
 
-        if (string.IsNullOrEmpty(commitSha))
+        if (!string.IsNullOrEmpty(commitSha))
         {
-            // Running locally - return dummy value
-            return "local0000";
+            return commitSha;
         }
 
-        return commitSha;
-    }
+        // Fallback: GITHUB_SHA is automatically set by GitHub Actions for all event types
+        var githubSha = Environment.GetEnvironmentVariable("GITHUB_SHA");
 
-    /// <summary>
-    /// Gets the workflow run ID that produced the CLI archive for the current test run, if one was provided.
-    /// </summary>
-    /// <returns>The workflow run ID, or <see langword="null"/> when the current environment should resolve the PR run dynamically.</returns>
-    internal static string? GetCliArchiveWorkflowRunId()
-    {
-        return CliInstallStrategy.GetCliArchiveWorkflowRunId();
+        if (!string.IsNullOrEmpty(githubSha))
+        {
+            return githubSha;
+        }
+
+        // Running locally - return dummy value
+        return "local0000";
     }
 
     /// <summary>
@@ -174,6 +172,7 @@ internal static class CliE2ETestHelpers
         output.WriteLine($"Creating Docker test terminal:");
         output.WriteLine($"  Test name:      {testName}");
         output.WriteLine($"  Strategy:       {strategy}");
+        output.WriteLine($"  Expected ver:   {Environment.GetEnvironmentVariable("ASPIRE_E2E_EXPECTED_CLI_VERSION") ?? "(not set)"}");
         output.WriteLine($"  Variant:        {variant}");
         output.WriteLine($"  Dockerfile:     {dockerfilePath}");
         output.WriteLine($"  Workspace:      {workspace?.WorkspaceRoot.FullName ?? "(none)"}");

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -18,6 +18,7 @@ namespace Aspire.Cli.EndToEnd.Tests.Helpers;
 internal static class CliE2ETestHelpers
 {
     internal const string CliArchiveDirEnvironmentVariableName = CliInstallStrategy.CliArchiveDirEnvironmentVariableName;
+    private static readonly Regex s_commitShaPattern = new("^[0-9a-fA-F]{40}$", RegexOptions.Compiled);
 
     /// <summary>
     /// Gets whether the tests are running in CI (GitHub Actions) vs locally.
@@ -45,31 +46,31 @@ internal static class CliE2ETestHelpers
         return prNumber;
     }
 
-    /// <summary>
-    /// Gets the commit SHA from the GITHUB_PR_HEAD_SHA environment variable,
-    /// falling back to GITHUB_SHA for non-PR CI runs (e.g., schedule-triggered workflows).
-    /// When running locally (not in CI), returns a dummy value for testing.
-    /// </summary>
-    /// <returns>The commit SHA, or a dummy value when running locally.</returns>
-    internal static string GetRequiredCommitSha()
+    internal static bool IsPullRequestContext =>
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER")) ||
+        string.Equals(Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME"), "pull_request", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool TryGetPullRequestHeadSha(out string commitSha)
     {
-        var commitSha = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA");
+        commitSha = string.Empty;
 
-        if (!string.IsNullOrEmpty(commitSha))
+        if (!IsPullRequestContext)
         {
-            return commitSha;
+            return false;
         }
 
-        // Fallback: GITHUB_SHA is automatically set by GitHub Actions for all event types
-        var githubSha = Environment.GetEnvironmentVariable("GITHUB_SHA");
-
-        if (!string.IsNullOrEmpty(githubSha))
+        commitSha = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA") ?? string.Empty;
+        if (string.IsNullOrEmpty(commitSha))
         {
-            return githubSha;
+            throw new InvalidOperationException("GITHUB_PR_HEAD_SHA must be set when running CLI E2E tests in pull request context.");
         }
 
-        // Running locally - return dummy value
-        return "local0000";
+        if (!s_commitShaPattern.IsMatch(commitSha))
+        {
+            throw new InvalidOperationException($"GITHUB_PR_HEAD_SHA must be a 40-character commit SHA, got: '{commitSha}'.");
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
@@ -51,7 +51,7 @@ public class CliInstallStrategyTests
     }
 
     [Fact]
-    public void Detect_ReturnsPullRequest_WhenBothPrMetadataAndArchiveDirAreSet()
+    public void Detect_ReturnsLocalArchive_WhenBothPrMetadataAndArchiveDirAreSet()
     {
         var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");
         try
@@ -62,14 +62,15 @@ public class CliInstallStrategyTests
                 ("ASPIRE_E2E_VERSION", null),
                 ("ASPIRE_E2E_PREINSTALLED", null),
                 ("GITHUB_PR_NUMBER", "16131"),
-                ("GITHUB_PR_HEAD_SHA", "abc123"),
+                ("GITHUB_PR_HEAD_SHA", "52669a7cac3d4f10c6269909fc38e77124ed177c"),
                 (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, tempDir.FullName),
                 ("CI", null),
                 ("GITHUB_ACTIONS", null));
 
             var strategy = CliInstallStrategy.Detect();
 
-            Assert.Equal(CliInstallMode.PullRequest, strategy.Mode);
+            Assert.Equal(CliInstallMode.LocalArchive, strategy.Mode);
+            Assert.Equal(tempDir.FullName, strategy.ArchiveDir);
         }
         finally
         {
@@ -373,6 +374,61 @@ public class CliInstallStrategyTests
     }
 
     [Fact]
+    public void FromLocalArchive_ExtractsExpectedVersionFromNupkg()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir.FullName, "Aspire.Cli.13.3.0-preview.1.12345.1.nupkg"), "");
+
+            var strategy = CliInstallStrategy.FromLocalArchive(tempDir.FullName);
+
+            Assert.Equal("13.3.0-preview.1.12345.1", strategy.ExpectedVersion);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FromLocalArchive_ThrowsWhenNupkgVersionIsMalformed()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir.FullName, "Aspire.Cli.13.3.0;bad.nupkg"), "");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => CliInstallStrategy.FromLocalArchive(tempDir.FullName));
+
+            Assert.Contains("Invalid Aspire.Cli nupkg version", exception.Message);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FromLocalArchive_ThrowsWhenMultipleCliNupkgsArePresent()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir.FullName, "Aspire.Cli.13.3.0.nupkg"), "");
+            File.WriteAllText(Path.Combine(tempDir.FullName, "Aspire.Cli.13.4.0.nupkg"), "");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => CliInstallStrategy.FromLocalArchive(tempDir.FullName));
+
+            Assert.Contains("Found 2 Aspire.Cli nupkg files", exception.Message);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void Detect_ReturnsDotnetToolLocalSource_WhenBothToolSourceAndArchiveDirAreSet()
     {
         var nupkgDir = Directory.CreateTempSubdirectory("aspire-test-nupkg-");
@@ -441,6 +497,62 @@ public class CliInstallStrategyTests
             ("GITHUB_PR_HEAD_SHA", null));
 
         Assert.Throws<InvalidOperationException>(CliInstallStrategy.FromPullRequest);
+    }
+
+    [Fact]
+    public void TryGetPullRequestHeadSha_ReturnsFalseOutsidePrContext()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            ("GITHUB_EVENT_NAME", null),
+            ("GITHUB_SHA", "52669a7cac3d4f10c6269909fc38e77124ed177c"));
+
+        var result = CliE2ETestHelpers.TryGetPullRequestHeadSha(out var commitSha);
+
+        Assert.False(result);
+        Assert.Equal(string.Empty, commitSha);
+    }
+
+    [Fact]
+    public void TryGetPullRequestHeadSha_ThrowsInPrContextWithoutHeadSha()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("GITHUB_PR_NUMBER", "16131"),
+            ("GITHUB_PR_HEAD_SHA", null),
+            ("GITHUB_EVENT_NAME", null));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CliE2ETestHelpers.TryGetPullRequestHeadSha(out _));
+
+        Assert.Contains("GITHUB_PR_HEAD_SHA must be set", exception.Message);
+    }
+
+    [Fact]
+    public void TryGetPullRequestHeadSha_ThrowsInPrContextWithInvalidHeadSha()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", "abc123"),
+            ("GITHUB_EVENT_NAME", "pull_request"));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CliE2ETestHelpers.TryGetPullRequestHeadSha(out _));
+
+        Assert.Contains("40-character commit SHA", exception.Message);
+    }
+
+    [Fact]
+    public void TryGetPullRequestHeadSha_ReturnsHeadShaInPrContext()
+    {
+        const string expectedSha = "52669a7cac3d4f10c6269909fc38e77124ed177c";
+        using var environment = new EnvironmentVariableScope(
+            ("GITHUB_PR_NUMBER", "16131"),
+            ("GITHUB_PR_HEAD_SHA", expectedSha),
+            ("GITHUB_EVENT_NAME", null));
+
+        var result = CliE2ETestHelpers.TryGetPullRequestHeadSha(out var commitSha);
+
+        Assert.True(result);
+        Assert.Equal(expectedSha, commitSha);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
@@ -10,40 +10,458 @@ namespace Aspire.Cli.EndToEnd.Tests.Helpers;
 public class CliInstallStrategyTests
 {
     [Fact]
-    public void GetPullRequestInstallArgs_UsesPrNumberWhenWorkflowRunIdIsMissing()
+    public void GetPullRequestInstallArgs_ReturnsPrNumber()
     {
-        using var environment = new EnvironmentVariableScope(
-            (CliE2ETestHelpers.CliArchiveWorkflowRunIdEnvironmentVariableName, null));
-
         Assert.Equal("123", AspireCliShellCommandHelpers.GetPullRequestInstallArgs(123));
     }
 
     [Fact]
-    public void GetPullRequestInstallArgs_AppendsWorkflowRunIdWhenProvided()
+    public void GetLocalArchiveInstallCommand_FormatsCorrectly()
     {
-        using var environment = new EnvironmentVariableScope(
-            (CliE2ETestHelpers.CliArchiveWorkflowRunIdEnvironmentVariableName, "987654321"));
-
-        Assert.Equal("123 --run-id 987654321", AspireCliShellCommandHelpers.GetPullRequestInstallArgs(123));
+        var command = AspireCliShellCommandHelpers.GetLocalArchiveInstallCommand("/tmp/cli-archives", "/opt/aspire-scripts/get-aspire-cli-pr.sh");
+        Assert.Equal("/opt/aspire-scripts/get-aspire-cli-pr.sh --local-dir '/tmp/cli-archives'", command);
     }
 
     [Fact]
-    public void ConfigureContainer_AddsWorkflowRunIdForPullRequestStrategy()
+    public void Detect_ReturnsLocalArchive_WhenArchiveDirIsSet()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");
+        try
+        {
+            using var environment = new EnvironmentVariableScope(
+                ("ASPIRE_E2E_ARCHIVE", null),
+                ("ASPIRE_E2E_QUALITY", null),
+                ("ASPIRE_E2E_VERSION", null),
+                ("ASPIRE_E2E_PREINSTALLED", null),
+                ("GITHUB_PR_NUMBER", null),
+                ("GITHUB_PR_HEAD_SHA", null),
+                (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, tempDir.FullName),
+                ("CI", null),
+                ("GITHUB_ACTIONS", null));
+
+            var strategy = CliInstallStrategy.Detect();
+
+            Assert.Equal(CliInstallMode.LocalArchive, strategy.Mode);
+            Assert.Equal(tempDir.FullName, strategy.ArchiveDir);
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public void Detect_ReturnsPullRequest_WhenBothPrMetadataAndArchiveDirAreSet()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");
+        try
+        {
+            using var environment = new EnvironmentVariableScope(
+                ("ASPIRE_E2E_ARCHIVE", null),
+                ("ASPIRE_E2E_QUALITY", null),
+                ("ASPIRE_E2E_VERSION", null),
+                ("ASPIRE_E2E_PREINSTALLED", null),
+                ("GITHUB_PR_NUMBER", "16131"),
+                ("GITHUB_PR_HEAD_SHA", "abc123"),
+                (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, tempDir.FullName),
+                ("CI", null),
+                ("GITHUB_ACTIONS", null));
+
+            var strategy = CliInstallStrategy.Detect();
+
+            Assert.Equal(CliInstallMode.PullRequest, strategy.Mode);
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public void Detect_FallsBackToDevQuality_WhenNoArchiveContextInCI()
     {
         using var environment = new EnvironmentVariableScope(
             ("ASPIRE_E2E_ARCHIVE", null),
             ("ASPIRE_E2E_QUALITY", null),
             ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_PREINSTALLED", null),
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", "true"));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.InstallScript, strategy.Mode);
+    }
+
+    [Fact]
+    public void ConfigureContainer_MountsArchiveDirForLocalArchive()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");
+        try
+        {
+            using var environment = new EnvironmentVariableScope(
+                ("ASPIRE_E2E_ARCHIVE", null),
+                ("ASPIRE_E2E_QUALITY", null),
+                ("ASPIRE_E2E_VERSION", null),
+                ("ASPIRE_E2E_PREINSTALLED", null),
+                ("GITHUB_PR_NUMBER", null),
+                ("GITHUB_PR_HEAD_SHA", null),
+                (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, tempDir.FullName));
+
+            var strategy = CliInstallStrategy.Detect();
+            var options = new DockerContainerOptions();
+
+            strategy.ConfigureContainer(options);
+
+            Assert.Contains($"{tempDir.FullName}:/tmp/aspire-cli-archives:ro", options.Volumes);
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public void ConfigureContainer_AddsPrMetadataForPullRequest()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", null),
+            ("ASPIRE_E2E_QUALITY", null),
+            ("ASPIRE_E2E_VERSION", null),
             ("GITHUB_PR_NUMBER", "16131"),
             ("GITHUB_PR_HEAD_SHA", "52669a7cac3d4f10c6269909fc38e77124ed177c"),
-            (CliE2ETestHelpers.CliArchiveWorkflowRunIdEnvironmentVariableName, "24404068249"));
+            (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, null));
 
         var strategy = CliInstallStrategy.Detect();
         var options = new DockerContainerOptions();
 
         strategy.ConfigureContainer(options);
 
-        Assert.Equal("24404068249", options.Environment[CliE2ETestHelpers.CliArchiveWorkflowRunIdEnvironmentVariableName]);
+        Assert.Equal("16131", options.Environment["GITHUB_PR_NUMBER"]);
+        Assert.Equal("52669a7cac3d4f10c6269909fc38e77124ed177c", options.Environment["GITHUB_PR_HEAD_SHA"]);
+    }
+
+    [Fact]
+    public void Detect_DotnetTool_WhenEnvironmentVariableIsSet()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", "true"),
+            ("ASPIRE_E2E_QUALITY", null),
+            ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_PREINSTALLED", null),
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", null));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+        Assert.Null(strategy.Version);
+        Assert.Null(strategy.NupkgSourcePath);
+    }
+
+    [Fact]
+    public void Detect_DotnetTool_WithVersion()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", "true"),
+            ("ASPIRE_E2E_QUALITY", null),
+            ("ASPIRE_E2E_VERSION", "9.5.0"),
+            ("ASPIRE_E2E_PREINSTALLED", null),
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", null));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+        Assert.Equal("9.5.0", strategy.Version);
+        Assert.Null(strategy.NupkgSourcePath);
+    }
+
+    [Fact]
+    public void Detect_DotnetToolLocalSource_WithVersionAndPath()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test-nupkg-");
+
+        try
+        {
+            using var environment = new EnvironmentVariableScope(
+                ("ASPIRE_E2E_ARCHIVE", null),
+                ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", tempDir.FullName),
+                ("ASPIRE_E2E_DOTNET_TOOL", null),
+                ("ASPIRE_E2E_QUALITY", null),
+                ("ASPIRE_E2E_VERSION", "13.3.0-preview.1.25175.1"),
+                ("ASPIRE_E2E_PREINSTALLED", null),
+                ("GITHUB_PR_NUMBER", null),
+                ("GITHUB_PR_HEAD_SHA", null),
+                ("CI", null),
+                ("GITHUB_ACTIONS", null));
+
+            var strategy = CliInstallStrategy.Detect();
+
+            Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+            Assert.Equal("13.3.0-preview.1.25175.1", strategy.Version);
+            Assert.Equal(tempDir.FullName, strategy.NupkgSourcePath);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Detect_DotnetToolLocalSource_ThrowsWithoutVersion()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test-nupkg-");
+
+        try
+        {
+            using var environment = new EnvironmentVariableScope(
+                ("ASPIRE_E2E_ARCHIVE", null),
+                ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", tempDir.FullName),
+                ("ASPIRE_E2E_DOTNET_TOOL", null),
+                ("ASPIRE_E2E_QUALITY", null),
+                ("ASPIRE_E2E_VERSION", null),
+                ("ASPIRE_E2E_PREINSTALLED", null),
+                ("GITHUB_PR_NUMBER", null),
+                ("GITHUB_PR_HEAD_SHA", null),
+                ("CI", null),
+                ("GITHUB_ACTIONS", null));
+
+            Assert.Throws<InvalidOperationException>(() => CliInstallStrategy.Detect());
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Detect_DotnetTool_TakesPriorityOverQuality()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", "true"),
+            ("ASPIRE_E2E_QUALITY", "dev"),
+            ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_PREINSTALLED", null),
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", null));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+    }
+
+    [Fact]
+    public void ConfigureContainer_MountsNupkgSourceForDotnetToolLocalSource()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test-nupkg-");
+
+        try
+        {
+            var strategy = CliInstallStrategy.FromDotnetToolLocalSource(tempDir.FullName, "13.3.0");
+            var options = new DockerContainerOptions();
+
+            strategy.ConfigureContainer(options);
+
+            Assert.Contains(options.Volumes, v => v.Contains("/tmp/aspire-nupkg-source:ro"));
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ConfigureContainer_NoVolumeForDotnetToolPublishedFeed()
+    {
+        var strategy = CliInstallStrategy.FromDotnetTool("9.5.0");
+        var options = new DockerContainerOptions();
+
+        strategy.ConfigureContainer(options);
+
+        Assert.DoesNotContain(options.Volumes, v => v.Contains("aspire-nupkg-source"));
+    }
+
+    [Fact]
+    public void GetDotnetToolInstallCommandInDocker_WithVersionOnly()
+    {
+        var strategy = CliInstallStrategy.FromDotnetTool("9.5.0");
+        var command = AspireCliShellCommandHelpers.GetDotnetToolInstallCommandInDocker(strategy);
+
+        Assert.Equal("dotnet tool install --global Aspire.Cli --version 9.5.0", command);
+    }
+
+    [Fact]
+    public void GetDotnetToolInstallCommandInDocker_WithLocalSource()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-test-nupkg-");
+
+        try
+        {
+            var strategy = CliInstallStrategy.FromDotnetToolLocalSource(tempDir.FullName, "13.3.0");
+            var command = AspireCliShellCommandHelpers.GetDotnetToolInstallCommandInDocker(strategy);
+
+            Assert.Equal("dotnet tool install --global Aspire.Cli --version 13.3.0 --add-source /tmp/aspire-nupkg-source", command);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetDotnetToolInstallCommandInDocker_WithoutVersion()
+    {
+        var strategy = CliInstallStrategy.FromDotnetTool();
+        var command = AspireCliShellCommandHelpers.GetDotnetToolInstallCommandInDocker(strategy);
+
+        Assert.Equal("dotnet tool install --global Aspire.Cli", command);
+    }
+
+    [Fact]
+    public void Detect_ReturnsLocalArchive_WhenArchiveDirIsSetInCIWithoutPrMetadata()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");
+        try
+        {
+            using var environment = new EnvironmentVariableScope(
+                ("ASPIRE_E2E_ARCHIVE", null),
+                ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+                ("ASPIRE_E2E_DOTNET_TOOL", null),
+                ("ASPIRE_E2E_QUALITY", null),
+                ("ASPIRE_E2E_VERSION", null),
+                ("ASPIRE_E2E_PREINSTALLED", null),
+                ("GITHUB_PR_NUMBER", null),
+                ("GITHUB_PR_HEAD_SHA", null),
+                (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, tempDir.FullName),
+                ("CI", "true"),
+                ("GITHUB_ACTIONS", "true"));
+
+            var strategy = CliInstallStrategy.Detect();
+
+            Assert.Equal(CliInstallMode.LocalArchive, strategy.Mode);
+            Assert.Equal(tempDir.FullName, strategy.ArchiveDir);
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
+    }
+
+    [Fact]
+    public void FromLocalArchive_ThrowsWhenDirectoryDoesNotExist()
+    {
+        Assert.Throws<DirectoryNotFoundException>(() =>
+            CliInstallStrategy.FromLocalArchive("/nonexistent/cli-archives-path"));
+    }
+
+    [Fact]
+    public void Detect_ReturnsDotnetToolLocalSource_WhenBothToolSourceAndArchiveDirAreSet()
+    {
+        var nupkgDir = Directory.CreateTempSubdirectory("aspire-test-nupkg-");
+        var archiveDir = Directory.CreateTempSubdirectory("cli-archives-test");
+        try
+        {
+            using var environment = new EnvironmentVariableScope(
+                ("ASPIRE_E2E_ARCHIVE", null),
+                ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", nupkgDir.FullName),
+                ("ASPIRE_E2E_DOTNET_TOOL", null),
+                ("ASPIRE_E2E_QUALITY", null),
+                ("ASPIRE_E2E_VERSION", "10.0.0-dev.12345.1"),
+                ("ASPIRE_E2E_PREINSTALLED", null),
+                ("GITHUB_PR_NUMBER", null),
+                ("GITHUB_PR_HEAD_SHA", null),
+                (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, archiveDir.FullName),
+                ("CI", null),
+                ("GITHUB_ACTIONS", null));
+
+            var strategy = CliInstallStrategy.Detect();
+
+            Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+            Assert.Equal(nupkgDir.FullName, strategy.NupkgSourcePath);
+            Assert.Equal("10.0.0-dev.12345.1", strategy.Version);
+        }
+        finally
+        {
+            nupkgDir.Delete(recursive: true);
+            archiveDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Detect_ReturnsDotnetTool_WhenBothToolFlagAndPrMetadataAreSet()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", "true"),
+            ("ASPIRE_E2E_QUALITY", null),
+            ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_PREINSTALLED", null),
+            ("GITHUB_PR_NUMBER", "16131"),
+            ("GITHUB_PR_HEAD_SHA", "abc123"),
+            (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", null));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+    }
+
+    [Fact]
+    public void FromDotnetToolLocalSource_ThrowsWhenDirectoryDoesNotExist()
+    {
+        Assert.Throws<DirectoryNotFoundException>(() =>
+            CliInstallStrategy.FromDotnetToolLocalSource("/nonexistent/nupkg-path", "1.0.0"));
+    }
+
+    [Fact]
+    public void FromPullRequest_ThrowsWhenPrMetadataIsMissing()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null));
+
+        Assert.Throws<InvalidOperationException>(CliInstallStrategy.FromPullRequest);
+    }
+
+    [Fact]
+    public void Detect_ReturnsPreinstalled_WhenPreinstalledIsSet()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", null),
+            ("ASPIRE_E2E_QUALITY", null),
+            ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_PREINSTALLED", "true"),
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            (CliE2ETestHelpers.CliArchiveDirEnvironmentVariableName, null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", null));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.Preinstalled, strategy.Mode);
     }
 
     private sealed class EnvironmentVariableScope : IDisposable

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
@@ -139,51 +139,6 @@ internal static class KubernetesDeployTestHelpers
     }
 
     /// <summary>
-    /// Runs <c>aspire --version</c> and verifies the CLI version matches the expected version
-    /// from the <c>ASPIRE_E2E_EXPECTED_CLI_VERSION</c> environment variable.
-    /// Build metadata (<c>+commit</c>) is stripped before comparison since NuGet package versions
-    /// omit it, while <c>aspire --version</c> includes it via AssemblyInformationalVersion.
-    /// When the environment variable is not set (e.g. local development), the check is skipped.
-    /// </summary>
-    internal static async Task AssertAspireVersionAsync(
-        this Hex1bTerminalAutomator auto,
-        SequenceCounter counter,
-        ITestOutputHelper output)
-    {
-        var expectedVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_EXPECTED_CLI_VERSION");
-
-        if (string.IsNullOrEmpty(expectedVersion))
-        {
-            output.WriteLine("⚠️ ASPIRE_E2E_EXPECTED_CLI_VERSION is not set — skipping exact version verification.");
-            return;
-        }
-
-        output.WriteLine($"CLI version verification: exact match against '{expectedVersion}'");
-
-        await auto.TypeAsync($"VER=$(aspire --version 2>/dev/null) && BASE_VER=${{VER%%+*}} && [ \"$BASE_VER\" = \"{expectedVersion}\" ] && echo \"CLI_VERSION_EXACT:$VER\" || echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"");
-        await auto.EnterAsync();
-
-        var foundExact = false;
-        await auto.WaitUntilAsync(
-            snapshot =>
-            {
-                if (new CellPatternSearcher().Find("CLI_VERSION_EXACT:").Search(snapshot).Count > 0)
-                {
-                    foundExact = true;
-                    return true;
-                }
-                return new CellPatternSearcher().Find("CLI_VERSION_MISMATCH:").Search(snapshot).Count > 0;
-            },
-            timeout: TimeSpan.FromSeconds(30),
-            description: "CLI version exact match assertion");
-
-        await auto.WaitForAnyPromptAsync(counter);
-
-        Assert.True(foundExact, $"Aspire CLI version mismatch. Expected '{expectedVersion}' but got a different version. This may indicate the wrong CLI binary was installed.");
-        output.WriteLine($"✅ CLI version matches expected: {expectedVersion}");
-    }
-
-    /// <summary>
     /// Scaffolds an Aspire project using <c>aspire new</c> (Starter template, no Redis),
     /// then adds hosting/client packages and injects custom code into the existing source files.
     /// Asserts the "Using project templates version:" message appears with a prerelease suffix.

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
@@ -148,28 +148,63 @@ internal static class KubernetesDeployTestHelpers
         SequenceCounter counter,
         ITestOutputHelper output)
     {
-        // Run aspire --version and assert it contains a prerelease suffix (hyphen) via shell
-        await auto.TypeAsync("VER=$(aspire --version 2>/dev/null) && echo \"$VER\" | grep -q '-' && echo \"CLI_VERSION_OK:$VER\" || { echo \"CLI_VERSION_FAIL:$VER\"; false; }");
-        await auto.EnterAsync();
+        var expectedVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_EXPECTED_CLI_VERSION");
 
-        var foundOk = false;
-        await auto.WaitUntilAsync(
-            snapshot =>
-            {
-                if (new CellPatternSearcher().Find("CLI_VERSION_OK:").Search(snapshot).Count > 0)
+        output.WriteLine($"CLI version verification: ASPIRE_E2E_EXPECTED_CLI_VERSION={expectedVersion ?? "(not set)"}");
+        output.WriteLine(string.IsNullOrEmpty(expectedVersion)
+            ? "  Mode: prerelease-suffix check (no exact version configured)"
+            : $"  Mode: exact version match against '{expectedVersion}'");
+
+        if (!string.IsNullOrEmpty(expectedVersion))
+        {
+            // When an expected version is set (CI builds), verify the exact version matches
+            await auto.TypeAsync($"VER=$(aspire --version 2>/dev/null) && [ \"$VER\" = \"{expectedVersion}\" ] && echo \"CLI_VERSION_EXACT:$VER\" || echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"");
+            await auto.EnterAsync();
+
+            var foundExact = false;
+            await auto.WaitUntilAsync(
+                snapshot =>
                 {
-                    foundOk = true;
-                    return true;
-                }
-                return new CellPatternSearcher().Find("CLI_VERSION_FAIL:").Search(snapshot).Count > 0;
-            },
-            timeout: TimeSpan.FromSeconds(30),
-            description: "CLI version prerelease assertion");
+                    if (new CellPatternSearcher().Find("CLI_VERSION_EXACT:").Search(snapshot).Count > 0)
+                    {
+                        foundExact = true;
+                        return true;
+                    }
+                    return new CellPatternSearcher().Find("CLI_VERSION_MISMATCH:").Search(snapshot).Count > 0;
+                },
+                timeout: TimeSpan.FromSeconds(30),
+                description: "CLI version exact match assertion");
 
-        await auto.WaitForAnyPromptAsync(counter);
+            await auto.WaitForAnyPromptAsync(counter);
 
-        Assert.True(foundOk, "Aspire CLI version does not contain a prerelease suffix. Expected a development build (e.g. 13.3.0-dev or 13.3.0-pr.NNNNN).");
-        output.WriteLine("✅ CLI version contains prerelease suffix");
+            Assert.True(foundExact, $"Aspire CLI version mismatch. Expected '{expectedVersion}' but got a different version. This may indicate the wrong CLI binary was installed.");
+            output.WriteLine($"✅ CLI version matches expected: {expectedVersion}");
+        }
+        else
+        {
+            // Fallback: verify the CLI version contains a prerelease suffix (hyphen)
+            await auto.TypeAsync("VER=$(aspire --version 2>/dev/null) && echo \"$VER\" | grep -q '-' && echo \"CLI_VERSION_OK:$VER\" || { echo \"CLI_VERSION_FAIL:$VER\"; false; }");
+            await auto.EnterAsync();
+
+            var foundOk = false;
+            await auto.WaitUntilAsync(
+                snapshot =>
+                {
+                    if (new CellPatternSearcher().Find("CLI_VERSION_OK:").Search(snapshot).Count > 0)
+                    {
+                        foundOk = true;
+                        return true;
+                    }
+                    return new CellPatternSearcher().Find("CLI_VERSION_FAIL:").Search(snapshot).Count > 0;
+                },
+                timeout: TimeSpan.FromSeconds(30),
+                description: "CLI version prerelease assertion");
+
+            await auto.WaitForAnyPromptAsync(counter);
+
+            Assert.True(foundOk, "Aspire CLI version does not contain a prerelease suffix. Expected a development build (e.g. 13.3.0-dev or 13.3.0-pr.NNNNN).");
+            output.WriteLine("✅ CLI version contains prerelease suffix");
+        }
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
@@ -139,11 +139,11 @@ internal static class KubernetesDeployTestHelpers
     }
 
     /// <summary>
-    /// Runs <c>aspire --version</c> and verifies the CLI version.
-    /// When the <c>ASPIRE_E2E_EXPECTED_CLI_VERSION</c> environment variable is set (CI builds),
-    /// performs an exact version match against the expected value.
-    /// Otherwise, falls back to asserting the version contains a prerelease suffix
-    /// (e.g. <c>-dev</c>, <c>-pr.NNNNN</c>) to ensure the test runs against a development build.
+    /// Runs <c>aspire --version</c> and verifies the CLI version matches the expected version
+    /// from the <c>ASPIRE_E2E_EXPECTED_CLI_VERSION</c> environment variable.
+    /// Build metadata (<c>+commit</c>) is stripped before comparison since NuGet package versions
+    /// omit it, while <c>aspire --version</c> includes it via AssemblyInformationalVersion.
+    /// When the environment variable is not set (e.g. local development), the check is skipped.
     /// </summary>
     internal static async Task AssertAspireVersionAsync(
         this Hex1bTerminalAutomator auto,
@@ -152,63 +152,35 @@ internal static class KubernetesDeployTestHelpers
     {
         var expectedVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_EXPECTED_CLI_VERSION");
 
-        output.WriteLine($"CLI version verification: ASPIRE_E2E_EXPECTED_CLI_VERSION={expectedVersion ?? "(not set)"}");
-        output.WriteLine(string.IsNullOrEmpty(expectedVersion)
-            ? "  Mode: prerelease-suffix check (no exact version configured)"
-            : $"  Mode: exact version match against '{expectedVersion}'");
-
-        if (!string.IsNullOrEmpty(expectedVersion))
+        if (string.IsNullOrEmpty(expectedVersion))
         {
-            // When an expected version is set (CI builds), verify the version matches after stripping
-            // build metadata (+commit). The nupkg version omits the +metadata suffix per NuGet spec,
-            // but aspire --version includes it via AssemblyInformationalVersion.
-            await auto.TypeAsync($"VER=$(aspire --version 2>/dev/null) && BASE_VER=${{VER%%+*}} && [ \"$BASE_VER\" = \"{expectedVersion}\" ] && echo \"CLI_VERSION_EXACT:$VER\" || echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"");
-            await auto.EnterAsync();
-
-            var foundExact = false;
-            await auto.WaitUntilAsync(
-                snapshot =>
-                {
-                    if (new CellPatternSearcher().Find("CLI_VERSION_EXACT:").Search(snapshot).Count > 0)
-                    {
-                        foundExact = true;
-                        return true;
-                    }
-                    return new CellPatternSearcher().Find("CLI_VERSION_MISMATCH:").Search(snapshot).Count > 0;
-                },
-                timeout: TimeSpan.FromSeconds(30),
-                description: "CLI version exact match assertion");
-
-            await auto.WaitForAnyPromptAsync(counter);
-
-            Assert.True(foundExact, $"Aspire CLI version mismatch. Expected '{expectedVersion}' but got a different version. This may indicate the wrong CLI binary was installed.");
-            output.WriteLine($"✅ CLI version matches expected: {expectedVersion}");
+            output.WriteLine("⚠️ ASPIRE_E2E_EXPECTED_CLI_VERSION is not set — skipping exact version verification.");
+            return;
         }
-        else
-        {
-            // Fallback: verify the CLI version contains a prerelease suffix (hyphen)
-            await auto.TypeAsync("VER=$(aspire --version 2>/dev/null) && echo \"$VER\" | grep -q '-' && echo \"CLI_VERSION_OK:$VER\" || { echo \"CLI_VERSION_FAIL:$VER\"; false; }");
-            await auto.EnterAsync();
 
-            var foundOk = false;
-            await auto.WaitUntilAsync(
-                snapshot =>
+        output.WriteLine($"CLI version verification: exact match against '{expectedVersion}'");
+
+        await auto.TypeAsync($"VER=$(aspire --version 2>/dev/null) && BASE_VER=${{VER%%+*}} && [ \"$BASE_VER\" = \"{expectedVersion}\" ] && echo \"CLI_VERSION_EXACT:$VER\" || echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"");
+        await auto.EnterAsync();
+
+        var foundExact = false;
+        await auto.WaitUntilAsync(
+            snapshot =>
+            {
+                if (new CellPatternSearcher().Find("CLI_VERSION_EXACT:").Search(snapshot).Count > 0)
                 {
-                    if (new CellPatternSearcher().Find("CLI_VERSION_OK:").Search(snapshot).Count > 0)
-                    {
-                        foundOk = true;
-                        return true;
-                    }
-                    return new CellPatternSearcher().Find("CLI_VERSION_FAIL:").Search(snapshot).Count > 0;
-                },
-                timeout: TimeSpan.FromSeconds(30),
-                description: "CLI version prerelease assertion");
+                    foundExact = true;
+                    return true;
+                }
+                return new CellPatternSearcher().Find("CLI_VERSION_MISMATCH:").Search(snapshot).Count > 0;
+            },
+            timeout: TimeSpan.FromSeconds(30),
+            description: "CLI version exact match assertion");
 
-            await auto.WaitForAnyPromptAsync(counter);
+        await auto.WaitForAnyPromptAsync(counter);
 
-            Assert.True(foundOk, "Aspire CLI version does not contain a prerelease suffix. Expected a development build (e.g. 13.3.0-dev or 13.3.0-pr.NNNNN).");
-            output.WriteLine("✅ CLI version contains prerelease suffix");
-        }
+        Assert.True(foundExact, $"Aspire CLI version mismatch. Expected '{expectedVersion}' but got a different version. This may indicate the wrong CLI binary was installed.");
+        output.WriteLine($"✅ CLI version matches expected: {expectedVersion}");
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
@@ -139,9 +139,11 @@ internal static class KubernetesDeployTestHelpers
     }
 
     /// <summary>
-    /// Runs <c>aspire --version</c> and asserts the CLI version contains a prerelease suffix (e.g. <c>-dev</c>, <c>-pr.NNNNN</c>).
-    /// This ensures the test is running against a development build, not a GA release.
-    /// Fails the test if the version does not contain a hyphen (indicating a prerelease suffix).
+    /// Runs <c>aspire --version</c> and verifies the CLI version.
+    /// When the <c>ASPIRE_E2E_EXPECTED_CLI_VERSION</c> environment variable is set (CI builds),
+    /// performs an exact version match against the expected value.
+    /// Otherwise, falls back to asserting the version contains a prerelease suffix
+    /// (e.g. <c>-dev</c>, <c>-pr.NNNNN</c>) to ensure the test runs against a development build.
     /// </summary>
     internal static async Task AssertAspireVersionAsync(
         this Hex1bTerminalAutomator auto,
@@ -157,8 +159,10 @@ internal static class KubernetesDeployTestHelpers
 
         if (!string.IsNullOrEmpty(expectedVersion))
         {
-            // When an expected version is set (CI builds), verify the exact version matches
-            await auto.TypeAsync($"VER=$(aspire --version 2>/dev/null) && [ \"$VER\" = \"{expectedVersion}\" ] && echo \"CLI_VERSION_EXACT:$VER\" || echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"");
+            // When an expected version is set (CI builds), verify the version matches after stripping
+            // build metadata (+commit). The nupkg version omits the +metadata suffix per NuGet spec,
+            // but aspire --version includes it via AssemblyInformationalVersion.
+            await auto.TypeAsync($"VER=$(aspire --version 2>/dev/null) && BASE_VER=${{VER%%+*}} && [ \"$BASE_VER\" = \"{expectedVersion}\" ] && echo \"CLI_VERSION_EXACT:$VER\" || echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"");
             await auto.EnterAsync();
 
             var foundExact = false;

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaCodegenValidationTests.cs
@@ -18,7 +18,7 @@ public sealed class JavaCodegenValidationTests(ITestOutputHelper output)
     public async Task RestoreGeneratesSdkFiles()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.PolyglotJava, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaEmptyAppHostTemplateTests.cs
@@ -20,7 +20,7 @@ public sealed class JavaEmptyAppHostTemplateTests(ITestOutputHelper output)
     public async Task CreateAndRunJavaEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.PolyglotJava, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotTests.cs
@@ -18,7 +18,7 @@ public sealed class JavaPolyglotTests(ITestOutputHelper output)
     public async Task CreateJavaAppHostWithViteApp()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.PolyglotJava, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptPublishTests.cs
@@ -26,7 +26,7 @@ public sealed class JavaScriptPublishTests(ITestOutputHelper output)
     public async Task AllPublishMethodsBuildDockerImages()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/JsReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JsReactTemplateTests.cs
@@ -20,7 +20,7 @@ public sealed class JsReactTemplateTests(ITestOutputHelper output)
     public async Task CreateAndRunJsReactProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployBasicApiServiceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployBasicApiServiceTests.cs
@@ -45,9 +45,6 @@ public sealed class KubernetesDeployBasicApiServiceTests(ITestOutputHelper outpu
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             // =====================================================================

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployBasicApiServiceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployBasicApiServiceTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployBasicApiServiceTests(ITestOutputHelper outpu
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -40,10 +39,7 @@ public sealed class KubernetesDeployBasicApiServiceTests(ITestOutputHelper outpu
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployBasicApiServiceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployBasicApiServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployBasicApiServiceTests(ITestOutputHelper outpu
     public async Task DeployK8sBasicApiService()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployTypeScriptTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployTypeScriptTests.cs
@@ -24,7 +24,6 @@ public sealed class KubernetesDeployTypeScriptTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -40,10 +39,7 @@ public sealed class KubernetesDeployTypeScriptTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployTypeScriptTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployTypeScriptTests.cs
@@ -21,7 +21,7 @@ public sealed class KubernetesDeployTypeScriptTests(ITestOutputHelper output)
     public async Task DeployTypeScriptAppToKubernetes()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployTypeScriptTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployTypeScriptTests.cs
@@ -45,8 +45,6 @@ public sealed class KubernetesDeployTypeScriptTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             // =====================================================================

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithGarnetTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithGarnetTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployWithGarnetTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -39,10 +38,7 @@ public sealed class KubernetesDeployWithGarnetTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithGarnetTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithGarnetTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployWithGarnetTests(ITestOutputHelper output)
     public async Task DeployK8sWithGarnet()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithGarnetTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithGarnetTests.cs
@@ -44,9 +44,6 @@ public sealed class KubernetesDeployWithGarnetTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMongoDBTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMongoDBTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployWithMongoDBTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -39,10 +38,7 @@ public sealed class KubernetesDeployWithMongoDBTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMongoDBTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMongoDBTests.cs
@@ -44,9 +44,6 @@ public sealed class KubernetesDeployWithMongoDBTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMongoDBTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMongoDBTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployWithMongoDBTests(ITestOutputHelper output)
     public async Task DeployK8sWithMongoDB()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMySqlTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMySqlTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployWithMySqlTests(ITestOutputHelper output)
     public async Task DeployK8sWithMySql()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMySqlTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMySqlTests.cs
@@ -44,9 +44,6 @@ public sealed class KubernetesDeployWithMySqlTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMySqlTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithMySqlTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployWithMySqlTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -39,10 +38,7 @@ public sealed class KubernetesDeployWithMySqlTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithNatsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithNatsTests.cs
@@ -25,7 +25,6 @@ public sealed class KubernetesDeployWithNatsTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -41,10 +40,7 @@ public sealed class KubernetesDeployWithNatsTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithNatsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithNatsTests.cs
@@ -22,7 +22,7 @@ public sealed class KubernetesDeployWithNatsTests(ITestOutputHelper output)
     public async Task DeployK8sWithNats()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithNatsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithNatsTests.cs
@@ -46,9 +46,6 @@ public sealed class KubernetesDeployWithNatsTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithPostgresTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithPostgresTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployWithPostgresTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -39,10 +38,7 @@ public sealed class KubernetesDeployWithPostgresTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithPostgresTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithPostgresTests.cs
@@ -44,9 +44,6 @@ public sealed class KubernetesDeployWithPostgresTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithPostgresTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithPostgresTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployWithPostgresTests(ITestOutputHelper output)
     public async Task DeployK8sWithPostgres()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRabbitMQTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRabbitMQTests.cs
@@ -44,9 +44,6 @@ public sealed class KubernetesDeployWithRabbitMQTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRabbitMQTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRabbitMQTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployWithRabbitMQTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -39,10 +38,7 @@ public sealed class KubernetesDeployWithRabbitMQTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRabbitMQTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRabbitMQTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployWithRabbitMQTests(ITestOutputHelper output)
     public async Task DeployK8sWithRabbitMQ()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRedisTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRedisTests.cs
@@ -44,9 +44,6 @@ public sealed class KubernetesDeployWithRedisTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRedisTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRedisTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployWithRedisTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -39,10 +38,7 @@ public sealed class KubernetesDeployWithRedisTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRedisTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithRedisTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployWithRedisTests(ITestOutputHelper output)
     public async Task DeployK8sWithRedis()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithSqlServerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithSqlServerTests.cs
@@ -44,9 +44,6 @@ public sealed class KubernetesDeployWithSqlServerTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithSqlServerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithSqlServerTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployWithSqlServerTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -39,10 +38,7 @@ public sealed class KubernetesDeployWithSqlServerTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithSqlServerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithSqlServerTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployWithSqlServerTests(ITestOutputHelper output)
     public async Task DeployK8sWithSqlServer()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithValkeyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithValkeyTests.cs
@@ -23,7 +23,6 @@ public sealed class KubernetesDeployWithValkeyTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
         var k8sNamespace = $"test-{clusterName[..16]}";
 
@@ -39,10 +38,7 @@ public sealed class KubernetesDeployWithValkeyTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithValkeyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithValkeyTests.cs
@@ -20,7 +20,7 @@ public sealed class KubernetesDeployWithValkeyTests(ITestOutputHelper output)
     public async Task DeployK8sWithValkey()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithValkeyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithValkeyTests.cs
@@ -44,9 +44,6 @@ public sealed class KubernetesDeployWithValkeyTests(ITestOutputHelper output)
             await auto.VerifyAspireCliVersionAsync(commitSha, counter);
         }
 
-        // Assert CLI version has a prerelease suffix (runs in both CI and local)
-        await auto.AssertAspireVersionAsync(counter, output);
-
         try
         {
             await auto.InstallKindAndHelmAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
@@ -35,7 +35,6 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var clusterName = GenerateUniqueClusterName();
 
         output.WriteLine($"Using KinD version: {KindVersion}");
@@ -52,10 +51,7 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         try
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
@@ -32,7 +32,7 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
     public async Task CreateAndPublishToKubernetes()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();

--- a/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
@@ -18,7 +18,7 @@ public sealed class ListStepsTests(ITestOutputHelper output)
     public async Task DoListStepsShowsPipelineSteps()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
@@ -39,7 +39,7 @@ public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
     public async Task LegacySettingsMigration_AdjustsRelativeAppHostPath()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(

--- a/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
@@ -19,7 +19,7 @@ public sealed class LogsCommandTests(ITestOutputHelper output)
     public async Task LogsCommandShowsResourceLogs()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
@@ -18,7 +18,7 @@ public sealed class MultipleAppHostTests(ITestOutputHelper output)
     public async Task DetachFormatJsonProducesValidJson()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -81,7 +81,7 @@ public sealed class MultipleAppHostTests(ITestOutputHelper output)
     public async Task DetachFormatJsonProducesValidJsonWhenRestartingExistingInstance()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/NewWithAgentInitTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/NewWithAgentInitTests.cs
@@ -33,7 +33,7 @@ public sealed class NewWithAgentInitTests(ITestOutputHelper output)
     public async Task AspireNew_WithAgentInit_InstallsPlaywrightWithoutErrors()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
@@ -27,7 +27,7 @@ public sealed class OtelLogsTests(ITestOutputHelper output)
     private async Task OtelLogsReturnsStructuredLogsFromStarterAppCore(bool isolated)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         using var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
@@ -29,7 +29,7 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
     public async Task AgentInit_InstallsPlaywrightCli_AndGeneratesSkillFiles()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
@@ -115,7 +115,7 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
     public async Task AgentInit_WhenCwdDiffersFromWorkspaceRoot_PlacesSkillFilesInWorkspaceRoot()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/PodmanDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PodmanDeploymentTests.cs
@@ -25,7 +25,7 @@ public sealed class PodmanDeploymentTests(ITestOutputHelper output)
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         using var terminal = CliE2ETestHelpers.CreatePodmanDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/PodmanDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PodmanDeploymentTests.cs
@@ -26,7 +26,6 @@ public sealed class PodmanDeploymentTests(ITestOutputHelper output)
         using var workspace = TemporaryWorkspace.Create(output);
 
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         using var terminal = CliE2ETestHelpers.CreatePodmanDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
@@ -37,10 +36,7 @@ public sealed class PodmanDeploymentTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
-        if (strategy.Mode == CliInstallMode.PullRequest)
-        {
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.VerifyPullRequestCliVersionAsync(counter);
 
         // Step 0: Verify Podman is available inside the helper container.
         await auto.TypeAsync("podman --version || echo 'PODMAN_NOT_FOUND'");

--- a/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
@@ -23,7 +23,7 @@ public sealed class ProjectReferenceTests(ITestOutputHelper output)
     public async Task TypeScriptAppHostWithProjectReferenceIntegration()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
@@ -19,7 +19,7 @@ public sealed class PsCommandTests(ITestOutputHelper output)
     public async Task PsCommandListsRunningAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -89,7 +89,7 @@ public sealed class PsCommandTests(ITestOutputHelper output)
     public async Task PsFormatJsonOutputsOnlyJsonToStdout()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
@@ -19,7 +19,7 @@ public sealed class PythonReactTemplateTests(ITestOutputHelper output)
     public async Task CreateAndRunPythonReactProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/SecretDotNetAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SecretDotNetAppHostTests.cs
@@ -17,7 +17,7 @@ public sealed class SecretDotNetAppHostTests(ITestOutputHelper output)
     public async Task SecretCrudOnDotNetAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/SecretTypeScriptAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SecretTypeScriptAppHostTests.cs
@@ -17,7 +17,7 @@ public sealed class SecretTypeScriptAppHostTests(ITestOutputHelper output)
     public async Task SecretCrudOnTypeScriptAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.Polyglot, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -20,7 +20,7 @@ public sealed class SmokeTests(ITestOutputHelper output)
     public async Task CreateAndRunAspireStarterProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
@@ -19,7 +19,7 @@ public sealed class StagingChannelTests(ITestOutputHelper output)
     public async Task StagingChannel_ConfigureAndVerifySettings_ThenSwitchChannels()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -22,7 +22,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
     public async Task CreateStartAndStopAspireProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var projectSuffix = Guid.NewGuid().ToString("N")[..6];
         var projectName = $"StarterApp_{projectSuffix}";
 
@@ -101,7 +101,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
     public async Task StopWithNoRunningAppHostExitsSuccessfully()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -134,7 +134,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
     public async Task AddPackageWhileAppHostRunningDetached()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -190,7 +190,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
     public async Task AddPackageInteractiveWhileAppHostRunningDetached()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -20,7 +20,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
     public async Task StopNonInteractiveSingleAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -77,7 +77,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
     public async Task StopAllAppHostsFromAppHostDirectory()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -144,7 +144,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
     public async Task StopAllAppHostsFromUnrelatedDirectory()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -216,7 +216,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
     public async Task StopNonInteractiveMultipleAppHostsShowsError()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -28,7 +28,7 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
     public async Task RestoreGeneratesSdkFiles_WithConfiguredToolchain(string toolchain)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
         var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
             ["Aspire.Hosting.CodeGeneration.TypeScript.", "Aspire.Hosting.Redis.", "Aspire.Hosting.SqlServer."]);
@@ -118,7 +118,7 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
     public async Task RestoreRefreshesGeneratedSdkAfterAddingIntegration()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         // Use the DotNet container variant even for the TypeScript AppHost so local LocalHive
@@ -250,7 +250,7 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
     public async Task UnAwaitedChainsCompileWithAutoResolvePromises()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -20,7 +20,7 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
     public async Task CreateAndRunTypeScriptEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -29,7 +29,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
     public async Task CreateTypeScriptAppHostWithViteApp_UsesConfiguredToolchain(string toolchain)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
         var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
             ["Aspire.Hosting.CodeGeneration.TypeScript.", "Aspire.Hosting.JavaScript."]);
@@ -126,7 +126,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
     public async Task InitTypeScriptAppHost_AugmentsExistingViteRepoAtRoot()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
         var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
             ["Aspire.Hosting.CodeGeneration.TypeScript.", "Aspire.Hosting.JavaScript."]);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
@@ -18,7 +18,7 @@ public sealed class TypeScriptPublishTests(ITestOutputHelper output)
     public async Task PublishWithDockerComposeServiceCallbackSucceeds()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         using var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.DotNet, mountDockerSocket: true, workspace: workspace);
@@ -105,7 +105,7 @@ public sealed class TypeScriptPublishTests(ITestOutputHelper output)
     public async Task PublishWithoutOutputPathUsesAppHostDirectoryDefault()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         if (strategy.Mode == CliInstallMode.InstallScript && strategy.Quality is null && strategy.Version is null)
         {
@@ -196,7 +196,7 @@ public sealed class TypeScriptPublishTests(ITestOutputHelper output)
     public async Task PublishWithConfigureEnvFileUpdatesEnvOutput()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         if (strategy.Mode == CliInstallMode.InstallScript && strategy.Quality is null && strategy.Version is null)
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptReusablePackageTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptReusablePackageTests.cs
@@ -18,7 +18,7 @@ public sealed class TypeScriptReusablePackageTests(ITestOutputHelper output)
     public async Task RestoreSupportsConfigOnlyHelperPackageAndCrossPackageTypes()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.Polyglot, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptSqlServerNativeAssetsBundleTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptSqlServerNativeAssetsBundleTests.cs
@@ -20,7 +20,7 @@ public sealed class TypeScriptSqlServerNativeAssetsBundleTests(ITestOutputHelper
     public async Task StartAndWaitForTypeScriptSqlServerAppHostWithNativeAssets()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -20,7 +20,7 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
     public async Task CreateAndRunTypeScriptStarterProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);

--- a/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
@@ -20,7 +20,7 @@ public sealed class WaitCommandTests(ITestOutputHelper output)
     public async Task CreateStartWaitAndStopAspireProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
@@ -289,6 +289,7 @@ builder.Build().Run();
                 {
                     CliInstallMode.LocalHive or CliInstallMode.Preinstalled => "aspire update --channel local",
                     CliInstallMode.PullRequest => $"aspire update --channel pr-{DeploymentE2ETestHelpers.GetPrNumber()}",
+                    CliInstallMode.LocalArchive => "aspire update --channel run-local",
                     _ => "aspire update",
                 };
             }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2EAutomatorHelpers.cs
@@ -70,6 +70,15 @@ internal static class DeploymentE2EAutomatorHelpers
                 await auto.SourceAspireEnvironmentAsync(counter, includeBundlePath);
                 break;
 
+            case CliInstallMode.LocalArchive:
+                var archiveDir = strategy.ArchiveDir ?? throw new InvalidOperationException("LocalArchive strategy is missing the archive directory.");
+                await auto.RunCommandFailFastAsync(
+                    AspireCliShellCommandHelpers.GetLocalArchiveInstallCommandFromCurrentRef(archiveDir),
+                    counter,
+                    TimeSpan.FromSeconds(120));
+                await auto.SourceAspireEnvironmentAsync(counter, includeBundlePath);
+                break;
+
             case CliInstallMode.InstallScript:
                 await auto.RunCommandFailFastAsync(
                     AspireCliShellCommandHelpers.GetInstallScriptCommand(strategy, AspireCliShellCommandHelpers.AkaMsInstallScriptCommandPrefix),
@@ -77,6 +86,11 @@ internal static class DeploymentE2EAutomatorHelpers
                     TimeSpan.FromSeconds(300));
                 await auto.SourceAspireEnvironmentAsync(counter, includeBundlePath);
                 break;
+
+            case CliInstallMode.DotnetTool:
+                throw new InvalidOperationException(
+                    "DotnetTool install mode is not supported for deployment E2E tests. " +
+                    "Deployment tests require the native CLI. Clear ASPIRE_E2E_DOTNET_TOOL* environment variables and retry.");
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(strategy), strategy.Mode, "Unknown install mode");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
@@ -33,13 +33,20 @@ internal static class DeploymentE2ETestHelpers
     }
 
     /// <summary>
-    /// Gets the commit SHA from the GITHUB_PR_HEAD_SHA environment variable.
+    /// Gets the commit SHA from the GITHUB_PR_HEAD_SHA environment variable,
+    /// falling back to GITHUB_SHA for non-PR CI runs (e.g., schedule-triggered workflows).
     /// When running locally (not in CI), returns "local0000".
     /// </summary>
     internal static string GetCommitSha()
     {
         var commitSha = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA");
-        return string.IsNullOrEmpty(commitSha) ? "local0000" : commitSha;
+        if (!string.IsNullOrEmpty(commitSha))
+        {
+            return commitSha;
+        }
+
+        var githubSha = Environment.GetEnvironmentVariable("GITHUB_SHA");
+        return string.IsNullOrEmpty(githubSha) ? "local0000" : githubSha;
     }
 
     /// <summary>

--- a/tests/Shared/CliInstallStrategy.cs
+++ b/tests/Shared/CliInstallStrategy.cs
@@ -30,10 +30,23 @@ internal enum CliInstallMode
     PullRequest,
 
     /// <summary>
+    /// Install from pre-downloaded artifacts in a local directory using get-aspire-cli-pr.sh with --local-dir.
+    /// Used for same-workflow scenarios (e.g., quarantine/outerloop) where artifacts are already on disk.
+    /// </summary>
+    LocalArchive,
+
+    /// <summary>
     /// Install via get-aspire-cli.sh with optional --quality or --version.
     /// Covers GA releases, daily builds, preview, and explicit versions.
     /// </summary>
     InstallScript,
+
+    /// <summary>
+    /// Install via <c>dotnet tool install --global Aspire.Cli</c>.
+    /// Supports published NuGet feeds and local nupkg sources.
+    /// Set via ASPIRE_E2E_DOTNET_TOOL or ASPIRE_E2E_DOTNET_TOOL_SOURCE.
+    /// </summary>
+    DotnetTool,
 }
 
 /// <summary>
@@ -109,16 +122,58 @@ internal static class AspireCliShellCommandHelpers
 
     internal static string GetPullRequestInstallArgs(int prNumber)
     {
-        var workflowRunId = CliInstallStrategy.GetCliArchiveWorkflowRunId();
+        return prNumber.ToString(CultureInfo.InvariantCulture);
+    }
 
-        return workflowRunId is null
-            ? prNumber.ToString(CultureInfo.InvariantCulture)
-            : $"{prNumber.ToString(CultureInfo.InvariantCulture)} --run-id {workflowRunId}";
+    internal static string GetLocalArchiveInstallCommand(string localDir, string commandPrefix)
+    {
+        return $"{commandPrefix} --local-dir {QuoteBashArg(localDir)}";
+    }
+
+    internal static string GetLocalArchiveInstallCommandFromCurrentRef(string localDir)
+    {
+        var sha = Environment.GetEnvironmentVariable("GITHUB_SHA") ?? "main";
+        return $"curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/{sha}/eng/scripts/get-aspire-cli-pr.sh | bash -s -- --local-dir {QuoteBashArg(localDir)}";
     }
 
     internal static string QuoteBashArg(string value)
     {
         return $"'{value.Replace("'", "'\"'\"'")}'";
+    }
+
+    internal static string GetDotnetToolInstallCommand(CliInstallStrategy strategy)
+    {
+        var args = "--global Aspire.Cli";
+
+        if (strategy.Version is not null)
+        {
+            args += $" --version {strategy.Version}";
+        }
+
+        if (strategy.NupkgSourcePath is not null)
+        {
+            args += $" --add-source {QuoteBashArg(strategy.NupkgSourcePath)}";
+        }
+
+        return $"dotnet tool install {args}";
+    }
+
+    internal static string GetDotnetToolInstallCommandInDocker(CliInstallStrategy strategy)
+    {
+        var args = "--global Aspire.Cli";
+
+        if (strategy.Version is not null)
+        {
+            args += $" --version {strategy.Version}";
+        }
+
+        if (strategy.NupkgSourcePath is not null)
+        {
+            // In Docker, local nupkg source is mounted at /tmp/aspire-nupkg-source
+            args += " --add-source /tmp/aspire-nupkg-source";
+        }
+
+        return $"dotnet tool install {args}";
     }
 }
 
@@ -142,7 +197,7 @@ internal enum CliInstallQuality
 /// </summary>
 internal sealed class CliInstallStrategy
 {
-    internal const string CliArchiveWorkflowRunIdEnvironmentVariableName = "ASPIRE_CLI_WORKFLOW_RUN_ID";
+    internal const string CliArchiveDirEnvironmentVariableName = "ASPIRE_E2E_CLI_ARCHIVE_DIR";
 
     private const string PreinstalledEnvironmentVariableName = "ASPIRE_E2E_PREINSTALLED";
     private static readonly Regex s_versionPattern = new(@"^[0-9A-Za-z.\-]+$", RegexOptions.Compiled);
@@ -167,12 +222,24 @@ internal sealed class CliInstallStrategy
     /// </summary>
     public string? Version { get; }
 
-    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, CliInstallQuality? quality = null, string? version = null)
+    /// <summary>
+    /// For LocalArchive: the directory containing pre-downloaded CLI archives and NuGet packages.
+    /// </summary>
+    public string? ArchiveDir { get; }
+
+    /// <summary>
+    /// For DotnetTool: path to directory containing nupkg files (local feed).
+    /// </summary>
+    public string? NupkgSourcePath { get; }
+
+    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, CliInstallQuality? quality = null, string? version = null, string? archiveDir = null, string? nupkgSourcePath = null)
     {
         Mode = mode;
         ArchivePath = archivePath;
         Quality = quality;
         Version = version;
+        ArchiveDir = archiveDir;
+        NupkgSourcePath = nupkgSourcePath;
     }
 
     /// <summary>
@@ -234,6 +301,19 @@ internal sealed class CliInstallStrategy
     }
 
     /// <summary>
+    /// Creates a LocalArchive strategy from a directory containing pre-downloaded CLI archives and NuGet packages.
+    /// </summary>
+    public static CliInstallStrategy FromLocalArchive(string archiveDir)
+    {
+        if (!Directory.Exists(archiveDir))
+        {
+            throw new DirectoryNotFoundException($"LocalArchive directory not found: {archiveDir}");
+        }
+
+        return new CliInstallStrategy(CliInstallMode.LocalArchive, archiveDir: archiveDir);
+    }
+
+    /// <summary>
     /// Creates an InstallScript strategy for the latest GA release.
     /// </summary>
     public static CliInstallStrategy LatestGa()
@@ -242,42 +322,86 @@ internal sealed class CliInstallStrategy
     }
 
     /// <summary>
-    /// Gets the workflow run ID that produced the CLI archive for the current test run, if one was provided.
+    /// Creates a DotnetTool strategy to install from a published NuGet feed.
     /// </summary>
-    public static string? GetCliArchiveWorkflowRunId()
+    public static CliInstallStrategy FromDotnetTool(string? version = null)
     {
-        var runId = Environment.GetEnvironmentVariable(CliArchiveWorkflowRunIdEnvironmentVariableName);
-
-        if (string.IsNullOrEmpty(runId))
+        if (version is not null && !s_versionPattern.IsMatch(version))
         {
-            return null;
+            throw new ArgumentException($"Invalid version format: '{version}'. Must contain only alphanumeric characters, dots, and dashes.", nameof(version));
         }
 
-        if (!long.TryParse(runId, out _))
+        return new CliInstallStrategy(CliInstallMode.DotnetTool, version: version);
+    }
+
+    /// <summary>
+    /// Creates a DotnetTool strategy to install from a local directory of nupkg files.
+    /// </summary>
+    public static CliInstallStrategy FromDotnetToolLocalSource(string nupkgSourcePath, string version)
+    {
+        if (!Directory.Exists(nupkgSourcePath))
         {
-            throw new ArgumentException($"{CliArchiveWorkflowRunIdEnvironmentVariableName} must be a valid integer, got: {runId}");
+            throw new DirectoryNotFoundException($"Nupkg source directory not found: {nupkgSourcePath}");
         }
 
-        return runId;
+        if (!s_versionPattern.IsMatch(version))
+        {
+            throw new ArgumentException($"Invalid version format: '{version}'. Must contain only alphanumeric characters, dots, and dashes.", nameof(version));
+        }
+
+        return new CliInstallStrategy(CliInstallMode.DotnetTool, version: version, nupkgSourcePath: nupkgSourcePath);
     }
 
     /// <summary>
     /// Auto-detect the install strategy from the environment.
     /// Priority:
     ///   1. ASPIRE_E2E_ARCHIVE → LocalHive
-    ///   2. ASPIRE_E2E_QUALITY → InstallScript with quality
-    ///   3. ASPIRE_E2E_VERSION → InstallScript with version
-    ///   4. ASPIRE_E2E_PREINSTALLED → Preinstalled
-    ///   5. GITHUB_PR_NUMBER + GITHUB_PR_HEAD_SHA → PullRequest
-    ///   6. CI/GITHUB_ACTIONS → InstallScript (dev/daily)
-    ///   7. Local fallback → InstallScript (latest GA)
+    ///   2. ASPIRE_E2E_DOTNET_TOOL_SOURCE → DotnetTool with local nupkg source
+    ///   3. ASPIRE_E2E_DOTNET_TOOL=true → DotnetTool from published feed
+    ///   4. ASPIRE_E2E_QUALITY → InstallScript with quality
+    ///   5. ASPIRE_E2E_VERSION → InstallScript with version
+    ///   6. ASPIRE_E2E_PREINSTALLED → Preinstalled
+    ///   7. GITHUB_PR_NUMBER + GITHUB_PR_HEAD_SHA → PullRequest
+    ///   8. ASPIRE_E2E_CLI_ARCHIVE_DIR → LocalArchive
+    ///   9. CI/GITHUB_ACTIONS → InstallScript (dev/daily)
+    ///  10. Local fallback → InstallScript (latest GA)
     /// </summary>
-    public static CliInstallStrategy Detect()
+    /// <param name="log">Optional log callback (e.g. <c>output.WriteLine</c>) for tracing the detection logic.</param>
+    public static CliInstallStrategy Detect(Action<string>? log = null)
     {
+        log?.Invoke("CLI install strategy detection starting...");
+
+        var expectedVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_EXPECTED_CLI_VERSION");
+        log?.Invoke($"  ASPIRE_E2E_EXPECTED_CLI_VERSION = {(string.IsNullOrEmpty(expectedVersion) ? "(not set)" : expectedVersion)}");
+
         var archivePath = Environment.GetEnvironmentVariable("ASPIRE_E2E_ARCHIVE");
         if (!string.IsNullOrEmpty(archivePath))
         {
+            log?.Invoke($"  → Selected: LocalHive (ASPIRE_E2E_ARCHIVE={archivePath})");
             return FromLocalHive(archivePath);
+        }
+
+        var dotnetToolSource = Environment.GetEnvironmentVariable("ASPIRE_E2E_DOTNET_TOOL_SOURCE");
+        if (!string.IsNullOrEmpty(dotnetToolSource))
+        {
+            var toolVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
+            if (string.IsNullOrEmpty(toolVersion))
+            {
+                throw new InvalidOperationException(
+                    "ASPIRE_E2E_DOTNET_TOOL_SOURCE requires ASPIRE_E2E_VERSION to specify which version to install.");
+            }
+
+            log?.Invoke($"  → Selected: DotnetTool local source (ASPIRE_E2E_DOTNET_TOOL_SOURCE={dotnetToolSource}, version={toolVersion})");
+            return FromDotnetToolLocalSource(dotnetToolSource, toolVersion);
+        }
+
+        var dotnetTool = Environment.GetEnvironmentVariable("ASPIRE_E2E_DOTNET_TOOL");
+        if (string.Equals(dotnetTool, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(dotnetTool, "1", StringComparison.OrdinalIgnoreCase))
+        {
+            var toolVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
+            log?.Invoke($"  → Selected: DotnetTool published feed (ASPIRE_E2E_DOTNET_TOOL={dotnetTool}, version={toolVersion ?? "(latest)"})");
+            return FromDotnetTool(toolVersion);
         }
 
         var qualityStr = Environment.GetEnvironmentVariable("ASPIRE_E2E_QUALITY");
@@ -288,12 +412,14 @@ internal sealed class CliInstallStrategy
                 throw new ArgumentException($"Invalid ASPIRE_E2E_QUALITY value: '{qualityStr}'. Must be one of: {string.Join(", ", Enum.GetNames<CliInstallQuality>())}");
             }
 
+            log?.Invoke($"  → Selected: InstallScript quality={quality}");
             return FromQuality(quality);
         }
 
         var version = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
         if (!string.IsNullOrEmpty(version))
         {
+            log?.Invoke($"  → Selected: InstallScript version={version}");
             return FromVersion(version);
         }
 
@@ -301,6 +427,7 @@ internal sealed class CliInstallStrategy
         if (string.Equals(preinstalled, "true", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(preinstalled, "1", StringComparison.OrdinalIgnoreCase))
         {
+            log?.Invoke("  → Selected: Preinstalled");
             return Preinstalled();
         }
 
@@ -308,15 +435,25 @@ internal sealed class CliInstallStrategy
         var headSha = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA");
         if (!string.IsNullOrEmpty(prNumber) && !string.IsNullOrEmpty(headSha))
         {
+            log?.Invoke($"  → Selected: PullRequest (PR #{prNumber}, SHA={headSha})");
             return FromPullRequest();
+        }
+
+        var archiveDir = Environment.GetEnvironmentVariable(CliArchiveDirEnvironmentVariableName);
+        if (!string.IsNullOrEmpty(archiveDir))
+        {
+            log?.Invoke($"  → Selected: LocalArchive ({CliArchiveDirEnvironmentVariableName}={archiveDir})");
+            return FromLocalArchive(archiveDir);
         }
 
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")) ||
             !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")))
         {
+            log?.Invoke("  → Selected: InstallScript (CI fallback, quality=dev)");
             return FromQuality(CliInstallQuality.Dev);
         }
 
+        log?.Invoke("  → Selected: InstallScript (local fallback, latest GA)");
         return LatestGa();
     }
 
@@ -345,16 +482,26 @@ internal sealed class CliInstallStrategy
 
                 config.Environment["GITHUB_PR_NUMBER"] = Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER") ?? "";
                 config.Environment["GITHUB_PR_HEAD_SHA"] = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA") ?? "";
+                break;
 
-                var workflowRunId = GetCliArchiveWorkflowRunId();
-                if (!string.IsNullOrEmpty(workflowRunId))
+            case CliInstallMode.LocalArchive:
+                if (string.IsNullOrEmpty(ArchiveDir))
                 {
-                    config.Environment[CliArchiveWorkflowRunIdEnvironmentVariableName] = workflowRunId;
+                    throw new InvalidOperationException("LocalArchive mode requires ArchiveDir to be set.");
                 }
 
+                config.Volumes.Add($"{ArchiveDir}:/tmp/aspire-cli-archives:ro");
                 break;
 
             case CliInstallMode.InstallScript:
+                break;
+
+            case CliInstallMode.DotnetTool:
+                if (NupkgSourcePath is not null)
+                {
+                    config.Volumes.Add($"{NupkgSourcePath}:/tmp/aspire-nupkg-source:ro");
+                }
+
                 break;
 
             default:
@@ -372,9 +519,13 @@ internal sealed class CliInstallStrategy
             CliInstallMode.LocalHive => $"LocalHive ({ArchivePath})",
             CliInstallMode.Preinstalled => "Preinstalled (~/.aspire)",
             CliInstallMode.PullRequest => $"PullRequest (PR #{Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER")})",
+            CliInstallMode.LocalArchive => $"LocalArchive ({ArchiveDir})",
             CliInstallMode.InstallScript when Quality is not null => $"InstallScript (--quality {Quality.Value.ToString().ToLowerInvariant()})",
             CliInstallMode.InstallScript when Version is not null => $"InstallScript (--version {Version})",
             CliInstallMode.InstallScript => "InstallScript (latest GA)",
+            CliInstallMode.DotnetTool when NupkgSourcePath is not null => $"DotnetTool (local: {NupkgSourcePath}, --version {Version})",
+            CliInstallMode.DotnetTool when Version is not null => $"DotnetTool (--version {Version})",
+            CliInstallMode.DotnetTool => "DotnetTool (latest)",
             _ => Mode.ToString(),
         };
     }

--- a/tests/Shared/CliInstallStrategy.cs
+++ b/tests/Shared/CliInstallStrategy.cs
@@ -393,7 +393,15 @@ internal sealed class CliInstallStrategy
                 "Expected exactly one non-symbol Aspire.Cli.*.nupkg.");
         }
 
-        return matches[0]!["Aspire.Cli.".Length..^".nupkg".Length];
+        var version = matches[0]!["Aspire.Cli.".Length..^".nupkg".Length];
+        if (!s_versionPattern.IsMatch(version))
+        {
+            throw new InvalidOperationException(
+                $"Invalid Aspire.Cli nupkg version '{version}' in '{matches[0]}'. " +
+                "Expected only alphanumeric characters, dots, and dashes.");
+        }
+
+        return version;
     }
 
     /// <summary>
@@ -405,8 +413,8 @@ internal sealed class CliInstallStrategy
     ///   4. ASPIRE_E2E_QUALITY → InstallScript with quality
     ///   5. ASPIRE_E2E_VERSION → InstallScript with version
     ///   6. ASPIRE_E2E_PREINSTALLED → Preinstalled
-    ///   7. GITHUB_PR_NUMBER + GITHUB_PR_HEAD_SHA → PullRequest
-    ///   8. ASPIRE_E2E_CLI_ARCHIVE_DIR → LocalArchive
+    ///   7. ASPIRE_E2E_CLI_ARCHIVE_DIR → LocalArchive
+    ///   8. GITHUB_PR_NUMBER + GITHUB_PR_HEAD_SHA → PullRequest
     ///   9. CI/GITHUB_ACTIONS → InstallScript (dev/daily)
     ///  10. Local fallback → InstallScript (latest GA)
     /// </summary>
@@ -472,19 +480,19 @@ internal sealed class CliInstallStrategy
             return Preinstalled();
         }
 
+        var archiveDir = Environment.GetEnvironmentVariable(CliArchiveDirEnvironmentVariableName);
+        if (!string.IsNullOrEmpty(archiveDir))
+        {
+            log?.Invoke($"  → Selected: LocalArchive ({CliArchiveDirEnvironmentVariableName}={archiveDir})");
+            return FromLocalArchive(archiveDir);
+        }
+
         var prNumber = Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER");
         var headSha = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA");
         if (!string.IsNullOrEmpty(prNumber) && !string.IsNullOrEmpty(headSha))
         {
             log?.Invoke($"  → Selected: PullRequest (PR #{prNumber}, SHA={headSha})");
             return FromPullRequest();
-        }
-
-        var archiveDir = Environment.GetEnvironmentVariable(CliArchiveDirEnvironmentVariableName);
-        if (!string.IsNullOrEmpty(archiveDir))
-        {
-            log?.Invoke($"  → Selected: LocalArchive ({CliArchiveDirEnvironmentVariableName}={archiveDir})");
-            return FromLocalArchive(archiveDir);
         }
 
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")) ||

--- a/tests/Shared/CliInstallStrategy.cs
+++ b/tests/Shared/CliInstallStrategy.cs
@@ -207,6 +207,7 @@ internal sealed class CliInstallStrategy
 
     private const string PreinstalledEnvironmentVariableName = "ASPIRE_E2E_PREINSTALLED";
     private static readonly Regex s_versionPattern = new(@"^[0-9A-Za-z.\-]+$", RegexOptions.Compiled);
+    private static readonly Regex s_cliNupkgPattern = new(@"^Aspire\.Cli\.\d", RegexOptions.Compiled);
 
     /// <summary>
     /// The install mode.
@@ -238,7 +239,14 @@ internal sealed class CliInstallStrategy
     /// </summary>
     public string? NupkgSourcePath { get; }
 
-    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, CliInstallQuality? quality = null, string? version = null, string? archiveDir = null, string? nupkgSourcePath = null)
+    /// <summary>
+    /// The expected CLI version after installation, when known.
+    /// Set automatically for modes where the version is deterministic (LocalArchive, DotnetTool local source, explicit version).
+    /// Used by post-install verification to assert the correct CLI binary was installed.
+    /// </summary>
+    public string? ExpectedVersion { get; }
+
+    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, CliInstallQuality? quality = null, string? version = null, string? archiveDir = null, string? nupkgSourcePath = null, string? expectedVersion = null)
     {
         Mode = mode;
         ArchivePath = archivePath;
@@ -246,6 +254,7 @@ internal sealed class CliInstallStrategy
         Version = version;
         ArchiveDir = archiveDir;
         NupkgSourcePath = nupkgSourcePath;
+        ExpectedVersion = expectedVersion;
     }
 
     /// <summary>
@@ -308,6 +317,7 @@ internal sealed class CliInstallStrategy
 
     /// <summary>
     /// Creates a LocalArchive strategy from a directory containing pre-downloaded CLI archives and NuGet packages.
+    /// Automatically extracts the expected CLI version from the <c>Aspire.Cli.{version}.nupkg</c> file in the directory.
     /// </summary>
     public static CliInstallStrategy FromLocalArchive(string archiveDir)
     {
@@ -316,7 +326,8 @@ internal sealed class CliInstallStrategy
             throw new DirectoryNotFoundException($"LocalArchive directory not found: {archiveDir}");
         }
 
-        return new CliInstallStrategy(CliInstallMode.LocalArchive, archiveDir: archiveDir);
+        var expectedVersion = ExtractExpectedVersionFromNupkgs(archiveDir);
+        return new CliInstallStrategy(CliInstallMode.LocalArchive, archiveDir: archiveDir, expectedVersion: expectedVersion);
     }
 
     /// <summary>
@@ -355,7 +366,34 @@ internal sealed class CliInstallStrategy
             throw new ArgumentException($"Invalid version format: '{version}'. Must contain only alphanumeric characters, dots, and dashes.", nameof(version));
         }
 
-        return new CliInstallStrategy(CliInstallMode.DotnetTool, version: version, nupkgSourcePath: nupkgSourcePath);
+        return new CliInstallStrategy(CliInstallMode.DotnetTool, version: version, nupkgSourcePath: nupkgSourcePath, expectedVersion: version);
+    }
+
+    /// <summary>
+    /// Extracts the CLI version from an <c>Aspire.Cli.{version}.nupkg</c> file in the given directory.
+    /// Returns <c>null</c> when no matching nupkg is found.
+    /// Throws if multiple non-symbol <c>Aspire.Cli.*.nupkg</c> files are found (ambiguous).
+    /// </summary>
+    internal static string? ExtractExpectedVersionFromNupkgs(string archiveDir)
+    {
+        var matches = Directory.GetFiles(archiveDir, "Aspire.Cli.*.nupkg")
+            .Select(Path.GetFileName)
+            .Where(f => f is not null && !f.Contains(".symbols.", StringComparison.OrdinalIgnoreCase) && s_cliNupkgPattern.IsMatch(f))
+            .ToList();
+
+        if (matches.Count == 0)
+        {
+            return null;
+        }
+
+        if (matches.Count > 1)
+        {
+            throw new InvalidOperationException(
+                $"Found {matches.Count} Aspire.Cli nupkg files in '{archiveDir}': {string.Join(", ", matches)}. " +
+                "Expected exactly one non-symbol Aspire.Cli.*.nupkg.");
+        }
+
+        return matches[0]!["Aspire.Cli.".Length..^".nupkg".Length];
     }
 
     /// <summary>
@@ -376,9 +414,6 @@ internal sealed class CliInstallStrategy
     public static CliInstallStrategy Detect(Action<string>? log = null)
     {
         log?.Invoke("CLI install strategy detection starting...");
-
-        var expectedVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_EXPECTED_CLI_VERSION");
-        log?.Invoke($"  ASPIRE_E2E_EXPECTED_CLI_VERSION = {(string.IsNullOrEmpty(expectedVersion) ? "(not set)" : expectedVersion)}");
 
         var archivePath = Environment.GetEnvironmentVariable("ASPIRE_E2E_ARCHIVE");
         if (!string.IsNullOrEmpty(archivePath))
@@ -520,7 +555,7 @@ internal sealed class CliInstallStrategy
     /// </summary>
     public override string ToString()
     {
-        return Mode switch
+        var description = Mode switch
         {
             CliInstallMode.LocalHive => $"LocalHive ({ArchivePath})",
             CliInstallMode.Preinstalled => "Preinstalled (~/.aspire)",
@@ -534,5 +569,9 @@ internal sealed class CliInstallStrategy
             CliInstallMode.DotnetTool => "DotnetTool (latest)",
             _ => Mode.ToString(),
         };
+
+        return ExpectedVersion is not null
+            ? $"{description} [expected={ExpectedVersion}]"
+            : description;
     }
 }

--- a/tests/Shared/CliInstallStrategy.cs
+++ b/tests/Shared/CliInstallStrategy.cs
@@ -133,6 +133,12 @@ internal static class AspireCliShellCommandHelpers
     internal static string GetLocalArchiveInstallCommandFromCurrentRef(string localDir)
     {
         var sha = Environment.GetEnvironmentVariable("GITHUB_SHA") ?? "main";
+
+        if (!Regex.IsMatch(sha, @"^[0-9a-fA-F]{7,40}$") && sha != "main")
+        {
+            throw new InvalidOperationException($"GITHUB_SHA contains an unexpected value: '{sha}'. Expected a hex commit SHA or 'main'.");
+        }
+
         return $"curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/{sha}/eng/scripts/get-aspire-cli-pr.sh | bash -s -- --local-dir {QuoteBashArg(localDir)}";
     }
 


### PR DESCRIPTION
## Summary

Adds two new CLI install modes for E2E tests and strengthens version verification, so CI catches more problems and covers more distribution channels.

### What's new

- **LocalArchive mode**: Quarantine and outerloop workflows now build CLI archives + packages from the current ref and test against those — instead of falling back to the daily/dev published CLI when there's no PR context.

- **DotnetTool mode**: E2E tests can now exercise the `dotnet tool install` distribution channel (from CI-built nupkgs, a local directory, or the published NuGet feed).

- **Exact version verification**: `AssertAspireVersionAsync` now compares the installed CLI version against the version extracted from the built nupkg (`ASPIRE_E2E_EXPECTED_CLI_VERSION`), catching cases where the wrong CLI binary was picked up. Previously it only checked for a prerelease suffix.

- **Build fix**: Narrowed a glob in `eng/Build.props` so `Aspire.Cli.Tool.csproj` is no longer excluded from package builds.

### Testing

- Unit tests for install strategy detection priority and error paths
- `DotnetToolSmokeTests` for the dotnet-tool channel
- Shell script tests for `--local-dir` flag
- Deployment E2E helpers updated for new modes

### CI Validation

- ✅ Full quarantine workflow — all 6 jobs passed
- ✅ Full outerloop workflow — 18/19 passed (1 unrelated Playwright timeout)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
