### PR TITLE
Resolve dashboard app args from effective args

### DIFF
--- a/playground/Stress/Stress.AppHost/AppHost.cs
+++ b/playground/Stress/Stress.AppHost/AppHost.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
+#pragma warning disable ASPIREDOTNETTOOL
+
 var builder = DistributedApplication.CreateBuilder(args);
 builder.Services.AddHttpClient();
 builder.Services.AddHealthChecks().AddAsyncCheck("health-test", async (ct) =>
@@ -12,6 +14,27 @@ builder.Services.AddHealthChecks().AddAsyncCheck("health-test", async (ct) =>
     await Task.Delay(5_000, ct);
     return HealthCheckResult.Healthy();
 });
+
+var manualArgSource = builder.AddExecutable("manual-arg-source", "dotnet", Environment.CurrentDirectory)
+    .WithHttpEndpoint(targetPort: 8088);
+var manualArgEndpoint = manualArgSource.GetEndpoint("http");
+
+manualArgSource.WithArgs("--dashboard-port")
+    .WithArgs(c => c.Args.Add(manualArgEndpoint.Property(EndpointProperty.Port)));
+
+builder.AddProject<Projects.Stress_Empty>("manual-project-args", launchProfileName: null)
+    .WithArgs("--dashboard-port")
+    .WithArgs(c => c.Args.Add(manualArgEndpoint.Property(EndpointProperty.Port)));
+
+builder.AddContainer("manual-container-args", "alpine")
+    .WithEntrypoint("sleep")
+    .WithArgs("3600", "--dashboard-port")
+    .WithArgs(c => c.Args.Add(manualArgEndpoint.Property(EndpointProperty.Port)));
+
+builder.AddDotnetTool("manual-dotnet-tool-args", "dotnet-dump")
+    .WithArgs("--version", "--dashboard-port")
+    .WithArgs(c => c.Args.Add(manualArgEndpoint.Property(EndpointProperty.Port)))
+    .WithExplicitStart();
 
 for (var i = 0; i < 2; i++)
 {

--- a/src/Aspire.Hosting/ApplicationModel/AppLaunchArgumentAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AppLaunchArgumentAnnotation.cs
@@ -8,8 +8,8 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a container or project application launch argument.
 /// </summary>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Argument = {Argument}, IsSensitive = {IsSensitive}")]
-internal sealed class AppLaunchArgumentAnnotation(string argument, bool isSensitive)
+[DebuggerDisplay("Type = {GetType().Name,nq}, Argument = {Argument}, IsSensitive = {IsSensitive}, EffectiveArgumentIndex = {EffectiveArgumentIndex}")]
+internal sealed class AppLaunchArgumentAnnotation(string argument, bool isSensitive, int? effectiveArgumentIndex = null)
 {
     /// <summary>
     /// The evaluated launch argument.
@@ -20,4 +20,9 @@ internal sealed class AppLaunchArgumentAnnotation(string argument, bool isSensit
     /// Whether the argument contains a secret.
     /// </summary>
     public bool IsSensitive { get; } = isSensitive;
+
+    /// <summary>
+    /// The index of the corresponding effective launch argument, if one exists.
+    /// </summary>
+    public int? EffectiveArgumentIndex { get; } = effectiveArgumentIndex;
 }

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -284,16 +284,20 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
             throw new FailedToApplyEnvironmentException($"Failed to apply configuration to container {cr.ModelResource.Name}", configuration.Exception);
         }
 
-        var args = configuration.Arguments.Select(a => a.Value);
+        var args = configuration.Arguments.ToList();
         if (modelContainer is ContainerResource { ShellExecution: true })
         {
-            spec.Args = ["-c", $"{string.Join(' ', args)}"];
+            spec.Args = ["-c", $"{string.Join(' ', args.Select(a => a.Value))}"];
         }
         else
         {
-            spec.Args = args.ToList();
+            spec.Args = args.Select(a => a.Value).ToList();
         }
-        dcpContainer.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, configuration.Arguments.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive)));
+
+        var appLaunchArgumentAnnotations = modelContainer is ContainerResource { ShellExecution: true }
+            ? args.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive))
+            : args.Select((a, index) => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive, effectiveArgumentIndex: index));
+        dcpContainer.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, appLaunchArgumentAnnotations);
 
         spec.Env = configuration.EnvironmentVariables.Select(kvp => new EnvVar { Name = kvp.Key, Value = kvp.Value }).ToList();
         spec.CreateFiles = createFiles;

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -92,7 +92,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
 
         spec.PemCertificates = pemCertificates;
 
