### PR TITLE
Fix Azure Functions VS Code no-build launch

### DIFF
--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -69,6 +69,7 @@ export function isBrowserLaunchConfiguration(obj: any): obj is BrowserLaunchConf
 export interface AzureFunctionsLaunchConfiguration extends ExecutableLaunchConfiguration {
     type: "azure-functions";
     project_path: string;
+    suppress_build?: boolean;
 }
 
 export function isAzureFunctionsLaunchConfiguration(obj: any): obj is AzureFunctionsLaunchConfiguration {

--- a/extension/src/debugger/languages/azureFunctions.ts
+++ b/extension/src/debugger/languages/azureFunctions.ts
@@ -7,6 +7,7 @@ import { ResourceDebuggerExtension } from '../debuggerExtensions';
 import { registerRunCleanup } from '../runCleanupRegistry';
 
 const AF_EXTENSION_ID = 'ms-azuretools.vscode-azurefunctions';
+const NO_BUILD_ARG = '--no-build';
 
 /**
  * Result from the Azure Functions extension's startFuncProcess API.
@@ -38,6 +39,16 @@ const workerPidsByRunId = new Map<string, number>();
 
 /** Tracks the VS Code Task executions (func host start) by runId for cleanup. */
 const taskExecutionsByRunId = new Map<string, vscode.TaskExecution>();
+
+export function getAzureFunctionsHostStartArgs(args: string[] | undefined, suppressBuild: boolean | undefined): string[] {
+    const startArgs = [...(args ?? [])];
+
+    if (suppressBuild === true && !startArgs.some(arg => arg.toLowerCase() === NO_BUILD_ARG)) {
+        startArgs.push(NO_BUILD_ARG);
+    }
+
+    return startArgs;
+}
 
 /** Kill the func host task and worker process for the given runId, if any. */
 function killFuncProcess(runId: string): void {
@@ -126,8 +137,7 @@ export const azureFunctionsDebuggerExtension: ResourceDebuggerExtension = {
         // Start func host via the Azure Functions extension API.
         // The API creates a VS Code Task running "func host start", polls
         // /admin/host/status until ready, then finds the dotnet worker child
-        // process and returns its PID. We let func handle the build itself
-        // so it outputs to its expected bin/output/ location.
+        // process and returns its PID.
         //
         // The AF extension API has no stopFuncProcess method, so we track the
         // VS Code Task it creates by diffing taskExecutions before/after the call.
@@ -135,7 +145,8 @@ export const azureFunctionsDebuggerExtension: ResourceDebuggerExtension = {
         extensionLogOutputChannel.info(`Got Azure Functions API (version ${api.apiVersion}), calling startFuncProcess`);
 
         const executionsBefore = new Set(vscode.tasks.taskExecutions);
-        const result = await api.startFuncProcess(projectDir, args ?? [], dcpEnv);
+        const startArgs = getAzureFunctionsHostStartArgs(args, launchConfig.suppress_build);
+        const result = await api.startFuncProcess(projectDir, startArgs, dcpEnv);
 
         // Find the new task execution that was created by startFuncProcess.
         // Filter by task name containing "func" to reduce the chance of capturing

--- a/extension/src/test/azureFunctionsDebugger.test.ts
+++ b/extension/src/test/azureFunctionsDebugger.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert';
+import { getAzureFunctionsHostStartArgs } from '../debugger/languages/azureFunctions';
+
+suite('Azure Functions Debugger Extension Tests', () => {
+    test('adds no-build when suppress build is true', () => {
+        assert.deepStrictEqual(
+            getAzureFunctionsHostStartArgs(['--port', '52341'], true),
+            ['--port', '52341', '--no-build']);
+    });
+
+    test('does not add no-build when suppress build is false', () => {
+        assert.deepStrictEqual(
+            getAzureFunctionsHostStartArgs(['--port', '52341'], false),
+            ['--port', '52341']);
+    });
+
+    test('does not add no-build when suppress build is undefined', () => {
+        assert.deepStrictEqual(
+            getAzureFunctionsHostStartArgs(['--port', '52341'], undefined),
+            ['--port', '52341']);
+    });
+
+    test('does not duplicate no-build', () => {
+        assert.deepStrictEqual(
+            getAzureFunctionsHostStartArgs(['--port', '52341', '--no-build'], true),
+            ['--port', '52341', '--no-build']);
+    });
+
+    test('handles missing args', () => {
+        assert.deepStrictEqual(
+            getAzureFunctionsHostStartArgs(undefined, true),
+            ['--no-build']);
+    });
+});

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -187,7 +187,12 @@ public static class AzureFunctionsProjectResourceExtensions
         var functionsBuilder = builder.AddResource(resource)
             .WithAnnotation(projectMetadata)
             .WithAnnotation(new AzureFunctionsAnnotation())
-            .WithDebugSupport(mode => new AzureFunctionsLaunchConfiguration { ProjectPath = projectMetadata.ProjectPath, Mode = mode }, "azure-functions");
+            .WithDebugSupport(mode => new AzureFunctionsLaunchConfiguration
+            {
+                ProjectPath = projectMetadata.ProjectPath,
+                Mode = mode,
+                SuppressBuild = projectMetadata.SuppressBuild
+            }, "azure-functions");
 #pragma warning restore ASPIREEXTENSION001
 
         // Only validate Azure Functions Core Tools in run mode (not during publish)
@@ -449,5 +454,9 @@ public static class AzureFunctionsProjectResourceExtensions
 
         [JsonPropertyName("project_path")]
         public string ProjectPath { get; set; } = string.Empty;
+
+        [JsonPropertyName("suppress_build")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool SuppressBuild { get; set; }
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -101,6 +101,28 @@ public class AzureFunctionsTests
     }
 
     [Fact]
+    public void AddAzureFunctionsProject_IncludesSuppressBuildInLaunchConfiguration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var funcApp = builder.AddAzureFunctionsProject<TestProjectSuppressBuild>("funcapp");
+
+        var launchConfiguration = GetAzureFunctionsLaunchConfiguration(funcApp.Resource);
+
+        Assert.True(launchConfiguration["suppress_build"]?.GetValue<bool>());
+    }
+
+    [Fact]
+    public void AddAzureFunctionsProject_OmitsSuppressBuildFromLaunchConfigurationByDefault()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var funcApp = builder.AddAzureFunctionsProject<TestProject>("funcapp");
+
+        var launchConfiguration = GetAzureFunctionsLaunchConfiguration(funcApp.Resource);
+
+        Assert.False(launchConfiguration.ContainsKey("suppress_build"));
+    }
+
+    [Fact]
     public void AddAzureFunctionsProject_WiresUpHttpEndpointCorrectly_WhenMultiplePortArgumentsProvided()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -457,6 +479,23 @@ public class AzureFunctionsTests
     private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>
         AzureManifestUtils.GetManifestWithBicep(resource, skipPreparer: true);
 
+    private static JsonObject GetAzureFunctionsLaunchConfiguration(AzureFunctionsProjectResource resource)
+    {
+        var supportsDebuggingAnnotation = Assert.Single(resource.Annotations, a => a.GetType().Name == "SupportsDebuggingAnnotation");
+        var annotator = (Delegate)supportsDebuggingAnnotation.GetType().GetProperty("LaunchConfigurationAnnotator")!.GetValue(supportsDebuggingAnnotation)!;
+
+        var executableType = typeof(DistributedApplication).Assembly.GetType("Aspire.Hosting.Dcp.Model.Executable", throwOnError: true)!;
+        var executable = executableType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!.Invoke(null, ["funcapp", "dotnet"])!;
+
+        annotator.DynamicInvoke(executable, "Debug");
+
+        var metadata = executableType.GetProperty("Metadata")!.GetValue(executable)!;
+        var annotations = (IDictionary<string, string>)metadata.GetType().GetProperty("Annotations")!.GetValue(metadata)!;
+        var launchConfigurations = JsonNode.Parse(annotations["executable.usvc-dev.developer.microsoft.com/launch-configurations"])!.AsArray();
+
+        return Assert.IsType<JsonObject>(Assert.Single(launchConfigurations)!);
+    }
+
     private sealed class TestProject : IProjectMetadata
     {
         public string ProjectPath => "some-path";
@@ -468,6 +507,24 @@ public class AzureFunctionsTests
                 ["funcapp"] = new()
                 {
                     CommandLineArgs = "--port 7071",
+                    LaunchBrowser = false,
+                }
+            }
+        };
+    }
+
+    private sealed class TestProjectSuppressBuild : IProjectMetadata
+    {
+        public string ProjectPath => "some-path";
+
+        public bool SuppressBuild => true;
+
+        public LaunchSettings LaunchSettings => new()
+        {
+            Profiles = new Dictionary<string, LaunchProfile>
+            {
+                ["funcapp"] = new()
+                {
                     LaunchBrowser = false,
                 }
             }


### PR DESCRIPTION
## Description

This fixes the Aspire VS Code Azure Functions launch path so function apps created from AppHost project references do not redundantly build when launched through the Azure Functions extension API.

The Hosting launch payload now carries `SuppressBuild` for Azure Functions resources and omits the field when false/default for compatibility. The VS Code extension treats the field as optional and appends `--no-build` only when it is `true`, preserving existing startup args such as Aspire's allocated `--port` values.

Validation:
- `dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.AzureFunctionsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `cd extension && npm run compile-tests && npm run lint`
- `cd extension && npx vscode-test --grep "Azure Functions Debugger"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
