### PR TITLE
Use friendly channel names in CLI download logs

### DIFF
--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -477,37 +477,25 @@ function Get-DownloadDescriptor {
     [OutputType([string])]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Uri
+        [string]$Uri,
+
+        [Parameter()]
+        [string]$Source
     )
 
     try {
         $downloadUri = [System.Uri]$Uri
         $fileName = [System.IO.Path]::GetFileName($downloadUri.AbsolutePath)
-        $trimmedPath = $downloadUri.AbsolutePath.Trim("/")
-        $source = $downloadUri.Host
-
-        if ($trimmedPath -match "^dotnet/[^/]+/aspire/(?<source>.+)/(?<file>[^/]+)$") {
-            $source = $Matches["source"]
-            $fileName = $Matches["file"]
-        }
-        elseif ($trimmedPath -match "^public(?:-checksums)?/aspire/+(?<version>[^/]+)/(?<file>[^/]+)$") {
-            $source = "version/$($Matches["version"])"
-            $fileName = $Matches["file"]
-        }
-        elseif ($trimmedPath -match "^(?<source>.+)/(?<file>[^/]+)$") {
-            $source = $Matches["source"]
-            $fileName = $Matches["file"]
-        }
 
         if ([string]::IsNullOrWhiteSpace($fileName)) {
             return $Uri
         }
 
-        if ([string]::IsNullOrWhiteSpace($source)) {
+        if ([string]::IsNullOrWhiteSpace($Source)) {
             return $fileName
         }
 
-        return "$fileName from '$source'"
+        return "$fileName from $Source"
     }
     catch {
         return $Uri
@@ -986,7 +974,11 @@ function Get-AspireExtension {
     Write-Message "Downloading Aspire VS Code extension" -Level Info
 
     $extensionUrl = Get-AspireExtensionUrl -Version $Version -Quality $Quality
-    $extensionDescriptor = Get-DownloadDescriptor -Uri $extensionUrl
+    $extensionSource = $null
+    if ([string]::IsNullOrWhiteSpace($Version) -and -not [string]::IsNullOrWhiteSpace($Quality)) {
+        $extensionSource = "the $(ConvertTo-ChannelName -Quality $Quality) channel"
+    }
+    $extensionDescriptor = Get-DownloadDescriptor -Uri $extensionUrl -Source $extensionSource
     $extensionArchive = Join-Path $TempDir $Script:ExtensionArtifactName
 
     try {
@@ -1212,8 +1204,12 @@ function Install-AspireCli {
         $runtimeIdentifier = "$targetOS-$targetArch"
         $extension = if ($targetOS -eq "win") { "zip" } else { "tar.gz" }
         $urls = Get-AspireCliUrl -Version $Version -Quality $Quality -RuntimeIdentifier $runtimeIdentifier -Extension $extension
-        $archiveDescriptor = Get-DownloadDescriptor -Uri $urls.ArchiveUrl
-        $checksumDescriptor = Get-DownloadDescriptor -Uri $urls.ChecksumUrl
+        $downloadSource = $null
+        if ([string]::IsNullOrWhiteSpace($Version) -and -not [string]::IsNullOrWhiteSpace($Quality)) {
+            $downloadSource = "the $(ConvertTo-ChannelName -Quality $Quality) channel"
+        }
+        $archiveDescriptor = Get-DownloadDescriptor -Uri $urls.ArchiveUrl -Source $downloadSource
+        $checksumDescriptor = Get-DownloadDescriptor -Uri $urls.ChecksumUrl -Source $downloadSource
 
         $archivePath = Join-Path $tempDir $urls.ArchiveFilename
         $checksumPath = Join-Path $tempDir $urls.ChecksumFilename

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -297,22 +297,12 @@ secure_curl() {
 # Build a compact display string for download messages without exposing the full URL.
 get_download_descriptor() {
     local url="$1"
-    local file_name source
-
-    if [[ "$url" =~ ^https://aka\.ms/dotnet/[^/]+/aspire/(.+)/([^/]+)$ ]]; then
-        source="${BASH_REMATCH[1]}"
-        file_name="${BASH_REMATCH[2]}"
-    elif [[ "$url" =~ ^https://ci\.dot\.net/public(-checksums)?/aspire/+([^/]+)/([^/]+)$ ]]; then
-        source="version/${BASH_REMATCH[2]}"
-        file_name="${BASH_REMATCH[3]}"
-    else
-        file_name="${url##*/}"
-        source="${url#https://}"
-        source="${source%%/*}"
-    fi
+    local source="${2:-}"
+    local url_without_query="${url%%[\?#]*}"
+    local file_name="${url_without_query##*/}"
 
     if [[ -n "$file_name" && -n "$source" ]]; then
-        printf "%s from '%s'" "$file_name" "$source"
+        printf "%s from %s" "$file_name" "$source"
     else
         printf "%s" "$file_name"
     fi
@@ -348,9 +338,10 @@ download_file() {
     local max_retries="${4:-5}"
     local validate_content_type="${5:-true}"
     local use_temp_file="${6:-true}"
+    local descriptor_source="${7:-}"
     local download_descriptor
 
-    download_descriptor=$(get_download_descriptor "$url")
+    download_descriptor=$(get_download_descriptor "$url" "$descriptor_source")
 
     if [[ "$DRY_RUN" == true ]]; then
         say_info "[DRY RUN] Would download $download_descriptor"
@@ -861,6 +852,7 @@ download_aspire_extension() {
     local version="$2"
     local quality="$3"
     local url extension_archive
+    local download_source=""
 
     say_info "Downloading Aspire VS Code extension"
 
@@ -869,8 +861,11 @@ download_aspire_extension() {
     fi
 
     extension_archive="${temp_dir}/${EXTENSION_ARTIFACT_NAME}"
+    if [[ -z "$version" && -n "$quality" ]]; then
+        download_source="the $(map_quality_to_channel "$quality") channel"
+    fi
 
-    if ! download_file "$url" "$extension_archive" $ARCHIVE_DOWNLOAD_TIMEOUT_SEC; then
+    if ! download_file "$url" "$extension_archive" "$ARCHIVE_DOWNLOAD_TIMEOUT_SEC" 5 true true "$download_source"; then
         return 1
     fi
 
@@ -948,6 +943,7 @@ download_and_install_archive() {
     local temp_dir="$1"
     local os arch runtimeIdentifier url filename checksum_url checksum_filename extension
     local cli_exe cli_path
+    local download_source=""
 
     # Detect OS and architecture if not provided
     if [[ -z "$OS" ]]; then
@@ -989,14 +985,17 @@ download_and_install_archive() {
 
     filename="${temp_dir}/aspire-cli-${runtimeIdentifier}.${extension}"
     checksum_filename="${temp_dir}/aspire-cli-${runtimeIdentifier}.${extension}.sha512"
+    if [[ -z "$VERSION" && -n "$QUALITY" ]]; then
+        download_source="the $(map_quality_to_channel "$QUALITY") channel"
+    fi
 
     # Download the Aspire CLI archive
-    if ! download_file "$url" "$filename" $ARCHIVE_DOWNLOAD_TIMEOUT_SEC; then
+    if ! download_file "$url" "$filename" "$ARCHIVE_DOWNLOAD_TIMEOUT_SEC" 5 true true "$download_source"; then
         return 1
     fi
 
     # Download and test the checksum
-    if ! download_file "$checksum_url" "$checksum_filename" $CHECKSUM_DOWNLOAD_TIMEOUT_SEC; then
+    if ! download_file "$checksum_url" "$checksum_filename" "$CHECKSUM_DOWNLOAD_TIMEOUT_SEC" 5 true true "$download_source"; then
         return 1
     fi
 

--- a/src/Aspire.Cli/Utils/CliDownloader.cs
+++ b/src/Aspire.Cli/Utils/CliDownloader.cs
@@ -44,7 +44,7 @@ internal class CliDownloader(
             throw new InvalidOperationException($"Channel '{channelName}' does not support CLI downloads.");
         }
 
-        var baseUrl = channel.CliDownloadBaseUrl;
+        var baseUrl = channel.CliDownloadBaseUrl.TrimEnd('/');
 
         var (os, arch) = DetectPlatform();
         var runtimeIdentifier = $"{os}-{arch}";
@@ -61,14 +61,13 @@ internal class CliDownloader(
         {
             var archivePath = Path.Combine(tempDir, archiveFilename);
             var checksumPath = Path.Combine(tempDir, checksumFilename);
+            var archiveDescriptor = GetDownloadDescriptor(archiveUrl, $"the {channel.Name} channel");
 
-            // Download archive
-            _ = await interactionService.ShowStatusAsync($"Downloading Aspire CLI from: {archiveUrl}", async () =>
+            _ = await interactionService.ShowStatusAsync($"Downloading {archiveDescriptor}", async () =>
             {
                 logger.LogDebug("Downloading archive from {Url} to {Path}", archiveUrl, archivePath);
                 await DownloadFileAsync(archiveUrl, archivePath, ArchiveDownloadTimeoutSeconds, cancellationToken);
 
-                // Download checksum
                 logger.LogDebug("Downloading checksum from {Url} to {Path}", checksumUrl, checksumPath);
                 await DownloadFileAsync(checksumUrl, checksumPath, ChecksumDownloadTimeoutSeconds, cancellationToken);
                 
@@ -98,6 +97,28 @@ internal class CliDownloader(
             }
             throw;
         }
+    }
+
+    internal static string GetDownloadDescriptor(string url, string? source = null)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return url;
+        }
+
+        var fileName = Path.GetFileName(uri.AbsolutePath);
+
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return url;
+        }
+
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return fileName;
+        }
+
+        return $"{fileName} from {source}";
     }
 
     private static (string os, string arch) DetectPlatform()

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
@@ -157,6 +157,33 @@ public class ReleaseScriptFunctionTests(ITestOutputHelper testOutput)
 
     #endregion
 
+    #region get_download_descriptor
+
+    [Theory]
+    [InlineData("https://aka.ms/dotnet/9/aspire/ga/daily/aspire-cli-linux-x64.tar.gz", "the stable channel", "aspire-cli-linux-x64.tar.gz from the stable channel")]
+    [InlineData("https://aka.ms/dotnet/9/aspire/daily/aspire-cli-linux-x64.tar.gz", "the daily channel", "aspire-cli-linux-x64.tar.gz from the daily channel")]
+    [InlineData("https://aka.ms/dotnet/9/aspire/rc/daily/aspire-cli-linux-x64.tar.gz", "the staging channel", "aspire-cli-linux-x64.tar.gz from the staging channel")]
+    public async Task GetDownloadDescriptor_WithSource_ReturnsFriendlyChannelSource(string url, string source, string expectedDescriptor)
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            $"get_download_descriptor '{url}' '{source}'",
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
+        var descriptor = result.Output.Trim();
+        Assert.Equal(expectedDescriptor, descriptor);
+        Assert.DoesNotContain("dotnet", descriptor, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ga/daily", descriptor, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("rc/daily", descriptor, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
+
     #region validate_checksum
 
     [Fact]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
@@ -157,6 +157,33 @@ public class ReleaseScriptPSFunctionTests(ITestOutputHelper testOutput)
 
     #endregion
 
+    #region Get-DownloadDescriptor
+
+    [Theory]
+    [InlineData("https://aka.ms/dotnet/9/aspire/ga/daily/aspire-cli-linux-x64.tar.gz", "the stable channel", "aspire-cli-linux-x64.tar.gz from the stable channel")]
+    [InlineData("https://aka.ms/dotnet/9/aspire/daily/aspire-cli-linux-x64.tar.gz", "the daily channel", "aspire-cli-linux-x64.tar.gz from the daily channel")]
+    [InlineData("https://aka.ms/dotnet/9/aspire/rc/daily/aspire-cli-linux-x64.tar.gz", "the staging channel", "aspire-cli-linux-x64.tar.gz from the staging channel")]
+    public async Task GetDownloadDescriptor_WithSource_ReturnsFriendlyChannelSource(string url, string source, string expectedDescriptor)
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            $"Get-DownloadDescriptor -Uri '{url}' -Source '{source}'",
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
+        var descriptor = result.Output.Trim();
+        Assert.Equal(expectedDescriptor, descriptor);
+        Assert.DoesNotContain("dotnet", descriptor, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ga/daily", descriptor, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("rc/daily", descriptor, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
+
     #region Test-FileChecksum
 
     [Fact]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPowerShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPowerShellTests.cs
@@ -152,10 +152,10 @@ public class ReleaseScriptPowerShellTests(ITestOutputHelper testOutput)
     }
 
     [Theory]
-    [InlineData("dev")]
-    [InlineData("staging")]
-    [InlineData("release")]
-    public async Task QualityVariants_AreRecognized(string quality)
+    [InlineData("dev", "from the daily channel")]
+    [InlineData("staging", "from the staging channel")]
+    [InlineData("release", "from the stable channel")]
+    public async Task QualityVariants_AreRecognized(string quality, string expectedSource)
     {
         using var env = new TestEnvironment();
         using var cmd = new ScriptToolCommand(s_scriptPath, env, _testOutput);
@@ -163,6 +163,10 @@ public class ReleaseScriptPowerShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("What if", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(expectedSource, result.Output);
+        Assert.DoesNotContain("dotnet", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ga/daily", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("rc/daily", result.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptShellTests.cs
@@ -90,7 +90,7 @@ public class ReleaseScriptShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         // In dry-run mode, the script outputs a download descriptor like:
-        // [DRY RUN] Would download aspire-cli-linux-x64.tar.gz from 'ga/daily'
+        // [DRY RUN] Would download aspire-cli-linux-x64.tar.gz from the stable channel
         Assert.Contains("[DRY RUN] Would download", result.Output);
     }
 
@@ -107,9 +107,9 @@ public class ReleaseScriptShellTests(ITestOutputHelper testOutput)
     }
 
     [Theory]
-    [InlineData("dev", "from 'daily'")]
-    [InlineData("staging", "from 'rc/daily'")]
-    [InlineData("release", "from 'ga/daily'")]
+    [InlineData("dev", "from the daily channel")]
+    [InlineData("staging", "from the staging channel")]
+    [InlineData("release", "from the stable channel")]
     public async Task QualityVariants_AreRecognized(string quality, string expectedSource)
     {
         using var env = new TestEnvironment();
@@ -119,6 +119,9 @@ public class ReleaseScriptShellTests(ITestOutputHelper testOutput)
         result.EnsureSuccessful();
         Assert.Contains("[DRY RUN]", result.Output);
         Assert.Contains(expectedSource, result.Output);
+        Assert.DoesNotContain("dotnet", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ga/daily", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("rc/daily", result.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliDownloaderTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliDownloaderTests.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class CliDownloaderTests
+{
+    [Theory]
+    [InlineData("https://aka.ms/dotnet/9/aspire/ga/daily/aspire-cli-linux-x64.tar.gz", "the stable channel", "aspire-cli-linux-x64.tar.gz from the stable channel")]
+    [InlineData("https://aka.ms/dotnet/9/aspire/daily/aspire-cli-osx-arm64.tar.gz", "the daily channel", "aspire-cli-osx-arm64.tar.gz from the daily channel")]
+    [InlineData("https://aka.ms/dotnet/9/aspire/rc/daily/aspire-cli-win-x64.zip", "the staging channel", "aspire-cli-win-x64.zip from the staging channel")]
+    [InlineData("https://ci.dot.net/public/aspire//13.2.0-preview.1.25366.3/aspire-cli-linux-x64-13.2.0-preview.1.25366.3.tar.gz", "the stable channel", "aspire-cli-linux-x64-13.2.0-preview.1.25366.3.tar.gz from the stable channel")]
+    [InlineData("https://ci.dot.net/public-checksums/aspire/13.2.0-preview.1.25366.3/aspire-cli-linux-x64-13.2.0-preview.1.25366.3.tar.gz.sha512", "the stable channel", "aspire-cli-linux-x64-13.2.0-preview.1.25366.3.tar.gz.sha512 from the stable channel")]
+    [InlineData("https://example.com/downloads/aspire-cli-linux-x64.tar.gz?sig=123", null, "aspire-cli-linux-x64.tar.gz")]
+    [InlineData("not a url", "the stable channel", "not a url")]
+    public void GetDownloadDescriptor_ReturnsCompactDescriptor(string url, string? source, string expectedDescriptor)
+    {
+        var descriptor = CliDownloader.GetDownloadDescriptor(url, source);
+
+        Assert.Equal(expectedDescriptor, descriptor);
+        Assert.DoesNotContain("dotnet", descriptor, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ga/", descriptor, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("rc/", descriptor, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Description

Update Aspire CLI download status messages to show friendly Aspire channel names instead of URL-derived source labels.

This applies to:

- `aspire update --self`
- `eng/scripts/get-aspire-cli.sh`
- `eng/scripts/get-aspire-cli.ps1`

The actual download URLs are unchanged, but user-facing output now says things like `from the stable channel`, `from the daily channel`, or `from the staging channel` instead of exposing the full aka.ms implementation URL or internal path labels.

### Output previews

For `aspire update --self`, the status line now describes the Aspire channel instead of showing the full implementation URL:

```text
Downloading aspire-cli-osx-arm64.tar.gz from the stable channel
Validating downloaded file...
Download completed successfully
```

The same wording is used for the install scripts. Bash dry-run examples:

```text
$ eng/scripts/get-aspire-cli.sh --dry-run --quality release --os osx --arch arm64 --verbose
[DRY RUN] Would download aspire-cli-osx-arm64.tar.gz from the stable channel
[DRY RUN] Would download aspire-cli-osx-arm64.tar.gz.sha512 from the stable channel
```

```text
$ eng/scripts/get-aspire-cli.sh --dry-run --quality dev --os linux --arch x64 --verbose
[DRY RUN] Would download aspire-cli-linux-x64.tar.gz from the daily channel
[DRY RUN] Would download aspire-cli-linux-x64.tar.gz.sha512 from the daily channel
```

```text
$ eng/scripts/get-aspire-cli.sh --dry-run --quality staging --os win --arch x64 --verbose
[DRY RUN] Would download aspire-cli-win-x64.zip from the staging channel
[DRY RUN] Would download aspire-cli-win-x64.zip.sha512 from the staging channel
```

PowerShell `-WhatIf` output uses the same descriptors:

```text
What if: Performing the operation "Download CLI archive (aspire-cli-win-x64.zip from the stable channel)" on target "...".
What if: Performing the operation "Download CLI archive (aspire-cli-linux-x64.tar.gz from the daily channel)" on target "...".
What if: Performing the operation "Download CLI archive (aspire-cli-linux-x64.tar.gz from the staging channel)" on target "...".
```

Version-pinned downloads still show only the artifact name, not a channel:

```text
Downloading aspire-cli-linux-x64-13.2.0-preview.1.25366.3.tar.gz
```

Validation:

- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.CliDownloaderTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test tests/Aspire.Acquisition.Tests/Aspire.Acquisition.Tests.csproj -- --filter-class "*.ReleaseScriptShellTests" --filter-class "*.ReleaseScriptFunctionTests" --filter-class "*.ReleaseScriptPowerShellTests" --filter-class "*.ReleaseScriptPSFunctionTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `bash -n eng/scripts/get-aspire-cli.sh`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