-        var launchArgs = BuildLaunchArgs(er, spec, configuration.Arguments);
+        var launchArgs = BuildLaunchArgs(er, spec, configuration.Arguments, spec.Args?.Count ?? 0);
         var executableArgs = launchArgs.Where(a => a.Executable).Select(a => a.Value).ToList();
         var displayArgs = launchArgs.Where(a => a.Display).ToList();
         if (executableArgs.Count > 0)
@@ -101,7 +101,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             spec.Args.AddRange(executableArgs);
         }
         // Arg annotations are what is displayed in the dashboard.
-        er.DcpResource.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, displayArgs.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive)));
+        er.DcpResource.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, displayArgs.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive, effectiveArgumentIndex: a.EffectiveArgumentIndex)));
 
         spec.Env = configuration.EnvironmentVariables.Select(kvp => new EnvVar { Name = kvp.Key, Value = kvp.Value }).ToList();
 
@@ -405,13 +405,21 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         return (configuration, pemCertificates);
     }
 
-    private static List<(string Value, bool IsSensitive, bool Executable, bool Display)> BuildLaunchArgs(RenderedModelResource<Executable> er, ExecutableSpec spec, IEnumerable<(string Value, bool IsSensitive)> appHostArgs)
+    private static List<LaunchArgument> BuildLaunchArgs(RenderedModelResource<Executable> er, ExecutableSpec spec, IEnumerable<(string Value, bool IsSensitive)> appHostArgs, int executableArgumentStartIndex)
     {
         // Launch args is the final list of args that are displayed in the UI and possibly added to the executable spec.
         // They're built from app host resource model args and any args in the effective launch profile.
         // Follows behavior in the IDE execution spec when in IDE execution mode:
         // https://github.com/microsoft/aspire/blob/main/docs/specs/IDE-execution.md#project-launch-configuration-type-project
-        var launchArgs = new List<(string Value, bool IsSensitive, bool Executable, bool Display)>();
+        var appHostArgList = appHostArgs.ToList();
+        var launchArgs = new List<LaunchArgument>();
+        var nextExecutableArgumentIndex = executableArgumentStartIndex;
+
+        LaunchArgument CreateLaunchArgument(string value, bool isSensitive, bool executable, bool display)
+        {
+            var effectiveArgumentIndex = executable ? nextExecutableArgumentIndex++ : (int?)null;
+            return new(value, isSensitive, executable, display, effectiveArgumentIndex);
+        }
 
         // If the executable is a project then include any command line args from the launch profile.
         if (er.ModelResource is ProjectResource project)
@@ -419,34 +427,34 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             // Args in the launch profile is used when:
             // 1. The project is run as an executable. Launch profile args are combined with app host supplied args.
             // 2. The project is run by the IDE and no app host args are specified.
-            if (spec.ExecutionType == ExecutionType.Process || (spec.ExecutionType == ExecutionType.IDE && !appHostArgs.Any()))
+            if (spec.ExecutionType == ExecutionType.Process || (spec.ExecutionType == ExecutionType.IDE && appHostArgList.Count == 0))
             {
                 // When the .NET project is launched from an IDE the launch profile args are automatically added.
                 // We still want to display the args in the dashboard so only add them to the custom arg annotations.
                 var executableArg = spec.ExecutionType != ExecutionType.IDE;
 
                 var launchProfileArgs = GetLaunchProfileArgs(project.GetEffectiveLaunchProfile()?.LaunchProfile);
-                if (launchProfileArgs.Count > 0 && appHostArgs.Any())
+                if (launchProfileArgs.Count > 0 && appHostArgList.Count > 0)
                 {
                     // If there are app host args, add a double-dash to separate them from the launch args.
                     launchProfileArgs.Insert(0, "--");
                 }
 
-                launchArgs.AddRange(launchProfileArgs.Select(a => (a, isSensitive: false, executableArg, true)));
+                launchArgs.AddRange(launchProfileArgs.Select(a => CreateLaunchArgument(a, isSensitive: false, executableArg, display: true)));
             }
         }
