### PR TITLE
Return build output from rebuild command

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text;
 using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Resources;
 using Microsoft.Extensions.DependencyInjection;
@@ -156,13 +157,9 @@ internal static class CommandsConfigurationExtensions
             {
                 lock (rebuildLock)
                 {
-                    if (activeRebuildTask is null || activeRebuildTask.IsCompleted)
-                    {
-                        activeRebuildTask = ExecuteRebuildAsync(context, projectResource);
-                    }
+                    activeRebuildTask ??= ExecuteRebuildAndResetAsync(context);
+                    return activeRebuildTask;
                 }
-
-                return activeRebuildTask;
             },
             updateState: context =>
             {
@@ -177,6 +174,21 @@ internal static class CommandsConfigurationExtensions
             iconName: "ArrowSync",
             iconVariant: IconVariant.Regular,
             isHighlighted: false));
+
+        async Task<ExecuteCommandResult> ExecuteRebuildAndResetAsync(ExecuteCommandContext context)
+        {
+            try
+            {
+                return await ExecuteRebuildAsync(context, projectResource).ConfigureAwait(false);
+            }
+            finally
+            {
+                lock (rebuildLock)
+                {
+                    activeRebuildTask = null;
+                }
+            }
+        }
     }
 
     private static async Task<ExecuteCommandResult> ExecuteRebuildAsync(ExecuteCommandContext context, ProjectResource projectResource)
@@ -194,6 +206,7 @@ internal static class CommandsConfigurationExtensions
 
         var mainLogger = loggerService.GetLogger(projectResource);
         var replicaNames = projectResource.GetResolvedResourceNames();
+        using var buildOutput = new BuildOutputCollector();
 
         // Capture each replica's state before rebuild so we can restore inactive replicas.
         var preRebuildStates = new Dictionary<string, string?>(StringComparer.Ordinal);
@@ -212,7 +225,7 @@ internal static class CommandsConfigurationExtensions
             !preRebuildStates.TryGetValue(name, out var state)
             || state != KnownResourceStates.Waiting);
 
-        mainLogger.LogInformation(BuildLogPrefix + "Stopping resource for rebuild...");
+        LogBuildInformation(mainLogger, buildOutput, "Stopping resource for rebuild...");
         await Task.WhenAll(replicasToStop.Select(name => orchestrator.StopResourceAsync(name, context.CancellationToken))).ConfigureAwait(false);
 
         // Set state to Building after replicas are stopped. Leave Waiting replicas in their
@@ -227,12 +240,24 @@ internal static class CommandsConfigurationExtensions
         // Start forwarding logs from the rebuilder to the main resource's console.
         using var logCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
         var rebuilderInstanceName = rebuilderResource.GetResolvedResourceNames()[0];
-        var logForwardTask = ForwardLogsAsync(loggerService, rebuilderInstanceName, mainLogger, logCts.Token);
+        var logForwardTask = ForwardLogsAsync(loggerService, rebuilderInstanceName, mainLogger, buildOutput, logCts.Token);
+        var logForwardingStopped = false;
+
+        async Task<ExecuteCommandResult> FinishAsync(ExecuteCommandResult result)
+        {
+            if (!logForwardingStopped)
+            {
+                await StopLogForwardingAsync(logCts, logForwardTask).ConfigureAwait(false);
+                logForwardingStopped = true;
+            }
+
+            return AttachBuildOutput(result, buildOutput.GetOutput());
+        }
 
         try
         {
             // Start the rebuilder resource (runs dotnet build).
-            mainLogger.LogInformation(BuildLogPrefix + "Building project...");
+            LogBuildInformation(mainLogger, buildOutput, "Building project...");
             await orchestrator.StartResourceAsync(rebuilderInstanceName, context.CancellationToken).ConfigureAwait(false);
 
             // Wait for the rebuilder to reach a terminal state, with a timeout.
@@ -255,13 +280,13 @@ internal static class CommandsConfigurationExtensions
             catch (OperationCanceledException) when (!context.CancellationToken.IsCancellationRequested)
             {
                 // Build timed out.
-                mainLogger.LogError(BuildLogPrefix + "Build timed out.");
+                LogBuildError(mainLogger, buildOutput, "Build timed out.");
 
                 await resourceNotificationService.PublishUpdateAsync(projectResource, s => s with
                 {
                     State = new ResourceStateSnapshot(KnownResourceStates.FailedToStart, KnownResourceStateStyles.Error)
                 }).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = false, Message = "Build timed out." };
+                return await FinishAsync(new ExecuteCommandResult { Success = false, Message = "Build timed out." }).ConfigureAwait(false);
             }
 
             if (exitCode == 0)
