### PR TITLE
Add first-class Kubernetes Ingress and Gateway API resources

### DIFF
--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesIngressExtensions.cs
@@ -24,7 +24,7 @@ public static class AzureKubernetesIngressExtensions
     /// <para>
     /// This method delegates to the inner <see cref="KubernetesEnvironmentResource"/> of the AKS
     /// environment. To use an AKS-specific ingress controller (e.g., Azure Application Gateway
-    /// for Containers), call <see cref="KubernetesIngressExtensions.WithIngressClass"/> with the
+    /// for Containers), call <see cref="KubernetesIngressExtensions.WithIngressClass(IResourceBuilder{KubernetesIngressResource}, string)"/> with the
     /// appropriate class name.
     /// </para>
     /// </remarks>

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesIngressExtensions.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
+using Aspire.Hosting.Kubernetes;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for adding Kubernetes Ingress and Gateway resources to AKS environments.
+/// </summary>
+public static class AzureKubernetesIngressExtensions
+{
+    /// <summary>
+    /// Adds a Kubernetes Ingress resource to the application model, associated with the
+    /// inner Kubernetes environment of the specified AKS environment. The ingress generates
+    /// a <c>networking.k8s.io/v1 Ingress</c> resource in the Helm chart output at publish time.
+    /// </summary>
+    /// <param name="builder">The AKS environment resource builder.</param>
+    /// <param name="name">The name of the ingress resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method delegates to the inner <see cref="KubernetesEnvironmentResource"/> of the AKS
+    /// environment. To use an AKS-specific ingress controller (e.g., Azure Application Gateway
+    /// for Containers), call <see cref="KubernetesIngressExtensions.WithIngressClass"/> with the
+    /// appropriate class name.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var aks = builder.AddAzureKubernetesEnvironment("aks");
+    /// var ingress = aks.AddIngress("public")
+    ///     .WithIngressClass("azure-alb-external");
+    ///
+    /// var api = builder.AddProject&lt;MyApi&gt;("api");
+    /// ingress.WithRoute("/api", api.GetEndpoint("http"));
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Adds a Kubernetes Ingress resource to an AKS environment")]
+    public static IResourceBuilder<KubernetesIngressResource> AddIngress(
+        this IResourceBuilder<AzureKubernetesEnvironmentResource> builder,
+        [ResourceName] string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var k8sEnvBuilder = builder.ApplicationBuilder.CreateResourceBuilder(builder.Resource.KubernetesEnvironment);
+        return k8sEnvBuilder.AddIngress(name);
+    }
+
+    /// <summary>
+    /// Adds a Kubernetes Gateway API Gateway resource to the application model, associated with the
+    /// inner Kubernetes environment of the specified AKS environment.
+    /// </summary>
+    /// <param name="builder">The AKS environment resource builder.</param>
+    /// <param name="name">The name of the gateway resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// var aks = builder.AddAzureKubernetesEnvironment("aks");
+    /// var gateway = aks.AddGateway("public")
+    ///     .WithGatewayClass("azure-alb-external");
+    ///
+    /// var api = builder.AddProject&lt;MyApi&gt;("api");
+    /// gateway.WithRoute("/api", api.GetEndpoint("http"));
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Adds a Kubernetes Gateway API Gateway to an AKS environment")]
+    public static IResourceBuilder<KubernetesGatewayResource> AddGateway(
+        this IResourceBuilder<AzureKubernetesEnvironmentResource> builder,
+        [ResourceName] string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var k8sEnvBuilder = builder.ApplicationBuilder.CreateResourceBuilder(builder.Resource.KubernetesEnvironment);
+        return k8sEnvBuilder.AddGateway(name);
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -4,8 +4,12 @@
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Kubernetes.Extensions;
+using Aspire.Hosting.Kubernetes.Resources;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -218,6 +222,22 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 steps.AddRange(engineSteps);
             }
 
+            // TLS bootstrap step — creates self-signed placeholder secrets after Helm deploy
+            // for any Ingress/Gateway with TLS configured, if the secret doesn't already exist.
+            var tlsSecrets = CollectTlsSecrets(model, environment);
+            if (tlsSecrets.Count > 0)
+            {
+                var tlsBootstrapStep = new PipelineStep
+                {
+                    Name = $"tls-bootstrap-{environment.Name}",
+                    Description = "Creates self-signed bootstrap TLS secrets if they don't already exist",
+                    Action = ctx => BootstrapTlsSecretsAsync(ctx, environment, tlsSecrets)
+                };
+                tlsBootstrapStep.DependsOn($"helm-deploy-{environment.Name}");
+                tlsBootstrapStep.RequiredBy(WellKnownPipelineSteps.Deploy);
+                steps.Add(tlsBootstrapStep);
+            }
+
             // Expand deployment target steps for compute resources (including dashboard if enabled)
             var resources = environment.DashboardEnabled && environment.Dashboard?.Resource is KubernetesAspireDashboardResource dashboard
                 ? [.. model.GetComputeResources(), dashboard]
@@ -377,6 +397,23 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 ContainerRegistry = containerRegistry
             });
         }
+
+        // Build deployment target lookup for endpoint resolution
+        var targetEnv = (IComputeEnvironmentResource?)OwningComputeEnvironment ?? this;
+        var deploymentTargets = new Dictionary<IResource, KubernetesResource>();
+        foreach (var resource in appModel.Resources)
+        {
+            if (resource.GetDeploymentTargetAnnotation(targetEnv)?.DeploymentTarget is KubernetesResource k8sResource)
+            {
+                deploymentTargets[resource] = k8sResource;
+            }
+        }
+
+        // Process Ingress resources
+        ProcessIngressResources(appModel, deploymentTargets, logger);
+
+        // Process Gateway API resources
+        ProcessGatewayResources(appModel, deploymentTargets, logger);
     }
 
     private static IContainerRegistry? GetContainerRegistry(KubernetesEnvironmentResource environment, DistributedApplicationModel appModel)
@@ -410,6 +447,498 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 context.EnvironmentVariables[KnownOtelConfigNames.ServiceName] = resource.Name;
                 return Task.CompletedTask;
             }));