-        else if (er.ModelResource is DotnetToolResource tool)
+        else if (er.ModelResource is DotnetToolResource)
         {
-            var argSeparator = appHostArgs.Select((a, i) => (index: i, value: a.Value))
+            var argSeparator = appHostArgList.Select((a, i) => (index: i, value: a.Value))
                 .FirstOrDefault(x => x.value == DotnetToolResourceExtensions.ArgumentSeparator);
 
-            var args = appHostArgs.Select((a, i) => (arg: a, display: i > argSeparator.index));
-            launchArgs.AddRange(args.Select(x => (x.arg.Value, x.arg.IsSensitive, true, x.display)));
+            var args = appHostArgList.Select((a, i) => (arg: a, display: i > argSeparator.index));
+            launchArgs.AddRange(args.Select(x => CreateLaunchArgument(x.arg.Value, x.arg.IsSensitive, executable: true, x.display)));
             return launchArgs;
         }
 
         // In the situation where args are combined (process execution) the app host args are added after the launch profile args.
-        launchArgs.AddRange(appHostArgs.Select(a => (a.Value, a.IsSensitive, true, true)));
+        launchArgs.AddRange(appHostArgList.Select(a => CreateLaunchArgument(a.Value, a.IsSensitive, executable: true, display: true)));
 
         return launchArgs;
     }
@@ -505,4 +513,6 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         resource.AddLifeCycleCommands();
         _nameGenerator.EnsureDcpInstancesPopulated(resource);
     }
+
+    private sealed record LaunchArgument(string Value, bool IsSensitive, bool Executable, bool Display, int? EffectiveArgumentIndex);
 }

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -23,6 +23,7 @@ internal class ResourceSnapshotBuilder
         var urls = GetUrls(container, container.Status?.State);
         var volumes = GetVolumes(container);
 
+        var effectiveArgs = container.Status?.EffectiveArgs;
         var environment = GetEnvironmentVariables(container.Status?.EffectiveEnv ?? container.Spec.Env, container.Spec.Env);
         var state = container.Status?.State;
 
@@ -39,7 +40,7 @@ internal class ResourceSnapshotBuilder
             _resourceState.ApplicationModel.TryGetValue(container.AppModelResourceName, out var appModelResource))
         {
             relationships = ApplicationModel.ResourceSnapshotBuilder.BuildRelationships(appModelResource);
-            launchArguments = GetLaunchArgs(container);
+            launchArguments = GetLaunchArgs(container, effectiveArgs);
         }
 
         return previous with
@@ -52,7 +53,7 @@ internal class ResourceSnapshotBuilder
                 new(KnownProperties.Container.Image, container.Spec.Image),
                 new(KnownProperties.Container.Id, containerId),
                 new(KnownProperties.Container.Command, container.Spec.Command),
-                new(KnownProperties.Container.Args, container.Status?.EffectiveArgs ?? []) { IsSensitive = true },
+                new(KnownProperties.Container.Args, effectiveArgs ?? []) { IsSensitive = true },
                 new(KnownProperties.Container.Ports, GetPorts()),
                 new(KnownProperties.Container.Lifetime, GetContainerLifetime()),
                 new(KnownProperties.Resource.AppArgs, launchArguments?.Args) { IsSensitive = launchArguments?.IsSensitive ?? false },
@@ -98,7 +99,8 @@ internal class ResourceSnapshotBuilder
 
         var state = executable.AppModelInitialState is "Hidden" ? "Hidden" : executable.Status?.State;
         var environment = GetEnvironmentVariables(executable.Status?.EffectiveEnv, executable.Spec.Env);
-        var launchArguments = GetLaunchArgs(executable);
+        var effectiveArgs = executable.Status?.EffectiveArgs;
+        var launchArguments = GetLaunchArgs(executable, effectiveArgs);
 
         var relationships = ImmutableArray<RelationshipSnapshot>.Empty;
         if (appModelResource != null)
