### PR TITLE
Add BrowserLogs screenshot artifacts

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandArtifacts.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandArtifacts.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+// Writes durable resource-command artifacts outside of command output so commands can return concise, agent-friendly
+// summaries while large payloads stay on disk.
+internal interface IResourceCommandArtifactWriter
+{
+    Task<ResourceCommandArtifact> WriteArtifactAsync(
+        string? appHostKey,
+        string resourceName,
+        string artifactType,
+        string fileExtension,
+        string mimeType,
+        ReadOnlyMemory<byte> content,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResourceCommandArtifactWriter : IResourceCommandArtifactWriter
+{
+    private const int AppHostKeySegmentLength = 16;
+    private readonly Func<string> _rootDirectoryFactory;
+    private readonly TimeProvider _timeProvider;
+
+    public ResourceCommandArtifactWriter(TimeProvider timeProvider)
+        : this(timeProvider, GetAspireCommandArtifactRoot)
+    {
+    }
+
+    internal ResourceCommandArtifactWriter(TimeProvider timeProvider, Func<string> rootDirectoryFactory)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(rootDirectoryFactory);
+
+        _timeProvider = timeProvider;
+        _rootDirectoryFactory = rootDirectoryFactory;
+    }
+
+    public async Task<ResourceCommandArtifact> WriteArtifactAsync(
+        string? appHostKey,
+        string resourceName,
+        string artifactType,
+        string fileExtension,
+        string mimeType,
+        ReadOnlyMemory<byte> content,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileExtension);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mimeType);
+
+        var createdAt = _timeProvider.GetUtcNow();
+        var normalizedArtifactType = SanitizePathSegment(artifactType, fallback: "artifact");
+        var directory = Path.Combine(
+            _rootDirectoryFactory(),
+            GetAppHostSegment(appHostKey),
+            SanitizePathSegment(resourceName, fallback: "resource"),
+            normalizedArtifactType);
+
+        Directory.CreateDirectory(directory);
+
+        var timestamp = createdAt.UtcDateTime.ToString("yyyyMMddTHHmmss.fffffffZ", CultureInfo.InvariantCulture);
+        var extension = fileExtension.StartsWith(".", StringComparison.Ordinal) ? fileExtension : "." + fileExtension;
+
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            var suffix = attempt == 0 ? string.Empty : $"-{attempt}";
+            var fileName = $"{timestamp}-{normalizedArtifactType}{suffix}{extension}";
+            var filePath = Path.Combine(directory, fileName);
+
+            FileStream stream;
+            try
+            {
+                stream = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read, bufferSize: 64 * 1024, useAsync: true);
+            }
+            catch (IOException) when (attempt < 99 && File.Exists(filePath))
+            {
+                continue;
+            }
+
+            await using (stream.ConfigureAwait(false))
+            {
+                await stream.WriteAsync(content, cancellationToken).ConfigureAwait(false);
+            }
+
+            return new ResourceCommandArtifact(resourceName, artifactType, filePath, mimeType, content.Length, createdAt);
+        }
+
+        throw new IOException($"Unable to create a unique resource command artifact file under '{directory}'.");
+    }
+
+    private static string GetAppHostSegment(string? appHostKey)
+    {
+        if (string.IsNullOrWhiteSpace(appHostKey))
+        {
+            return "unknown-apphost";
+        }
+
+        var segment = appHostKey.Length > AppHostKeySegmentLength
+            ? appHostKey[..AppHostKeySegmentLength]
+            : appHostKey;
+
+        return SanitizePathSegment(segment, fallback: "unknown-apphost");
+    }
+
+    private static string GetAspireCommandArtifactRoot()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Aspire",
+                "CommandArtifacts");
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Library",
+                "Application Support",
+                "Aspire",
+                "CommandArtifacts");
+        }
+
+        var xdgDataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+        var dataHome = !string.IsNullOrEmpty(xdgDataHome)
+            ? xdgDataHome
+            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+        return Path.Combine(dataHome, "aspire", "command-artifacts");
+    }
+
+    private static string SanitizePathSegment(string value, string fallback)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var buffer = new char[value.Length];
+        var hasValidCharacter = false;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (Array.IndexOf(invalidChars, c) >= 0 || c == ' ')
+            {
+                buffer[i] = '_';
+            }
+            else
+            {
+                buffer[i] = char.ToLowerInvariant(c);
+                hasValidCharacter = true;
+            }
+        }
+
+        return hasValidCharacter ? new string(buffer) : fallback;
+    }
+}
+
+internal sealed record ResourceCommandArtifact(
+    string ResourceName,
+    string ArtifactType,
+    string FilePath,
+    string MimeType,
+    long SizeBytes,
+    DateTimeOffset CreatedAt);

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsArtifacts.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsArtifacts.cs
@@ -3,13 +3,13 @@
 
 using System.Globalization;
 
-namespace Aspire.Hosting.ApplicationModel;
+namespace Aspire.Hosting;
 
-// Writes durable resource-command artifacts outside of command output so commands can return concise, agent-friendly
+// Writes durable browser-log command artifacts outside of command output so commands can return concise, agent-friendly
 // summaries while large payloads stay on disk.
-internal interface IResourceCommandArtifactWriter
+internal interface IBrowserLogsArtifactWriter
 {
-    Task<ResourceCommandArtifact> WriteArtifactAsync(
+    Task<BrowserLogsArtifact> WriteArtifactAsync(
         string? appHostKey,
         string resourceName,
         string artifactType,
@@ -19,18 +19,18 @@ internal interface IResourceCommandArtifactWriter
         CancellationToken cancellationToken);
 }
 
-internal sealed class ResourceCommandArtifactWriter : IResourceCommandArtifactWriter
+internal sealed class BrowserLogsArtifactWriter : IBrowserLogsArtifactWriter
 {
     private const int AppHostKeySegmentLength = 16;
     private readonly Func<string> _rootDirectoryFactory;
     private readonly TimeProvider _timeProvider;
 
-    public ResourceCommandArtifactWriter(TimeProvider timeProvider)
+    public BrowserLogsArtifactWriter(TimeProvider timeProvider)
         : this(timeProvider, GetAspireCommandArtifactRoot)
     {
     }
 
-    internal ResourceCommandArtifactWriter(TimeProvider timeProvider, Func<string> rootDirectoryFactory)
+    internal BrowserLogsArtifactWriter(TimeProvider timeProvider, Func<string> rootDirectoryFactory)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(rootDirectoryFactory);
@@ -39,7 +39,7 @@ internal sealed class ResourceCommandArtifactWriter : IResourceCommandArtifactWr
         _rootDirectoryFactory = rootDirectoryFactory;
     }
 
-    public async Task<ResourceCommandArtifact> WriteArtifactAsync(
+    public async Task<BrowserLogsArtifact> WriteArtifactAsync(
         string? appHostKey,
         string resourceName,
         string artifactType,
@@ -87,10 +87,10 @@ internal sealed class ResourceCommandArtifactWriter : IResourceCommandArtifactWr
                 await stream.WriteAsync(content, cancellationToken).ConfigureAwait(false);
             }
 
-            return new ResourceCommandArtifact(resourceName, artifactType, filePath, mimeType, content.Length, createdAt);
+            return new BrowserLogsArtifact(resourceName, artifactType, filePath, mimeType, content.Length, createdAt);
         }
 
-        throw new IOException($"Unable to create a unique resource command artifact file under '{directory}'.");
+        throw new IOException($"Unable to create a unique browser-log command artifact file under '{directory}'.");
     }
 
     private static string GetAppHostSegment(string? appHostKey)
@@ -158,7 +158,7 @@ internal sealed class ResourceCommandArtifactWriter : IResourceCommandArtifactWr
     }
 }
 
-internal sealed record ResourceCommandArtifact(
+internal sealed record BrowserLogsArtifact(
     string ResourceName,
     string ArtifactType,
     string FilePath,

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsBuilderExtensions.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Resources;
 using Microsoft.Extensions.Configuration;
@@ -36,10 +37,15 @@ public static class BrowserLogsBuilderExtensions
     internal const string LastErrorPropertyName = "Last error";
     internal const string LastSessionPropertyName = "Last session";
     internal const string OpenTrackedBrowserCommandName = "open-tracked-browser";
+    internal const string CaptureScreenshotCommandName = "capture-screenshot";
+    private static readonly JsonSerializerOptions s_commandResultJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
 
     /// <summary>
-    /// Adds a child resource that can open the application's primary browser endpoint in a tracked browser session and
-    /// surface browser console output in the dashboard console logs.
+    /// Adds a child resource that can open the application's primary browser endpoint in a tracked browser session,
+    /// surface browser diagnostics, and capture screenshots.
     /// </summary>
     /// <typeparam name="T">The type of resource being configured.</typeparam>
     /// <param name="builder">The resource builder.</param>
@@ -69,8 +75,8 @@ public static class BrowserLogsBuilderExtensions
     /// <para>
     /// This method adds a child browser logs resource beneath the parent resource represented by <paramref name="builder"/>.
     /// The child resource exposes a dashboard command that launches a Chromium-based browser in a tracked mode, attaches to
-    /// the browser's debugging protocol, and forwards browser console, error, and exception output to the child resource's
-    /// console log stream.
+    /// the browser's debugging protocol, forwards browser console, error, exception, and network output to the child
+    /// resource's console log stream, and can capture screenshots as command artifacts.
     /// </para>
     /// <para>
     /// The tracked browser session uses the <a href="https://chromedevtools.github.io/devtools-protocol/">Chrome DevTools
@@ -101,7 +107,7 @@ public static class BrowserLogsBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIREBROWSERLOGS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExport(Description = "Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.")]
+    [AspireExport(Description = "Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.")]
     public static IResourceBuilder<T> WithBrowserLogs<T>(
         this IResourceBuilder<T> builder,
         string? browser = null,
@@ -184,6 +190,53 @@ public static class BrowserLogsBuilderExtensions
 
                         return ResourceCommandState.Disabled;
                     }
+                })
+            .WithCommand(
+                CaptureScreenshotCommandName,
+                CommandStrings.CaptureScreenshotName,
+                async context =>
+                {
+                    try
+                    {
+                        var sessionManager = context.ServiceProvider.GetRequiredService<IBrowserLogsSessionManager>();
+                        var result = await sessionManager.CaptureScreenshotAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
+                        var resultJson = JsonSerializer.Serialize(
+                            new BrowserLogsScreenshotCommandResult(
+                                result.Artifact.ResourceName,
+                                result.SessionId,
+                                result.TargetUrl.ToString(),
+                                result.Artifact.FilePath,
+                                result.Artifact.MimeType,
+                                result.Artifact.SizeBytes,
+                                result.Artifact.CreatedAt),
+                            s_commandResultJsonOptions);
+
+                        return CommandResults.Success(
+                            $"Captured screenshot to '{result.Artifact.FilePath}'.",
+                            new CommandResultData
+                            {
+                                Value = resultJson,
+                                Format = CommandResultFormat.Json,
+                                DisplayImmediately = true
+                            });
+                    }
+                    catch (Exception ex)
+                    {
+                        return CommandResults.Failure(ex.Message);
+                    }
+                },
+                new CommandOptions
+                {
+                    Description = CommandStrings.CaptureScreenshotDescription,
+                    IconName = "Camera",
+                    IconVariant = IconVariant.Regular,
+                    UpdateState = context =>
+                    {
+                        var childState = context.ResourceSnapshot.State?.Text;
+                        return childState == KnownResourceStates.Running
+                            ? ResourceCommandState.Enabled
+                            : ResourceCommandState.Disabled;
+                    }
                 });
 
         builder.OnBeforeResourceStarted((_, @event, _) => RefreshBrowserLogsResourceAsync(@event.Services.GetRequiredService<ResourceNotificationService>()))