@@ -269,7 +294,7 @@ internal static class CommandsConfigurationExtensions
                 // Restart replicas that were Running before the rebuild.
                 // Waiting replicas are already in the startup pipeline — when their deps become
                 // ready, CreateExecutableAsync will launch the freshly-built binary automatically.
-                mainLogger.LogInformation(BuildLogPrefix + "Build succeeded. Restarting resource...");
+                LogBuildInformation(mainLogger, buildOutput, "Build succeeded. Restarting resource...");
                 var anyRestarted = false;
                 foreach (var name in replicaNames)
                 {
@@ -284,7 +309,7 @@ internal static class CommandsConfigurationExtensions
                         // The resource is still waiting for dependencies. The build output on disk
                         // has been updated, so when dependencies become ready the new binary will
                         // be launched. Log a message so the user knows the build succeeded.
-                        mainLogger.LogInformation(BuildLogPrefix + "Build succeeded. Resource will start with the updated binary when dependencies are ready.");
+                        LogBuildInformation(mainLogger, buildOutput, "Build succeeded. Resource will start with the updated binary when dependencies are ready.");
                         anyRestarted = true;
                     }
                     else if (wasActive)
@@ -316,33 +341,57 @@ internal static class CommandsConfigurationExtensions
                     }
                 }
 
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceRebuilt, projectResource.Name) };
+                return await FinishAsync(new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceRebuilt, projectResource.Name) }).ConfigureAwait(false);
             }
             else
             {
-                mainLogger.LogError(BuildLogPrefix + "Build failed with exit code {ExitCode}.", exitCode);
+                var failureMessage = $"Build failed with exit code {exitCode}.";
+                LogBuildError(mainLogger, buildOutput, failureMessage);
                 await resourceNotificationService.PublishUpdateAsync(projectResource, s => s with
                 {
                     State = new ResourceStateSnapshot(KnownResourceStates.FailedToStart, KnownResourceStateStyles.Error)
                 }).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = false, Message = $"Build failed with exit code {exitCode}." };
+                return await FinishAsync(new ExecuteCommandResult { Success = false, Message = failureMessage }).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
         {
             // The command was cancelled (e.g. user navigated away or the dashboard closed).
             // The replicas were already stopped for the rebuild, so set them to Exited.
-            mainLogger.LogWarning(BuildLogPrefix + "Rebuild was cancelled.");
+            LogBuildWarning(mainLogger, buildOutput, "Rebuild was cancelled.");
             await resourceNotificationService.PublishUpdateAsync(projectResource, s => s with
             {
                 State = new ResourceStateSnapshot(KnownResourceStates.Finished, KnownResourceStateStyles.Info)
             }).ConfigureAwait(false);
-            return new ExecuteCommandResult { Success = false, Message = "Rebuild was cancelled." };
+            return await FinishAsync(new ExecuteCommandResult { Success = false, Message = "Rebuild was cancelled." }).ConfigureAwait(false);
         }
         finally
         {
-            await StopLogForwardingAsync(logCts, logForwardTask).ConfigureAwait(false);
+            if (!logForwardingStopped)
+            {
+                await StopLogForwardingAsync(logCts, logForwardTask).ConfigureAwait(false);
+            }
         }
+    }
+
+    private static ExecuteCommandResult AttachBuildOutput(ExecuteCommandResult result, string output)
+    {
+        if (result.Data is not null || string.IsNullOrWhiteSpace(output))
+        {
+            return result;
+        }
+
+        return new ExecuteCommandResult
+        {
+            Success = result.Success,
+            Canceled = result.Canceled,
+            Message = result.Message,
+            Data = new CommandResultData
+            {
+                Value = output,
+                Format = CommandResultFormat.Text
+            }
+        };
     }
 
     private static async Task StopLogForwardingAsync(CancellationTokenSource logCts, Task logForwardTask)
@@ -359,7 +408,25 @@ internal static class CommandsConfigurationExtensions
         }
     }
 