@@ -113,7 +115,7 @@ internal class ResourceSnapshotBuilder
             ExitCode = executable.Status?.ExitCode,
             Properties = previous.Properties.SetResourcePropertyRange([
                 new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
-                new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
+                new(KnownProperties.Executable.Args, effectiveArgs ?? []) { IsSensitive = true },
                 new(KnownProperties.Resource.AppArgs, launchArguments?.Args) { IsSensitive = launchArguments?.IsSensitive ?? false },
                 new(KnownProperties.Resource.AppArgsSensitivity, launchArguments?.ArgsAreSensitive) { IsSensitive = launchArguments?.IsSensitive ?? false },
             ]),
@@ -145,6 +147,7 @@ internal class ResourceSnapshotBuilder
 
         var urls = GetUrls(executable, executable.Status?.State);
 
+        var effectiveArgs = executable.Status?.EffectiveArgs;
         var environment = GetEnvironmentVariables(executable.Status?.EffectiveEnv, executable.Spec.Env);
 
         var relationships = ImmutableArray<RelationshipSnapshot>.Empty;
@@ -153,7 +156,7 @@ internal class ResourceSnapshotBuilder
             relationships = ApplicationModel.ResourceSnapshotBuilder.BuildRelationships(appModelResource);
         }
 
-        var launchArguments = GetLaunchArgs(executable);
+        var launchArguments = GetLaunchArgs(executable, effectiveArgs);
 
         if (projectPath is not null)
         {
@@ -165,7 +168,7 @@ internal class ResourceSnapshotBuilder
                 Properties = previous.Properties.SetResourcePropertyRange([
                     new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
                     new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
-                    new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
+                    new(KnownProperties.Executable.Args, effectiveArgs ?? []) { IsSensitive = true },
                     new(KnownProperties.Executable.Pid, executable.Status?.ProcessId),
                     new(KnownProperties.Project.Path, projectPath),
                     new(KnownProperties.Project.LaunchProfile, launchProfileName),
@@ -189,7 +192,7 @@ internal class ResourceSnapshotBuilder
             Properties = previous.Properties.SetResourcePropertyRange([
                 new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
                 new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
-                new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
+                new(KnownProperties.Executable.Args, effectiveArgs ?? []) { IsSensitive = true },
                 new(KnownProperties.Executable.Pid, executable.Status?.ProcessId),
                 new(KnownProperties.Resource.AppArgs, launchArguments?.Args) { IsSensitive = launchArguments?.IsSensitive ?? false },
                 new(KnownProperties.Resource.AppArgsSensitivity, launchArguments?.ArgsAreSensitive) { IsSensitive = launchArguments?.IsSensitive ?? false },
@@ -203,7 +206,7 @@ internal class ResourceSnapshotBuilder
         };
     }
 
-    private static (ImmutableArray<string> Args, ImmutableArray<int>? ArgsAreSensitive, bool IsSensitive)? GetLaunchArgs(CustomResource resource)
+    private static (ImmutableArray<string> Args, ImmutableArray<int>? ArgsAreSensitive, bool IsSensitive)? GetLaunchArgs(CustomResource resource, IReadOnlyList<string>? effectiveArgs)
     {
         if (!resource.TryGetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, out List<AppLaunchArgumentAnnotation>? launchArgumentAnnotations))
         {
@@ -221,11 +224,23 @@ internal class ResourceSnapshotBuilder
                 anySensitive = true;
             }
 
-            launchArgsBuilder.Add(annotation.Argument);
+            launchArgsBuilder.Add(GetArgumentValue(annotation, effectiveArgs));
             argsAreSensitiveBuilder.Add(Convert.ToInt32(annotation.IsSensitive));
         }
 
         return (launchArgsBuilder.ToImmutable(), argsAreSensitiveBuilder.ToImmutable(), anySensitive);
+
+        static string GetArgumentValue(AppLaunchArgumentAnnotation annotation, IReadOnlyList<string>? effectiveArgs)
+        {
+            if (annotation.EffectiveArgumentIndex is int index &&
+                effectiveArgs is not null &&
+                (uint)index < (uint)effectiveArgs.Count)
+            {
+                return effectiveArgs[index];
+            }
+
+            return annotation.Argument;
+        }
     }
 
     private ImmutableArray<UrlSnapshot> GetUrls(CustomResource resource, string? resourceState)

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Channels;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Tests.Utils;
@@ -203,6 +204,93 @@ public class DcpExecutorTests
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
         Assert.Equal(toolArgs, argAnnotations.Select(a => a.Argument));
         AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, exe.Spec.Args);