+        }
+    }
+
+    private void ProcessIngressResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger)
+    {
+        var ingressResources = model.Resources
+            .OfType<KubernetesIngressResource>()
+            .Where(i => i.Parent == this);
+
+        foreach (var ingressResource in ingressResources)
+        {
+            if (ingressResource.Routes.Count == 0 && ingressResource.DefaultBackend is null)
+            {
+                logger.LogWarning("Ingress '{IngressName}' has no routes or default backend configured. Skipping.", ingressResource.Name);
+                continue;
+            }
+
+            var ingress = BuildIngressObject(ingressResource, deploymentTargets, logger);
+            if (ingress is not null)
+            {
+                ingressResource.GeneratedIngress = ingress;
+            }
+        }
+    }
+
+    private static Ingress? BuildIngressObject(
+        KubernetesIngressResource ingressResource,
+        Dictionary<IResource, KubernetesResource> deploymentTargets,
+        ILogger logger)
+    {
+        var ingress = new Ingress
+        {
+            Metadata =
+            {
+                Name = ingressResource.Name.ToKubernetesResourceName(),
+            }
+        };
+
+        if (ingressResource.IngressClassName is not null)
+        {
+            ingress.Spec.IngressClassName = ingressResource.IngressClassName;
+        }
+
+        foreach (var (key, value) in ingressResource.IngressAnnotations)
+        {
+            ingress.Metadata.Annotations[key] = value;
+        }
+
+        var routesByHost = ingressResource.Routes.GroupBy(r => r.Host ?? string.Empty);
+
+        foreach (var hostGroup in routesByHost)
+        {
+            var rule = new IngressRuleV1();
+            if (!string.IsNullOrEmpty(hostGroup.Key))
+            {
+                rule.Host = hostGroup.Key;
+            }
+
+            foreach (var route in hostGroup)
+            {
+                var backend = ResolveIngressBackend(route.Endpoint, deploymentTargets, ingressResource.Name, logger);
+                if (backend is null)
+                {
+                    continue;
+                }
+
+                rule.Http.Paths.Add(new HttpIngressPathV1
+                {
+                    Path = route.Path,
+                    PathType = route.PathType.ToKubernetesString(),
+                    Backend = backend
+                });
+            }
+
+            if (rule.Http.Paths.Count > 0)
+            {
+                ingress.Spec.Rules.Add(rule);
+            }
+        }
+
+        if (ingressResource.DefaultBackend is not null)
+        {
+            var defaultBackend = ResolveIngressBackend(ingressResource.DefaultBackend.Endpoint, deploymentTargets, ingressResource.Name, logger);
+            if (defaultBackend is not null)
+            {
+                ingress.Spec.DefaultBackend = defaultBackend;
+            }
+        }
+
+        foreach (var tls in ingressResource.TlsConfigs)
+        {
+            var tlsEntry = new IngressTLSV1
+            {
+                SecretName = tls.SecretName,
+            };
+
+            foreach (var host in tls.Hosts)
+            {
+                tlsEntry.Hosts.Add(host);
+            }
+
+            ingress.Spec.Tls.Add(tlsEntry);
+        }
+
+        // Auto-generate rules for TLS hosts that don't have explicit routes.
+        if (ingress.Spec.DefaultBackend is not null)
+        {
+            var hostsWithRules = new HashSet<string>(
+                ingress.Spec.Rules
+                    .Where(r => r.Host is not null)
+                    .Select(r => r.Host!),
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (var tls in ingressResource.TlsConfigs)
+            {
+                foreach (var host in tls.Hosts)
+                {
+                    if (!hostsWithRules.Contains(host))
+                    {
+                        ingress.Spec.Rules.Add(new IngressRuleV1
+                        {
+                            Host = host,
+                            Http = new HttpIngressRuleValueV1
+                            {
+                                Paths =
+                                {
+                                    new HttpIngressPathV1
+                                    {
+                                        Path = "/",
+                                        PathType = IngressPathType.Prefix.ToKubernetesString(),
+                                        Backend = new IngressBackendV1
+                                        {
+                                            Service = new IngressServiceBackendV1
+                                            {
+                                                Name = ingress.Spec.DefaultBackend.Service.Name,
+                                                Port = new ServiceBackendPortV1
+                                                {
+                                                    Name = ingress.Spec.DefaultBackend.Service.Port.Name,
+                                                    Number = ingress.Spec.DefaultBackend.Service.Port.Number
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+            }
+        }
+
+        if (ingress.Spec.Rules.Count == 0 && ingress.Spec.DefaultBackend is null)
+        {
+            logger.LogWarning("Ingress '{IngressName}' produced no valid rules or default backend. Skipping.", ingressResource.Name);
+            return null;
+        }
+
+        return ingress;
+    }
+
+    private static IngressBackendV1? ResolveIngressBackend(
+        EndpointReference endpointRef,
+        Dictionary<IResource, KubernetesResource> deploymentTargets,
+        string ingressName,
+        ILogger logger)
+    {
+        var targetResource = endpointRef.Resource;
+
+        if (!deploymentTargets.TryGetValue(targetResource, out var k8sResource))
+        {
+            logger.LogWarning(
+                "Ingress '{IngressName}' references endpoint on resource '{ResourceName}' which has no Kubernetes deployment target. Skipping this route.",
+                ingressName, targetResource.Name);
+            return null;
+        }
+
+        var endpointName = endpointRef.EndpointName;
+        if (!k8sResource.EndpointMappings.TryGetValue(endpointName, out var mapping))
+        {
+            logger.LogWarning(
+                "Ingress '{IngressName}' references endpoint '{EndpointName}' on resource '{ResourceName}' but no matching endpoint mapping was found. Skipping this route.",
+                ingressName, endpointName, targetResource.Name);
+            return null;
+        }
+
+        return new IngressBackendV1
+        {
+            Service = new IngressServiceBackendV1
+            {
+                Name = k8sResource.Service?.Metadata.Name ?? targetResource.Name.ToServiceName(),
+                Port = new ServiceBackendPortV1
+                {
+                    Name = mapping.Name
+                }
+            }
+        };
+    }
+
+    private void ProcessGatewayResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger)
+    {
+        var gatewayResources = model.Resources
+            .OfType<KubernetesGatewayResource>()
+            .Where(g => g.Parent == this);
+
+        foreach (var gatewayResource in gatewayResources)
+        {
+            if (gatewayResource.Routes.Count == 0)
+            {
+                logger.LogWarning("Gateway '{GatewayName}' has no routes configured. Skipping.", gatewayResource.Name);
+                continue;
+            }
+
+            BuildGatewayObjects(gatewayResource, deploymentTargets, logger);
+        }
+    }
+
+    private static void BuildGatewayObjects(
+        KubernetesGatewayResource gatewayResource,
+        Dictionary<IResource, KubernetesResource> deploymentTargets,
+        ILogger logger)
+    {
+        var gatewayName = gatewayResource.Name.ToKubernetesResourceName();
+
+        var gateway = new GatewayV1
+        {
+            Metadata = { Name = gatewayName }
+        };
+
+        if (gatewayResource.GatewayClassName is not null)
+        {
+            gateway.Spec.GatewayClassName = gatewayResource.GatewayClassName;
+        }
+
+        foreach (var (key, value) in gatewayResource.GatewayAnnotations)
+        {
+            gateway.Metadata.Annotations[key] = value;
+        }
+
+        gateway.Spec.Listeners.Add(new GatewayListenerV1
+        {
+            Name = "http",
+            Protocol = "HTTP",
+            Port = 80,
+            AllowedRoutes = new GatewayAllowedRoutesV1
+            {
+                Namespaces = new GatewayRouteNamespacesV1 { From = "Same" }
+            }
+        });
+
+        var tlsListenerIndex = 0;
+        foreach (var tls in gatewayResource.TlsConfigs)
+        {
+            foreach (var host in tls.Hosts)
+            {
+                var listenerName = tlsListenerIndex == 0 ? "https" : $"https-{tlsListenerIndex}";
+                tlsListenerIndex++;
+
+                gateway.Spec.Listeners.Add(new GatewayListenerV1
+                {
+                    Name = listenerName,
+                    Protocol = "HTTPS",
+                    Port = 443,
+                    Hostname = host,
+                    Tls = new GatewayTlsConfigV1
+                    {
+                        Mode = "Terminate",
+                        CertificateRefs = { new GatewayCertificateRefV1 { Name = tls.SecretName } }
+                    },
+                    AllowedRoutes = new GatewayAllowedRoutesV1
+                    {
+                        Namespaces = new GatewayRouteNamespacesV1 { From = "Same" }
+                    }
+                });
+            }
+        }
+
+        gatewayResource.GeneratedGateway = gateway;
+
+        var routesByHost = gatewayResource.Routes.GroupBy(r => r.Host ?? string.Empty);
+
+        foreach (var hostGroup in routesByHost)
+        {
+            var routeName = string.IsNullOrEmpty(hostGroup.Key)
+                ? $"{gatewayName}-route"
+                : $"{gatewayName}-{hostGroup.Key.Replace(".", "-")}-route";
+
+            var httpRoute = new HttpRouteV1
+            {
+                Metadata = { Name = routeName }
+            };
+
+            httpRoute.Spec.ParentRefs.Add(new HttpRouteParentRefV1 { Name = gatewayName });
+
+            if (!string.IsNullOrEmpty(hostGroup.Key))
+            {
+                httpRoute.Spec.Hostnames.Add(hostGroup.Key);
+            }
+
+            foreach (var route in hostGroup)
+            {
+                var backendRef = ResolveGatewayBackendRef(route.Endpoint, deploymentTargets, gatewayResource.Name, logger);
+                if (backendRef is null)
+                {
+                    continue;
+                }
+
+                var pathType = route.PathType switch
+                {
+                    IngressPathType.Exact => "Exact",
+                    IngressPathType.Prefix => "PathPrefix",
+                    IngressPathType.ImplementationSpecific => "PathPrefix",
+                    _ => throw new ArgumentOutOfRangeException(nameof(gatewayResource), route.PathType, "Unknown path type.")
+                };
+
+                var rule = new HttpRouteRuleV1();
+                rule.Matches.Add(new HttpRouteMatchV1
+                {
+                    Path = new HttpRoutePathMatchV1
+                    {
+                        Type = pathType,
+                        Value = route.Path
+                    }
+                });
+                rule.BackendRefs.Add(backendRef);
+                httpRoute.Spec.Rules.Add(rule);
+            }
+
+            if (httpRoute.Spec.Rules.Count > 0)
+            {
+                gatewayResource.GeneratedHttpRoutes.Add(httpRoute);
+            }
+        }
+    }
+
+    private static HttpRouteBackendRefV1? ResolveGatewayBackendRef(
+        EndpointReference endpointRef,
+        Dictionary<IResource, KubernetesResource> deploymentTargets,
+        string gatewayName,
+        ILogger logger)
+    {
+        var targetResource = endpointRef.Resource;
+
+        if (!deploymentTargets.TryGetValue(targetResource, out var k8sResource))
+        {
+            logger.LogWarning(
+                "Gateway '{GatewayName}' references endpoint on resource '{ResourceName}' which has no Kubernetes deployment target. Skipping this route.",
+                gatewayName, targetResource.Name);
+            return null;
+        }
+
+        var endpointName = endpointRef.EndpointName;
+        if (!k8sResource.EndpointMappings.TryGetValue(endpointName, out var mapping))
+        {
+            logger.LogWarning(
+                "Gateway '{GatewayName}' references endpoint '{EndpointName}' on resource '{ResourceName}' but no matching endpoint mapping was found. Skipping this route.",
+                gatewayName, endpointName, targetResource.Name);
+            return null;
+        }
+
+        var portValue = mapping.ServicePort ?? mapping.Port;
+        if (!int.TryParse(portValue.Value?.ToString(), out var portNumber))
+        {
+            portNumber = 8080;
+        }
+
+        return new HttpRouteBackendRefV1
+        {
+            Name = k8sResource.Service?.Metadata.Name ?? targetResource.Name.ToServiceName(),
+            Port = portNumber
+        };
+    }
+
+    private static HashSet<(string SecretName, string Hostname)> CollectTlsSecrets(DistributedApplicationModel model, KubernetesEnvironmentResource environment)
+    {
+        var tlsSecrets = new HashSet<(string SecretName, string Hostname)>();
+
+        foreach (var gateway in model.Resources.OfType<KubernetesGatewayResource>().Where(g => g.Parent == environment))
+        {
+            foreach (var tls in gateway.TlsConfigs)
+            {
+                foreach (var host in tls.Hosts)
+                {
+                    tlsSecrets.Add((tls.SecretName, host));
+                }
+            }
+        }
+
+        foreach (var ingress in model.Resources.OfType<KubernetesIngressResource>().Where(i => i.Parent == environment))
+        {
+            foreach (var tls in ingress.TlsConfigs)
+            {
+                foreach (var host in tls.Hosts)
+                {
+                    tlsSecrets.Add((tls.SecretName, host));
+                }
+            }
+        }
+
+        return tlsSecrets;
+    }
+
+    private static async Task BootstrapTlsSecretsAsync(
+        PipelineStepContext context,
+        KubernetesEnvironmentResource environment,
+        HashSet<(string SecretName, string Hostname)> tlsSecrets)
+    {
+        var @namespace = "default";
+        if (environment.TryGetLastAnnotation<KubernetesNamespaceAnnotation>(out var nsAnnotation))
+        {
+            var resolvedNs = await nsAnnotation.Namespace.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(resolvedNs))
+            {
+                @namespace = resolvedNs;
+            }
+        }
+
+        foreach (var (secretName, hostname) in tlsSecrets)
+        {
+            var checkArgs = $"get secret {secretName} --namespace {@namespace}";
+            if (environment.KubeConfigPath is not null)
+            {
+                checkArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+            }
+
+            var (checkResult, checkDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+            {
+                Arguments = checkArgs,
+                ThrowOnNonZeroReturnCode = false,
+                InheritEnv = true,
+                OnOutputData = _ => { },
+                OnErrorData = _ => { }
+            });
+
+            await using (checkDisposable.ConfigureAwait(false))
+            {
+                var result = await checkResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                if (result.ExitCode == 0)
+                {
+                    context.Logger.LogInformation("TLS secret '{SecretName}' already exists, skipping bootstrap.", secretName);
+                    continue;
+                }
+            }
+
+            context.Logger.LogInformation("Creating bootstrap TLS secret '{SecretName}' for '{Hostname}'.", secretName, hostname);
+
+            using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+            var request = new CertificateRequest($"CN={hostname}", ecdsa, HashAlgorithmName.SHA256);
+            using var cert = request.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+
+            var certPem = cert.ExportCertificatePem();
+            var keyPem = ecdsa.ExportECPrivateKeyPem();
+
+            var tempDir = Directory.CreateTempSubdirectory(".aspire-tls-bootstrap");
+            try
+            {
+                var certPath = Path.Combine(tempDir.FullName, "tls.crt");
+                var keyPath = Path.Combine(tempDir.FullName, "tls.key");
+                await File.WriteAllTextAsync(certPath, certPem, context.CancellationToken).ConfigureAwait(false);
+                await File.WriteAllTextAsync(keyPath, keyPem, context.CancellationToken).ConfigureAwait(false);
+
+                var createArgs = $"create secret tls {secretName} --cert=\"{certPath}\" --key=\"{keyPath}\" --namespace {@namespace}";
+                if (environment.KubeConfigPath is not null)
+                {
+                    createArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                }
+
+                var (createResult, createDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+                {
+                    Arguments = createArgs,
+                    ThrowOnNonZeroReturnCode = false,
+                    InheritEnv = true,
+                    OnOutputData = line => context.Logger.LogDebug("{Line}", line),
+                    OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+                });
+
+                await using (createDisposable.ConfigureAwait(false))
+                {
+                    var createExitResult = await createResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                    if (createExitResult.ExitCode != 0)
+                    {
+                        context.Logger.LogWarning("Failed to create bootstrap TLS secret '{SecretName}' (exit code {ExitCode}).", secretName, createExitResult.ExitCode);
+                    }
+                    else
+                    {
+                        context.Logger.LogInformation("Bootstrap TLS secret '{SecretName}' created for '{Hostname}'. Replace with a real cert via cert-manager or manually.", secretName, hostname);
+                    }
+                }
+            }
+            finally
+            {
+                try { tempDir.Delete(recursive: true); } catch { }
+            }
         }
     }
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -459,12 +459,10 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     {
         try
         {
-            return await ResolveExpressionAsync(expression, cancellationToken).ConfigureAwait(false);
+            return (await expression.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
         }
         catch (MissingParameterValueException)
         {
-            // Parameter has no default and no configured value — use its format string
-            // (which is the parameter name for simple parameter references).
             return expression.Format;
         }
     }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -505,7 +505,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         if (ingressResource.IngressClassName is not null)
         {
-            ingress.Spec.IngressClassName = ingressResource.IngressClassName;
+            ingress.Spec.IngressClassName = await ResolveExpressionAsync(ingressResource.IngressClassName, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var (key, value) in ingressResource.IngressAnnotations)
@@ -688,7 +688,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(gatewayResource.GatewayClassName))
+        if (gatewayResource.GatewayClassName is null)
         {
             throw new InvalidOperationException(
                 $"Gateway '{gatewayResource.Name}' must have a GatewayClassName set via WithGatewayClass(). " +
@@ -702,7 +702,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             Metadata = { Name = gatewayName }
         };
 
-        gateway.Spec.GatewayClassName = gatewayResource.GatewayClassName;
+        gateway.Spec.GatewayClassName = await ResolveExpressionAsync(gatewayResource.GatewayClassName, cancellationToken).ConfigureAwait(false);
 
         foreach (var (key, value) in gatewayResource.GatewayAnnotations)
         {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -410,10 +410,10 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         }
 
         // Process Ingress resources
-        ProcessIngressResources(appModel, deploymentTargets, logger);
+        await ProcessIngressResources(appModel, deploymentTargets, logger, context.CancellationToken).ConfigureAwait(false);
 
         // Process Gateway API resources
-        ProcessGatewayResources(appModel, deploymentTargets, logger);
+        await ProcessGatewayResources(appModel, deploymentTargets, logger, context.CancellationToken).ConfigureAwait(false);
     }
 
     private static IContainerRegistry? GetContainerRegistry(KubernetesEnvironmentResource environment, DistributedApplicationModel appModel)
@@ -450,7 +450,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         }
     }
 
-    private void ProcessIngressResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger)
+    private async Task ProcessIngressResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger, CancellationToken cancellationToken)
     {
         var ingressResources = model.Resources
             .OfType<KubernetesIngressResource>()
@@ -464,7 +464,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 continue;
             }
 
-            var ingress = BuildIngressObject(ingressResource, deploymentTargets, logger);
+            var ingress = await BuildIngressObject(ingressResource, deploymentTargets, logger, cancellationToken).ConfigureAwait(false);
             if (ingress is not null)
             {
                 ingressResource.GeneratedIngress = ingress;
@@ -472,10 +472,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         }
     }
 
-    private static Ingress? BuildIngressObject(
+    private static async Task<Ingress?> BuildIngressObject(
         KubernetesIngressResource ingressResource,
         Dictionary<IResource, KubernetesResource> deploymentTargets,
-        ILogger logger)
+        ILogger logger,
+        CancellationToken cancellationToken)
     {
         var ingress = new Ingress
         {
@@ -492,7 +493,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         foreach (var (key, value) in ingressResource.IngressAnnotations)
         {
-            ingress.Metadata.Annotations[key] = value;
+            ingress.Metadata.Annotations[key] = (await value.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
         }
 
         var routesByHost = ingressResource.Routes.GroupBy(r => r.Host ?? string.Empty);
@@ -540,12 +541,12 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             var tlsEntry = new IngressTLSV1
             {
-                SecretName = tls.SecretName,
+                SecretName = (await tls.SecretName.GetValueAsync(cancellationToken).ConfigureAwait(false))!,
             };
 
             foreach (var host in tls.Hosts)
             {
-                tlsEntry.Hosts.Add(host);
+                tlsEntry.Hosts.Add((await host.GetValueAsync(cancellationToken).ConfigureAwait(false))!);
             }
 
             ingress.Spec.Tls.Add(tlsEntry);
@@ -564,11 +565,12 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             {
                 foreach (var host in tls.Hosts)
                 {
-                    if (!hostsWithRules.Contains(host))
+                    var resolvedHost = (await host.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
+                    if (!hostsWithRules.Contains(resolvedHost))
                     {
                         ingress.Spec.Rules.Add(new IngressRuleV1
                         {
-                            Host = host,
+                            Host = resolvedHost,
                             Http = new HttpIngressRuleValueV1
                             {
                                 Paths =
@@ -645,7 +647,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         };
     }
 
-    private void ProcessGatewayResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger)
+    private async Task ProcessGatewayResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger, CancellationToken cancellationToken)
     {
         var gatewayResources = model.Resources
             .OfType<KubernetesGatewayResource>()
@@ -659,14 +661,15 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 continue;
             }
 
-            BuildGatewayObjects(gatewayResource, deploymentTargets, logger);
+            await BuildGatewayObjects(gatewayResource, deploymentTargets, logger, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private static void BuildGatewayObjects(
+    private static async Task BuildGatewayObjects(
         KubernetesGatewayResource gatewayResource,
         Dictionary<IResource, KubernetesResource> deploymentTargets,
-        ILogger logger)
+        ILogger logger,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(gatewayResource.GatewayClassName))
         {
@@ -686,7 +689,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         foreach (var (key, value) in gatewayResource.GatewayAnnotations)
         {
-            gateway.Metadata.Annotations[key] = value;
+            gateway.Metadata.Annotations[key] = (await value.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
         }
 
         gateway.Spec.Listeners.Add(new GatewayListenerV1
@@ -708,16 +711,19 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 var listenerName = tlsListenerIndex == 0 ? "https" : $"https-{tlsListenerIndex}";
                 tlsListenerIndex++;
 
+                var resolvedHost = (await host.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
+                var resolvedSecretName = (await tls.SecretName.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
+
                 gateway.Spec.Listeners.Add(new GatewayListenerV1
                 {
                     Name = listenerName,
                     Protocol = "HTTPS",
                     Port = 443,
-                    Hostname = host,
+                    Hostname = resolvedHost,
                     Tls = new GatewayTlsConfigV1
                     {
                         Mode = "Terminate",
-                        CertificateRefs = { new GatewayCertificateRefV1 { Name = tls.SecretName } }
+                        CertificateRefs = { new GatewayCertificateRefV1 { Name = resolvedSecretName } }
                     },
                     AllowedRoutes = new GatewayAllowedRoutesV1
                     {
@@ -823,9 +829,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         };
     }
 
-    private static HashSet<(string SecretName, string Hostname)> CollectTlsSecrets(DistributedApplicationModel model, KubernetesEnvironmentResource environment)
+    private static HashSet<(ReferenceExpression SecretName, ReferenceExpression Hostname)> CollectTlsSecrets(DistributedApplicationModel model, KubernetesEnvironmentResource environment)
     {
-        var tlsSecrets = new HashSet<(string SecretName, string Hostname)>();
+        var tlsSecrets = new HashSet<(ReferenceExpression SecretName, ReferenceExpression Hostname)>();
 
         foreach (var gateway in model.Resources.OfType<KubernetesGatewayResource>().Where(g => g.Parent == environment))
         {
@@ -855,7 +861,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     private static async Task BootstrapTlsSecretsAsync(
         PipelineStepContext context,
         KubernetesEnvironmentResource environment,
-        HashSet<(string SecretName, string Hostname)> tlsSecrets)
+        HashSet<(ReferenceExpression SecretName, ReferenceExpression Hostname)> tlsSecrets)
     {
         var @namespace = "default";
         if (environment.TryGetLastAnnotation<KubernetesNamespaceAnnotation>(out var nsAnnotation))
@@ -867,8 +873,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             }
         }
 
-        foreach (var (secretName, hostname) in tlsSecrets)
+        foreach (var (secretNameExpr, hostnameExpr) in tlsSecrets)
         {
+            var secretName = await secretNameExpr.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+            var hostname = await hostnameExpr.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+
             var checkArgs = $"get secret {secretName} --namespace {@namespace}";
             if (environment.KubeConfigPath is not null)
             {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -668,6 +668,13 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         Dictionary<IResource, KubernetesResource> deploymentTargets,
         ILogger logger)
     {
+        if (string.IsNullOrWhiteSpace(gatewayResource.GatewayClassName))
+        {
+            throw new InvalidOperationException(
+                $"Gateway '{gatewayResource.Name}' must have a GatewayClassName set via WithGatewayClass(). " +
+                $"The Gateway API requires a gatewayClassName to select the controller implementation.");
+        }
+
         var gatewayName = gatewayResource.Name.ToKubernetesResourceName();
 
         var gateway = new GatewayV1
@@ -675,10 +682,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             Metadata = { Name = gatewayName }
         };
 
-        if (gatewayResource.GatewayClassName is not null)
-        {
-            gateway.Spec.GatewayClassName = gatewayResource.GatewayClassName;
-        }
+        gateway.Spec.GatewayClassName = gatewayResource.GatewayClassName;
 
         foreach (var (key, value) in gatewayResource.GatewayAnnotations)
         {
@@ -731,7 +735,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             var routeName = string.IsNullOrEmpty(hostGroup.Key)
                 ? $"{gatewayName}-route"
-                : $"{gatewayName}-{hostGroup.Key.Replace(".", "-")}-route";
+                : $"{gatewayName}-{hostGroup.Key.Replace(".", "-").Replace("*", "wildcard").ToLowerInvariant()}-route";
 
             var httpRoute = new HttpRouteV1
             {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -450,6 +450,25 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         }
     }
 
+    /// <summary>
+    /// Resolves a <see cref="ReferenceExpression"/> to a string value. If the expression wraps
+    /// a <see cref="ParameterResource"/> that has no value yet (common during publish), returns
+    /// the parameter's name as a fallback so it can be used in Helm values.
+    /// </summary>
+    private static async Task<string> ResolveExpressionAsync(ReferenceExpression expression, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await ResolveExpressionAsync(expression, cancellationToken).ConfigureAwait(false);
+        }
+        catch (MissingParameterValueException)
+        {
+            // Parameter has no default and no configured value — use its format string
+            // (which is the parameter name for simple parameter references).
+            return expression.Format;
+        }
+    }
+
     private async Task ProcessIngressResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger, CancellationToken cancellationToken)
     {
         var ingressResources = model.Resources
@@ -493,7 +512,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         foreach (var (key, value) in ingressResource.IngressAnnotations)
         {
-            ingress.Metadata.Annotations[key] = (await value.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
+            ingress.Metadata.Annotations[key] = await ResolveExpressionAsync(value, cancellationToken).ConfigureAwait(false);
         }
 
         var routesByHost = ingressResource.Routes.GroupBy(r => r.Host ?? string.Empty);
@@ -541,12 +560,12 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             var tlsEntry = new IngressTLSV1
             {
-                SecretName = (await tls.SecretName.GetValueAsync(cancellationToken).ConfigureAwait(false))!,
+                SecretName = await ResolveExpressionAsync(tls.SecretName, cancellationToken).ConfigureAwait(false),
             };
 
             foreach (var host in tls.Hosts)
             {
-                tlsEntry.Hosts.Add((await host.GetValueAsync(cancellationToken).ConfigureAwait(false))!);
+                tlsEntry.Hosts.Add(await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false));
             }
 
             ingress.Spec.Tls.Add(tlsEntry);
@@ -565,7 +584,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             {
                 foreach (var host in tls.Hosts)
                 {
-                    var resolvedHost = (await host.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
+                    var resolvedHost = await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false);
                     if (!hostsWithRules.Contains(resolvedHost))
                     {
                         ingress.Spec.Rules.Add(new IngressRuleV1
@@ -689,7 +708,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         foreach (var (key, value) in gatewayResource.GatewayAnnotations)
         {
-            gateway.Metadata.Annotations[key] = (await value.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
+            gateway.Metadata.Annotations[key] = await ResolveExpressionAsync(value, cancellationToken).ConfigureAwait(false);
         }
 
         gateway.Spec.Listeners.Add(new GatewayListenerV1
@@ -711,8 +730,8 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 var listenerName = tlsListenerIndex == 0 ? "https" : $"https-{tlsListenerIndex}";
                 tlsListenerIndex++;
 
-                var resolvedHost = (await host.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
-                var resolvedSecretName = (await tls.SecretName.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
+                var resolvedHost = await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false);
+                var resolvedSecretName = await ResolveExpressionAsync(tls.SecretName, cancellationToken).ConfigureAwait(false);
 
                 gateway.Spec.Listeners.Add(new GatewayListenerV1
                 {
@@ -875,8 +894,8 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         foreach (var (secretNameExpr, hostnameExpr) in tlsSecrets)
         {
-            var secretName = await secretNameExpr.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
-            var hostname = await hostnameExpr.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+            var secretName = await ResolveExpressionAsync(secretNameExpr, context.CancellationToken).ConfigureAwait(false);
+            var hostname = await ResolveExpressionAsync(hostnameExpr, context.CancellationToken).ConfigureAwait(false);
 
             var checkArgs = $"get secret {secretName} --namespace {@namespace}";
             if (environment.KubeConfigPath is not null)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -139,49 +139,88 @@ public static class KubernetesGatewayExtensions
     }
 
     /// <summary>
+    /// Adds a hostname that this gateway's routes match. Multiple hostnames can be added by calling
+    /// this method repeatedly. Hostnames are used as <c>hostnames</c> in generated <c>HTTPRoute</c>
+    /// resources and as HTTPS listener hostnames when TLS is configured.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="hostname">The hostname to match (e.g., <c>"api.example.com"</c>).</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport(Description = "Adds a hostname to a Kubernetes Gateway")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithHostname(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        string hostname)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(hostname);
+
+        builder.Resource.Hostnames.Add(hostname);
+        return builder;
+    }
+
+    /// <summary>
     /// Configures TLS termination on the gateway by adding an HTTPS listener that references
     /// a Kubernetes TLS secret. The Gateway terminates TLS and forwards plain HTTP to backends.
-    /// This does not create a separate route ΓÇö existing HTTPRoutes serve both HTTP and HTTPS.
+    /// This does not create a separate route — existing HTTPRoutes serve both HTTP and HTTPS.
+    /// The TLS configuration applies to all hostnames configured via <see cref="WithHostname"/>.
     /// </summary>
     /// <param name="builder">The gateway resource builder.</param>
     /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret.</param>
-    /// <param name="hosts">One or more hostnames that the TLS certificate covers.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
     [AspireExport(Description = "Configures TLS on a Kubernetes Gateway listener")]
     public static IResourceBuilder<KubernetesGatewayResource> WithTls(
         this IResourceBuilder<KubernetesGatewayResource> builder,
-        string secretName,
-        params string[] hosts)
+        string secretName)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(secretName);
-        ArgumentNullException.ThrowIfNull(hosts);
-
-        if (hosts.Length == 0)
-        {
-            throw new ArgumentException("At least one host must be specified for TLS.", nameof(hosts));
-        }
 
         builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
             SecretName: secretName,
-            Hosts: [.. hosts]));
+            Hosts: [.. builder.Resource.Hostnames]));
 
         return builder;
     }
 
     /// <summary>
-    /// Adds a Kubernetes metadata annotation to the generated Gateway resource. These are
-    /// key-value pairs in the <c>metadata.annotations</c> field of the K8S Gateway, commonly
-    /// used for controller-specific configuration (e.g., AGC's <c>alb.networking.azure.io/alb-name</c>).
+    /// Configures TLS termination on the gateway with an auto-generated secret name
+    /// derived from the gateway resource name. The TLS configuration applies to all
+    /// hostnames configured via <see cref="WithHostname"/>.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport("withGatewayTlsAuto", Description = "Configures TLS on a Kubernetes Gateway with an auto-generated secret")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithTls(
+        this IResourceBuilder<KubernetesGatewayResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var secretName = $"{builder.Resource.Name}-tls";
+
+        builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
+            SecretName: secretName,
+            Hosts: [.. builder.Resource.Hostnames]));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a Kubernetes metadata annotation to the generated Gateway resource.
     /// </summary>
     /// <param name="builder">The gateway resource builder.</param>
     /// <param name="key">The annotation key.</param>
     /// <param name="value">The annotation value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
     /// <remarks>
-    /// This method sets Kubernetes metadata annotations, not Aspire <see cref="ApplicationModel.IResourceAnnotation"/>
-    /// instances. For Azure Application Gateway for Containers (AGC), you typically need:
+    /// <para>
+    /// This sets Kubernetes <c>metadata.annotations</c> on the generated K8S Gateway resource,
+    /// not Aspire <see cref="ApplicationModel.IResourceAnnotation"/> instances. These are key-value
+    /// string pairs used by ingress controllers for provider-specific configuration.
+    /// </para>
+    /// <para>
+    /// For Azure Application Gateway for Containers (AGC), you typically need:
     /// <c>alb.networking.azure.io/alb-name</c> and <c>alb.networking.azure.io/alb-namespace</c>.
+    /// </para>
     /// </remarks>
     [AspireExport(Description = "Adds a Kubernetes metadata annotation to a Gateway")]
     public static IResourceBuilder<KubernetesGatewayResource> WithGatewayAnnotation(

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -66,6 +66,26 @@ public static class KubernetesGatewayExtensions
     }
 
     /// <summary>
+    /// Sets the GatewayClass name using a parameter that will be resolved at deploy time.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="className">A parameter resource builder for the GatewayClass name.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport("withGatewayClassParam", Description = "Sets a parameterized GatewayClass for a Kubernetes Gateway")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithGatewayClass(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        IResourceBuilder<ParameterResource> className)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(className);
+
+        // Store as string — will need async resolution during pipeline step
+        // For now, use the parameter's default value or name as placeholder
+        builder.Resource.GatewayClassName = className.Resource.Name;
+        return builder;
+    }
+
+    /// <summary>
     /// Adds a path-based routing rule to the gateway. The rule matches all hosts and routes
     /// traffic matching the specified path to the given endpoint's backing Kubernetes service.
     /// This generates an <c>HTTPRoute</c> resource attached to the Gateway.
@@ -154,7 +174,25 @@ public static class KubernetesGatewayExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(hostname);
 
-        builder.Resource.Hostnames.Add(hostname);
+        builder.Resource.Hostnames.Add(ReferenceExpression.Create($"{hostname}"));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a hostname using a parameter that will be resolved at deploy time.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="hostname">A parameter resource builder for the hostname value.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport("withGatewayHostnameParam", Description = "Adds a parameterized hostname to a Kubernetes Gateway")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithHostname(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        IResourceBuilder<ParameterResource> hostname)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(hostname);
+
+        builder.Resource.Hostnames.Add(ReferenceExpression.Create($"{hostname.Resource}"));
         return builder;
     }
 
@@ -162,7 +200,7 @@ public static class KubernetesGatewayExtensions
     /// Configures TLS termination on the gateway by adding an HTTPS listener that references
     /// a Kubernetes TLS secret. The Gateway terminates TLS and forwards plain HTTP to backends.
     /// This does not create a separate route — existing HTTPRoutes serve both HTTP and HTTPS.
-    /// The TLS configuration applies to all hostnames configured via <see cref="WithHostname"/>.
+    /// The TLS configuration applies to all hostnames configured via <see cref="WithHostname(IResourceBuilder{KubernetesGatewayResource}, string)"/>.
     /// </summary>
     /// <param name="builder">The gateway resource builder.</param>
     /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret.</param>
@@ -176,16 +214,35 @@ public static class KubernetesGatewayExtensions
         ArgumentException.ThrowIfNullOrEmpty(secretName);
 
         builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
-            SecretName: secretName,
+            SecretName: ReferenceExpression.Create($"{secretName}"),
             Hosts: [.. builder.Resource.Hostnames]));
 
         return builder;
     }
 
     /// <summary>
-    /// Configures TLS termination on the gateway with an auto-generated secret name
-    /// derived from the gateway resource name. The TLS configuration applies to all
-    /// hostnames configured via <see cref="WithHostname"/>.
+    /// Configures TLS termination using a parameter for the secret name.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="secretName">A parameter resource builder for the secret name.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport("withGatewayTlsParam", Description = "Configures TLS on a Kubernetes Gateway with a parameterized secret")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithTls(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        IResourceBuilder<ParameterResource> secretName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(secretName);
+
+        builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
+            SecretName: ReferenceExpression.Create($"{secretName.Resource}"),
+            Hosts: [.. builder.Resource.Hostnames]));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures TLS termination with an auto-generated secret name derived from the gateway name.
     /// </summary>
     /// <param name="builder">The gateway resource builder.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
@@ -198,7 +255,7 @@ public static class KubernetesGatewayExtensions
         var secretName = $"{builder.Resource.Name}-tls";
 
         builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
-            SecretName: secretName,
+            SecretName: ReferenceExpression.Create($"{secretName}"),
             Hosts: [.. builder.Resource.Hostnames]));
 
         return builder;
@@ -232,7 +289,29 @@ public static class KubernetesGatewayExtensions
         ArgumentException.ThrowIfNullOrEmpty(key);
         ArgumentNullException.ThrowIfNull(value);
 
-        builder.Resource.GatewayAnnotations[key] = value;
+        builder.Resource.GatewayAnnotations[key] = ReferenceExpression.Create($"{value}");
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a Kubernetes metadata annotation with a parameter value that will be resolved at deploy time.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="key">The annotation key.</param>
+    /// <param name="value">A parameter resource builder for the annotation value.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport("withGatewayAnnotationParam", Description = "Adds a parameterized Kubernetes metadata annotation to a Gateway")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithGatewayAnnotation(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        string key,
+        IResourceBuilder<ParameterResource> value)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        builder.Resource.GatewayAnnotations[key] = ReferenceExpression.Create($"{value.Resource}");
         return builder;
     }
 }
+

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -61,7 +61,7 @@ public static class KubernetesGatewayExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(className);
 
-        builder.Resource.GatewayClassName = className;
+        builder.Resource.GatewayClassName = ReferenceExpression.Create($"{className}");
         return builder;
     }
 
@@ -79,9 +79,7 @@ public static class KubernetesGatewayExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(className);
 
-        // Store as string — will need async resolution during pipeline step
-        // For now, use the parameter's default value or name as placeholder
-        builder.Resource.GatewayClassName = className.Resource.Name;
+        builder.Resource.GatewayClassName = ReferenceExpression.Create($"{className.Resource}");
         return builder;
     }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -1,0 +1,199 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Provides extension methods for configuring Kubernetes Gateway API resources in the Aspire application model.
+/// </summary>
+public static class KubernetesGatewayExtensions
+{
+    /// <summary>
+    /// Adds a Kubernetes Gateway API Gateway resource to the application model as a child of the specified
+    /// Kubernetes environment. The gateway generates a <c>gateway.networking.k8s.io/v1 Gateway</c> resource
+    /// and one or more <c>HTTPRoute</c> resources in the Helm chart output at publish time.
+    /// </summary>
+    /// <param name="builder">The Kubernetes environment resource builder.</param>
+    /// <param name="name">The name of the gateway resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// var k8s = builder.AddKubernetesEnvironment("k8s");
+    /// var gateway = k8s.AddGateway("public")
+    ///     .WithGatewayClass("azure-alb-external");
+    ///
+    /// var api = builder.AddProject&lt;MyApi&gt;("api");
+    /// gateway.WithRoute("/api", api.GetEndpoint("http"));
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Adds a Kubernetes Gateway API Gateway resource")]
+    public static IResourceBuilder<KubernetesGatewayResource> AddGateway(
+        this IResourceBuilder<KubernetesEnvironmentResource> builder,
+        [ResourceName] string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var gateway = new KubernetesGatewayResource(name, builder.Resource);
+
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            return builder.ApplicationBuilder.CreateResourceBuilder(gateway);
+        }
+
+        return builder.ApplicationBuilder.AddResource(gateway)
+            .ExcludeFromManifest();
+    }
+
+    /// <summary>
+    /// Sets the GatewayClass name that selects which controller implementation handles this gateway.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="className">The GatewayClass name (e.g., <c>"azure-alb-external"</c>, <c>"istio"</c>).</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport(Description = "Sets the GatewayClass for a Kubernetes Gateway")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithGatewayClass(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        string className)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(className);
+
+        builder.Resource.GatewayClassName = className;
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a path-based routing rule to the gateway. The rule matches all hosts and routes
+    /// traffic matching the specified path to the given endpoint's backing Kubernetes service.
+    /// This generates an <c>HTTPRoute</c> resource attached to the Gateway.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="path">The URL path to match (e.g., <c>"/"</c> or <c>"/api"</c>). Must start with <c>/</c>.</param>
+    /// <param name="endpoint">The endpoint reference identifying the target service and port.</param>
+    /// <param name="pathType">The path matching strategy. Defaults to <see cref="IngressPathType.Prefix"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport("withGatewayPathRoute", Description = "Adds a path-based route to a Kubernetes Gateway")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithRoute(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        string path,
+        EndpointReference endpoint,
+        IngressPathType pathType = IngressPathType.Prefix)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!path.StartsWith('/'))
+        {
+            throw new ArgumentException("Path must start with '/'.", nameof(path));
+        }
+
+        builder.Resource.Routes.Add(new GatewayRouteConfig(
+            Host: null,
+            Path: path,
+            PathType: pathType,
+            Endpoint: endpoint));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a host-and-path-based routing rule to the gateway. The rule matches traffic for
+    /// the specified host and path, routing it to the given endpoint's backing Kubernetes service.
+    /// This generates an <c>HTTPRoute</c> resource with a <c>hostnames</c> filter.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="host">The hostname to match (e.g., <c>"api.example.com"</c>).</param>
+    /// <param name="path">The URL path to match. Must start with <c>/</c>.</param>
+    /// <param name="endpoint">The endpoint reference identifying the target service and port.</param>
+    /// <param name="pathType">The path matching strategy. Defaults to <see cref="IngressPathType.Prefix"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport("withGatewayHostRoute", Description = "Adds a host-and-path route to a Kubernetes Gateway")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithRoute(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        string host,
+        string path,
+        EndpointReference endpoint,
+        IngressPathType pathType = IngressPathType.Prefix)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(host);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!path.StartsWith('/'))
+        {
+            throw new ArgumentException("Path must start with '/'.", nameof(path));
+        }
+
+        builder.Resource.Routes.Add(new GatewayRouteConfig(
+            Host: host,
+            Path: path,
+            PathType: pathType,
+            Endpoint: endpoint));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures TLS termination on the gateway by adding an HTTPS listener that references
+    /// a Kubernetes TLS secret. The Gateway terminates TLS and forwards plain HTTP to backends.
+    /// This does not create a separate route ΓÇö existing HTTPRoutes serve both HTTP and HTTPS.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret.</param>
+    /// <param name="hosts">One or more hostnames that the TLS certificate covers.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    [AspireExport(Description = "Configures TLS on a Kubernetes Gateway listener")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithTls(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        string secretName,
+        params string[] hosts)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(secretName);
+        ArgumentNullException.ThrowIfNull(hosts);
+
+        if (hosts.Length == 0)
+        {
+            throw new ArgumentException("At least one host must be specified for TLS.", nameof(hosts));
+        }
+
+        builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
+            SecretName: secretName,
+            Hosts: [.. hosts]));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a Kubernetes metadata annotation to the generated Gateway resource. These are
+    /// key-value pairs in the <c>metadata.annotations</c> field of the K8S Gateway, commonly
+    /// used for controller-specific configuration (e.g., AGC's <c>alb.networking.azure.io/alb-name</c>).
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="key">The annotation key.</param>
+    /// <param name="value">The annotation value.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// This method sets Kubernetes metadata annotations, not Aspire <see cref="ApplicationModel.IResourceAnnotation"/>
+    /// instances. For Azure Application Gateway for Containers (AGC), you typically need:
+    /// <c>alb.networking.azure.io/alb-name</c> and <c>alb.networking.azure.io/alb-namespace</c>.
+    /// </remarks>
+    [AspireExport(Description = "Adds a Kubernetes metadata annotation to a Gateway")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithGatewayAnnotation(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        string key,
+        string value)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        builder.Resource.GatewayAnnotations[key] = value;
+        return builder;
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Represents a Kubernetes Gateway API Gateway as a first-class resource in the Aspire application model.
+/// A Gateway defines listeners (ports, protocols, TLS) and HTTPRoutes attach to it for routing.
+/// </summary>
+/// <param name="name">The name of the gateway resource.</param>
+/// <param name="environment">The parent Kubernetes environment resource.</param>
+/// <remarks>
+/// <para>
+/// Create a gateway using <see cref="KubernetesGatewayExtensions.AddGateway"/> and configure
+/// routes using <see cref="KubernetesGatewayExtensions.WithRoute(IResourceBuilder{KubernetesGatewayResource}, string, EndpointReference, IngressPathType)"/>.
+/// </para>
+/// <para>
+/// At publish time, the gateway generates a <c>gateway.networking.k8s.io/v1 Gateway</c> resource
+/// with auto-inferred listeners and one or more <c>HTTPRoute</c> resources in the Helm chart output.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var k8s = builder.AddKubernetesEnvironment("k8s");
+/// var gateway = k8s.AddGateway("public")
+///     .WithGatewayClass("azure-alb-external");
+///
+/// var api = builder.AddProject&lt;MyApi&gt;("api");
+/// gateway.WithRoute("/api", api.GetEndpoint("http"));
+/// </code>
+/// </example>
+[AspireExport]
+public class KubernetesGatewayResource(
+    string name,
+    KubernetesEnvironmentResource environment) : Resource(name), IResourceWithParent<KubernetesEnvironmentResource>
+{
+    /// <summary>
+    /// Gets the parent Kubernetes environment resource.
+    /// </summary>
+    public KubernetesEnvironmentResource Parent { get; } = environment ?? throw new ArgumentNullException(nameof(environment));
+
+    /// <summary>
+    /// Gets or sets the GatewayClass name that selects which controller implementation
+    /// handles this gateway.
+    /// </summary>
+    /// <remarks>
+    /// Common values include <c>"azure-alb-external"</c> (for AKS with AGC),
+    /// <c>"istio"</c>, or controller-specific class names.
+    /// </remarks>
+    public string? GatewayClassName { get; set; }
+
+    /// <summary>
+    /// Gets the list of routing rules configured for this gateway.
+    /// </summary>
+    internal List<GatewayRouteConfig> Routes { get; } = [];
+
+    /// <summary>
+    /// Gets the list of TLS configurations. Each creates an HTTPS listener on the gateway.
+    /// </summary>
+    internal List<GatewayTlsConfig> TlsConfigs { get; } = [];
+
+    /// <summary>
+    /// Gets the Kubernetes metadata annotations to add to the generated Gateway resource.
+    /// </summary>
+    internal Dictionary<string, string> GatewayAnnotations { get; } = [];
+
+    /// <summary>
+    /// Gets the generated K8S Gateway object, populated during infrastructure processing.
+    /// </summary>
+    internal Resources.GatewayV1? GeneratedGateway { get; set; }
+
+    /// <summary>
+    /// Gets the generated K8S HTTPRoute objects, populated during infrastructure processing.
+    /// </summary>
+    internal List<Resources.HttpRouteV1> GeneratedHttpRoutes { get; } = [];
+}
+
+/// <summary>
+/// Stores a single routing rule for a <see cref="KubernetesGatewayResource"/>.
+/// </summary>
+internal sealed record GatewayRouteConfig(
+    string? Host,
+    string Path,
+    IngressPathType PathType,
+    EndpointReference Endpoint);
+
+/// <summary>
+/// Stores TLS configuration for a <see cref="KubernetesGatewayResource"/>.
+/// Configures an HTTPS listener on the Gateway with TLS termination.
+/// </summary>
+internal sealed record GatewayTlsConfig(
+    string SecretName,
+    List<string> Hosts);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
@@ -52,6 +52,11 @@ public class KubernetesGatewayResource(
     public string? GatewayClassName { get; set; }
 
     /// <summary>
+    /// Gets the list of hostnames this gateway matches.
+    /// </summary>
+    internal List<string> Hostnames { get; } = [];
+
+    /// <summary>
     /// Gets the list of routing rules configured for this gateway.
     /// </summary>
     internal List<GatewayRouteConfig> Routes { get; } = [];

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
@@ -54,7 +54,7 @@ public class KubernetesGatewayResource(
     /// <summary>
     /// Gets the list of hostnames this gateway matches.
     /// </summary>
-    internal List<string> Hostnames { get; } = [];
+    internal List<ReferenceExpression> Hostnames { get; } = [];
 
     /// <summary>
     /// Gets the list of routing rules configured for this gateway.
@@ -69,7 +69,7 @@ public class KubernetesGatewayResource(
     /// <summary>
     /// Gets the Kubernetes metadata annotations to add to the generated Gateway resource.
     /// </summary>
-    internal Dictionary<string, string> GatewayAnnotations { get; } = [];
+    internal Dictionary<string, ReferenceExpression> GatewayAnnotations { get; } = [];
 
     /// <summary>
     /// Gets the generated K8S Gateway object, populated during infrastructure processing.
@@ -96,5 +96,5 @@ internal sealed record GatewayRouteConfig(
 /// Configures an HTTPS listener on the Gateway with TLS termination.
 /// </summary>
 internal sealed record GatewayTlsConfig(
-    string SecretName,
-    List<string> Hosts);
+    ReferenceExpression SecretName,
+    List<ReferenceExpression> Hosts);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
@@ -49,7 +49,7 @@ public class KubernetesGatewayResource(
     /// Common values include <c>"azure-alb-external"</c> (for AKS with AGC),
     /// <c>"istio"</c>, or controller-specific class names.
     /// </remarks>
-    public string? GatewayClassName { get; set; }
+    public ReferenceExpression? GatewayClassName { get; set; }
 
     /// <summary>
     /// Gets the list of hostnames this gateway matches.

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -178,26 +178,35 @@ public static class KubernetesIngressExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(hostname);
 
-        builder.Resource.Hostnames.Add(hostname);
+        builder.Resource.Hostnames.Add(ReferenceExpression.Create($"{hostname}"));
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a hostname using a parameter that will be resolved at deploy time.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="hostname">A parameter resource builder for the hostname value.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    [AspireExport("withIngressHostnameParam", Description = "Adds a parameterized hostname to a Kubernetes Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithHostname(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        IResourceBuilder<ParameterResource> hostname)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(hostname);
+
+        builder.Resource.Hostnames.Add(ReferenceExpression.Create($"{hostname.Resource}"));
         return builder;
     }
 
     /// <summary>
     /// Configures TLS termination for the ingress by referencing a Kubernetes TLS secret.
-    /// The secret must contain <c>tls.crt</c> and <c>tls.key</c> entries and exist in the
-    /// same namespace as the ingress. The TLS configuration applies to all hostnames
-    /// configured via <see cref="WithHostname"/>.
+    /// The TLS configuration applies to all hostnames configured via <see cref="WithHostname(IResourceBuilder{KubernetesIngressResource}, string)"/>.
     /// </summary>
     /// <param name="builder">The ingress resource builder.</param>
-    /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret containing
-    /// the TLS certificate and private key.</param>
+    /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
-    /// <example>
-    /// <code>
-    /// ingress.WithHostname("api.example.com")
-    ///        .WithTls("my-tls-secret");
-    /// </code>
-    /// </example>
     [AspireExport(Description = "Configures TLS for a Kubernetes Ingress using a K8S secret")]
     public static IResourceBuilder<KubernetesIngressResource> WithTls(
         this IResourceBuilder<KubernetesIngressResource> builder,
@@ -207,16 +216,35 @@ public static class KubernetesIngressExtensions
         ArgumentException.ThrowIfNullOrEmpty(secretName);
 
         builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
-            SecretName: secretName,
+            SecretName: ReferenceExpression.Create($"{secretName}"),
             Hosts: [.. builder.Resource.Hostnames]));
 
         return builder;
     }
 
     /// <summary>
-    /// Configures TLS termination for the ingress with an auto-generated secret name
-    /// derived from the ingress resource name. The TLS configuration applies to all
-    /// hostnames configured via <see cref="WithHostname"/>.
+    /// Configures TLS termination using a parameter for the secret name.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="secretName">A parameter resource builder for the secret name.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    [AspireExport("withIngressTlsParam", Description = "Configures TLS for a Kubernetes Ingress with a parameterized secret")]
+    public static IResourceBuilder<KubernetesIngressResource> WithTls(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        IResourceBuilder<ParameterResource> secretName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(secretName);
+
+        builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
+            SecretName: ReferenceExpression.Create($"{secretName.Resource}"),
+            Hosts: [.. builder.Resource.Hostnames]));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures TLS termination with an auto-generated secret name derived from the ingress name.
     /// </summary>
     /// <param name="builder">The ingress resource builder.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
@@ -229,7 +257,7 @@ public static class KubernetesIngressExtensions
         var secretName = $"{builder.Resource.Name}-tls";
 
         builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
-            SecretName: secretName,
+            SecretName: ReferenceExpression.Create($"{secretName}"),
             Hosts: [.. builder.Resource.Hostnames]));
 
         return builder;
@@ -284,7 +312,28 @@ public static class KubernetesIngressExtensions
         ArgumentException.ThrowIfNullOrEmpty(key);
         ArgumentNullException.ThrowIfNull(value);
 
-        builder.Resource.IngressAnnotations[key] = value;
+        builder.Resource.IngressAnnotations[key] = ReferenceExpression.Create($"{value}");
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a Kubernetes metadata annotation with a parameter value that will be resolved at deploy time.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="key">The annotation key.</param>
+    /// <param name="value">A parameter resource builder for the annotation value.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    [AspireExport("withIngressAnnotationParam", Description = "Adds a parameterized Kubernetes metadata annotation to an Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithIngressAnnotation(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        string key,
+        IResourceBuilder<ParameterResource> value)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        builder.Resource.IngressAnnotations[key] = ReferenceExpression.Create($"{value.Resource}");
         return builder;
     }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -1,0 +1,263 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Provides extension methods for configuring Kubernetes Ingress resources in the Aspire application model.