-    private static async Task ForwardLogsAsync(ResourceLoggerService loggerService, string sourceResourceName, ILogger targetLogger, CancellationToken cancellationToken)
+    private static void LogBuildInformation(ILogger logger, BuildOutputCollector buildOutput, string message)
+    {
+        buildOutput.Append(message);
+        logger.LogInformation(BuildLogPrefix + "{Message}", message);
+    }
+
+    private static void LogBuildWarning(ILogger logger, BuildOutputCollector buildOutput, string message)
+    {
+        buildOutput.Append(message);
+        logger.LogWarning(BuildLogPrefix + "{Message}", message);
+    }
+
+    private static void LogBuildError(ILogger logger, BuildOutputCollector buildOutput, string message)
+    {
+        buildOutput.Append(message);
+        logger.LogError(BuildLogPrefix + "{Message}", message);
+    }
+
+    private static async Task ForwardLogsAsync(ResourceLoggerService loggerService, string sourceResourceName, ILogger targetLogger, BuildOutputCollector buildOutput, CancellationToken cancellationToken)
     {
         try
         {
@@ -367,6 +434,8 @@ internal static class CommandsConfigurationExtensions
             {
                 foreach (var line in batch)
                 {
+                    buildOutput.Append(line.Content);
+
                     if (line.IsErrorMessage)
                     {
                         targetLogger.LogWarning(BuildLogPrefix + "{Content}", line.Content);
@@ -381,6 +450,63 @@ internal static class CommandsConfigurationExtensions
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             // Expected when the log forwarding is cancelled.
+        }
+    }
+
+    private sealed class BuildOutputCollector : IDisposable
+    {
+        private const int MaxBuildOutputLineCount = 10_000;
+
+        private readonly object _lock = new();
+        private readonly Queue<string> _lines = new();
+        private int _droppedLineCount;
+
+        public void Append(string content)
+        {
+            lock (_lock)
+            {
+                if (_lines.Count == MaxBuildOutputLineCount)
+                {
+                    _lines.Dequeue();
+                    _droppedLineCount++;
+                }
+
+                _lines.Enqueue(BuildLogPrefix + content);
+            }
+        }
+
+        public string GetOutput()
+        {
+            lock (_lock)
+            {
+                var builder = new StringBuilder();
+                if (_droppedLineCount > 0)
+                {
+                    builder
+                        .Append(BuildLogPrefix)
+                        .Append("Output truncated to last ")
+                        .Append(MaxBuildOutputLineCount)
+                        .Append(" lines. ")
+                        .Append(_droppedLineCount)
+                        .AppendLine(" earlier lines omitted.");
+                }
+
+                foreach (var line in _lines)
+                {
+                    builder.AppendLine(line);
+                }
+
+                return builder.ToString().TrimEnd();
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                _lines.Clear();
+                _droppedLineCount = 0;
+            }
         }
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -346,7 +346,8 @@ internal static class CommandsConfigurationExtensions
             else
             {
                 var failureMessage = $"Build failed with exit code {exitCode}.";
-                LogBuildError(mainLogger, buildOutput, failureMessage);
+                buildOutput.Append(failureMessage);
+                mainLogger.LogError(BuildLogPrefix + "Build failed with exit code {ExitCode}.", exitCode);
                 await resourceNotificationService.PublishUpdateAsync(projectResource, s => s with
                 {
                     State = new ResourceStateSnapshot(KnownResourceStates.FailedToStart, KnownResourceStateStyles.Error)
@@ -463,16 +464,29 @@ internal static class CommandsConfigurationExtensions
 
         public void Append(string content)
         {
+            var lines = content
+                .Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace('\r', '\n')
+                .Split('\n');
+
             lock (_lock)
             {
-                if (_lines.Count == MaxBuildOutputLineCount)
+                foreach (var line in lines)
                 {
-                    _lines.Dequeue();
-                    _droppedLineCount++;
+                    AppendLine(line);
                 }
-
-                _lines.Enqueue(BuildLogPrefix + content);
             }
+        }
+
+        private void AppendLine(string content)
+        {
+            if (_lines.Count == MaxBuildOutputLineCount)
+            {
+                _lines.Dequeue();
+                _droppedLineCount++;
+            }
+
+            _lines.Enqueue(BuildLogPrefix + content);
         }
 
         public string GetOutput()

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -4,6 +4,7 @@
 using System.Threading.Channels;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Tests;
 
@@ -480,6 +481,33 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task ExecuteCommandAsync_RebuildCommand_ReturnsBuildOutput()
+    {
+        const string rebuildOutputMarker = "ASPIRE_REBUILD_OUTPUT_MARKER";
+
+        using var tempDirectory = new TestTempDirectory();
+        var projectPath = CreateBuildOutputTestProject(tempDirectory.Path, rebuildOutputMarker);
+
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var project = builder.AddProject("myProject", projectPath, options => options.ExcludeLaunchProfile = true);
+        using var app = builder.Build();
+
+        await app.StartAsync().DefaultTimeout(TimeSpan.FromMinutes(2));
+
+        var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
+        await resourceNotificationService.WaitForResourceAsync(project.Resource.Name, e => KnownResourceStates.BuildableStates.Contains(e.Snapshot.State?.Text), cts.Token).DefaultTimeout(TimeSpan.FromMinutes(2));
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(project.Resource, KnownResourceCommands.RebuildCommand).DefaultTimeout(TimeSpan.FromMinutes(2));
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal(CommandResultFormat.Text, result.Data.Format);
+        Assert.Contains("[build] Building project...", result.Data.Value);
+        Assert.Contains(rebuildOutputMarker, result.Data.Value);
+    }
+
+    [Fact]
     public void CommandResults_SuccessWithResult_ProducesCorrectResult()
     {
         var result = CommandResults.Success("Success.", "{\"key\": \"value\"}", CommandResultFormat.Json);
@@ -499,6 +527,35 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(result.Data);
         Assert.Equal("hello world", result.Data.Value);
         Assert.Equal(CommandResultFormat.Text, result.Data.Format);
+    }
+
+    private static string CreateBuildOutputTestProject(string directoryPath, string buildOutputMarker)
+    {
+        var projectPath = Path.Combine(directoryPath, "BuildOutputProject.csproj");
+        var programPath = Path.Combine(directoryPath, "Program.cs");
+
+        File.WriteAllText(projectPath,
+            $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+
+              <Target Name="EmitAspireRebuildOutputMarker" AfterTargets="Build">
+                <Message Importance="High" Text="{{buildOutputMarker}}" />
+              </Target>
+            </Project>
+            """);
+
+        File.WriteAllText(programPath,
+            """
+            Console.WriteLine("Hello from rebuild test project.");
+            """);
+
+        return projectPath;
     }
 
     private sealed class CustomResource(string name) : Resource(name), IResourceWithEndpoints, IResourceWithWaitSupport


### PR DESCRIPTION
## Description

Return project-resource rebuild command output as text command result data. The rebuild flow still forwards the `[build]` output to resource logs, now also returns bounded text output to command consumers, and clears collected output promptly after the command result is produced.

Added unit coverage for the rebuild command result data.

Fixes # (issue)

Validation:

```bash
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj -- --filter-class "*.ResourceCommandServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Real playground validation:

```bash
artifacts/bin/Aspire.Cli/Debug/net10.0/aspire start --apphost playground/yarp/Yarp.AppHost/Yarp.AppHost.csproj --isolated --non-interactive --nologo --format Json
artifacts/bin/Aspire.Cli/Debug/net10.0/aspire wait frontend --status up --timeout 180 --apphost playground/yarp/Yarp.AppHost/Yarp.AppHost.csproj --non-interactive --nologo
artifacts/bin/Aspire.Cli/Debug/net10.0/aspire resource frontend rebuild --apphost playground/yarp/Yarp.AppHost/Yarp.AppHost.csproj --non-interactive --nologo
```

Output excerpt:

```text
[build] Stopping resource for rebuild...
[build] Building project...
[build] ... Determining projects to restore...
[build] ... All projects are up-to-date for restore.
[build] ... Playground.ServiceDefaults -> .../Playground.ServiceDefaults.dll
[build] ... Yarp.Frontend -> .../Yarp.Frontend.dll
[build] ... Build succeeded.
[build] ...     0 Warning(s)
[build] ...     0 Error(s)
[build] ... Time Elapsed 00:00:01.27
[build] Build succeeded. Restarting resource...
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