+    }
+
+    [Fact]
+    public async Task CreateExecutable_ProjectArgsResolvedInSnapshot_UsesEffectiveArgsFromCreatorIndexes()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        var project = builder.AddProject<Projects.ServiceA>("ServiceA", launchProfileName: null)
+            .WithHttpEndpoint(targetPort: 8080);
+        var endpoint = project.GetEndpoint("http");
+
+        project.WithArgs("--port")
+            .WithArgs(c => c.Args.Add(endpoint.Property(EndpointProperty.Port)));
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>());
+        Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
+        Assert.Equal(2, argAnnotations.Count);
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, exe.Spec.Args);
+
+        var effectiveArgs = exe.Spec.Args!.ToList();
+        var portArgument = Assert.Single(argAnnotations, a => a.Argument != "--port");
+        effectiveArgs[Assert.IsType<int>(portArgument.EffectiveArgumentIndex)] = "52731";
+        exe.Status = new ExecutableStatus
+        {
+            EffectiveArgs = effectiveArgs
+        };
+
+        var snapshot = CreateSnapshotBuilder(distributedAppModel).ToSnapshot(exe, CreatePreviousSnapshot());
+
+        Assert.Equal(["--port", "52731"], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
+        Assert.Equal(effectiveArgs, GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Executable.Args).ToArray());
+    }
+
+    [Fact]
+    public async Task CreateContainer_ArgsResolvedInSnapshot_UsesEffectiveArgsFromCreatorIndexes()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var executable = builder.AddExecutable("anExecutable", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1234, port: 5678, isProxied: true);
+
+        builder.AddContainer("aContainer", "image")
+            .WithArgs(c =>
+            {
+                c.Args.Add("--port");
+                c.Args.Add(executable.GetEndpoint("http").Property(EndpointProperty.Port));
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var dcpOptions = new DcpOptions
+        {
+            EnableAspireContainerTunnel = true,
+        };
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions);
+        await appExecutor.RunApplicationAsync();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "aContainer");
+        Assert.True(container.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
+        Assert.Equal(2, argAnnotations.Count);
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, container.Spec.Args);
+
+        var effectiveArgs = container.Spec.Args!.ToList();
+        var portArgument = Assert.Single(argAnnotations, a => a.Argument != "--port");
+        effectiveArgs[Assert.IsType<int>(portArgument.EffectiveArgumentIndex)] = "5678";
+        container.Status = new ContainerStatus
+        {
+            EffectiveArgs = effectiveArgs
+        };
+
+        var snapshot = CreateSnapshotBuilder(distributedAppModel).ToSnapshot(container, CreatePreviousSnapshot());
+
+        Assert.Equal(["--port", "5678"], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
+        Assert.Equal(effectiveArgs, GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Container.Args).ToArray());
     }
 
     [Fact]
@@ -3342,6 +3430,31 @@ public class DcpExecutorTests
             Assert.InRange(index, 0, specArgs.Count - 1);
             Assert.Equal(annotation.Argument, specArgs[index]);
         }