+/// </summary>
+public static class KubernetesIngressExtensions
+{
+    /// <summary>
+    /// Adds a Kubernetes Ingress resource to the application model as a child of the specified
+    /// Kubernetes environment. The ingress generates a <c>networking.k8s.io/v1 Ingress</c> resource
+    /// in the Helm chart output at publish time.
+    /// </summary>
+    /// <param name="builder">The Kubernetes environment resource builder.</param>
+    /// <param name="name">The name of the ingress resource. This is used as the Kubernetes resource name.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// After creating the ingress, configure routes using
+    /// <see cref="WithRoute(IResourceBuilder{KubernetesIngressResource}, string, EndpointReference, IngressPathType)"/>
+    /// and optionally set an ingress class with <see cref="WithIngressClass"/>.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var k8s = builder.AddKubernetesEnvironment("k8s");
+    /// var ingress = k8s.AddIngress("public")
+    ///     .WithIngressClass("nginx");
+    ///
+    /// var api = builder.AddProject&lt;MyApi&gt;("api");
+    /// ingress.WithRoute("/api", api.GetEndpoint("http"));
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Adds a Kubernetes Ingress resource for HTTP routing")]
+    public static IResourceBuilder<KubernetesIngressResource> AddIngress(
+        this IResourceBuilder<KubernetesEnvironmentResource> builder,
+        [ResourceName] string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var ingress = new KubernetesIngressResource(name, builder.Resource);
+
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            return builder.ApplicationBuilder.CreateResourceBuilder(ingress);
+        }
+
+        return builder.ApplicationBuilder.AddResource(ingress)
+            .ExcludeFromManifest();
+    }
+
+    /// <summary>
+    /// Sets the Kubernetes ingress class name that selects which ingress controller
+    /// handles this ingress resource.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="className">The ingress class name (e.g., <c>"nginx"</c>, <c>"traefik"</c>,
+    /// <c>"azure-alb-external"</c>).</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    [AspireExport(Description = "Sets the ingress class for a Kubernetes Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithIngressClass(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        string className)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(className);
+
+        builder.Resource.IngressClassName = className;
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a path-based routing rule to the ingress. The rule matches all hosts and routes
+    /// traffic matching the specified path to the given endpoint's backing Kubernetes service.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="path">The URL path to match (e.g., <c>"/"</c> or <c>"/api"</c>). Must start with <c>/</c>.</param>
+    /// <param name="endpoint">The endpoint reference identifying the target service and port.</param>
+    /// <param name="pathType">The path matching strategy. Defaults to <see cref="IngressPathType.Prefix"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// var api = builder.AddProject&lt;MyApi&gt;("api");
+    /// ingress.WithRoute("/api", api.GetEndpoint("http"));
+    /// </code>
+    /// </example>
+    [AspireExport("withIngressPathRoute", Description = "Adds a path-based route to a Kubernetes Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithRoute(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        string path,
+        EndpointReference endpoint,
+        IngressPathType pathType = IngressPathType.Prefix)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!path.StartsWith('/'))
+        {
+            throw new ArgumentException("Path must start with '/'.", nameof(path));
+        }
+
+        builder.Resource.Routes.Add(new IngressRouteConfig(
+            Host: null,
+            Path: path,
+            PathType: pathType,
+            Endpoint: endpoint));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a host-and-path-based routing rule to the ingress. The rule matches traffic for
+    /// the specified host and path, routing it to the given endpoint's backing Kubernetes service.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="host">The hostname to match (e.g., <c>"api.example.com"</c>).</param>
+    /// <param name="path">The URL path to match (e.g., <c>"/"</c> or <c>"/api"</c>). Must start with <c>/</c>.</param>
+    /// <param name="endpoint">The endpoint reference identifying the target service and port.</param>
+    /// <param name="pathType">The path matching strategy. Defaults to <see cref="IngressPathType.Prefix"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// var api = builder.AddProject&lt;MyApi&gt;("api");
+    /// ingress.WithRoute("api.example.com", "/", api.GetEndpoint("http"));
+    /// </code>
+    /// </example>
+    [AspireExport("withIngressHostRoute", Description = "Adds a host-and-path route to a Kubernetes Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithRoute(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        string host,
+        string path,
+        EndpointReference endpoint,
+        IngressPathType pathType = IngressPathType.Prefix)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(host);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!path.StartsWith('/'))
+        {
+            throw new ArgumentException("Path must start with '/'.", nameof(path));
+        }
+
+        builder.Resource.Routes.Add(new IngressRouteConfig(
+            Host: host,
+            Path: path,
+            PathType: pathType,
+            Endpoint: endpoint));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures TLS termination for the ingress by referencing a Kubernetes TLS secret.
+    /// The secret must contain <c>tls.crt</c> and <c>tls.key</c> entries and exist in the
+    /// same namespace as the ingress.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret containing
+    /// the TLS certificate and private key.</param>
+    /// <param name="hosts">One or more hostnames that the TLS certificate covers.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// ingress.WithTls("my-tls-secret", "api.example.com", "www.example.com");
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Configures TLS for a Kubernetes Ingress using a K8S secret")]
+    public static IResourceBuilder<KubernetesIngressResource> WithTls(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        string secretName,
+        params string[] hosts)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(secretName);
+        ArgumentNullException.ThrowIfNull(hosts);
+
+        if (hosts.Length == 0)
+        {
+            throw new ArgumentException("At least one host must be specified for TLS.", nameof(hosts));
+        }
+
+        builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
+            SecretName: secretName,
+            Hosts: [.. hosts]));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the default backend for the ingress. The default backend handles requests that
+    /// do not match any of the defined routing rules.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="endpoint">The endpoint reference identifying the default backend service and port.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    [AspireExport(Description = "Sets the default backend for a Kubernetes Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithDefaultBackend(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        EndpointReference endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        builder.Resource.DefaultBackend = new IngressDefaultBackendConfig(endpoint);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a Kubernetes metadata annotation to the generated Ingress resource. These are
+    /// key-value pairs in the <c>metadata.annotations</c> field of the K8S Ingress, commonly
+    /// used to configure ingress controller-specific behavior.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="key">The annotation key (e.g., <c>"nginx.ingress.kubernetes.io/rewrite-target"</c>).</param>
+    /// <param name="value">The annotation value.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// This method sets Kubernetes metadata annotations, not Aspire <see cref="ApplicationModel.IResourceAnnotation"/>
+    /// instances. Use these for controller-specific features like path rewriting, rate limiting,
+    /// CORS configuration, or SSL redirect behavior.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// ingress.WithIngressAnnotation("nginx.ingress.kubernetes.io/rewrite-target", "/$1");
+    /// ingress.WithIngressAnnotation("nginx.ingress.kubernetes.io/ssl-redirect", "true");
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Adds a Kubernetes metadata annotation to a Kubernetes Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithIngressAnnotation(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        string key,
+        string value)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        builder.Resource.IngressAnnotations[key] = value;
+        return builder;
+    }
+
+    /// <summary>
+    /// Converts an <see cref="IngressPathType"/> enum value to the Kubernetes API string representation.
+    /// </summary>
+    internal static string ToKubernetesString(this IngressPathType pathType)
+    {
+        return pathType switch
+        {
+            IngressPathType.Prefix => "Prefix",
+            IngressPathType.Exact => "Exact",
+            IngressPathType.ImplementationSpecific => "ImplementationSpecific",
+            _ => throw new ArgumentOutOfRangeException(nameof(pathType), pathType, "Unknown path type.")
+        };
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -22,7 +22,7 @@ public static class KubernetesIngressExtensions
     /// <para>
     /// After creating the ingress, configure routes using
     /// <see cref="WithRoute(IResourceBuilder{KubernetesIngressResource}, string, EndpointReference, IngressPathType)"/>
-    /// and optionally set an ingress class with <see cref="WithIngressClass"/>.
+    /// and optionally set an ingress class with <see cref="WithIngressClass(IResourceBuilder{KubernetesIngressResource}, string)"/>.
     /// </para>
     /// </remarks>
     /// <example>
@@ -71,6 +71,24 @@ public static class KubernetesIngressExtensions
         ArgumentException.ThrowIfNullOrEmpty(className);
 
         builder.Resource.IngressClassName = className;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the Kubernetes ingress class name using a parameter that will be resolved at deploy time.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="className">A parameter resource builder for the ingress class name.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    [AspireExport("withIngressClassParam", Description = "Sets a parameterized ingress class for a Kubernetes Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithIngressClass(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        IResourceBuilder<ParameterResource> className)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(className);
+
+        builder.Resource.IngressClassName = className.Resource.Name;
         return builder;
     }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -70,7 +70,7 @@ public static class KubernetesIngressExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(className);
 
-        builder.Resource.IngressClassName = className;
+        builder.Resource.IngressClassName = ReferenceExpression.Create($"{className}");
         return builder;
     }
 
@@ -88,7 +88,7 @@ public static class KubernetesIngressExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(className);
 
-        builder.Resource.IngressClassName = className.Resource.Name;
+        builder.Resource.IngressClassName = ReferenceExpression.Create($"{className.Resource}");
         return builder;
     }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -158,38 +158,79 @@ public static class KubernetesIngressExtensions
     }
 
     /// <summary>