@@ -252,4 +305,12 @@ public static class BrowserLogsBuilderExtensions
         }
     }
 
+    private sealed record BrowserLogsScreenshotCommandResult(
+        string ResourceName,
+        string SessionId,
+        string TargetUrl,
+        string Path,
+        string MimeType,
+        long SizeBytes,
+        DateTimeOffset CreatedAt);
 }

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsBuilderExtensions.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsBuilderExtensions.cs
@@ -204,6 +204,11 @@ public static class BrowserLogsBuilderExtensions
                             new BrowserLogsScreenshotCommandResult(
                                 result.Artifact.ResourceName,
                                 result.SessionId,
+                                result.Browser,
+                                result.BrowserExecutable,
+                                result.BrowserHostOwnership,
+                                result.ProcessId,
+                                result.TargetId,
                                 result.TargetUrl.ToString(),
                                 result.Artifact.FilePath,
                                 result.Artifact.MimeType,
@@ -308,6 +313,11 @@ public static class BrowserLogsBuilderExtensions
     private sealed record BrowserLogsScreenshotCommandResult(
         string ResourceName,
         string SessionId,
+        string Browser,
+        string BrowserExecutable,
+        string BrowserHostOwnership,
+        int? ProcessId,
+        string TargetId,
         string TargetUrl,
         string Path,
         string MimeType,

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsCdpConnection.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsCdpConnection.cs
@@ -25,6 +25,8 @@ internal interface IBrowserLogsCdpConnection : IAsyncDisposable
 
     Task EnablePageInstrumentationAsync(string sessionId, CancellationToken cancellationToken);
 
+    Task<BrowserLogsCaptureScreenshotResult> CaptureScreenshotAsync(string sessionId, CancellationToken cancellationToken);
+
     Task<BrowserLogsCommandAck> NavigateAsync(string sessionId, Uri url, CancellationToken cancellationToken);
 }
 
@@ -37,6 +39,10 @@ internal sealed class BrowserLogsCdpConnection : IBrowserLogsCdpConnection
     // timers without sending frequent pings during normal local development.
     private static readonly TimeSpan s_closeTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan s_commandTimeout = TimeSpan.FromSeconds(10);
+    // Screenshot capture asks the browser to rasterize and encode the current surface. Real browsers can take longer
+    // than lightweight lifecycle/enable commands, especially under CI or agent load, so give this command a larger
+    // protocol budget without slowing down ordinary command failures.
+    private static readonly TimeSpan s_screenshotCommandTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan s_keepAliveInterval = TimeSpan.FromSeconds(15);
 
     private readonly CancellationTokenSource _disposeCts = new();
@@ -156,6 +162,21 @@ internal sealed class BrowserLogsCdpConnection : IBrowserLogsCdpConnection
         await SendCommandAsync(BrowserLogsCdpProtocol.NetworkEnableMethod, sessionId, writeParameters: null, BrowserLogsCdpProtocol.ParseCommandAckResponse, cancellationToken).ConfigureAwait(false);
     }
 
+    public Task<BrowserLogsCaptureScreenshotResult> CaptureScreenshotAsync(string sessionId, CancellationToken cancellationToken)
+    {
+        return SendCommandAsync(
+            BrowserLogsCdpProtocol.PageCaptureScreenshotMethod,
+            sessionId,
+            static writer =>
+            {
+                writer.WriteString("format", "png");
+                writer.WriteBoolean("fromSurface", true);
+            },
+            BrowserLogsCdpProtocol.ParseCaptureScreenshotResponse,
+            cancellationToken,
+            s_screenshotCommandTimeout);
+    }
+
     public Task<BrowserLogsCommandAck> NavigateAsync(string sessionId, Uri url, CancellationToken cancellationToken)
     {
         return SendCommandAsync(
@@ -204,7 +225,8 @@ internal sealed class BrowserLogsCdpConnection : IBrowserLogsCdpConnection
         string? sessionId,
         Action<Utf8JsonWriter>? writeParameters,
         ResponseParser<TResult> parseResponse,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TimeSpan? commandTimeout = null)
     {
         var commandId = Interlocked.Increment(ref _nextCommandId);
         var pendingCommand = new PendingCommand<TResult>(parseResponse);
@@ -213,7 +235,7 @@ internal sealed class BrowserLogsCdpConnection : IBrowserLogsCdpConnection
         try
         {
             using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token);
-            sendCts.CancelAfter(s_commandTimeout);
+            sendCts.CancelAfter(commandTimeout ?? s_commandTimeout);
 
             using var registration = sendCts.Token.Register(static state =>
             {

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsCdpProtocol.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsCdpProtocol.cs
@@ -40,6 +40,7 @@ internal static class BrowserLogsCdpProtocol
     internal const string NetworkRequestWillBeSentMethod = "Network.requestWillBeSent";
     internal const string NetworkResponseReceivedMethod = "Network.responseReceived";
     internal const string PageEnableMethod = "Page.enable";
+    internal const string PageCaptureScreenshotMethod = "Page.captureScreenshot";
     internal const string PageNavigateMethod = "Page.navigate";
     internal const string RuntimeConsoleApiCalledMethod = "Runtime.consoleAPICalled";
     internal const string RuntimeEnableMethod = "Runtime.enable";
@@ -191,6 +192,20 @@ internal static class BrowserLogsCdpProtocol
         ThrowIfProtocolError(envelope.Error);
 
         return BrowserLogsCommandAck.Instance;
+    }
+
+    internal static BrowserLogsCaptureScreenshotResult ParseCaptureScreenshotResponse(ReadOnlySpan<byte> framePayload)
+    {
+        var envelope = DeserializeFrame(framePayload, BrowserLogsCdpProtocolJsonContext.Default.BrowserLogsCaptureScreenshotResponseEnvelope);
+        ThrowIfProtocolError(envelope.Error);
+
+        var result = envelope.Result ?? throw new InvalidOperationException("Tracked browser screenshot capture did not return a result payload.");
+        if (string.IsNullOrWhiteSpace(result.Data))
+        {
+            throw new InvalidOperationException("Tracked browser screenshot capture did not return image data.");
+        }
+
+        return result;
     }
 
     internal static string DescribeFrame(ReadOnlySpan<byte> framePayload, int maxLength = 512)
@@ -402,6 +417,24 @@ internal sealed class BrowserLogsCommandAckResponseEnvelope
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
+}
+
+internal sealed class BrowserLogsCaptureScreenshotResponseEnvelope
+{
+    [JsonPropertyName("error")]
+    public BrowserLogsCdpProtocolError? Error { get; init; }
+
+    [JsonPropertyName("id")]
+    public long Id { get; init; }
+
+    [JsonPropertyName("result")]
+    public BrowserLogsCaptureScreenshotResult? Result { get; init; }
+}
+
+internal sealed class BrowserLogsCaptureScreenshotResult
+{
+    [JsonPropertyName("data")]
+    public string? Data { get; init; }
 }
 
 internal interface IBrowserLogsEventEnvelope<out TParameters>
@@ -899,6 +932,7 @@ internal sealed class BrowserLogsCdpProtocolValueJsonConverter : JsonConverter<B
 
 [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(BrowserLogsAttachToTargetResponseEnvelope))]
+[JsonSerializable(typeof(BrowserLogsCaptureScreenshotResponseEnvelope))]
 [JsonSerializable(typeof(BrowserLogsCommandAckResponseEnvelope))]
 [JsonSerializable(typeof(BrowserLogsConsoleApiCalledEnvelope))]
 [JsonSerializable(typeof(BrowserLogsCreateTargetResponseEnvelope))]

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsRunningSession.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsRunningSession.cs
@@ -25,6 +25,8 @@ internal interface IBrowserLogsRunningSession
 
     Task StartCompletionObserver(Func<int?, Exception?, Task> onCompleted);
 
+    Task<byte[]> CaptureScreenshotAsync(CancellationToken cancellationToken);
+
     Task StopAsync(CancellationToken cancellationToken);
 }
 
@@ -171,6 +173,21 @@ internal sealed class BrowserLogsRunningSession : IBrowserLogsRunningSession
         return ObserveCompletionAsync(onCompleted);
     }
 