+    }
+
+    private static Aspire.Hosting.Dcp.ResourceSnapshotBuilder CreateSnapshotBuilder(DistributedApplicationModel model)
+    {
+        return new(new DcpResourceState(model.Resources.ToDictionary(r => r.Name), []));
+    }
+
+    private static CustomResourceSnapshot CreatePreviousSnapshot()
+    {
+        return new()
+        {
+            ResourceType = "resource",
+            Properties = []
+        };
+    }
+
+    private static ResourcePropertySnapshot GetProperty(CustomResourceSnapshot snapshot, string name)
+    {
+        return Assert.Single(snapshot.Properties, p => p.Name == name);
+    }
+
+    private static IEnumerable<T> GetEnumerablePropertyValue<T>(CustomResourceSnapshot snapshot, string name)
+    {
+        var property = GetProperty(snapshot, name);
+        return Assert.IsAssignableFrom<IEnumerable<T>>(property.Value);
     }
 
     private sealed class TestExecutableResource(string directory) : ExecutableResource("TestExecutable", "test", directory);

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -165,6 +165,7 @@ public class DcpExecutorTests
 
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
         Assert.Equal(expectedAnnotations, argAnnotations.Select(a => a.Argument));
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, exe.Spec.Args);
     }
 
     [Theory]
@@ -201,6 +202,7 @@ public class DcpExecutorTests
 
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
         Assert.Equal(toolArgs, argAnnotations.Select(a => a.Argument));
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, exe.Spec.Args);
     }
 
     [Fact]
@@ -244,6 +246,7 @@ public class DcpExecutorTests
         Assert.Single(exe1.Spec.Args!, a => a == "--test");
         Assert.True(exe1.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations1));
         Assert.Single(argAnnotations1, a => a.Argument == "--test");
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations1, exe1.Spec.Args);
 
         var reference = appExecutor.GetResource(exe1.Metadata.Name);
 
@@ -262,6 +265,7 @@ public class DcpExecutorTests
         Assert.Single(exe2.Spec.Args!, a => a == "--test");
         Assert.True(exe2.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations2));
         Assert.Single(argAnnotations2, a => a.Argument == "--test");
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations2, exe2.Spec.Args);
     }
 
     [Fact]
@@ -2853,6 +2857,10 @@ public class DcpExecutorTests
         await appExecutor.RunApplicationAsync();
 
         Assert.Equal(1, callCount);
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "aContainer");
+        Assert.True(container.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, container.Spec.Args);
     }
 
     // Ensures that command-line argument callbacks are invoked after the OnResourceStarting event is raised for the resource,
@@ -3319,6 +3327,21 @@ public class DcpExecutorTests
             .AddTimeout(TimeSpan.FromMilliseconds(timeoutMilliseconds))
             .Build();
         return retry.Execute(check);
+    }
+
+    private static void AssertEffectiveArgumentIndexesMatchSpecArgs(IReadOnlyList<AppLaunchArgumentAnnotation> argAnnotations, IReadOnlyList<string>? specArgs)
+    {
+        foreach (var annotation in argAnnotations)
+        {
+            if (annotation.EffectiveArgumentIndex is not int index)
+            {
+                continue;
+            }
+
+            Assert.NotNull(specArgs);
+            Assert.InRange(index, 0, specArgs.Count - 1);
+            Assert.Equal(annotation.Argument, specArgs[index]);
+        }
     }
 
     private sealed class TestExecutableResource(string directory) : ExecutableResource("TestExecutable", "test", directory);