+    /// Adds a hostname that this ingress matches. Multiple hostnames can be added by calling
+    /// this method repeatedly. If no hostnames are configured, the ingress matches all hosts.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="hostname">The hostname to match (e.g., <c>"api.example.com"</c>).</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// ingress.WithHostname("api.example.com")
+    ///        .WithHostname("www.example.com");
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Adds a hostname to a Kubernetes Ingress")]
+    public static IResourceBuilder<KubernetesIngressResource> WithHostname(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        string hostname)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(hostname);
+
+        builder.Resource.Hostnames.Add(hostname);
+        return builder;
+    }
+
+    /// <summary>
     /// Configures TLS termination for the ingress by referencing a Kubernetes TLS secret.
     /// The secret must contain <c>tls.crt</c> and <c>tls.key</c> entries and exist in the
-    /// same namespace as the ingress.
+    /// same namespace as the ingress. The TLS configuration applies to all hostnames
+    /// configured via <see cref="WithHostname"/>.
     /// </summary>
     /// <param name="builder">The ingress resource builder.</param>
     /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret containing
     /// the TLS certificate and private key.</param>
-    /// <param name="hosts">One or more hostnames that the TLS certificate covers.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
     /// <example>
     /// <code>
-    /// ingress.WithTls("my-tls-secret", "api.example.com", "www.example.com");
+    /// ingress.WithHostname("api.example.com")
+    ///        .WithTls("my-tls-secret");
     /// </code>
     /// </example>
     [AspireExport(Description = "Configures TLS for a Kubernetes Ingress using a K8S secret")]
     public static IResourceBuilder<KubernetesIngressResource> WithTls(
         this IResourceBuilder<KubernetesIngressResource> builder,
-        string secretName,
-        params string[] hosts)
+        string secretName)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(secretName);
-        ArgumentNullException.ThrowIfNull(hosts);
-
-        if (hosts.Length == 0)
-        {
-            throw new ArgumentException("At least one host must be specified for TLS.", nameof(hosts));
-        }
 
         builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
             SecretName: secretName,