+    public async Task<byte[]> CaptureScreenshotAsync(CancellationToken cancellationToken)
+    {
+        var pageSession = _pageSession ?? throw new InvalidOperationException("Browser page session is not available.");
+        var result = await pageSession.CaptureScreenshotAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            return Convert.FromBase64String(result.Data!);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException("Tracked browser screenshot capture returned invalid image data.", ex);
+        }
+    }
+
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         _stopCts.Cancel();
@@ -304,9 +321,8 @@ internal sealed class BrowserLogsRunningSession : IBrowserLogsRunningSession
         }
         finally
         {
-            // Always dispose the stop CTS even if lease release threw. BrowserHostLease.DisposeAsync can propagate
-            // OperationCanceledException from its release timeout; without try/finally we leak the CTS and any
-            // registrations on it.
+            // Always dispose the stop CTS even if page or lease cleanup fails; otherwise the CTS and any registrations
+            // on it leak until process exit.
             _stopCts.Dispose();
         }
     }

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsSessionManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsSessionManager.cs
@@ -22,7 +22,7 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
     private readonly ResourceNotificationService _resourceNotificationService;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<BrowserLogsSessionManager> _logger;
-    private readonly IResourceCommandArtifactWriter _artifactWriter;
+    private readonly IBrowserLogsArtifactWriter _artifactWriter;
     private readonly IBrowserLogsRunningSessionFactory _sessionFactory;
     private readonly ConcurrentDictionary<string, ResourceSessionState> _resourceStates = new(StringComparer.Ordinal);
     private int _disposing;
@@ -37,7 +37,7 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
             resourceNotificationService,
             timeProvider,
             logger,
-            new ResourceCommandArtifactWriter(timeProvider),
+            new BrowserLogsArtifactWriter(timeProvider),
             new BrowserLogsRunningSessionFactory(logger, timeProvider))
     {
     }
@@ -47,14 +47,14 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
         ResourceNotificationService resourceNotificationService,
         TimeProvider timeProvider,
         ILogger<BrowserLogsSessionManager> logger,
-        IResourceCommandArtifactWriter? artifactWriter,
+        IBrowserLogsArtifactWriter? artifactWriter,
         IBrowserLogsRunningSessionFactory sessionFactory)
     {
         _resourceLoggerService = resourceLoggerService;
         _resourceNotificationService = resourceNotificationService;
         _timeProvider = timeProvider;
         _logger = logger;
-        _artifactWriter = artifactWriter ?? new ResourceCommandArtifactWriter(timeProvider);
+        _artifactWriter = artifactWriter ?? new BrowserLogsArtifactWriter(timeProvider);
         _sessionFactory = sessionFactory;
     }
 

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsSessionManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsSessionManager.cs
@@ -220,13 +220,27 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
             content: screenshotBytes,
             cancellationToken).ConfigureAwait(false);
 
+        var processDescription = FormatProcessId(activeSession.ProcessId);
         _resourceLoggerService.GetLogger(resourceName).LogInformation(
-            "[{SessionId}] Captured browser screenshot artifact '{ArtifactPath}' ({SizeBytes} bytes).",
+            "[{SessionId}] Captured browser screenshot artifact '{ArtifactPath}' ({SizeBytes} bytes) from target '{TargetId}' at '{TargetUrl}' using '{Browser}' ({BrowserHostOwnership}, {ProcessDescription}).",
             activeSession.SessionId,
             artifact.FilePath,
-            artifact.SizeBytes);
+            artifact.SizeBytes,
+            activeSession.TargetId,
+            activeSession.TargetUrl,
+            activeSession.Browser,
+            activeSession.BrowserHostOwnership,
+            processDescription);
 
-        return new BrowserLogsScreenshotCaptureResult(activeSession.SessionId, activeSession.TargetUrl, artifact);
+        return new BrowserLogsScreenshotCaptureResult(
+            activeSession.SessionId,
+            activeSession.Browser,
+            activeSession.BrowserExecutable,
+            activeSession.BrowserHostOwnership,
+            activeSession.ProcessId,
+            activeSession.TargetId,
+            activeSession.TargetUrl,
+            artifact);
 
         void ThrowIfDisposing()
         {

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsSessionManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsSessionManager.cs
@@ -198,7 +198,9 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
             activeSession = resourceState.LastSessionId is { } lastSessionId &&
                 resourceState.ActiveSessions.TryGetValue(lastSessionId, out var lastSession)
                     ? lastSession
-                    : resourceState.ActiveSessions.Values.MaxBy(static session => session.StartedAt);
+                    : resourceState.ActiveSessions.Count == 0
+                        ? null
+                        : resourceState.ActiveSessions.Values.MaxBy(static session => session.StartedAt);
 
             if (activeSession is null)
             {

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsSessionManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsSessionManager.cs
@@ -22,6 +22,7 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
     private readonly ResourceNotificationService _resourceNotificationService;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<BrowserLogsSessionManager> _logger;
+    private readonly IResourceCommandArtifactWriter _artifactWriter;
     private readonly IBrowserLogsRunningSessionFactory _sessionFactory;
     private readonly ConcurrentDictionary<string, ResourceSessionState> _resourceStates = new(StringComparer.Ordinal);
     private int _disposing;
@@ -36,6 +37,7 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
             resourceNotificationService,
             timeProvider,
             logger,
+            new ResourceCommandArtifactWriter(timeProvider),
             new BrowserLogsRunningSessionFactory(logger, timeProvider))
     {
     }
@@ -45,12 +47,14 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
         ResourceNotificationService resourceNotificationService,
         TimeProvider timeProvider,
         ILogger<BrowserLogsSessionManager> logger,
+        IResourceCommandArtifactWriter? artifactWriter,
         IBrowserLogsRunningSessionFactory sessionFactory)
     {
         _resourceLoggerService = resourceLoggerService;
         _resourceNotificationService = resourceNotificationService;
         _timeProvider = timeProvider;
         _logger = logger;
+        _artifactWriter = artifactWriter ?? new ResourceCommandArtifactWriter(timeProvider);
         _sessionFactory = sessionFactory;
     }
 
