### PR TITLE
Reduce extension CLI polling when Aspire view is hidden

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Aspire",
   "description": "%extension.description%",
   "publisher": "microsoft-aspire",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "icon": "dotnet-aspire-logo-128.png",
   "license": "SEE LICENSE IN LICENSE.TXT",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -89,7 +89,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   appHostTreeProvider.setTreeView(appHostTreeView);
 
-  // Global-mode polling is tied to panel visibility
+  // Running AppHosts data sources are tied to panel visibility.
   dataRepository.setPanelVisible(appHostTreeView.visible);
   appHostTreeView.onDidChangeVisibility(e => {
     dataRepository.setPanelVisible(e.visible);
@@ -118,7 +118,7 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.commands.executeCommand('setContext', 'aspire.noRunningAppHosts', true);
   vscode.commands.executeCommand('setContext', 'aspire.loading', true);
 
-  // Activate the data repository (starts workspace describe --follow; global polling begins when the panel is visible)
+  // Activate the data repository. Workspace describe watching and global polling begin when the panel is visible.
   dataRepository.activate();
 
   context.subscriptions.push(appHostTreeView, refreshRunningAppHostsRegistration, switchToGlobalViewRegistration, switchToWorkspaceViewRegistration, openDashboardRegistration, openAppHostSourceRegistration, stopAppHostRegistration, stopResourceRegistration, startResourceRegistration, restartResourceRegistration, viewResourceLogsRegistration, executeResourceCommandRegistration, copyEndpointUrlRegistration, openInExternalBrowserRegistration, openInIntegratedBrowserRegistration, copyResourceNameRegistration, copyPidRegistration, copyAppHostPathRegistration, expandAllRegistration, { dispose: () => { appHostTreeProvider.dispose(); dataRepository.dispose(); } });

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -1,0 +1,125 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { AppHostDataRepository } from '../views/AppHostDataRepository';
+import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+import * as cliModule from '../debugger/languages/cli';
+
+class TestChildProcess extends EventEmitter {
+    stdout = new PassThrough();
+    stderr = new PassThrough();
+    killed = false;
+
+    kill(): boolean {
+        this.killed = true;
+        this.emit('close', null);
+        return true;
+    }
+}
+
+suite('AppHostDataRepository', () => {
+    let terminalProvider: AspireTerminalProvider;
+    let subscriptions: vscode.Disposable[];
+    let getCliPathStub: sinon.SinonStub;
+    let spawnStub: sinon.SinonStub;
+
+    setup(() => {
+        subscriptions = [];
+        terminalProvider = new AspireTerminalProvider(subscriptions);
+        getCliPathStub = sinon.stub(terminalProvider, 'getAspireCliExecutablePath').resolves('aspire');
+        spawnStub = sinon.stub(cliModule, 'spawnCliProcess');
+        spawnStub.callsFake(() => new TestChildProcess());
+    });
+
+    teardown(() => {
+        spawnStub.restore();
+        getCliPathStub.restore();
+        subscriptions.forEach(subscription => subscription.dispose());
+    });
+
+    test('activate does not start describe watch while panel is hidden', async () => {
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        await waitForMicrotasks();
+
+        assert.strictEqual(getCliPathStub.called, false);
+        assert.strictEqual(spawnStub.called, false);
+
+        repository.dispose();
+    });
+
+    test('visible workspace panel starts describe watch', async () => {
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        assert.strictEqual(getCliPathStub.calledOnce, true);
+        assert.strictEqual(spawnStub.calledOnce, true);
+        assert.deepStrictEqual(spawnStub.firstCall.args[2], ['describe', '--follow', '--format', 'json']);
+
+        repository.dispose();
+    });
+
+    test('visible workspace panel before activation starts describe watch once', async () => {
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.setPanelVisible(true);
+        repository.activate();
+        await waitForMicrotasks();
+
+        assert.strictEqual(getCliPathStub.calledOnce, true);
+        assert.strictEqual(spawnStub.calledOnce, true);
+
+        repository.dispose();
+    });
+
+    test('hiding workspace panel stops describe watch', async () => {
+        const childProcess = new TestChildProcess();
+        spawnStub.returns(childProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        repository.setPanelVisible(false);
+
+        assert.strictEqual(childProcess.killed, true);
+
+        repository.dispose();
+    });
+
+    test('hiding workspace panel before cli path resolves prevents describe watch from starting', async () => {
+        const cliPath = createDeferred<string>();
+        getCliPathStub.returns(cliPath.promise);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setPanelVisible(true);
+        repository.setPanelVisible(false);
+        cliPath.resolve('aspire');
+        await waitForMicrotasks();
+
+        assert.strictEqual(spawnStub.called, false);
+
+        repository.dispose();
+    });
+});
+
+async function waitForMicrotasks(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve: (value: T) => void = () => { };
+    const promise = new Promise<T>(promiseResolve => {
+        resolve = promiseResolve;
+    });
+    return { promise, resolve };
+}

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -94,6 +94,25 @@ suite('AppHostDataRepository', () => {
         repository.dispose();
     });
 
+    test('hiding workspace panel clears workspace resources', async () => {
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        const lineCallback = spawnStub.firstCall.args[3].lineCallback;
+        lineCallback(JSON.stringify({ name: 'api' }));
+
+        assert.strictEqual(repository.workspaceResources.length, 1);
+
+        repository.setPanelVisible(false);
+
+        assert.strictEqual(repository.workspaceResources.length, 0);
+
+        repository.dispose();
+    });
+
     test('hiding workspace panel before cli path resolves prevents describe watch from starting', async () => {
         const cliPath = createDeferred<string>();
         getCliPathStub.returns(cliPath.promise);

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -128,6 +128,34 @@ suite('AppHostDataRepository', () => {
 
         repository.dispose();
     });
+
+    test('late close from stopped describe watch does not orphan replacement watch', async () => {
+        const firstChildProcess = new TestChildProcess();
+        const secondChildProcess = new TestChildProcess();
+        spawnStub.onFirstCall().returns(firstChildProcess);
+        spawnStub.onSecondCall().returns(secondChildProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+        const firstLineCallback = spawnStub.firstCall.args[3].lineCallback;
+        const firstExitCallback = spawnStub.firstCall.args[3].exitCallback;
+
+        repository.setPanelVisible(false);
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        firstLineCallback(JSON.stringify({ name: 'stale' }));
+        firstExitCallback(0);
+        repository.setPanelVisible(false);
+
+        assert.strictEqual(repository.workspaceResources.length, 0);
+        assert.strictEqual(firstChildProcess.killed, true);
+        assert.strictEqual(secondChildProcess.killed, true);
+
+        repository.dispose();
+    });
 });
 
 async function waitForMicrotasks(): Promise<void> {

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -53,8 +53,8 @@ export type ViewMode = 'workspace' | 'global';
  *
  * Owns two independent data sources:
  *  - `aspire describe --follow` (workspace mode) — streams resource updates
- *    via NDJSON.  Runs unconditionally from activation so workspace data is
- *    available across the extension.
+ *    via NDJSON.  Only active while the tree-view panel is visible **and**
+ *    workspace mode is selected.
  *  - `aspire ps` polling (global mode) — periodically fetches all running
  *    app hosts.  Only active while the tree-view panel is visible **and**
  *    global mode is selected.
@@ -74,6 +74,8 @@ export class AppHostDataRepository {
     private _describeRestartDelay = 5000;
     private _describeRestartTimer: ReturnType<typeof setTimeout> | undefined;
     private _describeReceivedData = false;
+    private _describeStartPending = false;
+    private _describeStartVersion = 0;
 
     // ── Global mode state (ps polling) ──
     private _appHosts: AppHostDisplayInfo[] = [];
@@ -163,7 +165,9 @@ export class AppHostDataRepository {
         this._setError(undefined);
         this._updateWorkspaceContext();
         this._describeRestartDelay = 5000;
-        this._startDescribeWatch();
+        if (this._shouldWatchWorkspace) {
+            this._startDescribeWatch();
+        }
         if (this._shouldPoll) {
             this._fetchAppHosts();
         }
@@ -171,7 +175,7 @@ export class AppHostDataRepository {
 
     activate(): void {
         vscode.commands.executeCommand('setContext', 'aspire.viewMode', this._viewMode);
-        this._startDescribeWatch();
+        this._syncPolling();
     }
 
     dispose(): void {
@@ -189,10 +193,21 @@ export class AppHostDataRepository {
         return this._panelVisible && this._viewMode === 'global';
     }
 
+    private get _shouldWatchWorkspace(): boolean {
+        return this._panelVisible && this._viewMode === 'workspace';
+    }
+
     private _syncPolling(): void {
         if (this._disposed) {
             return;
         }
+
+        if (this._shouldWatchWorkspace) {
+            this._startDescribeWatch();
+        } else {
+            this._stopDescribeWatch();
+        }
+
         if (this._shouldPoll) {
             this._startPsPolling();
         } else {
@@ -260,12 +275,15 @@ export class AppHostDataRepository {
     // ── Workspace mode: describe --follow ──
 
     private _startDescribeWatch(): void {
-        if (this._describeProcess || this._disposed) {
+        if (this._describeProcess || this._describeStartPending || this._disposed) {
             return;
         }
 
+        this._describeStartPending = true;
+        const startVersion = ++this._describeStartVersion;
+
         this._terminalProvider.getAspireCliExecutablePath().then(cliPath => {
-            if (this._disposed) {
+            if (this._disposed || !this._shouldWatchWorkspace || startVersion !== this._describeStartVersion) {
                 return;
             }
 
@@ -322,14 +340,23 @@ export class AppHostDataRepository {
                 }
             });
         }).catch(error => {
+            if (this._disposed || !this._shouldWatchWorkspace || startVersion !== this._describeStartVersion) {
+                return;
+            }
             extensionLogOutputChannel.warn(`Failed to start describe watch: ${error}`);
             this._loadingWorkspace = false;
             this._updateLoadingContext();
             this._setError(errorFetchingAppHosts(String(error)));
+        }).finally(() => {
+            if (startVersion === this._describeStartVersion) {
+                this._describeStartPending = false;
+            }
         });
     }
 
     private _stopDescribeWatch(): void {
+        this._describeStartVersion++;
+        this._describeStartPending = false;
         if (this._describeRestartTimer) {
             clearTimeout(this._describeRestartTimer);
             this._describeRestartTimer = undefined;

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -70,7 +70,6 @@ export class AppHostDataRepository {
     // ── Workspace mode state (describe --follow) ──
     private _workspaceResources: Map<string, ResourceJson> = new Map();
     private _describeProcess: ChildProcessWithoutNullStreams | undefined;
-    private _describeRestarting = false;
     private _describeRestartDelay = 5000;
     private _describeRestartTimer: ReturnType<typeof setTimeout> | undefined;
     private _describeReceivedData = false;
@@ -294,16 +293,23 @@ export class AppHostDataRepository {
             extensionLogOutputChannel.info('Starting aspire describe --follow for workspace resources');
 
             this._describeReceivedData = false;
-            this._describeProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
+            const describeProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                 noExtensionVariables: true,
                 lineCallback: (line) => {
+                    if (this._describeProcess !== describeProcess) {
+                        return;
+                    }
                     this._handleDescribeLine(line);
                 },
                 exitCallback: (code) => {
+                    if (this._describeProcess !== describeProcess) {
+                        return;
+                    }
+
                     extensionLogOutputChannel.info(`aspire describe --follow exited with code ${code}`);
                     this._describeProcess = undefined;
 
-                    if (!this._disposed && !this._describeRestarting) {
+                    if (!this._disposed) {
                         if (!this._describeReceivedData && code !== 0) {
                             // The process exited with a non-zero code without ever producing valid data.
                             // This is expected when no apphost is running. Don't set the error state
@@ -323,24 +329,28 @@ export class AppHostDataRepository {
                             extensionLogOutputChannel.info(`Restarting describe --follow in ${delay}ms`);
                             this._describeRestartTimer = setTimeout(() => {
                                 this._describeRestartTimer = undefined;
-                                if (!this._disposed) {
+                                if (!this._disposed && this._shouldWatchWorkspace) {
                                     this._startDescribeWatch();
                                 }
                             }, delay);
                         }
                     }
-                    this._describeRestarting = false;
                 },
                 errorCallback: (error) => {
+                    if (this._describeProcess !== describeProcess) {
+                        return;
+                    }
+
                     extensionLogOutputChannel.warn(`aspire describe --follow error: ${error.message}`);
                     this._describeProcess = undefined;
-                    if (!this._disposed && !this._describeRestarting) {
+                    if (!this._disposed) {
                         this._loadingWorkspace = false;
                         this._updateLoadingContext();
                         this._setError(errorFetchingAppHosts(error.message));
                     }
                 }
             });
+            this._describeProcess = describeProcess;
         }).catch(error => {
             if (this._disposed || !this._shouldWatchWorkspace || startVersion !== this._describeStartVersion) {
                 return;
@@ -364,9 +374,9 @@ export class AppHostDataRepository {
             this._describeRestartTimer = undefined;
         }
         if (this._describeProcess) {
-            this._describeRestarting = true;
-            this._describeProcess.kill();
+            const describeProcess = this._describeProcess;
             this._describeProcess = undefined;
+            describeProcess.kill();
         }
         if (options?.clearWorkspaceResources) {
             this._clearWorkspaceResources();

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -205,7 +205,7 @@ export class AppHostDataRepository {
         if (this._shouldWatchWorkspace) {
             this._startDescribeWatch();
         } else {
-            this._stopDescribeWatch();
+            this._stopDescribeWatch({ clearWorkspaceResources: true });
         }
 
         if (this._shouldPoll) {
@@ -279,6 +279,8 @@ export class AppHostDataRepository {
             return;
         }
 
+        this._loadingWorkspace = true;
+        this._updateLoadingContext();
         this._describeStartPending = true;
         const startVersion = ++this._describeStartVersion;
 
@@ -354,7 +356,7 @@ export class AppHostDataRepository {
         });
     }
 
-    private _stopDescribeWatch(): void {
+    private _stopDescribeWatch(options?: { clearWorkspaceResources?: boolean }): void {
         this._describeStartVersion++;
         this._describeStartPending = false;
         if (this._describeRestartTimer) {
@@ -366,6 +368,18 @@ export class AppHostDataRepository {
             this._describeProcess.kill();
             this._describeProcess = undefined;
         }
+        if (options?.clearWorkspaceResources) {
+            this._clearWorkspaceResources();
+        }
+    }
+
+    private _clearWorkspaceResources(): void {
+        if (this._workspaceResources.size === 0) {
+            return;
+        }
+
+        this._workspaceResources.clear();
+        this._updateWorkspaceContext();
     }
 
     private _handleDescribeLine(line: string): void {

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -375,6 +375,7 @@ export class AppHostDataRepository {
         }
         if (this._describeProcess) {
             const describeProcess = this._describeProcess;
+            extensionLogOutputChannel.info(`aspire describe --follow exited with code ${code}`);
             this._describeProcess = undefined;
             describeProcess.kill();
         }
@@ -439,6 +440,7 @@ export class AppHostDataRepository {
         if (this._pollingInterval) {
             clearInterval(this._pollingInterval);
             this._pollingInterval = undefined;
+            extensionLogOutputChannel.info(`aspire ps polling stopped`);
         }
     }
 

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -375,7 +375,7 @@ export class AppHostDataRepository {
         }
         if (this._describeProcess) {
             const describeProcess = this._describeProcess;
-            extensionLogOutputChannel.info(`aspire describe --follow exited with code ${code}`);
+            extensionLogOutputChannel.info('Stopping aspire describe --follow for workspace resources');
             this._describeProcess = undefined;
             describeProcess.kill();
         }


### PR DESCRIPTION
## Description

Reduces background Aspire CLI invocations from the VS Code extension when the Aspire Running AppHosts view is not visible.

- Starts workspace `aspire describe --follow` only while the Running AppHosts view is visible in workspace mode, matching the existing global `aspire ps` polling lifecycle.
- Cancels pending describe startup if the view is hidden before CLI path resolution completes.
- Prevents duplicate describe startup when initial view visibility is applied before repository activation.
- Adds lifecycle tests for hidden activation, visible activation ordering, stopping the watch, and pending-start cancellation.
- Ignores stale `describe --follow` callbacks after the view is hidden or a replacement watch has started, preventing orphaned CLI processes and stale resource updates during rapid hide/show transitions.

Fixes #15984

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No