-            Hosts: [.. hosts]));
+            Hosts: [.. builder.Resource.Hostnames]));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures TLS termination for the ingress with an auto-generated secret name
+    /// derived from the ingress resource name. The TLS configuration applies to all
+    /// hostnames configured via <see cref="WithHostname"/>.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    [AspireExport("withIngressTlsAuto", Description = "Configures TLS for a Kubernetes Ingress with an auto-generated secret")]
+    public static IResourceBuilder<KubernetesIngressResource> WithTls(
+        this IResourceBuilder<KubernetesIngressResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var secretName = $"{builder.Resource.Name}-tls";
+
+        builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
+            SecretName: secretName,
+            Hosts: [.. builder.Resource.Hostnames]));
 
         return builder;
     }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
@@ -52,6 +52,11 @@ public class KubernetesIngressResource(
     public string? IngressClassName { get; set; }
 
     /// <summary>
+    /// Gets the list of hostnames this ingress matches. If empty, the ingress matches all hosts.
+    /// </summary>
+    internal List<string> Hostnames { get; } = [];
+
+    /// <summary>
     /// Gets the list of routing rules configured for this ingress.
     /// </summary>
     internal List<IngressRouteConfig> Routes { get; } = [];

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Represents a Kubernetes Ingress as a first-class resource in the Aspire application model.
+/// An Ingress defines HTTP routing rules that direct external traffic to services in the cluster.
+/// </summary>
+/// <param name="name">The name of the ingress resource.</param>
+/// <param name="environment">The parent Kubernetes environment resource.</param>
+/// <remarks>
+/// <para>
+/// Create an ingress using <see cref="KubernetesIngressExtensions.AddIngress"/> and configure
+/// routes using <see cref="KubernetesIngressExtensions.WithRoute(IResourceBuilder{KubernetesIngressResource}, string, EndpointReference, IngressPathType)"/>.
+/// </para>
+/// <para>
+/// At publish time, the ingress generates a Kubernetes <c>networking.k8s.io/v1 Ingress</c> resource
+/// in the Helm chart output with rules derived from the configured routes.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var k8s = builder.AddKubernetesEnvironment("k8s");
+/// var ingress = k8s.AddIngress("public")
+///     .WithIngressClass("nginx");
+///
+/// var api = builder.AddProject&lt;MyApi&gt;("api");
+/// ingress.WithRoute("/api", api.GetEndpoint("http"));
+/// </code>
+/// </example>
+[AspireExport]
+public class KubernetesIngressResource(
+    string name,
+    KubernetesEnvironmentResource environment) : Resource(name), IResourceWithParent<KubernetesEnvironmentResource>
+{
+    /// <summary>
+    /// Gets the parent Kubernetes environment resource.
+    /// </summary>
+    public KubernetesEnvironmentResource Parent { get; } = environment ?? throw new ArgumentNullException(nameof(environment));
+
+    /// <summary>
+    /// Gets or sets the Kubernetes ingress class name that selects which ingress controller
+    /// will handle this ingress resource.
+    /// </summary>
+    /// <remarks>
+    /// Common values include <c>"nginx"</c>, <c>"traefik"</c>, <c>"azure-alb-external"</c> (for AKS with AGC),
+    /// or controller-specific class names. If not set, the cluster's default ingress class is used.
+    /// </remarks>
+    public string? IngressClassName { get; set; }
+
+    /// <summary>
+    /// Gets the list of routing rules configured for this ingress.
+    /// </summary>
+    internal List<IngressRouteConfig> Routes { get; } = [];
+
+    /// <summary>
+    /// Gets the list of TLS configurations for this ingress.
+    /// </summary>
+    internal List<IngressTlsConfig> TlsConfigs { get; } = [];
+
+    /// <summary>
+    /// Gets the Kubernetes metadata annotations to add to the generated Ingress resource.
+    /// These are key-value pairs placed in the <c>metadata.annotations</c> field of the K8S Ingress,
+    /// not Aspire <see cref="IResourceAnnotation"/> instances.
+    /// </summary>
+    internal Dictionary<string, string> IngressAnnotations { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the default backend configuration for unmatched requests.
+    /// </summary>
+    internal IngressDefaultBackendConfig? DefaultBackend { get; set; }
+
+    /// <summary>
+    /// Gets the generated K8S Ingress object, populated during infrastructure processing.
+    /// </summary>
+    internal Resources.Ingress? GeneratedIngress { get; set; }
+}
+
+/// <summary>
+/// Specifies the type of path matching used in a Kubernetes Ingress rule.
+/// </summary>
+public enum IngressPathType
+{
+    /// <summary>
+    /// Matches based on a URL path prefix split by <c>/</c>. Matching is case-sensitive
+    /// and done element-by-element. For example, <c>/api</c> matches <c>/api</c>, <c>/api/</c>,
+    /// and <c>/api/v1</c> but not <c>/apiv1</c>.
+    /// </summary>
+    Prefix,
+
+    /// <summary>
+    /// Matches the URL path exactly and with case sensitivity.
+    /// </summary>
+    Exact,
+
+    /// <summary>
+    /// Matching is delegated to the ingress controller. Check the controller's documentation
+    /// for the supported matching semantics.
+    /// </summary>
+    ImplementationSpecific
+}
+
+/// <summary>
+/// Stores a single routing rule for a <see cref="KubernetesIngressResource"/>.
+/// </summary>
+internal sealed record IngressRouteConfig(
+    string? Host,
+    string Path,
+    IngressPathType PathType,
+    EndpointReference Endpoint);
+
+/// <summary>
+/// Stores TLS configuration for a <see cref="KubernetesIngressResource"/>.
+/// </summary>
+internal sealed record IngressTlsConfig(
+    string SecretName,
+    List<string> Hosts);
+
+/// <summary>
+/// Stores the default backend configuration for a <see cref="KubernetesIngressResource"/>.
+/// </summary>
+internal sealed record IngressDefaultBackendConfig(EndpointReference Endpoint);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
@@ -54,7 +54,7 @@ public class KubernetesIngressResource(
     /// <summary>
     /// Gets the list of hostnames this ingress matches. If empty, the ingress matches all hosts.
     /// </summary>
-    internal List<string> Hostnames { get; } = [];
+    internal List<ReferenceExpression> Hostnames { get; } = [];
 
     /// <summary>
     /// Gets the list of routing rules configured for this ingress.
@@ -71,7 +71,7 @@ public class KubernetesIngressResource(
     /// These are key-value pairs placed in the <c>metadata.annotations</c> field of the K8S Ingress,
     /// not Aspire <see cref="IResourceAnnotation"/> instances.
     /// </summary>
-    internal Dictionary<string, string> IngressAnnotations { get; } = [];
+    internal Dictionary<string, ReferenceExpression> IngressAnnotations { get; } = [];
 
     /// <summary>
     /// Gets or sets the default backend configuration for unmatched requests.
@@ -121,8 +121,8 @@ internal sealed record IngressRouteConfig(
 /// Stores TLS configuration for a <see cref="KubernetesIngressResource"/>.
 /// </summary>
 internal sealed record IngressTlsConfig(
-    string SecretName,
-    List<string> Hosts);
+    ReferenceExpression SecretName,
+    List<ReferenceExpression> Hosts);
 
 /// <summary>
 /// Stores the default backend configuration for a <see cref="KubernetesIngressResource"/>.

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
@@ -49,7 +49,7 @@ public class KubernetesIngressResource(
     /// Common values include <c>"nginx"</c>, <c>"traefik"</c>, <c>"azure-alb-external"</c> (for AKS with AGC),
     /// or controller-specific class names. If not set, the cluster's default ingress class is used.
     /// </remarks>
-    public string? IngressClassName { get; set; }
+    public ReferenceExpression? IngressClassName { get; set; }
 
     /// <summary>
     /// Gets the list of hostnames this ingress matches. If empty, the ingress matches all hosts.

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -116,6 +116,26 @@ internal sealed class KubernetesPublishingContext(
             }
         }
 
+        // Write Ingress resources as standalone templates.
+        foreach (var ingressResource in resources.OfType<KubernetesIngressResource>())
+        {
+            if (ingressResource.Parent == environment && ingressResource.GeneratedIngress is { } generatedIngress)
+            {
+                await WriteKubernetesTemplatesForResource(ingressResource, [generatedIngress]).ConfigureAwait(false);
+            }
+        }
+
+        // Write Gateway API resources (Gateway + HTTPRoutes) as standalone templates.
+        foreach (var gatewayResource in resources.OfType<KubernetesGatewayResource>())
+        {
+            if (gatewayResource.Parent == environment && gatewayResource.GeneratedGateway is { } generatedGateway)
+            {
+                var gatewayObjects = new List<BaseKubernetesResource> { generatedGateway };
+                gatewayObjects.AddRange(gatewayResource.GeneratedHttpRoutes);
+                await WriteKubernetesTemplatesForResource(gatewayResource, gatewayObjects).ConfigureAwait(false);
+            }
+        }
+
         await WriteKubernetesHelmChartAsync(environment).ConfigureAwait(false);
         await WriteKubernetesHelmValuesAsync().ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting.Kubernetes/Resources/GatewayV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/GatewayV1.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.Kubernetes.Resources;
+
+/// <summary>
+/// Represents a Gateway resource in Kubernetes (gateway.networking.k8s.io/v1).
+/// </summary>
+[YamlSerializable]
+public sealed class GatewayV1() : BaseKubernetesResource("gateway.networking.k8s.io/v1", "Gateway")
+{
+    /// <summary>
+    /// Gets or sets the specification of the Gateway resource.
+    /// </summary>
+    [YamlMember(Alias = "spec")]
+    public GatewaySpecV1 Spec { get; set; } = new();
+}
+
+/// <summary>
+/// Represents the specification of a Gateway resource.
+/// </summary>
+[YamlSerializable]
+public sealed class GatewaySpecV1
+{
+    /// <summary>
+    /// Gets or sets the name of the GatewayClass that this Gateway is associated with.
+    /// </summary>
+    [YamlMember(Alias = "gatewayClassName")]
+    public string GatewayClassName { get; set; } = null!;
+
+    /// <summary>
+    /// Gets the listeners associated with this Gateway. Each listener defines a port,
+    /// protocol, and optional TLS configuration.
+    /// </summary>
+    [YamlMember(Alias = "listeners")]
+    public List<GatewayListenerV1> Listeners { get; } = [];
+}
+
+/// <summary>
+/// Represents a listener on a Gateway. A listener defines how the Gateway receives traffic
+/// on a specific port and protocol.
+/// </summary>
+[YamlSerializable]
+public sealed class GatewayListenerV1
+{
+    /// <summary>
+    /// Gets or sets the name of this listener. Must be unique within the Gateway.
+    /// </summary>
+    [YamlMember(Alias = "name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the protocol for this listener (e.g., <c>"HTTP"</c>, <c>"HTTPS"</c>, <c>"TLS"</c>).
+    /// </summary>
+    [YamlMember(Alias = "protocol")]
+    public string Protocol { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the network port for this listener.
+    /// </summary>
+    [YamlMember(Alias = "port")]
+    public int Port { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional hostname for this listener. When set, only requests
+    /// matching this hostname are handled by this listener.
+    /// </summary>
+    [YamlMember(Alias = "hostname")]
+    public string? Hostname { get; set; }
+
+    /// <summary>
+    /// Gets or sets the TLS configuration for this listener. Required when protocol is HTTPS or TLS.
+    /// </summary>
+    [YamlMember(Alias = "tls")]
+    public GatewayTlsConfigV1? Tls { get; set; }
+
+    /// <summary>
+    /// Gets or sets the allowed routes configuration for this listener.
+    /// </summary>
+    [YamlMember(Alias = "allowedRoutes")]
+    public GatewayAllowedRoutesV1? AllowedRoutes { get; set; }
+}
+
+/// <summary>
+/// TLS configuration for a Gateway listener.
+/// </summary>
+[YamlSerializable]
+public sealed class GatewayTlsConfigV1
+{
+    /// <summary>
+    /// Gets or sets the TLS mode. Common values are <c>"Terminate"</c> (Gateway decrypts)
+    /// and <c>"Passthrough"</c> (backend decrypts).
+    /// </summary>
+    [YamlMember(Alias = "mode")]
+    public string Mode { get; set; } = "Terminate";
+
+    /// <summary>
+    /// Gets the certificate references for TLS termination.
+    /// </summary>
+    [YamlMember(Alias = "certificateRefs")]
+    public List<GatewayCertificateRefV1> CertificateRefs { get; } = [];
+}
+
+/// <summary>
+/// A reference to a TLS certificate stored as a Kubernetes Secret.
+/// </summary>
+[YamlSerializable]
+public sealed class GatewayCertificateRefV1
+{
+    /// <summary>
+    /// Gets or sets the name of the Kubernetes Secret containing the TLS certificate.
+    /// </summary>
+    [YamlMember(Alias = "name")]
+    public string Name { get; set; } = null!;
+}
+
+/// <summary>
+/// Defines which routes are allowed to attach to a Gateway listener.
+/// </summary>
+[YamlSerializable]
+public sealed class GatewayAllowedRoutesV1
+{
+    /// <summary>
+    /// Gets or sets the namespace selector for allowed routes.
+    /// </summary>
+    [YamlMember(Alias = "namespaces")]
+    public GatewayRouteNamespacesV1? Namespaces { get; set; }
+}
+
+/// <summary>
+/// Defines which namespaces routes can come from.
+/// </summary>
+[YamlSerializable]
+public sealed class GatewayRouteNamespacesV1
+{
+    /// <summary>
+    /// Gets or sets the namespace selection policy. Values: <c>"Same"</c>, <c>"All"</c>, <c>"Selector"</c>.
+    /// </summary>
+    [YamlMember(Alias = "from")]
+    public string From { get; set; } = "Same";
+}

--- a/src/Aspire.Hosting.Kubernetes/Resources/HttpRouteV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/HttpRouteV1.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.Kubernetes.Resources;
+
+/// <summary>
+/// Represents an HTTPRoute resource in Kubernetes (gateway.networking.k8s.io/v1).
+/// HTTPRoute defines HTTP routing rules that attach to a Gateway.
+/// </summary>
+[YamlSerializable]
+public sealed class HttpRouteV1() : BaseKubernetesResource("gateway.networking.k8s.io/v1", "HTTPRoute")
+{
+    /// <summary>
+    /// Gets or sets the specification of the HTTPRoute resource.
+    /// </summary>
+    [YamlMember(Alias = "spec")]
+    public HttpRouteSpecV1 Spec { get; set; } = new();
+}
+
+/// <summary>
+/// Represents the specification of an HTTPRoute resource.
+/// </summary>
+[YamlSerializable]
+public sealed class HttpRouteSpecV1
+{
+    /// <summary>
+    /// Gets the parent references that this route attaches to (typically Gateway resources).
+    /// </summary>
+    [YamlMember(Alias = "parentRefs")]
+    public List<HttpRouteParentRefV1> ParentRefs { get; } = [];
+
+    /// <summary>
+    /// Gets the hostnames that this route matches. If empty, matches all hostnames.
+    /// </summary>
+    [YamlMember(Alias = "hostnames")]
+    public List<string> Hostnames { get; } = [];
+
+    /// <summary>
+    /// Gets the routing rules for this HTTPRoute.
+    /// </summary>
+    [YamlMember(Alias = "rules")]
+    public List<HttpRouteRuleV1> Rules { get; } = [];
+}
+
+/// <summary>
+/// A reference to a parent resource (typically a Gateway) that an HTTPRoute attaches to.
+/// </summary>
+[YamlSerializable]
+public sealed class HttpRouteParentRefV1
+{
+    /// <summary>
+    /// Gets or sets the name of the parent Gateway resource.
+    /// </summary>
+    [YamlMember(Alias = "name")]
+    public string Name { get; set; } = null!;
+}
+
+/// <summary>
+/// A single routing rule in an HTTPRoute. Each rule matches requests and forwards
+/// them to one or more backend services.
+/// </summary>
+[YamlSerializable]
+public sealed class HttpRouteRuleV1
+{
+    /// <summary>
+    /// Gets the match conditions for this rule. A request must satisfy all conditions
+    /// in at least one match to be routed by this rule.
+    /// </summary>
+    [YamlMember(Alias = "matches")]
+    public List<HttpRouteMatchV1> Matches { get; } = [];
+
+    /// <summary>
+    /// Gets the backend references that matched requests are forwarded to.
+    /// </summary>
+    [YamlMember(Alias = "backendRefs")]
+    public List<HttpRouteBackendRefV1> BackendRefs { get; } = [];
+}
+
+/// <summary>
+/// Defines match conditions for an HTTPRoute rule.
+/// </summary>
+[YamlSerializable]
+public sealed class HttpRouteMatchV1
+{
+    /// <summary>
+    /// Gets or sets the path match condition.
+    /// </summary>
+    [YamlMember(Alias = "path")]
+    public HttpRoutePathMatchV1? Path { get; set; }
+
+    /// <summary>
+    /// Gets the header match conditions.
+    /// </summary>
+    [YamlMember(Alias = "headers")]
+    public List<HttpRouteHeaderMatchV1> Headers { get; } = [];
+}
+
+/// <summary>
+/// Defines a path match condition for an HTTPRoute rule.
+/// </summary>
+[YamlSerializable]
+public sealed class HttpRoutePathMatchV1
+{
+    /// <summary>
+    /// Gets or sets the type of path matching. Values: <c>"PathPrefix"</c>, <c>"Exact"</c>.
+    /// </summary>
+    [YamlMember(Alias = "type")]
+    public string Type { get; set; } = "PathPrefix";
+
+    /// <summary>
+    /// Gets or sets the path value to match.
+    /// </summary>
+    [YamlMember(Alias = "value")]
+    public string Value { get; set; } = null!;
+}
+
+/// <summary>
+/// Defines a header match condition for an HTTPRoute rule.
+/// </summary>
+[YamlSerializable]
+public sealed class HttpRouteHeaderMatchV1
+{
+    /// <summary>
+    /// Gets or sets the match type. Values: <c>"Exact"</c>, <c>"RegularExpression"</c>.
+    /// </summary>
+    [YamlMember(Alias = "type")]
+    public string Type { get; set; } = "Exact";
+
+    /// <summary>
+    /// Gets or sets the header name.
+    /// </summary>
+    [YamlMember(Alias = "name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the header value to match.
+    /// </summary>
+    [YamlMember(Alias = "value")]
+    public string Value { get; set; } = null!;
+}
+
+/// <summary>
+/// A reference to a backend service that receives matched traffic.
+/// </summary>
+[YamlSerializable]
+public sealed class HttpRouteBackendRefV1
+{
+    /// <summary>
+    /// Gets or sets the name of the Kubernetes Service.
+    /// </summary>
+    [YamlMember(Alias = "name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the port number on the service.
+    /// </summary>
+    [YamlMember(Alias = "port")]
+    public int Port { get; set; }
+}

--- a/src/Aspire.Hosting.Kubernetes/Resources/IngressBackendV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/IngressBackendV1.cs
@@ -25,12 +25,12 @@ public sealed class IngressBackendV1
     /// allowing specification of the resource's kind, name, and associated API group.
     /// </remarks>
     [YamlMember(Alias = "resource")]
-    public TypedLocalObjectReferenceV1 Resource { get; set; } = new();
+    public TypedLocalObjectReferenceV1 Resource { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the backend service information associated with the ingress resource.
     /// This includes the name of the service and its corresponding port configuration.
     /// </summary>
     [YamlMember(Alias = "service")]
-    public IngressServiceBackendV1 Service { get; set; } = new();
+    public IngressServiceBackendV1 Service { get; set; } = null!;
 }

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesIngressTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE003
+
+using Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureKubernetesIngressTests
+{
+    // With AKS, there are two compute environments (AKS + inner K8s),
+    // so the Helm chart output goes to {outputDir}/{k8sEnvName}/...
+    private const string K8sEnvSubdir = "aks-k8s";
+
+    [Fact]
+    public async Task AksAddIngress_WithRoute_GeneratesIngressInHelmOutput()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var ingress = aks.AddIngress("public")
+            .WithIngressClass("nginx");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithRoute("/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        // With AKS, the Helm output goes to the inner K8S env subdirectory
+        var ingressPath = Path.Combine(tempDir.Path, K8sEnvSubdir, "templates", "public", "public.yaml");
+        Assert.True(File.Exists(ingressPath), $"Expected ingress YAML at {ingressPath}");
+
+        var content = await File.ReadAllTextAsync(ingressPath);
+        Assert.Contains("Ingress", content);
+        Assert.Contains("nginx", content);
+    }
+
+    [Fact]
+    public void AksAddIngress_HasCorrectParent()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var ingress = aks.AddIngress("public");
+
+        // The ingress should be a child of the inner K8S environment, not the AKS environment
+        Assert.IsType<KubernetesIngressResource>(ingress.Resource);
+        Assert.IsType<KubernetesEnvironmentResource>(ingress.Resource.Parent);
+    }
+
+    [Fact]
+    public void AksAddGateway_HasCorrectParent()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var gateway = aks.AddGateway("public");
+
+        Assert.IsType<KubernetesGatewayResource>(gateway.Resource);
+        Assert.IsType<KubernetesEnvironmentResource>(gateway.Resource.Parent);
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -1,0 +1,230 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Kubernetes.Tests;
+
+public class KubernetesGatewayTests
+{
+    [Fact]
+    public async Task AddGateway_WithRoute_GeneratesGatewayAndHttpRoute()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public")
+            .WithGatewayClass("nginx");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway.WithRoute("/api", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        // Should generate Gateway and HTTPRoute files
+        var gatewayDir = Path.Combine(tempDir.Path, "templates", "public");
+        Assert.True(Directory.Exists(gatewayDir), $"Gateway templates dir not found at {gatewayDir}");
+
+        var files = Directory.GetFiles(gatewayDir);
+        Assert.True(files.Length >= 2, $"Expected at least 2 files (Gateway + HTTPRoute), got {files.Length}");
+
+        // Check Gateway YAML
+        var gatewayFile = files.FirstOrDefault(f => Path.GetFileName(f) == "public.yaml");
+        Assert.NotNull(gatewayFile);
+        var gatewayContent = await File.ReadAllTextAsync(gatewayFile);
+        Assert.Contains("Gateway", gatewayContent);
+        Assert.Contains("nginx", gatewayContent);
+        Assert.Contains("HTTP", gatewayContent);
+
+        // Check HTTPRoute YAML
+        var routeFile = files.FirstOrDefault(f => f.Contains("route"));
+        Assert.NotNull(routeFile);
+        var routeContent = await File.ReadAllTextAsync(routeFile);
+        Assert.Contains("HTTPRoute", routeContent);
+        Assert.Contains("/api", routeContent);
+        Assert.Contains("PathPrefix", routeContent);
+    }
+
+    [Fact]
+    public async Task AddGateway_WithHostRoute_GeneratesHostnameInHttpRoute()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway.WithRoute("api.example.com", "/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        var gatewayDir = Path.Combine(tempDir.Path, "templates", "public");
+        var routeFile = Directory.GetFiles(gatewayDir).FirstOrDefault(f => f.Contains("route"));
+        Assert.NotNull(routeFile);
+
+        var content = await File.ReadAllTextAsync(routeFile);
+        Assert.Contains("api.example.com", content);
+        Assert.Contains("HTTPRoute", content);
+    }
+
+    [Fact]
+    public async Task AddGateway_WithTls_GeneratesHttpsListener()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway
+            .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
+            .WithTls("my-tls-secret", "api.example.com");
+
+        var app = builder.Build();
+        app.Run();
+
+        // Check Gateway has HTTPS listener
+        var gatewayFile = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(gatewayFile);
+
+        Assert.Contains("HTTPS", content);
+        Assert.Contains("Terminate", content);
+        Assert.Contains("my-tls-secret", content);
+        Assert.Contains("api.example.com", content);
+        // Should also have HTTP listener
+        Assert.Contains("HTTP", content);
+    }
+
+    [Fact]
+    public async Task AddGateway_WithTls_DoesNotDuplicateRoutes()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway
+            .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
+            .WithTls("my-tls-secret", "api.example.com");
+
+        var app = builder.Build();
+        app.Run();
+
+        // Should have exactly 1 HTTPRoute file (TLS doesn't create a separate route)
+        var gatewayDir = Path.Combine(tempDir.Path, "templates", "public");
+        var routeFiles = Directory.GetFiles(gatewayDir).Where(f => f.Contains("route")).ToArray();
+        Assert.Single(routeFiles);
+    }
+
+    [Fact]
+    public async Task AddGateway_MultipleRoutes_GroupsByHost()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        var web = builder.AddContainer("myweb", "nginx")
+            .WithHttpEndpoint(targetPort: 80);
+
+        // Two routes on the same host ΓåÆ should be grouped into one HTTPRoute
+        gateway.WithRoute("example.com", "/api", api.GetEndpoint("http"));
+        gateway.WithRoute("example.com", "/", web.GetEndpoint("http"));
+        // One route on a different host
+        gateway.WithRoute("other.com", "/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        var gatewayDir = Path.Combine(tempDir.Path, "templates", "public");
+        var routeFiles = Directory.GetFiles(gatewayDir).Where(f => f.Contains("route")).ToArray();
+        // Should have 2 HTTPRoute files: one for example.com, one for other.com
+        Assert.Equal(2, routeFiles.Length);
+    }
+
+    [Fact]
+    public async Task AddGateway_NoRoutes_DoesNotGenerateYaml()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        k8s.AddGateway("empty");
+
+        builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        var app = builder.Build();
+        app.Run();
+
+        var gatewayDir = Path.Combine(tempDir.Path, "templates", "empty");
+        Assert.False(Directory.Exists(gatewayDir), $"Gateway directory should not exist at {gatewayDir}");
+    }
+
+    [Fact]
+    public void WithRoute_InvalidPath_Throws()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        Assert.Throws<ArgumentException>(() =>
+            gateway.WithRoute("no-leading-slash", api.GetEndpoint("http")));
+    }
+
+    [Fact]
+    public void AddGateway_HasCorrectParent()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public");
+
+        Assert.Equal(k8s.Resource, gateway.Resource.Parent);
+        Assert.IsType<KubernetesGatewayResource>(gateway.Resource);
+    }
+
+    [Fact]
+    public async Task AddGateway_BackwardCompatible_NoGatewayNoChange()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        builder.AddKubernetesEnvironment("env");
+
+        builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        var app = builder.Build();
+        app.Run();
+
+        // Service and deployment should exist but no gateway
+        var templatesDir = Path.Combine(tempDir.Path, "templates", "myapi");
+        Assert.True(Directory.Exists(templatesDir));
+
+        var files = Directory.GetFiles(templatesDir);
+        Assert.DoesNotContain(files, f => f.Contains("gateway", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(files, f => f.Contains("route", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -56,7 +56,7 @@ public class KubernetesGatewayTests
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
 
         var k8s = builder.AddKubernetesEnvironment("env");
-        var gateway = k8s.AddGateway("public");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
             .WithHttpEndpoint(targetPort: 8080);
@@ -82,14 +82,14 @@ public class KubernetesGatewayTests
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
 
         var k8s = builder.AddKubernetesEnvironment("env");
-        var gateway = k8s.AddGateway("public");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
             .WithHttpEndpoint(targetPort: 8080);
 
         gateway
             .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
-            .WithTls("my-tls-secret", "api.example.com");
+            .WithHostname("api.example.com").WithTls("my-tls-secret");
 
         var app = builder.Build();
         app.Run();
@@ -113,14 +113,14 @@ public class KubernetesGatewayTests
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
 
         var k8s = builder.AddKubernetesEnvironment("env");
-        var gateway = k8s.AddGateway("public");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
             .WithHttpEndpoint(targetPort: 8080);
 
         gateway
             .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
-            .WithTls("my-tls-secret", "api.example.com");
+            .WithHostname("api.example.com").WithTls("my-tls-secret");
 
         var app = builder.Build();
         app.Run();
@@ -138,7 +138,7 @@ public class KubernetesGatewayTests
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
 
         var k8s = builder.AddKubernetesEnvironment("env");
-        var gateway = k8s.AddGateway("public");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
             .WithHttpEndpoint(targetPort: 8080);
@@ -185,7 +185,7 @@ public class KubernetesGatewayTests
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
-        var gateway = k8s.AddGateway("public");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
             .WithHttpEndpoint(targetPort: 8080);
@@ -199,7 +199,7 @@ public class KubernetesGatewayTests
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
-        var gateway = k8s.AddGateway("public");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         Assert.Equal(k8s.Resource, gateway.Resource.Parent);
         Assert.IsType<KubernetesGatewayResource>(gateway.Resource);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -1,0 +1,352 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Kubernetes.Tests;
+
+public class KubernetesIngressTests
+{
+    [Fact]
+    public async Task AddIngress_WithRoute_GeneratesIngressYaml()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public")
+            .WithIngressClass("nginx");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithRoute("/api", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        // Verify ingress YAML was generated
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        Assert.True(File.Exists(ingressPath), $"Expected ingress YAML at {ingressPath}");
+
+        var content = await File.ReadAllTextAsync(ingressPath);
+        Assert.Contains("Ingress", content);
+        Assert.Contains("ingressClassName", content);
+        Assert.Contains("nginx", content);
+        Assert.Contains("path: \"/api\"", content);
+        Assert.Contains("pathType", content);
+        Assert.Contains("Prefix", content);
+    }
+
+    [Fact]
+    public async Task AddIngress_WithHostRoute_GeneratesHostRule()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithRoute("api.example.com", "/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        Assert.True(File.Exists(ingressPath), $"Expected ingress YAML at {ingressPath}");
+
+        var content = await File.ReadAllTextAsync(ingressPath);
+        Assert.Contains("api.example.com", content);
+        Assert.Contains("path: \"/\"", content);
+    }
+
+    [Fact]
+    public async Task AddIngress_WithTls_GeneratesTlsSection()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress
+            .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
+            .WithTls("my-tls-secret", "api.example.com");
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(ingressPath);
+
+        Assert.Contains("my-tls-secret", content);
+        Assert.Contains("api.example.com", content);
+    }
+
+    [Fact]
+    public async Task AddIngress_WithMultipleRoutes_GroupsByHost()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        var web = builder.AddContainer("myweb", "nginx")
+            .WithHttpEndpoint(targetPort: 80);
+
+        // Two routes on the same host
+        ingress.WithRoute("example.com", "/api", api.GetEndpoint("http"));
+        ingress.WithRoute("example.com", "/", web.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(ingressPath);
+
+        // Should have one host rule with two paths
+        Assert.Contains("example.com", content);
+        Assert.Contains("/api", content);
+        Assert.Contains("path: \"/\"", content);
+    }
+
+    [Fact]
+    public async Task AddIngress_WithAnnotations_GeneratesAnnotations()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public")
+            .WithIngressAnnotation("nginx.ingress.kubernetes.io/rewrite-target", "/$1");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithRoute("/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(ingressPath);
+
+        Assert.Contains("nginx.ingress.kubernetes.io/rewrite-target", content);
+    }
+
+    [Fact]
+    public async Task AddIngress_WithExactPathType_GeneratesExactPathType()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithRoute("/exact", api.GetEndpoint("http"), IngressPathType.Exact);
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(ingressPath);
+
+        Assert.Contains("Exact", content);
+    }
+
+    [Fact]
+    public async Task AddIngress_NoRoutes_DoesNotGenerateYaml()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        k8s.AddIngress("empty");
+
+        builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        var app = builder.Build();
+        app.Run();
+
+        // No ingress file should exist for empty ingress
+        var ingressDir = Path.Combine(tempDir.Path, "templates", "empty");
+        Assert.False(Directory.Exists(ingressDir), $"Ingress directory should not exist at {ingressDir}");
+    }
+
+    [Fact]
+    public async Task AddIngress_BackwardCompatible_NoIngressNoChange()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        // No ingress defined at all - should work as before
+        builder.AddKubernetesEnvironment("env");
+
+        builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        var app = builder.Build();
+        app.Run();
+
+        // Service and deployment should exist but no ingress
+        var templatesDir = Path.Combine(tempDir.Path, "templates", "myapi");
+        Assert.True(Directory.Exists(templatesDir));
+
+        var files = Directory.GetFiles(templatesDir);
+        Assert.DoesNotContain(files, f => f.Contains("ingress", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task AddIngress_MultipleIngresses_GeneratesSeparateYaml()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var publicIngress = k8s.AddIngress("public-ingress")
+            .WithIngressClass("nginx");
+
+        var internalIngress = k8s.AddIngress("internal-ingress")
+            .WithIngressClass("internal");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        var admin = builder.AddContainer("myadmin", "nginx")
+            .WithHttpEndpoint(targetPort: 9090);
+
+        publicIngress.WithRoute("/", api.GetEndpoint("http"));
+        internalIngress.WithRoute("/admin", admin.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        // Both ingresses should have their own template directories
+        var publicPath = Path.Combine(tempDir.Path, "templates", "public-ingress", "public-ingress.yaml");
+        var internalPath = Path.Combine(tempDir.Path, "templates", "internal-ingress", "internal-ingress.yaml");
+
+        Assert.True(File.Exists(publicPath), $"Public ingress YAML not found at {publicPath}");
+        Assert.True(File.Exists(internalPath), $"Internal ingress YAML not found at {internalPath}");
+
+        var publicContent = await File.ReadAllTextAsync(publicPath);
+        var internalContent = await File.ReadAllTextAsync(internalPath);
+
+        Assert.Contains("nginx", publicContent);
+        Assert.Contains("internal", internalContent);
+    }
+
+    [Fact]
+    public async Task AddIngress_TlsWithDefaultBackend_AutoGeneratesHostRule()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var web = builder.AddContainer("myweb", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        // TLS host + default backend but NO explicit route for the TLS host.
+        // The ingress should auto-generate a rule for the TLS host.
+        ingress
+            .WithDefaultBackend(web.GetEndpoint("http"))
+            .WithTls("my-tls-secret", "app.example.com");
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        Assert.True(File.Exists(ingressPath), $"Expected ingress YAML at {ingressPath}");
+
+        var content = await File.ReadAllTextAsync(ingressPath);
+
+        // Should have TLS config
+        Assert.Contains("my-tls-secret", content);
+        Assert.Contains("app.example.com", content);
+
+        // Should have auto-generated rule for the TLS host
+        Assert.Contains("Prefix", content);
+    }
+
+    [Fact]
+    public async Task AddIngress_TlsWithExplicitRoute_DoesNotDuplicate()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var web = builder.AddContainer("myweb", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        // Explicit route for the TLS host ΓÇö should NOT auto-generate another one
+        ingress
+            .WithRoute("app.example.com", "/", web.GetEndpoint("http"))
+            .WithDefaultBackend(web.GetEndpoint("http"))
+            .WithTls("my-tls-secret", "app.example.com");
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(ingressPath);
+
+        // Count occurrences of the host rule ΓÇö should appear exactly once
+        var hostCount = content.Split("app.example.com").Length - 1;
+        // TLS hosts list + one rule = 2 occurrences (not 3 which would mean duplicate rule)
+        Assert.Equal(2, hostCount);
+    }
+
+    [Fact]
+    public void WithRoute_InvalidPath_Throws()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        Assert.Throws<ArgumentException>(() =>
+            ingress.WithRoute("no-leading-slash", api.GetEndpoint("http")));
+    }
+
+    [Fact]
+    public void WithTls_NoHosts_Throws()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        Assert.Throws<ArgumentException>(() =>
+            ingress.WithTls("my-secret"));
+    }
+
+    [Fact]
+    public void AddIngress_ResourceType_HasCorrectParent()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        Assert.Equal(k8s.Resource, ingress.Resource.Parent);
+        Assert.IsType<KubernetesIngressResource>(ingress.Resource);
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -77,7 +77,7 @@ public class KubernetesIngressTests
 
         ingress
             .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
-            .WithTls("my-tls-secret", "api.example.com");
+            .WithHostname("api.example.com").WithTls("my-tls-secret");
 
         var app = builder.Build();
         app.Run();
@@ -266,7 +266,7 @@ public class KubernetesIngressTests
         // The ingress should auto-generate a rule for the TLS host.
         ingress
             .WithDefaultBackend(web.GetEndpoint("http"))
-            .WithTls("my-tls-secret", "app.example.com");
+            .WithHostname("app.example.com").WithTls("my-tls-secret");
 
         var app = builder.Build();
         app.Run();
@@ -300,7 +300,7 @@ public class KubernetesIngressTests
         ingress
             .WithRoute("app.example.com", "/", web.GetEndpoint("http"))
             .WithDefaultBackend(web.GetEndpoint("http"))
-            .WithTls("my-tls-secret", "app.example.com");
+            .WithHostname("app.example.com").WithTls("my-tls-secret");
 
         var app = builder.Build();
         app.Run();
@@ -329,14 +329,16 @@ public class KubernetesIngressTests
     }
 
     [Fact]
-    public void WithTls_NoHosts_Throws()
+    public void WithTls_NoArg_GeneratesSecretName()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
         var ingress = k8s.AddIngress("public");
 
-        Assert.Throws<ArgumentException>(() =>
-            ingress.WithTls("my-secret"));
+        ingress.WithTls();
+
+        Assert.Single(ingress.Resource.TlsConfigs);
+        Assert.Equal("public-tls", ingress.Resource.TlsConfigs[0].SecretName);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -338,7 +338,7 @@ public class KubernetesIngressTests
         ingress.WithTls();
 
         Assert.Single(ingress.Resource.TlsConfigs);
-        Assert.Equal("public-tls", ingress.Resource.TlsConfigs[0].SecretName);
+        Assert.Equal("public-tls", ingress.Resource.TlsConfigs[0].SecretName.Format);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Add first-class Kubernetes Ingress and Gateway API resources for defining HTTP routing rules in the Aspire application model. This enables users to declaratively configure how external traffic reaches their services when deploying to Kubernetes.

### What's included

**Ingress API (legacy K8S networking.k8s.io/v1):**
- `AddIngress()` on `KubernetesEnvironmentResource` and `AzureKubernetesEnvironmentResource`
- `WithRoute()` for path-only and host+path routing
- `WithIngressClass()`, `WithTls()`, `WithDefaultBackend()`, `WithIngressAnnotation()`
- `IngressPathType` enum (Prefix, Exact, ImplementationSpecific)
- Auto-generates rules for TLS hosts with defaultBackend (required by AGC)

**Gateway API (modern gateway.networking.k8s.io/v1):**
- `AddGateway()` on `KubernetesEnvironmentResource` and `AzureKubernetesEnvironmentResource`
- Same `WithRoute()` / `WithTls()` fluent API as Ingress
- `WithGatewayClass()`, `WithGatewayAnnotation()`
- Auto-infers listeners (HTTP on 80, HTTPS on 443 per `WithTls`)
- Generates `Gateway` + `HTTPRoute` resources (TLS configures a listener, not a separate route)

**K8S resource models:**
- `GatewayV1`, `HttpRouteV1` and supporting types for YAML serialization
- Fixed `IngressBackendV1` defaults (`null!` instead of `new()`)

**TLS bootstrap pipeline step:**
- After Helm deploy, creates self-signed placeholder TLS secrets if they don't exist
- Uses .NET `System.Security.Cryptography` (cross-platform, no openssl dependency)
- Idempotent — skips if secret already exists on redeploy
- Enables cert-manager or manual cert management as a follow-up

**Publishing integration:**
- Endpoint references resolved to K8S service names/ports via `DeploymentTargetAnnotation`
- Ingress and Gateway resources written as standalone Helm chart templates

### Tested with AKS + Azure Application Gateway for Containers (AGC)

Validated end-to-end with AGC including:
- Ingress with ALB annotations and TLS
- Gateway API with `azure-alb-external` GatewayClass
- cert-manager integration (Gateway API `gatewayHTTPRoute` solver works; Ingress HTTP-01 requires DNS-01 due to AGC per-Ingress frontends)

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
