### PR TITLE
Fix noisy OperationCanceledException on publish/run shutdown

### DIFF
--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
-using System.Threading.Channels;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Exec;
 using Aspire.Hosting.Pipelines;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -47,7 +47,7 @@ internal class AppHostRpcTarget(
 
             // Stream live entries — uses a helper that swallows OperationCanceledException on cancellation
             // instead of propagating it, since yield return cannot appear in a try/catch block.
-            await foreach (var entry in ReadChannelUntilCancelledAsync(channel.Reader, linkedToken).ConfigureAwait(false))
+            await foreach (var entry in AsyncEnumerableUtils.ReadChannelUntilCancelledAsync(channel.Reader, linkedToken).ConfigureAwait(false))
             {
                 yield return entry;
             }
@@ -55,38 +55,6 @@ internal class AppHostRpcTarget(
         finally
         {
             loggerProvider.Unsubscribe(subscriberId);
-        }
-    }
-
-    /// <summary>
-    /// Reads items from a <see cref="ChannelReader{T}"/> until the channel completes or the token is cancelled,
-    /// yielding each item. Cancellation causes the sequence to complete gracefully rather than throwing.
-    /// </summary>
-    private static async IAsyncEnumerable<T> ReadChannelUntilCancelledAsync<T>(
-        ChannelReader<T> reader,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            bool hasMore;
-            try
-            {
-                hasMore = await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                yield break;
-            }
-
-            if (!hasMore)
-            {
-                yield break;
-            }
-
-            while (reader.TryRead(out var item))
-            {
-                yield return item;
-            }
         }
     }
 