@@ -144,6 +148,7 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
             // inspect the exact target that is producing resource logs.
             resourceState.ActiveSessions[session.SessionId] = new ActiveBrowserSession(
                 session.SessionId,
+                configuration.AppHostKey,
                 configuration.Browser,
                 session.BrowserExecutable,
                 configuration.Profile,
@@ -170,6 +175,58 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
         {
             resourceState.Lock.Release();
         }
+
+        void ThrowIfDisposing()
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposing) != 0, this);
+        }
+    }
+
+    public async Task<BrowserLogsScreenshotCaptureResult> CaptureScreenshotAsync(string resourceName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+        ThrowIfDisposing();
+
+        var resourceState = _resourceStates.GetOrAdd(resourceName, static _ => new ResourceSessionState());
+        ActiveBrowserSession? activeSession;
+
+        await resourceState.Lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfDisposing();
+
+            activeSession = resourceState.LastSessionId is { } lastSessionId &&
+                resourceState.ActiveSessions.TryGetValue(lastSessionId, out var lastSession)
+                    ? lastSession
+                    : resourceState.ActiveSessions.Values.MaxBy(static session => session.StartedAt);
+
+            if (activeSession is null)
+            {
+                throw new InvalidOperationException("No active tracked browser session is available to capture.");
+            }
+        }
+        finally
+        {
+            resourceState.Lock.Release();
+        }
+
+        var screenshotBytes = await activeSession.Session.CaptureScreenshotAsync(cancellationToken).ConfigureAwait(false);
+        var artifact = await _artifactWriter.WriteArtifactAsync(
+            activeSession.AppHostKey,
+            resourceName,
+            artifactType: "screenshot",
+            fileExtension: ".png",
+            mimeType: "image/png",
+            content: screenshotBytes,
+            cancellationToken).ConfigureAwait(false);
+
+        _resourceLoggerService.GetLogger(resourceName).LogInformation(
+            "[{SessionId}] Captured browser screenshot artifact '{ArtifactPath}' ({SizeBytes} bytes).",
+            activeSession.SessionId,
+            artifact.FilePath,
+            artifact.SizeBytes);
+
+        return new BrowserLogsScreenshotCaptureResult(activeSession.SessionId, activeSession.TargetUrl, artifact);
 
         void ThrowIfDisposing()
         {
@@ -519,6 +576,7 @@ internal sealed class BrowserLogsSessionManager : IBrowserLogsSessionManager, IA
 
     private sealed record ActiveBrowserSession(
         string SessionId,
+        string? AppHostKey,
         string Browser,
         string BrowserExecutable,
         string? Profile,

--- a/src/Aspire.Hosting/BrowserLogs/BrowserPageSession.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserPageSession.cs
@@ -30,6 +30,10 @@ internal sealed class BrowserPageSession : IBrowserPageSession
     private readonly BrowserLogsCdpConnectionFactory _connectionFactory;
     private readonly Func<BrowserLogsCdpProtocolEvent, ValueTask> _eventHandler;
     private readonly IBrowserHost _host;
+    // Serializes every operation that replaces, disposes, or sends a command through the current CDP connection.
+    // Without this, screenshot capture can read a live connection reference while reconnect/dispose tears down that
+    // same websocket underneath it.
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
     private readonly ILogger<BrowserLogsSessionManager> _logger;
     private readonly bool _reuseInitialBlankTarget;
     private readonly string _sessionId;
@@ -70,6 +74,28 @@ internal sealed class BrowserPageSession : IBrowserPageSession
     public string TargetSessionId => _targetSessionId ?? throw new InvalidOperationException("Browser target session id is not available before the target session starts.");
 
     public Task<BrowserPageSessionResult> Completion => _monitorTask ?? throw new InvalidOperationException("Browser page session has not started.");
+
+    public async Task<BrowserLogsCaptureScreenshotResult> CaptureScreenshotAsync(CancellationToken cancellationToken)
+    {
+        await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+            var connection = _connection ?? throw new InvalidOperationException("Tracked browser debug connection is not available.");
+            var targetSessionId = _targetSessionId ?? throw new InvalidOperationException("Browser target session id is not available before the target session starts.");
+
+            // Keep the lock for the whole CDP command. Capturing only the fields under the lock is not enough because
+            // BrowserPageSession.DisposeAsync and reconnect both dispose the connection object itself.
+            using var captureCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _stopCts.Token);
+            return await connection.CaptureScreenshotAsync(targetSessionId, captureCts.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
 
     internal static BrowserPageSessionResult? TryGetPageCompletion(BrowserLogsCdpProtocolEvent protocolEvent, string? targetId, string? targetSessionId)
     {
@@ -159,18 +185,29 @@ internal sealed class BrowserPageSession : IBrowserPageSession
 
         _stopCts.Cancel();
 
-        var connection = _connection;
-        if (connection is not null && ReferenceEquals(connection, _connection) && _targetId is not null)
+        // Cancel first so any in-flight screenshot command holding _connectionLock is interrupted before disposal waits
+        // for the lock. Once the lock is acquired, no new capture/reconnect can use the connection while the target is
+        // being closed and the websocket is being disposed.
+        await _connectionLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
         {
-            try
+            var connection = _connection;
+            if (connection is not null && ReferenceEquals(connection, _connection) && _targetId is not null)
             {
-                using var closeTargetCts = new CancellationTokenSource(s_closeTargetTimeout);
-                await connection.CloseTargetAsync(_targetId, closeTargetCts.Token).ConfigureAwait(false);
+                try
+                {
+                    using var closeTargetCts = new CancellationTokenSource(s_closeTargetTimeout);
+                    await connection.CloseTargetAsync(_targetId, closeTargetCts.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Failed to close tracked browser target '{TargetId}' for session '{SessionId}'.", _targetId, _sessionId);
+                }
             }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to close tracked browser target '{TargetId}' for session '{SessionId}'.", _targetId, _sessionId);
-            }
+        }
+        finally
+        {
+            _connectionLock.Release();
         }
 
         _completionSource.TrySetResult(new BrowserPageSessionResult(BrowserPageSessionCompletionKind.Stopped, Error: null));
@@ -189,41 +226,53 @@ internal sealed class BrowserPageSession : IBrowserPageSession
         }
 
         _stopCts.Dispose();
+        _connectionLock.Dispose();
     }
 
     private async Task ConnectAsync(bool createTarget, CancellationToken cancellationToken)
     {
-        await DisposeConnectionAsync().ConfigureAwait(false);
+        // ConnectAsync is used for startup and reconnect. It swaps the current websocket, target attachment, and target
+        // session id as one critical section so command callers never observe a half-attached page session.
+        await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        _connection = await _connectionFactory(_host.DebugEndpoint, HandleEventAsync, _logger, cancellationToken).ConfigureAwait(false);
-        // Target discovery must be re-enabled for every browser-level connection, including reconnects. The
-        // subscription is attached to this websocket, not to the browser process, and it is what makes Chromium emit
-        // targetDestroyed/targetCrashed/detachedFromTarget events that tell us whether the tracked tab is gone.
-        await _connection.EnableTargetDiscoveryAsync(cancellationToken).ConfigureAwait(false);
-
-        if (createTarget)
+        try
         {
-            _targetId = await CreateTargetAsync(cancellationToken).ConfigureAwait(false);
+            await DisposeConnectionCoreAsync().ConfigureAwait(false);
+
+            _connection = await _connectionFactory(_host.DebugEndpoint, HandleEventAsync, _logger, cancellationToken).ConfigureAwait(false);
+            // Target discovery must be re-enabled for every browser-level connection, including reconnects. The
+            // subscription is attached to this websocket, not to the browser process, and it is what makes Chromium emit
+            // targetDestroyed/targetCrashed/detachedFromTarget events that tell us whether the tracked tab is gone.
+            await _connection.EnableTargetDiscoveryAsync(cancellationToken).ConfigureAwait(false);
+
+            if (createTarget)
+            {
+                _targetId = await CreateTargetAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (_targetId is null)
+            {
+                throw new InvalidOperationException("Tracked browser target id is not available.");
+            }
+
+            // Reconnects reuse the existing target id. A transient websocket drop does not necessarily close the browser
+            // tab, so recovering should reattach to the same page instead of opening a duplicate tab in the user's browser.
+            var attachToTargetResult = await _connection.AttachToTargetAsync(_targetId, cancellationToken).ConfigureAwait(false);
+            _targetSessionId = attachToTargetResult.SessionId
+                ?? throw new InvalidOperationException("Browser target attachment did not return a session id.");
+
+            // Runtime/Log/Page/Network subscriptions are scoped to the attached target session. They have to be re-enabled
+            // after every attach, including reconnects, or the page keeps running with no events flowing back to resource logs.
+            await _connection.EnablePageInstrumentationAsync(_targetSessionId, cancellationToken).ConfigureAwait(false);
+
+            if (createTarget)
+            {
+                await _connection.NavigateAsync(_targetSessionId, _url, cancellationToken).ConfigureAwait(false);
+            }
         }
-
-        if (_targetId is null)
+        finally
         {
-            throw new InvalidOperationException("Tracked browser target id is not available.");
-        }
-
-        // Reconnects reuse the existing target id. A transient websocket drop does not necessarily close the browser
-        // tab, so recovering should reattach to the same page instead of opening a duplicate tab in the user's browser.
-        var attachToTargetResult = await _connection.AttachToTargetAsync(_targetId, cancellationToken).ConfigureAwait(false);
-        _targetSessionId = attachToTargetResult.SessionId
-            ?? throw new InvalidOperationException("Browser target attachment did not return a session id.");
-
-        // Runtime/Log/Page/Network subscriptions are scoped to the attached target session. They have to be re-enabled
-        // after every attach, including reconnects, or the page keeps running with no events flowing back to resource logs.
-        await _connection.EnablePageInstrumentationAsync(_targetSessionId, cancellationToken).ConfigureAwait(false);
-
-        if (createTarget)
-        {
-            await _connection.NavigateAsync(_targetSessionId, _url, cancellationToken).ConfigureAwait(false);
+            _connectionLock.Release();
         }
     }
 
@@ -280,8 +329,10 @@ internal sealed class BrowserPageSession : IBrowserPageSession
         {
             while (true)
             {
-                var connection = _connection ?? throw new InvalidOperationException("Tracked browser debug connection is not available.");
-                var completedTask = await Task.WhenAny(_host.Termination, connection.Completion, _completionSource.Task).ConfigureAwait(false);
+                // Don't hold _connectionLock while awaiting the connection completion task: reconnect and disposal need
+                // the same lock. Instead snapshot the stable completion task under the lock, then await the snapshot.
+                var connectionSnapshot = await GetConnectionSnapshotAsync().ConfigureAwait(false);
+                var completedTask = await Task.WhenAny(_host.Termination, connectionSnapshot.Completion, _completionSource.Task).ConfigureAwait(false);
 
                 if (completedTask == _completionSource.Task)
                 {
@@ -298,7 +349,7 @@ internal sealed class BrowserPageSession : IBrowserPageSession
                 Exception? connectionError = null;
                 try
                 {
-                    await connection.Completion.ConfigureAwait(false);
+                    await connectionSnapshot.Completion.ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -400,7 +451,34 @@ internal sealed class BrowserPageSession : IBrowserPageSession
         }
     }
 
+    private async Task<ConnectionSnapshot> GetConnectionSnapshotAsync()
+    {
+        await _connectionLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            var connection = _connection ?? throw new InvalidOperationException("Tracked browser debug connection is not available.");
+            return new ConnectionSnapshot(connection.Completion);
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
     private async Task DisposeConnectionAsync()
+    {
+        await _connectionLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            await DisposeConnectionCoreAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    private async Task DisposeConnectionCoreAsync()
     {
         var connection = _connection;
         _connection = null;
@@ -410,4 +488,6 @@ internal sealed class BrowserPageSession : IBrowserPageSession
             await connection.DisposeAsync().ConfigureAwait(false);
         }
     }
+
+    private sealed record ConnectionSnapshot(Task Completion);
 }

--- a/src/Aspire.Hosting/BrowserLogs/IBrowserHost.cs
+++ b/src/Aspire.Hosting/BrowserLogs/IBrowserHost.cs
@@ -48,6 +48,8 @@ internal interface IBrowserPageSession : IAsyncDisposable
     // Completes when this page target is no longer available: the tab was closed/crashed, CDP reported a detach,
     // or the host terminated. Host-level reconnects should reattach and preserve this session when possible.
     Task<BrowserPageSessionResult> Completion { get; }
+
+    Task<BrowserLogsCaptureScreenshotResult> CaptureScreenshotAsync(CancellationToken cancellationToken);
 }
 
 // Normalized page-session completion signal consumed by BrowserLogsRunningSession so manager state is independent of

--- a/src/Aspire.Hosting/BrowserLogs/IBrowserLogsSessionManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/IBrowserLogsSessionManager.cs
@@ -12,5 +12,10 @@ internal interface IBrowserLogsSessionManager
 
 internal sealed record BrowserLogsScreenshotCaptureResult(
     string SessionId,
+    string Browser,
+    string BrowserExecutable,
+    string BrowserHostOwnership,
+    int? ProcessId,
+    string TargetId,
     Uri TargetUrl,
     ApplicationModel.ResourceCommandArtifact Artifact);

--- a/src/Aspire.Hosting/BrowserLogs/IBrowserLogsSessionManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/IBrowserLogsSessionManager.cs
@@ -18,4 +18,4 @@ internal sealed record BrowserLogsScreenshotCaptureResult(
     int? ProcessId,
     string TargetId,
     Uri TargetUrl,
-    ApplicationModel.ResourceCommandArtifact Artifact);
+    BrowserLogsArtifact Artifact);

--- a/src/Aspire.Hosting/BrowserLogs/IBrowserLogsSessionManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/IBrowserLogsSessionManager.cs
@@ -6,4 +6,11 @@ namespace Aspire.Hosting;
 internal interface IBrowserLogsSessionManager
 {
     Task StartSessionAsync(BrowserLogsResource resource, BrowserConfiguration configuration, string resourceName, Uri url, CancellationToken cancellationToken);
+
+    Task<BrowserLogsScreenshotCaptureResult> CaptureScreenshotAsync(string resourceName, CancellationToken cancellationToken);
 }
+
+internal sealed record BrowserLogsScreenshotCaptureResult(
+    string SessionId,
+    Uri TargetUrl,
+    ApplicationModel.ResourceCommandArtifact Artifact);

--- a/src/Aspire.Hosting/Resources/CommandStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/CommandStrings.Designer.cs
@@ -124,6 +124,24 @@ namespace Aspire.Hosting.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Capture a screenshot from the active tracked browser session and save it as a PNG artifact..
+        /// </summary>
+        internal static string CaptureScreenshotDescription {
+            get {
+                return ResourceManager.GetString("CaptureScreenshotDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Capture screenshot.
+        /// </summary>
+        internal static string CaptureScreenshotName {
+            get {
+                return ResourceManager.GetString("CaptureScreenshotName", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Stop the resource, rebuild the project from source, and restart. Use this to apply source code changes..
         /// </summary>
         internal static string RebuildDescription {

--- a/src/Aspire.Hosting/Resources/CommandStrings.resx
+++ b/src/Aspire.Hosting/Resources/CommandStrings.resx
@@ -156,6 +156,12 @@
   <data name="OpenTrackedBrowserName" xml:space="preserve">
     <value>Open tracked browser</value>
   </data>
+  <data name="CaptureScreenshotDescription" xml:space="preserve">
+    <value>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</value>
+  </data>
+  <data name="CaptureScreenshotName" xml:space="preserve">
+    <value>Capture screenshot</value>
+  </data>
   <data name="RebuildDescription" xml:space="preserve">
     <value>Stop the resource, rebuild the project from source, and restart. Use this to apply source code changes.</value>
   </data>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Odstranit hodnotu parametru</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Parameterwert löschen</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Eliminar valor de parámetro</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Supprimer la valeur du paramètre</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Elimina valore parametro</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">パラメーター値の削除</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">매개 변수 값 삭제</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Usuń wartość parametru</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Excluir valor do parâmetro</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Удалить значение параметра</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Parametre değerini sil</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">删除参数值</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="CaptureScreenshotDescription">
+        <source>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</source>
+        <target state="new">Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CaptureScreenshotName">
+        <source>Capture screenshot</source>
+        <target state="new">Capture screenshot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">刪除參數值</target>

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -663,7 +663,7 @@ func NewCSharpAppResource(handle *Handle, client *AspireClient) *CSharpAppResour
 	}
 }
 
-// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
 func (s *CSharpAppResource) WithBrowserLogs(browser *string, profile *string, userDataMode *BrowserUserDataMode) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
@@ -4007,7 +4007,7 @@ func NewContainerResource(handle *Handle, client *AspireClient) *ContainerResour
 	}
 }
 
-// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
 func (s *ContainerResource) WithBrowserLogs(browser *string, profile *string, userDataMode *BrowserUserDataMode) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
@@ -6243,7 +6243,7 @@ func NewDotnetToolResource(handle *Handle, client *AspireClient) *DotnetToolReso
 	}
 }
 
-// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
 func (s *DotnetToolResource) WithBrowserLogs(browser *string, profile *string, userDataMode *BrowserUserDataMode) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
@@ -8505,7 +8505,7 @@ func NewExecutableResource(handle *Handle, client *AspireClient) *ExecutableReso
 	}
 }
 
-// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
 func (s *ExecutableResource) WithBrowserLogs(browser *string, profile *string, userDataMode *BrowserUserDataMode) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
@@ -13730,7 +13730,7 @@ func NewProjectResource(handle *Handle, client *AspireClient) *ProjectResource {
 	}
 }
 
-// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
 func (s *ProjectResource) WithBrowserLogs(browser *string, profile *string, userDataMode *BrowserUserDataMode) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
@@ -15805,7 +15805,7 @@ func NewTestDatabaseResource(handle *Handle, client *AspireClient) *TestDatabase
 	}
 }
 
-// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
 func (s *TestDatabaseResource) WithBrowserLogs(browser *string, profile *string, userDataMode *BrowserUserDataMode) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
@@ -17617,7 +17617,7 @@ func NewTestRedisResource(handle *Handle, client *AspireClient) *TestRedisResour
 	}
 }
 
-// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
 func (s *TestRedisResource) WithBrowserLogs(browser *string, profile *string, userDataMode *BrowserUserDataMode) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
@@ -19654,7 +19654,7 @@ func NewTestVaultResource(handle *Handle, client *AspireClient) *TestVaultResour
 	}
 }
 
-// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+// WithBrowserLogs adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
 func (s *TestVaultResource) WithBrowserLogs(browser *string, profile *string, userDataMode *BrowserUserDataMode) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1455,7 +1455,7 @@ public class CSharpAppResource extends ResourceBuilderBase {
         super(handle, client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     public CSharpAppResource withBrowserLogs(WithBrowserLogsOptions options) {
         var browser = options == null ? null : options.getBrowser();
         var profile = options == null ? null : options.getProfile();
@@ -1467,7 +1467,7 @@ public class CSharpAppResource extends ResourceBuilderBase {
         return withBrowserLogs(null);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     private CSharpAppResource withBrowserLogsImpl(String browser, String profile, BrowserUserDataMode userDataMode) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -5206,7 +5206,7 @@ public class ContainerResource extends ResourceBuilderBase {
         super(handle, client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     public ContainerResource withBrowserLogs(WithBrowserLogsOptions options) {
         var browser = options == null ? null : options.getBrowser();
         var profile = options == null ? null : options.getProfile();
@@ -5218,7 +5218,7 @@ public class ContainerResource extends ResourceBuilderBase {
         return withBrowserLogs(null);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     private ContainerResource withBrowserLogsImpl(String browser, String profile, BrowserUserDataMode userDataMode) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -7542,7 +7542,7 @@ public class DotnetToolResource extends ResourceBuilderBase {
         super(handle, client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     public DotnetToolResource withBrowserLogs(WithBrowserLogsOptions options) {
         var browser = options == null ? null : options.getBrowser();
         var profile = options == null ? null : options.getProfile();
@@ -7554,7 +7554,7 @@ public class DotnetToolResource extends ResourceBuilderBase {
         return withBrowserLogs(null);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     private DotnetToolResource withBrowserLogsImpl(String browser, String profile, BrowserUserDataMode userDataMode) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -9657,7 +9657,7 @@ public class ExecutableResource extends ResourceBuilderBase {
         super(handle, client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     public ExecutableResource withBrowserLogs(WithBrowserLogsOptions options) {
         var browser = options == null ? null : options.getBrowser();
         var profile = options == null ? null : options.getProfile();
@@ -9669,7 +9669,7 @@ public class ExecutableResource extends ResourceBuilderBase {
         return withBrowserLogs(null);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     private ExecutableResource withBrowserLogsImpl(String browser, String profile, BrowserUserDataMode userDataMode) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -15170,7 +15170,7 @@ public class ProjectResource extends ResourceBuilderBase {
         super(handle, client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     public ProjectResource withBrowserLogs(WithBrowserLogsOptions options) {
         var browser = options == null ? null : options.getBrowser();
         var profile = options == null ? null : options.getProfile();
@@ -15182,7 +15182,7 @@ public class ProjectResource extends ResourceBuilderBase {
         return withBrowserLogs(null);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     private ProjectResource withBrowserLogsImpl(String browser, String profile, BrowserUserDataMode userDataMode) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -17606,7 +17606,7 @@ public class TestDatabaseResource extends ResourceBuilderBase {
         super(handle, client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     public TestDatabaseResource withBrowserLogs(WithBrowserLogsOptions options) {
         var browser = options == null ? null : options.getBrowser();
         var profile = options == null ? null : options.getProfile();
@@ -17618,7 +17618,7 @@ public class TestDatabaseResource extends ResourceBuilderBase {
         return withBrowserLogs(null);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     private TestDatabaseResource withBrowserLogsImpl(String browser, String profile, BrowserUserDataMode userDataMode) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -19529,7 +19529,7 @@ public class TestRedisResource extends ResourceBuilderBase {
         super(handle, client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     public TestRedisResource withBrowserLogs(WithBrowserLogsOptions options) {
         var browser = options == null ? null : options.getBrowser();
         var profile = options == null ? null : options.getProfile();
@@ -19541,7 +19541,7 @@ public class TestRedisResource extends ResourceBuilderBase {
         return withBrowserLogs(null);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     private TestRedisResource withBrowserLogsImpl(String browser, String profile, BrowserUserDataMode userDataMode) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -21605,7 +21605,7 @@ public class TestVaultResource extends ResourceBuilderBase {
         super(handle, client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     public TestVaultResource withBrowserLogs(WithBrowserLogsOptions options) {
         var browser = options == null ? null : options.getBrowser();
         var profile = options == null ? null : options.getProfile();
@@ -21617,7 +21617,7 @@ public class TestVaultResource extends ResourceBuilderBase {
         return withBrowserLogs(null);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     private TestVaultResource withBrowserLogsImpl(String browser, String profile, BrowserUserDataMode userDataMode) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -5839,7 +5839,7 @@ class AbstractResourceWithEndpoints(AbstractResource):
 
     @abc.abstractmethod
     def with_browser_logs(self, *, browser: str | None = None, profile: str | None = None, user_data_mode: BrowserUserDataMode | None = None) -> typing.Self:
-        """Adds a child browser logs resource that opens tracked browser sessions and captures browser logs."""
+        """Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots."""
 
     @abc.abstractmethod
     def with_mcp_server(self, *, path: str = "/mcp", endpoint_name: str | None = None) -> typing.Self:
@@ -7227,7 +7227,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         return "ContainerResource(handle={self._handle.handle_id})"
 
     def with_browser_logs(self, *, browser: str | None = None, profile: str | None = None, user_data_mode: BrowserUserDataMode | None = None) -> typing.Self:
-        """Adds a child browser logs resource that opens tracked browser sessions and captures browser logs."""
+        """Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         if browser is not None:
             rpc_args['browser'] = browser
@@ -8653,7 +8653,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         return "ProjectResource(handle={self._handle.handle_id})"
 
     def with_browser_logs(self, *, browser: str | None = None, profile: str | None = None, user_data_mode: BrowserUserDataMode | None = None) -> typing.Self:
-        """Adds a child browser logs resource that opens tracked browser sessions and captures browser logs."""
+        """Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         if browser is not None:
             rpc_args['browser'] = browser
@@ -9751,7 +9751,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         return "ExecutableResource(handle={self._handle.handle_id})"
 
     def with_browser_logs(self, *, browser: str | None = None, profile: str | None = None, user_data_mode: BrowserUserDataMode | None = None) -> typing.Self:
-        """Adds a child browser logs resource that opens tracked browser sessions and captures browser logs."""
+        """Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         if browser is not None:
             rpc_args['browser'] = browser

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -1089,7 +1089,7 @@ impl CSharpAppResource {
         &self.client
     }
 
-    /// Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+    /// Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
     pub fn with_browser_logs(&self, browser: Option<&str>, profile: Option<&str>, user_data_mode: Option<BrowserUserDataMode>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -3869,7 +3869,7 @@ impl ContainerResource {
         &self.client
     }
 
-    /// Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+    /// Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
     pub fn with_browser_logs(&self, browser: Option<&str>, profile: Option<&str>, user_data_mode: Option<BrowserUserDataMode>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -5798,7 +5798,7 @@ impl DotnetToolResource {
         &self.client
     }
 
-    /// Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+    /// Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
     pub fn with_browser_logs(&self, browser: Option<&str>, profile: Option<&str>, user_data_mode: Option<BrowserUserDataMode>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -7631,7 +7631,7 @@ impl ExecutableResource {
         &self.client
     }
 
-    /// Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+    /// Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
     pub fn with_browser_logs(&self, browser: Option<&str>, profile: Option<&str>, user_data_mode: Option<BrowserUserDataMode>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -12400,7 +12400,7 @@ impl ProjectResource {
         &self.client
     }
 
-    /// Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+    /// Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
     pub fn with_browser_logs(&self, browser: Option<&str>, profile: Option<&str>, user_data_mode: Option<BrowserUserDataMode>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -14208,7 +14208,7 @@ impl TestDatabaseResource {
         &self.client
     }
 
-    /// Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+    /// Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
     pub fn with_browser_logs(&self, browser: Option<&str>, profile: Option<&str>, user_data_mode: Option<BrowserUserDataMode>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -15669,7 +15669,7 @@ impl TestRedisResource {
         &self.client
     }
 
-    /// Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+    /// Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
     pub fn with_browser_logs(&self, browser: Option<&str>, profile: Option<&str>, user_data_mode: Option<BrowserUserDataMode>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -17303,7 +17303,7 @@ impl TestVaultResource {
         &self.client
     }
 
-    /// Adds a child browser logs resource that opens tracked browser sessions and captures browser logs.
+    /// Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots.
     pub fn with_browser_logs(&self, browser: Option<&str>, profile: Option<&str>, user_data_mode: Option<BrowserUserDataMode>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -10259,7 +10259,7 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
         return new ContainerResourceImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): ContainerResourcePromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -12197,7 +12197,7 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }
@@ -12989,7 +12989,7 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
         return new CSharpAppResourceImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): CSharpAppResourcePromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -14668,7 +14668,7 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }
@@ -15392,7 +15392,7 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
         return new DotnetToolResourceImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): DotnetToolResourcePromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -17158,7 +17158,7 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }
@@ -17900,7 +17900,7 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
         return new ExecutableResourceImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): ExecutableResourcePromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -19576,7 +19576,7 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }
@@ -22622,7 +22622,7 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
         return new ProjectResourceImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): ProjectResourcePromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -24301,7 +24301,7 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }
@@ -25045,7 +25045,7 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
         return new TestDatabaseResourceImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): TestDatabaseResourcePromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -26983,7 +26983,7 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }
@@ -27839,7 +27839,7 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
         return new TestRedisResourceImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): TestRedisResourcePromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -30005,7 +30005,7 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }
@@ -30911,7 +30911,7 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
         return new TestVaultResourceImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): TestVaultResourcePromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -32864,7 +32864,7 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }
@@ -35168,7 +35168,7 @@ class ResourceWithEndpointsImpl extends ResourceBuilderBase<IResourceWithEndpoin
         return new ResourceWithEndpointsImpl(result, this._client);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): ResourceWithEndpointsPromise {
         const browser = options?.browser;
         const profile = options?.profile;
@@ -35510,7 +35510,7 @@ class ResourceWithEndpointsPromiseImpl implements ResourceWithEndpointsPromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Adds a child browser logs resource that opens tracked browser sessions and captures browser logs. */
+    /** Adds a child browser logs resource that opens tracked browser sessions, captures browser logs, and captures screenshots. */
     withBrowserLogs(options?: WithBrowserLogsOptions): ResourceWithEndpointsPromise {
         return new ResourceWithEndpointsPromiseImpl(this._promise.then(obj => obj.withBrowserLogs(options)), this._client);
     }

--- a/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -53,6 +53,9 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         var command = Assert.Single(browserLogsResource.Annotations.OfType<ResourceCommandAnnotation>(), annotation => annotation.Name == BrowserLogsBuilderExtensions.OpenTrackedBrowserCommandName);
         Assert.Equal(CommandStrings.OpenTrackedBrowserName, command.DisplayName);
         Assert.Equal(CommandStrings.OpenTrackedBrowserDescription, command.DisplayDescription);
+        var screenshotCommand = Assert.Single(browserLogsResource.Annotations.OfType<ResourceCommandAnnotation>(), annotation => annotation.Name == BrowserLogsBuilderExtensions.CaptureScreenshotCommandName);
+        Assert.Equal(CommandStrings.CaptureScreenshotName, screenshotCommand.DisplayName);
+        Assert.Equal(CommandStrings.CaptureScreenshotDescription, screenshotCommand.DisplayDescription);
 
         var snapshot = browserLogsResource.Annotations.OfType<ResourceSnapshotAnnotation>().Single().InitialSnapshot;
         Assert.Equal(BrowserLogsBuilderExtensions.BrowserResourceType, snapshot.ResourceType);
@@ -327,6 +330,124 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public async Task WithBrowserLogs_CaptureScreenshotCommandReturnsArtifactResult()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var sessionManager = new FakeBrowserLogsSessionManager
+        {
+            ScreenshotResult = new BrowserLogsScreenshotCaptureResult(
+                "session-0002",
+                new Uri("https://localhost:8443/"),
+                new ResourceCommandArtifact(
+                    "web-browser-logs",
+                    "screenshot",
+                    Path.Combine(AppContext.BaseDirectory, "artifacts", "screenshot.png"),
+                    "image/png",
+                    1234,
+                    new DateTimeOffset(2026, 4, 27, 12, 0, 0, TimeSpan.Zero)))
+        };
+        builder.Services.AddSingleton<IBrowserLogsSessionManager>(sessionManager);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs(browser: "chrome");
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+        var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.CaptureScreenshotCommandName).DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal("web-browser-logs", Assert.Single(sessionManager.CaptureScreenshotCalls));
+        Assert.Contains("screenshot.png", result.Message);
+        Assert.NotNull(result.Data);
+        Assert.Equal(CommandResultFormat.Json, result.Data.Format);
+        Assert.True(result.Data.DisplayImmediately);
+
+        using var document = JsonDocument.Parse(result.Data.Value);
+        Assert.Equal("web-browser-logs", document.RootElement.GetProperty("resourceName").GetString());
+        Assert.Equal("session-0002", document.RootElement.GetProperty("sessionId").GetString());
+        Assert.Equal("https://localhost:8443/", document.RootElement.GetProperty("targetUrl").GetString());
+        Assert.EndsWith("screenshot.png", document.RootElement.GetProperty("path").GetString(), StringComparison.Ordinal);
+        Assert.Equal("image/png", document.RootElement.GetProperty("mimeType").GetString());
+        Assert.Equal(1234, document.RootElement.GetProperty("sizeBytes").GetInt32());
+    }
+
+    [Fact]
+    public async Task WithBrowserLogs_CaptureScreenshotCommandWritesPngArtifact()
+    {
+        var artifactDirectory = Directory.CreateTempSubdirectory();
+        try
+        {
+            using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+            var sessionFactory = new FakeBrowserLogsRunningSessionFactory();
+
+            builder.Services.AddSingleton<IBrowserLogsSessionManager>(sp =>
+                new BrowserLogsSessionManager(
+                    sp.GetRequiredService<ResourceLoggerService>(),
+                    sp.GetRequiredService<ResourceNotificationService>(),
+                    sp.GetRequiredService<TimeProvider>(),
+                    sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
+                    new ResourceCommandArtifactWriter(sp.GetRequiredService<TimeProvider>(), () => artifactDirectory.FullName),
+                    sessionFactory));
+
+            var web = builder.AddResource(new TestHttpResource("web"))
+                .WithHttpEndpoint(targetPort: 8080)
+                .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+                .WithInitialState(new CustomResourceSnapshot
+                {
+                    ResourceType = "TestHttp",
+                    State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                    Properties = []
+                });
+
+            web.WithBrowserLogs(browser: "chrome");
+
+            using var app = builder.Build();
+            await app.StartAsync();
+
+            var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+            var openResult = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.OpenTrackedBrowserCommandName).DefaultTimeout();
+            Assert.True(openResult.Success);
+
+            var session = Assert.Single(sessionFactory.Sessions);
+            session.ScreenshotBytes = [1, 2, 3, 4];
+
+            var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.CaptureScreenshotCommandName).DefaultTimeout();
+            var logs = await ConsoleLoggingTestHelpers.WatchForLogsAsync(
+                app.Services.GetRequiredService<ResourceLoggerService>().WatchAsync(browserLogsResource.Name),
+                targetLogCount: 6).DefaultTimeout();
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+
+            using var document = JsonDocument.Parse(result.Data.Value);
+            var path = document.RootElement.GetProperty("path").GetString();
+
+            Assert.NotNull(path);
+            Assert.StartsWith(artifactDirectory.FullName, path, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(session.ScreenshotBytes, await File.ReadAllBytesAsync(path));
+            Assert.Equal("session-0001", document.RootElement.GetProperty("sessionId").GetString());
+            Assert.Equal("http://localhost:8080/", document.RootElement.GetProperty("targetUrl").GetString());
+            Assert.Equal(session.ScreenshotBytes.Length, document.RootElement.GetProperty("sizeBytes").GetInt32());
+            Assert.Contains(logs, log => log.Content.Contains(path, StringComparison.Ordinal) && log.Content.Contains("4 bytes", StringComparison.Ordinal));
+        }
+        finally
+        {
+            artifactDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task WithBrowserLogs_CommandUsesLatestConfiguredSettingsAndRefreshesProperties()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
@@ -342,7 +463,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -397,7 +519,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -481,7 +604,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -553,7 +677,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -608,7 +733,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -667,7 +793,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -786,7 +913,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -920,7 +1048,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -987,7 +1116,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 sp.GetRequiredService<ResourceNotificationService>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                sessionFactory));
+                artifactWriter: null,
+                sessionFactory: sessionFactory));
 
         var web = builder.AddResource(new TestHttpResource("web"))
             .WithHttpEndpoint(targetPort: 8080)
@@ -1162,10 +1292,29 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     {
         public List<SessionStartCall> Calls { get; } = [];
 
+        public List<string> CaptureScreenshotCalls { get; } = [];
+
+        public BrowserLogsScreenshotCaptureResult ScreenshotResult { get; set; } = new(
+            "session-0001",
+            new Uri("https://localhost:5001/"),
+            new ResourceCommandArtifact(
+                "web-browser-logs",
+                "screenshot",
+                Path.Combine(AppContext.BaseDirectory, "screenshot.png"),
+                "image/png",
+                0,
+                DateTimeOffset.UnixEpoch));
+
         public Task StartSessionAsync(BrowserLogsResource resource, BrowserConfiguration configuration, string resourceName, Uri url, CancellationToken cancellationToken)
         {
             Calls.Add(new SessionStartCall(resource, configuration, resourceName, url));
             return Task.CompletedTask;
+        }
+
+        public Task<BrowserLogsScreenshotCaptureResult> CaptureScreenshotAsync(string resourceName, CancellationToken cancellationToken)
+        {
+            CaptureScreenshotCalls.Add(resourceName);
+            return Task.FromResult(ScreenshotResult);
         }
     }
 
@@ -1243,6 +1392,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
 
         public int StopCallCount { get; private set; }
 
+        public byte[] ScreenshotBytes { get; set; } = [0x89, 0x50, 0x4e, 0x47];
+
         public Task CompletionObserverStarted => CompletionObserverStartedSource.Task;
 
         private TaskCompletionSource<object?> CompletionObserverStartedSource { get; set; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1258,6 +1409,11 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
             StopCallCount++;
             _completionSource.TrySetResult((0, null));
             return Task.CompletedTask;
+        }
+
+        public Task<byte[]> CaptureScreenshotAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(ScreenshotBytes);
         }
 
         public async Task CompleteAsync(int exitCode, Exception? error = null)

--- a/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -337,6 +337,11 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         {
             ScreenshotResult = new BrowserLogsScreenshotCaptureResult(
                 "session-0002",
+                "msedge",
+                @"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
+                BrowserHostOwnership.Adopted.ToString(),
+                4242,
+                "target-0002",
                 new Uri("https://localhost:8443/"),
                 new ResourceCommandArtifact(
                     "web-browser-logs",
@@ -376,6 +381,11 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         using var document = JsonDocument.Parse(result.Data.Value);
         Assert.Equal("web-browser-logs", document.RootElement.GetProperty("resourceName").GetString());
         Assert.Equal("session-0002", document.RootElement.GetProperty("sessionId").GetString());
+        Assert.Equal("msedge", document.RootElement.GetProperty("browser").GetString());
+        Assert.Equal(@"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe", document.RootElement.GetProperty("browserExecutable").GetString());
+        Assert.Equal("Adopted", document.RootElement.GetProperty("browserHostOwnership").GetString());
+        Assert.Equal(4242, document.RootElement.GetProperty("processId").GetInt32());
+        Assert.Equal("target-0002", document.RootElement.GetProperty("targetId").GetString());
         Assert.Equal("https://localhost:8443/", document.RootElement.GetProperty("targetUrl").GetString());
         Assert.EndsWith("screenshot.png", document.RootElement.GetProperty("path").GetString(), StringComparison.Ordinal);
         Assert.Equal("image/png", document.RootElement.GetProperty("mimeType").GetString());
@@ -437,9 +447,16 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
             Assert.StartsWith(artifactDirectory.FullName, path, StringComparison.OrdinalIgnoreCase);
             Assert.Equal(session.ScreenshotBytes, await File.ReadAllBytesAsync(path));
             Assert.Equal("session-0001", document.RootElement.GetProperty("sessionId").GetString());
+            Assert.Equal("chrome", document.RootElement.GetProperty("browser").GetString());
+            Assert.Equal("/fake/browser-1", document.RootElement.GetProperty("browserExecutable").GetString());
+            Assert.Equal("Owned", document.RootElement.GetProperty("browserHostOwnership").GetString());
+            Assert.Equal(1001, document.RootElement.GetProperty("processId").GetInt32());
+            Assert.Equal("target-1", document.RootElement.GetProperty("targetId").GetString());
             Assert.Equal("http://localhost:8080/", document.RootElement.GetProperty("targetUrl").GetString());
             Assert.Equal(session.ScreenshotBytes.Length, document.RootElement.GetProperty("sizeBytes").GetInt32());
-            Assert.Contains(logs, log => log.Content.Contains(path, StringComparison.Ordinal) && log.Content.Contains("4 bytes", StringComparison.Ordinal));
+            Assert.Contains(logs, log => log.Content.Contains(path, StringComparison.Ordinal) &&
+                log.Content.Contains("4 bytes", StringComparison.Ordinal) &&
+                log.Content.Contains("target-1", StringComparison.Ordinal));
         }
         finally
         {
@@ -1296,6 +1313,11 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
 
         public BrowserLogsScreenshotCaptureResult ScreenshotResult { get; set; } = new(
             "session-0001",
+            "chrome",
+            "/fake/browser",
+            BrowserHostOwnership.Owned.ToString(),
+            1001,
+            "target-1",
             new Uri("https://localhost:5001/"),
             new ResourceCommandArtifact(
                 "web-browser-logs",

--- a/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -393,6 +393,33 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public async Task WithBrowserLogs_CaptureScreenshotCommandReturnsClearFailureWhenNoSessionIsActive()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs(browser: "chrome");
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+        var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.CaptureScreenshotCommandName).DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Equal("No active tracked browser session is available to capture.", result.Message);
+    }
+
+    [Fact]
     public async Task WithBrowserLogs_CaptureScreenshotCommandWritesPngArtifact()
     {
         var artifactDirectory = Directory.CreateTempSubdirectory();

--- a/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -343,7 +343,7 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 4242,
                 "target-0002",
                 new Uri("https://localhost:8443/"),
-                new ResourceCommandArtifact(
+                new BrowserLogsArtifact(
                     "web-browser-logs",
                     "screenshot",
                     Path.Combine(AppContext.BaseDirectory, "artifacts", "screenshot.png"),
@@ -434,7 +434,7 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                     sp.GetRequiredService<ResourceNotificationService>(),
                     sp.GetRequiredService<TimeProvider>(),
                     sp.GetRequiredService<ILogger<BrowserLogsSessionManager>>(),
-                    new ResourceCommandArtifactWriter(sp.GetRequiredService<TimeProvider>(), () => artifactDirectory.FullName),
+                    new BrowserLogsArtifactWriter(sp.GetRequiredService<TimeProvider>(), () => artifactDirectory.FullName),
                     sessionFactory));
 
             var web = builder.AddResource(new TestHttpResource("web"))
@@ -1346,7 +1346,7 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
             1001,
             "target-1",
             new Uri("https://localhost:5001/"),
-            new ResourceCommandArtifact(
+            new BrowserLogsArtifact(
                 "web-browser-logs",
                 "screenshot",
                 Path.Combine(AppContext.BaseDirectory, "screenshot.png"),

--- a/tests/Aspire.Hosting.Tests/BrowserLogsCdpConnectionTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsCdpConnectionTests.cs
@@ -109,6 +109,43 @@ public class BrowserLogsCdpConnectionTests
         await pair.ServerSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Done", CancellationToken.None).DefaultTimeout();
     }
 
+    [Fact]
+    public async Task CaptureScreenshotAsync_SendsPageCaptureScreenshotForTargetSession()
+    {
+        await using var pair = InMemoryWebSocketPair.Create();
+        var connector = new ConnectedClientWebSocketConnector(pair.ClientSocket);
+        await using var connection = await BrowserLogsCdpConnection.ConnectAsync(
+            new Uri("ws://127.0.0.1/devtools/browser/test"),
+            static _ => ValueTask.CompletedTask,
+            NullLogger<BrowserLogsSessionManager>.Instance,
+            CancellationToken.None,
+            () => connector);
+
+        var captureTask = connection.CaptureScreenshotAsync("target-session-1", CancellationToken.None);
+
+        var command = await ReceiveCommandAsync(pair.ServerSocket).DefaultTimeout();
+        Assert.Equal(BrowserLogsCdpProtocol.PageCaptureScreenshotMethod, command.Method);
+        Assert.Equal("target-session-1", command.SessionId);
+        Assert.Equal("png", command.Format);
+        Assert.Equal(true, command.FromSurface);
+
+        await SendTextAsync(
+            pair.ServerSocket,
+            $$"""
+            {
+              "id": {{command.Id}},
+              "result": {
+                "data": "aW1hZ2UtZGF0YQ=="
+              }
+            }
+            """).DefaultTimeout();
+
+        var result = await captureTask.DefaultTimeout();
+        Assert.Equal("aW1hZ2UtZGF0YQ==", result.Data);
+
+        await pair.ServerSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Done", CancellationToken.None).DefaultTimeout();
+    }
+
     private static async Task<ReceivedCommand> ReceiveCommandAsync(WebSocket socket)
     {
         using var document = await ReceiveJsonDocumentAsync(socket).DefaultTimeout();
@@ -127,8 +164,14 @@ public class BrowserLogsCdpConnectionTests
         var url = parameters?.TryGetProperty("url", out var urlElement) == true
             ? urlElement.GetString()
             : null;
+        var format = parameters?.TryGetProperty("format", out var formatElement) == true
+            ? formatElement.GetString()
+            : null;
+        var fromSurface = parameters?.TryGetProperty("fromSurface", out var fromSurfaceElement) == true
+            ? fromSurfaceElement.GetBoolean()
+            : (bool?)null;
 
-        return new ReceivedCommand(id, method, sessionId, targetId, url);
+        return new ReceivedCommand(id, method, sessionId, targetId, url, format, fromSurface);
     }
 
     private static async Task<JsonDocument> ReceiveJsonDocumentAsync(WebSocket socket)
@@ -157,7 +200,7 @@ public class BrowserLogsCdpConnectionTests
         return socket.SendAsync(Encoding.UTF8.GetBytes(text), WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None);
     }
 
-    private sealed record ReceivedCommand(long Id, string Method, string? SessionId, string? TargetId, string? Url);
+    private sealed record ReceivedCommand(long Id, string Method, string? SessionId, string? TargetId, string? Url, string? Format, bool? FromSurface);
 
     private sealed class ConnectedClientWebSocketConnector(WebSocket webSocket) : IClientWebSocketConnector
     {

--- a/tests/Aspire.Hosting.Tests/BrowserLogsCdpProtocolTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsCdpProtocolTests.cs
@@ -79,6 +79,23 @@ public class BrowserLogsCdpProtocolTests
     }
 
     [Fact]
+    public void ParseCaptureScreenshotResponse_ReturnsBase64ImageData()
+    {
+        var payload = Encoding.UTF8.GetBytes("""
+            {
+              "id": 5,
+              "result": {
+                "data": "aW1hZ2UtZGF0YQ=="
+              }
+            }
+            """);
+
+        var result = BrowserLogsCdpProtocol.ParseCaptureScreenshotResponse(payload);
+
+        Assert.Equal("aW1hZ2UtZGF0YQ==", result.Data);
+    }
+
+    [Fact]
     public void ParseEvent_TargetDetachedFromTarget_UsesParameterSessionId()
     {
         var payload = Encoding.UTF8.GetBytes("""

--- a/tests/Aspire.Hosting.Tests/BrowserLogsRunningSessionTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsRunningSessionTests.cs
@@ -156,6 +156,11 @@ public class BrowserLogsRunningSessionTests
 
         public int DisposeCount { get; private set; }
 
+        public Task<BrowserLogsCaptureScreenshotResult> CaptureScreenshotAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new BrowserLogsCaptureScreenshotResult { Data = Convert.ToBase64String([0x89, 0x50, 0x4e, 0x47]) });
+        }
+
         public ValueTask RaiseEventAsync(BrowserLogsCdpProtocolEvent protocolEvent)
         {
             return eventHandler(protocolEvent);

--- a/tests/Aspire.Hosting.Tests/BrowserLogsSessionManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsSessionManagerTests.cs
@@ -453,7 +453,8 @@ public class BrowserLogsSessionManagerTests
             ResourceNotificationServiceTestHelpers.Create(),
             TimeProvider.System,
             NullLogger<BrowserLogsSessionManager>.Instance,
-            sessionFactory);
+            artifactWriter: null,
+            sessionFactory: sessionFactory);
         var resource = new BrowserLogsResource(
             "web-browser-logs",
             new TestResourceWithEndpoints("web"),

--- a/tests/Aspire.Hosting.Tests/BrowserPageSessionTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserPageSessionTests.cs
@@ -137,6 +137,68 @@ public class BrowserPageSessionTests
     }
 
     [Fact]
+    public async Task CaptureScreenshotAsync_UsesCurrentTargetSession()
+    {
+        var host = new TestBrowserHost();
+        var connection = new FakeBrowserLogsCdpConnection
+        {
+            CreatedTargetId = "created-target",
+            ScreenshotData = "image-data"
+        };
+
+        var session = await BrowserPageSession.StartAsync(
+            host,
+            "session-0001",
+            new Uri("https://localhost:5001/"),
+            new BrowserConnectionDiagnosticsLogger("session-0001", NullLogger.Instance),
+            CreateConnectionFactory(host, connection),
+            static _ => ValueTask.CompletedTask,
+            NullLogger<BrowserLogsSessionManager>.Instance,
+            TimeProvider.System,
+            reuseInitialBlankTarget: false,
+            CancellationToken.None);
+
+        var result = await session.CaptureScreenshotAsync(CancellationToken.None);
+
+        Assert.Equal("image-data", result.Data);
+        Assert.Contains("CaptureScreenshot:target-session-1", connection.Calls);
+
+        await session.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task CaptureScreenshotAsync_IsCanceledWhenSessionIsDisposed()
+    {
+        var host = new TestBrowserHost();
+        var connection = new FakeBrowserLogsCdpConnection
+        {
+            CreatedTargetId = "created-target",
+            WaitForScreenshotCancellation = true
+        };
+
+        var session = await BrowserPageSession.StartAsync(
+            host,
+            "session-0001",
+            new Uri("https://localhost:5001/"),
+            new BrowserConnectionDiagnosticsLogger("session-0001", NullLogger.Instance),
+            CreateConnectionFactory(host, connection),
+            static _ => ValueTask.CompletedTask,
+            NullLogger<BrowserLogsSessionManager>.Instance,
+            TimeProvider.System,
+            reuseInitialBlankTarget: false,
+            CancellationToken.None);
+
+        var captureTask = session.CaptureScreenshotAsync(CancellationToken.None);
+        await connection.ScreenshotCaptureStarted.Task.DefaultTimeout();
+
+        var disposeTask = session.DisposeAsync().AsTask();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await captureTask.DefaultTimeout());
+        await disposeTask.DefaultTimeout();
+        Assert.True(connection.Disposed);
+    }
+
+    [Fact]
     public async Task MonitorAsync_ReconnectsToExistingTargetAfterConnectionLoss()
     {
         var host = new TestBrowserHost();
@@ -262,6 +324,12 @@ public class BrowserPageSessionTests
 
         public string AttachSessionId { get; init; } = "target-session-1";
 
+        public string ScreenshotData { get; init; } = Convert.ToBase64String([0x89, 0x50, 0x4e, 0x47]);
+
+        public bool WaitForScreenshotCancellation { get; init; }
+
+        public TaskCompletionSource ScreenshotCaptureStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public bool Disposed { get; private set; }
 
         public BrowserLogsTargetInfo[]? TargetInfos { get; init; }
@@ -311,6 +379,19 @@ public class BrowserPageSessionTests
         {
             Calls.Add($"Navigate:{sessionId}:{url}");
             return Task.FromResult(BrowserLogsCommandAck.Instance);
+        }
+
+        public async Task<BrowserLogsCaptureScreenshotResult> CaptureScreenshotAsync(string sessionId, CancellationToken cancellationToken)
+        {
+            Calls.Add($"CaptureScreenshot:{sessionId}");
+            ScreenshotCaptureStarted.TrySetResult();
+
+            if (WaitForScreenshotCancellation)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+
+            return new BrowserLogsCaptureScreenshotResult { Data = ScreenshotData };
         }
 
         public void SetEventHandler(Func<BrowserLogsCdpProtocolEvent, ValueTask> eventHandler)


### PR DESCRIPTION
## Description

Adds a BrowserLogs `capture-screenshot` resource command backed by CDP `Page.captureScreenshot`.

- Saves screenshot PNGs as durable local command artifacts instead of returning image bytes/base64 in command output.
- Returns compact JSON metadata for agents: resource name, session id, browser, browser executable, browser host ownership, process id, CDP target id, target URL, path, MIME type, size, and creation time.
- Logs the saved artifact path, byte size, selected browser/process, and selected CDP target to the BrowserLogs resource logs.
- Treats active browser-log sessions like replicas: a BrowserLogs resource can have multiple active browser targets, so the command defaults to the latest active session and makes the selected target explicit in the response/logs.
- Adds a generic resource command artifact writer for future large diagnostic payloads.
- Adds screenshot-specific CDP timeout handling and synchronizes screenshot capture with page session reconnect/dispose.
- Adds unit coverage for protocol parsing, command frames, artifact writing, command output/logging, and page-session concurrency.

Validation:

- `.\dotnet.cmd build src\Aspire.Hosting\Aspire.Hosting.csproj /p:SkipNativeBuild=true`
- `.\dotnet.cmd test --project tests\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.BrowserLogsCdpProtocolTests" --filter-class "*.BrowserLogsCdpConnectionTests" --filter-class "*.BrowserPageSessionTests" --filter-class "*.BrowserLogsRunningSessionTests" --filter-class "*.BrowserLogsBuilderExtensionsTests" --filter-class "*.BrowserLogsSessionManagerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `.\dotnet.cmd test --project tests\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.BrowserLogsBuilderExtensionsTests" --filter-class "*.BrowserLogsSessionManagerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- BrowserTelemetry playground smoke test with three preserved PNG screenshots captured from `web-browser-logs`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