--- a/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Dcp.Model;
+using DcpCustomResource = Aspire.Hosting.Dcp.Model.CustomResource;
+using DcpResourceSnapshotBuilder = Aspire.Hosting.Dcp.ResourceSnapshotBuilder;
+
+namespace Aspire.Hosting.Tests.Dcp;
+
+[Trait("Partition", "4")]
+public class ResourceSnapshotBuilderTests
+{
+    private const string DcpTemplateArgument = "{{- portForServing \"exe\" -}}";
+    private const string ResolvedPortArgument = "52731";
+
+    [Fact]
+    public void ExecutableSnapshotUsesEffectiveArgsForLaunchArguments()
+    {
+        var executable = CreateExecutable(
+            [
+                new("-port", isSensitive: false, effectiveArgumentIndex: 0),
+                new(DcpTemplateArgument, isSensitive: false, effectiveArgumentIndex: 1)
+            ],
+            ["-port", ResolvedPortArgument]);
+
+        var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
+
+        Assert.Equal(["-port", ResolvedPortArgument], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
+        Assert.Equal(["-port", ResolvedPortArgument], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Executable.Args).ToArray());
+    }
+
+    [Fact]
+    public void ExecutableSnapshotPreservesLaunchArgumentSensitivityWhenUsingEffectiveArgs()
+    {
+        var executable = CreateExecutable(
+            [
+                new("--secret", isSensitive: false, effectiveArgumentIndex: 0),
+                new("{{- secretRef \"connectionString\" -}}", isSensitive: true, effectiveArgumentIndex: 1)
+            ],
+            ["--secret", "resolved-secret"]);
+
+        var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
+
+        Assert.Equal(["--secret", "resolved-secret"], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
+        Assert.Equal([0, 1], GetEnumerablePropertyValue<int>(snapshot, KnownProperties.Resource.AppArgsSensitivity).ToArray());
+        Assert.True(GetProperty(snapshot, KnownProperties.Resource.AppArgs).IsSensitive);
+        Assert.True(GetProperty(snapshot, KnownProperties.Resource.AppArgsSensitivity).IsSensitive);
+    }
+
+    [Fact]
+    public void ExecutableSnapshotFallsBackToAnnotationValueWhenEffectiveArgMissing()
+    {
+        var executable = CreateExecutable(
+            [
+                new("-port", isSensitive: false, effectiveArgumentIndex: 0),
+                new(DcpTemplateArgument, isSensitive: false, effectiveArgumentIndex: 9)
+            ],
+            ["-port", ResolvedPortArgument]);
+
+        var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
+
+        Assert.Equal(["-port", DcpTemplateArgument], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
+    }
+
+    [Fact]
+    public void ContainerSnapshotUsesEffectiveArgsForLaunchArguments()
+    {
+        var container = Container.Create("container", "image");
+        container.Annotate(DcpCustomResource.ResourceNameAnnotation, "container");
+        container.Spec.Args = ["--url", "{{- endpointUri \"backend\" -}}"];
+        container.Status = new ContainerStatus
+        {
+            EffectiveArgs = ["--url", "http://localhost:52731"]
+        };
+        container.SetAnnotationAsObjectList(
+            DcpCustomResource.ResourceAppArgsAnnotation,
+            [
+                new AppLaunchArgumentAnnotation("--url", isSensitive: false, effectiveArgumentIndex: 0),
+                new AppLaunchArgumentAnnotation("{{- endpointUri \"backend\" -}}", isSensitive: false, effectiveArgumentIndex: 1)
+            ]);
+
+        var appResource = new ContainerResource("container");
+        var snapshotBuilder = CreateSnapshotBuilder(new Dictionary<string, IResource>
+        {
+            [appResource.Name] = appResource
+        });
+
+        var snapshot = snapshotBuilder.ToSnapshot(container, CreatePreviousSnapshot());
+
+        Assert.Equal(["--url", "http://localhost:52731"], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
+        Assert.Equal(["--url", "http://localhost:52731"], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Container.Args).ToArray());
+    }
+
+    private static Executable CreateExecutable(AppLaunchArgumentAnnotation[] launchArgumentAnnotations, IReadOnlyList<string> effectiveArgs)
+    {
+        var executable = Executable.Create("exe", "pwsh");
+        executable.Spec.Args = [.. launchArgumentAnnotations.Select(a => a.Argument)];
+        executable.Status = new ExecutableStatus
+        {
+            EffectiveArgs = [.. effectiveArgs]
+        };
+        executable.SetAnnotationAsObjectList(DcpCustomResource.ResourceAppArgsAnnotation, launchArgumentAnnotations);
+
+        return executable;
+    }
+
+    private static DcpResourceSnapshotBuilder CreateSnapshotBuilder(IDictionary<string, IResource>? applicationModel = null)
+    {
+        return new(new DcpResourceState(applicationModel ?? new Dictionary<string, IResource>(), []));
+    }
+
+    private static CustomResourceSnapshot CreatePreviousSnapshot()
+    {
+        return new()
+        {
+            ResourceType = "resource",
+            Properties = []
+        };
+    }
+
+    private static ResourcePropertySnapshot GetProperty(CustomResourceSnapshot snapshot, string name)
+    {
+        return Assert.Single(snapshot.Properties, p => p.Name == name);
+    }
+
+    private static IEnumerable<T> GetEnumerablePropertyValue<T>(CustomResourceSnapshot snapshot, string name)
+    {
+        var property = GetProperty(snapshot, name);
+        return Assert.IsAssignableFrom<IEnumerable<T>>(property.Value);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
@@ -16,22 +16,6 @@ public class ResourceSnapshotBuilderTests
     private const string ResolvedPortArgument = "52731";
 
     [Fact]
-    public void ExecutableSnapshotUsesEffectiveArgsForLaunchArguments()
-    {
-        var executable = CreateExecutable(
-            [
-                new("-port", isSensitive: false, effectiveArgumentIndex: 0),
-                new(DcpTemplateArgument, isSensitive: false, effectiveArgumentIndex: 1)
-            ],
-            ["-port", ResolvedPortArgument]);
-
-        var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
-
-        Assert.Equal(["-port", ResolvedPortArgument], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
-        Assert.Equal(["-port", ResolvedPortArgument], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Executable.Args).ToArray());
-    }
-
-    [Fact]
     public void ExecutableSnapshotPreservesLaunchArgumentSensitivityWhenUsingEffectiveArgs()
     {
         var executable = CreateExecutable(
@@ -62,35 +46,6 @@ public class ResourceSnapshotBuilderTests
         var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
 
         Assert.Equal(["-port", DcpTemplateArgument], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
-    }
-
-    [Fact]
-    public void ContainerSnapshotUsesEffectiveArgsForLaunchArguments()
-    {
-        var container = Container.Create("container", "image");
-        container.Annotate(DcpCustomResource.ResourceNameAnnotation, "container");
-        container.Spec.Args = ["--url", "{{- endpointUri \"backend\" -}}"];
-        container.Status = new ContainerStatus
-        {
-            EffectiveArgs = ["--url", "http://localhost:52731"]
-        };
-        container.SetAnnotationAsObjectList(
-            DcpCustomResource.ResourceAppArgsAnnotation,
-            [
-                new AppLaunchArgumentAnnotation("--url", isSensitive: false, effectiveArgumentIndex: 0),
-                new AppLaunchArgumentAnnotation("{{- endpointUri \"backend\" -}}", isSensitive: false, effectiveArgumentIndex: 1)
-            ]);
-
-        var appResource = new ContainerResource("container");
-        var snapshotBuilder = CreateSnapshotBuilder(new Dictionary<string, IResource>
-        {
-            [appResource.Name] = appResource
-        });
-
-        var snapshot = snapshotBuilder.ToSnapshot(container, CreatePreviousSnapshot());
-
-        Assert.Equal(["--url", "http://localhost:52731"], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Resource.AppArgs).ToArray());
-        Assert.Equal(["--url", "http://localhost:52731"], GetEnumerablePropertyValue<string>(snapshot, KnownProperties.Container.Args).ToArray());
     }
 
     private static Executable CreateExecutable(AppLaunchArgumentAnnotation[] launchArgumentAnnotations, IReadOnlyList<string> effectiveArgs)


### PR DESCRIPTION
## Description

Fixes #9047

Updates the DCP snapshot app-arguments path so the dashboard Source column can display resolved runtime argument values instead of raw DCP template expressions such as `{{- portForServing "exe" -}}`.

- Adds optional effective-argument indexing to app launch argument annotations.
- Populates indices for executable and non-shell container args when the displayed app argument maps to a DCP effective arg.
- Resolves `Resource.AppArgs` from `Status.EffectiveArgs` while preserving annotation-based sensitivity metadata.
- Adds regression coverage for executable/container snapshots and creation-time index metadata.

Validation:

- `dotnet test -- --filter-class "*.ResourceSnapshotBuilderTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test -- --filter-method "*.CreateExecutable_LaunchProfileHasCommandLineArgs_AnnotationsAdded" --filter-method "*.CreateExecutable_ToolHasCommandLineArgs_AnnotationsAdded" --filter-method "*.ResourceRestarted_EnvironmentCallbacksApplied" --filter-method "*.ArgsCallbacksInvokedOnceOnContainer" --filter-method "*.EnvironmentCallbacksInvokedOnceOnContainer" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