@@ -107,7 +75,7 @@ internal class AppHostRpcTarget(
             catch (OperationCanceledException) when (linkedToken.IsCancellationRequested)
             {
                 // Expected when the stream is cancelled due to shutdown or client disconnect.
-                logger.LogDebug("Publishing activities stream cancelled due to AppHost shutdown");
+                logger.LogDebug("Publishing activities stream cancelled.");
                 yield break;
             }
 
@@ -131,7 +99,7 @@ internal class AppHostRpcTarget(
 
         // Use a helper that swallows OperationCanceledException on cancellation instead of propagating it,
         // since yield return cannot appear in a try/catch block.
-        await foreach (var resourceEvent in ReadEnumerableUntilCancelledAsync(resourceEvents, linkedToken).ConfigureAwait(false))
+        await foreach (var resourceEvent in AsyncEnumerableUtils.ReadEnumerableUntilCancelledAsync(resourceEvents, linkedToken).ConfigureAwait(false))
         {
             if (resourceEvent.Resource.Name == "aspire-dashboard")
             {
@@ -161,43 +129,6 @@ internal class AppHostRpcTarget(
                 Endpoints = endpointUris,
                 Health = healthStatus?.ToString()
             };
-        }
-    }
-
-    /// <summary>
-    /// Iterates an <see cref="IAsyncEnumerable{T}"/> until it completes or the token is cancelled,
-    /// yielding each item. Cancellation causes the sequence to complete gracefully rather than throwing.
-    /// </summary>
-    private static async IAsyncEnumerable<T> ReadEnumerableUntilCancelledAsync<T>(
-        IAsyncEnumerable<T> source,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        var enumerator = source.GetAsyncEnumerator(cancellationToken);
-        try
-        {
-            while (true)
-            {
-                bool hasNext;
-                try
-                {
-                    hasNext = await enumerator.MoveNextAsync().ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    yield break;
-                }
-
-                if (!hasNext)
-                {
-                    yield break;
-                }
-
-                yield return enumerator.Current;
-            }
-        }
-        finally
-        {
-            await enumerator.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -47,7 +47,7 @@ internal class AppHostRpcTarget(
 
             // Stream live entries — uses a helper that swallows OperationCanceledException on cancellation
             // instead of propagating it, since yield return cannot appear in a try/catch block.
-            await foreach (var entry in AsyncEnumerableUtils.ReadChannelUntilCancelledAsync(channel.Reader, linkedToken).ConfigureAwait(false))
+            await foreach (var entry in AsyncEnumerableUtils.ReadUntilCancelledAsync(channel.Reader.ReadAllAsync(linkedToken), linkedToken).ConfigureAwait(false))
             {
                 yield return entry;
             }
@@ -99,7 +99,7 @@ internal class AppHostRpcTarget(
 
         // Use a helper that swallows OperationCanceledException on cancellation instead of propagating it,
         // since yield return cannot appear in a try/catch block.
-        await foreach (var resourceEvent in AsyncEnumerableUtils.ReadEnumerableUntilCancelledAsync(resourceEvents, linkedToken).ConfigureAwait(false))
+        await foreach (var resourceEvent in AsyncEnumerableUtils.ReadUntilCancelledAsync(resourceEvents, linkedToken).ConfigureAwait(false))
         {
             if (resourceEvent.Resource.Name == "aspire-dashboard")
             {

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Exec;
 using Aspire.Hosting.Pipelines;
@@ -44,8 +45,9 @@ internal class AppHostRpcTarget(
                 yield return entry;
             }
 
-            // Stream live entries
-            await foreach (var entry in channel.Reader.ReadAllAsync(linkedToken).ConfigureAwait(false))
+            // Stream live entries — uses a helper that swallows OperationCanceledException on cancellation
+            // instead of propagating it, since yield return cannot appear in a try/catch block.
+            await foreach (var entry in ReadChannelUntilCancelledAsync(channel.Reader, linkedToken).ConfigureAwait(false))
             {
                 yield return entry;
             }
@@ -53,6 +55,38 @@ internal class AppHostRpcTarget(
         finally
         {
             loggerProvider.Unsubscribe(subscriberId);
+        }
+    }
+
+    /// <summary>
+    /// Reads items from a <see cref="ChannelReader{T}"/> until the channel completes or the token is cancelled,
+    /// yielding each item. Cancellation causes the sequence to complete gracefully rather than throwing.
+    /// </summary>
+    private static async IAsyncEnumerable<T> ReadChannelUntilCancelledAsync<T>(
+        ChannelReader<T> reader,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            bool hasMore;
+            try
+            {
+                hasMore = await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                yield break;
+            }
+
+            if (!hasMore)
+            {
+                yield break;
+            }
+
+            while (reader.TryRead(out var item))
+            {
+                yield return item;
+            }
         }
     }
 
@@ -70,9 +104,9 @@ internal class AppHostRpcTarget(
             {
                 publishingActivity = await activityReporter.ActivityItemUpdated.Reader.ReadAsync(linkedToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) when (_shutdownCts.Token.IsCancellationRequested)
+            catch (OperationCanceledException) when (linkedToken.IsCancellationRequested)
             {
-                // Gracefully handle cancellation due to shutdown
+                // Expected when the stream is cancelled due to shutdown or client disconnect.
                 logger.LogDebug("Publishing activities stream cancelled due to AppHost shutdown");
                 yield break;
             }
@@ -95,7 +129,9 @@ internal class AppHostRpcTarget(
 
         var resourceEvents = resourceNotificationService.WatchAsync(linkedToken);
 
-        await foreach (var resourceEvent in resourceEvents.WithCancellation(linkedToken).ConfigureAwait(false))
+        // Use a helper that swallows OperationCanceledException on cancellation instead of propagating it,
+        // since yield return cannot appear in a try/catch block.
+        await foreach (var resourceEvent in ReadEnumerableUntilCancelledAsync(resourceEvents, linkedToken).ConfigureAwait(false))
         {
             if (resourceEvent.Resource.Name == "aspire-dashboard")
             {
@@ -125,6 +161,43 @@ internal class AppHostRpcTarget(
                 Endpoints = endpointUris,
                 Health = healthStatus?.ToString()
             };
+        }
+    }
+
+    /// <summary>
+    /// Iterates an <see cref="IAsyncEnumerable{T}"/> until it completes or the token is cancelled,
+    /// yielding each item. Cancellation causes the sequence to complete gracefully rather than throwing.
+    /// </summary>
+    private static async IAsyncEnumerable<T> ReadEnumerableUntilCancelledAsync<T>(
+        IAsyncEnumerable<T> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var enumerator = source.GetAsyncEnumerator(cancellationToken);
+        try
+        {
+            while (true)
+            {
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    yield break;
+                }
+
+                if (!hasNext)
+                {
+                    yield break;
+                }
+
+                yield return enumerator.Current;
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Aspire.Hosting/Backchannel/BackchannelService.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelService.cs
@@ -80,7 +80,7 @@ internal sealed class BackchannelService(
                 EventDispatchBehavior.NonBlockingConcurrent,
                 stoppingToken).ConfigureAwait(false);
         }
-        catch (TaskCanceledException ex)
+        catch (OperationCanceledException ex)
         {
             // This exception is expected when the service is shut down whilst waiting for
             // a socket and just means that we don't need to wait anymore.

--- a/src/Aspire.Hosting/Utils/AsyncEnumerableUtils.cs
+++ b/src/Aspire.Hosting/Utils/AsyncEnumerableUtils.cs
@@ -2,51 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
-using System.Threading.Channels;
 
 namespace Aspire.Hosting.Utils;
 
 internal static class AsyncEnumerableUtils
 {
     /// <summary>
-    /// Reads items from a <see cref="ChannelReader{T}"/> until the channel completes or the token is
-    /// cancelled, yielding each item. Cancellation causes the sequence to complete gracefully rather
-    /// than throwing, making it safe to use inside iterator methods that have <c>finally</c> blocks.
-    /// </summary>
-    public static async IAsyncEnumerable<T> ReadChannelUntilCancelledAsync<T>(
-        ChannelReader<T> reader,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            bool hasMore;
-            try
-            {
-                hasMore = await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                yield break;
-            }
-
-            if (!hasMore)
-            {
-                yield break;
-            }
-
-            while (reader.TryRead(out var item))
-            {
-                yield return item;
-            }
-        }
-    }
-
-    /// <summary>
     /// Iterates an <see cref="IAsyncEnumerable{T}"/> until it completes or the token is cancelled,
     /// yielding each item. Cancellation causes the sequence to complete gracefully rather than
     /// throwing, making it safe to use inside iterator methods that have <c>finally</c> blocks.
     /// </summary>
-    public static async IAsyncEnumerable<T> ReadEnumerableUntilCancelledAsync<T>(
+    public static async IAsyncEnumerable<T> ReadUntilCancelledAsync<T>(
         IAsyncEnumerable<T> source,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/src/Aspire.Hosting/Utils/AsyncEnumerableUtils.cs
+++ b/src/Aspire.Hosting/Utils/AsyncEnumerableUtils.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace Aspire.Hosting.Utils;
+
+internal static class AsyncEnumerableUtils
+{
+    /// <summary>
+    /// Reads items from a <see cref="ChannelReader{T}"/> until the channel completes or the token is
+    /// cancelled, yielding each item. Cancellation causes the sequence to complete gracefully rather
+    /// than throwing, making it safe to use inside iterator methods that have <c>finally</c> blocks.
+    /// </summary>
+    public static async IAsyncEnumerable<T> ReadChannelUntilCancelledAsync<T>(
+        ChannelReader<T> reader,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            bool hasMore;
+            try
+            {
+                hasMore = await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                yield break;
+            }
+
+            if (!hasMore)
+            {
+                yield break;
+            }
+
+            while (reader.TryRead(out var item))
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Iterates an <see cref="IAsyncEnumerable{T}"/> until it completes or the token is cancelled,
+    /// yielding each item. Cancellation causes the sequence to complete gracefully rather than
+    /// throwing, making it safe to use inside iterator methods that have <c>finally</c> blocks.
+    /// </summary>
+    public static async IAsyncEnumerable<T> ReadEnumerableUntilCancelledAsync<T>(
+        IAsyncEnumerable<T> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var enumerator = source.GetAsyncEnumerator(cancellationToken);
+        try
+        {
+            while (true)
+            {
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    yield break;
+                }
+
+                if (!hasNext)
+                {
+                    yield break;
+                }
+
+                yield return enumerator.Current;
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetCancellationTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetCancellationTests.cs
@@ -1,0 +1,254 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Backchannel;
+
+/// <summary>
+/// Tests that cancellation of streaming RPC methods on <see cref="AppHostRpcTarget"/> completes
+/// the stream gracefully (i.e. no <see cref="OperationCanceledException"/> propagates to callers).
+/// </summary>
+[Trait("Partition", "4")]
+public class AppHostRpcTargetCancellationTests(ITestOutputHelper outputHelper)
+{
+    // -------------------------------------------------------------------------
+    // GetAppHostLogEntriesAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAppHostLogEntriesAsync_WhenOuterTokenAlreadyCancelled_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Iterating with an already-cancelled token should complete without throwing.
+        await foreach (var _ in target.GetAppHostLogEntriesAsync(cts.Token))
+        {
+        }
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public async Task GetAppHostLogEntriesAsync_WhenOuterTokenCancelledDuringIteration_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        using var cts = new CancellationTokenSource();
+
+        // Start iterating; cancel the token after starting but let it complete normally.
+        var iterationTask = Task.Run(async () =>
+        {
+            await foreach (var _ in target.GetAppHostLogEntriesAsync(cts.Token))
+            {
+            }
+        });
+
+        await cts.CancelAsync();
+
+        // Should finish without exception within a short timeout.
+        await iterationTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public async Task GetAppHostLogEntriesAsync_WhenShutdownCtsCancelled_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        var iterationTask = Task.Run(async () =>
+        {
+            await foreach (var _ in target.GetAppHostLogEntriesAsync(CancellationToken.None))
+            {
+            }
+        });
+
+        // Simulate the shutdown path (same as RequestStopAsync calling _shutdownCts.Cancel()).
+        target.CancelInflightRpcCalls();
+
+        await iterationTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    // -------------------------------------------------------------------------
+    // GetPublishingActivitiesAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetPublishingActivitiesAsync_WhenOuterTokenAlreadyCancelled_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await foreach (var _ in target.GetPublishingActivitiesAsync(cts.Token))
+        {
+        }
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public async Task GetPublishingActivitiesAsync_WhenOuterTokenCancelledDuringIteration_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        using var cts = new CancellationTokenSource();
+
+        var iterationTask = Task.Run(async () =>
+        {
+            await foreach (var _ in target.GetPublishingActivitiesAsync(cts.Token))
+            {
+            }
+        });
+
+        await cts.CancelAsync();
+
+        await iterationTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public async Task GetPublishingActivitiesAsync_WhenShutdownCtsCancelled_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        var iterationTask = Task.Run(async () =>
+        {
+            await foreach (var _ in target.GetPublishingActivitiesAsync(CancellationToken.None))
+            {
+            }
+        });
+
+        target.CancelInflightRpcCalls();
+
+        await iterationTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    // -------------------------------------------------------------------------
+    // GetResourceStatesAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetResourceStatesAsync_WhenOuterTokenAlreadyCancelled_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await foreach (var _ in target.GetResourceStatesAsync(cts.Token))
+        {
+        }
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public async Task GetResourceStatesAsync_WhenOuterTokenCancelledDuringIteration_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        using var cts = new CancellationTokenSource();
+
+        var iterationTask = Task.Run(async () =>
+        {
+            await foreach (var _ in target.GetResourceStatesAsync(cts.Token))
+            {
+            }
+        });
+
+        await cts.CancelAsync();
+
+        await iterationTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public async Task GetResourceStatesAsync_WhenShutdownCtsCancelled_StreamCompletesWithoutException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        var iterationTask = Task.Run(async () =>
+        {
+            await foreach (var _ in target.GetResourceStatesAsync(CancellationToken.None))
+            {
+            }
+        });
+
+        target.CancelInflightRpcCalls();
+
+        await iterationTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+
+    // -------------------------------------------------------------------------
+    // BackchannelService — socket waiting when stoppingToken fires
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task BackchannelService_WhenStoppingTokenFiredWhileWaitingForConnection_AppStopsCleanly()
+    {
+        // Configure a socket path but never connect a client, so AcceptAsync will be
+        // waiting when the app host stops and fires the stoppingToken.
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        builder.Configuration[KnownConfigNames.UnixSocketPath] = UnixSocketHelper.GetBackchannelSocketPath();
+
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+
+        // Stop without ever connecting — BackchannelService's AcceptAsync is still waiting.
+        // Prior to the fix this would surface an unhandled OperationCanceledException;
+        // after the fix it should stop cleanly.
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+    }
+}


### PR DESCRIPTION
## Description

During `aspire publish` (and `aspire run`), the AppHost's streaming RPC methods were letting `OperationCanceledException` propagate out of user code on shutdown. Visual Studio shows these as "Exception thrown" first-chance exception notifications in the output window, which is noisy and confusing since the publish completes successfully.

**Root causes fixed:**

1. **`GetAppHostLogEntriesAsync`** — `Channel.ReadAllAsync` throws `OperationCanceledException` when cancelled. Replaced with a `ReadChannelUntilCancelledAsync` helper that catches it and does `yield break`. (C# prevents `yield return` inside a `try/catch` block, requiring the helper extraction.)

2. **`GetPublishingActivitiesAsync`** — The `catch` filter checked `_shutdownCts.Token.IsCancellationRequested` instead of `linkedToken.IsCancellationRequested`, so CLI-side cancellation was not caught, letting the exception propagate. Fixed to check the linked token.

3. **`GetResourceStatesAsync`** — Bare `await foreach` on `WatchAsync` throws when cancelled. Replaced with a `ReadEnumerableUntilCancelledAsync` helper that wraps `MoveNextAsync()` in a try/catch for the same reason.

4. **`BackchannelService.ExecuteAsync`** — `Socket.AcceptAsync(CancellationToken)` throws `OperationCanceledException` (the base class), not `TaskCanceledException` (the derived class). The catch was a no-op. Changed to catch `OperationCanceledException`.

New tests in `AppHostRpcTargetCancellationTests` cover all three streaming methods × three cancellation scenarios (pre-cancelled token, mid-iteration cancellation, shutdown CTS), plus the `BackchannelService` stop path. Tests were verified to fail (6/10) against the unfixed code.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
