### PR TITLE
Make dashboard reconnect notice modeless

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/ReconnectModal.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/ReconnectModal.razor.css
@@ -17,34 +17,35 @@
 
 
 #components-reconnect-modal {
-    background-color: white;
-    width: 20rem;
-    margin: 20vh auto;
-    padding: 2rem;
-    border: 0;
-    border-radius: 0.5rem;
-    box-shadow: 0 3px 6px 2px rgba(0, 0, 0, 0.3);
+    background-color: var(--reconnection-ui-bg);
+    color: var(--error-ui-foreground-color);
+    width: min(20rem, calc(100vw - 2rem));
+    margin: 0;
+    padding: 1rem;
+    border: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-rest);
+    border-radius: calc(var(--layer-corner-radius) * 1px);
+    box-shadow: var(--elevation-shadow-card-rest);
+    position: fixed;
+    inset-block-start: 1rem;
+    inset-inline-end: 1rem;
+    inset-inline-start: auto;
+    max-height: calc(100vh - 2rem);
+    overflow: auto;
+    z-index: 1100;
     opacity: 0;
-    transition: display 0.5s allow-discrete, overlay 0.5s allow-discrete;
     animation: components-reconnect-modal-fadeOutOpacity 0.5s both;
-    &[open]
+    box-sizing: border-box;
+}
 
-{
-    animation: components-reconnect-modal-slideUp 1.5s cubic-bezier(.05, .89, .25, 1.02) 0.3s, components-reconnect-modal-fadeInOpacity 0.5s ease-in-out 0.3s;
+#components-reconnect-modal[open] {
+    animation: components-reconnect-modal-slideIn 0.3s ease-out, components-reconnect-modal-fadeInOpacity 0.2s ease-in-out;
     animation-fill-mode: both;
 }
 
-}
 
-#components-reconnect-modal::backdrop {
-    background-color: rgba(0, 0, 0, 0.4);
-    animation: components-reconnect-modal-fadeInOpacity 0.5s ease-in-out;
-    opacity: 1;
-}
-
-@keyframes components-reconnect-modal-slideUp {
+@keyframes components-reconnect-modal-slideIn {
     0% {
-        transform: translateY(30px) scale(0.95);
+        transform: translateY(-8px);
     }
 
     100% {

--- a/src/Aspire.Dashboard/wwwroot/js/app-reconnect.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-reconnect.js
@@ -7,13 +7,25 @@ retryButton.addEventListener("click", retry);
 
 function handleReconnectStateChanged(event) {
     if (event.detail.state === "show") {
-        reconnectModal.showModal();
+        showReconnectDialog();
     } else if (event.detail.state === "hide") {
-        reconnectModal.close();
+        closeReconnectDialog();
     } else if (event.detail.state === "failed") {
         document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
     } else if (event.detail.state === "rejected") {
         location.reload();
+    }
+}
+
+function showReconnectDialog() {
+    if (!reconnectModal.open) {
+        reconnectModal.show();
+    }
+}
+
+function closeReconnectDialog() {
+    if (reconnectModal.open) {
+        reconnectModal.close();
     }
 }
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-reconnect.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-reconnect.js
@@ -1,6 +1,7 @@
 // Set up event handlers
 const reconnectModal = document.getElementById("components-reconnect-modal");
 reconnectModal.addEventListener("components-reconnect-state-changed", handleReconnectStateChanged);
+reconnectModal.addEventListener("cancel", preventReconnectDialogCancel);
 
 const retryButton = document.getElementById("components-reconnect-button");
 retryButton.addEventListener("click", retry);
@@ -27,6 +28,10 @@ function closeReconnectDialog() {
     if (reconnectModal.open) {
         reconnectModal.close();
     }
+}
+
+function preventReconnectDialogCancel(event) {
+    event.preventDefault();
 }
 
 async function retry() {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ReconnectTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ReconnectTests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
+using Aspire.TestUtilities;
+using Microsoft.AspNetCore.InternalTesting;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Integration.Playwright;
+
+[RequiresFeature(TestFeature.Playwright)]
+public class ReconnectTests : PlaywrightTestsBase<DashboardServerFixture>
+{
+    public ReconnectTests(DashboardServerFixture dashboardServerFixture)
+        : base(dashboardServerFixture)
+    {
+    }
+
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task ReconnectNotice_Shown_IsModeless()
+    {
+        await RunTestAsync(async page =>
+        {
+            await PlaywrightFixture.GoToHomeAndWaitForDataGridLoad(page).DefaultTimeout();
+
+            var reconnectState = await page.EvaluateAsync<bool[]>(
+                """
+                () => {
+                    const reconnectDialog = document.getElementById("components-reconnect-modal");
+                    reconnectDialog.dispatchEvent(new CustomEvent("components-reconnect-state-changed", { detail: { state: "show" } }));
+
+                    return [reconnectDialog.open, reconnectDialog.matches(":modal")];
+                }
+                """).DefaultTimeout();
+
+            Assert.Collection(
+                reconnectState,
+                open => Assert.True(open),
+                modal => Assert.False(modal));
+
+            var isOpenAfterHide = await page.EvaluateAsync<bool>(
+                """
+                () => {
+                    const reconnectDialog = document.getElementById("components-reconnect-modal");
+                    reconnectDialog.dispatchEvent(new CustomEvent("components-reconnect-state-changed", { detail: { state: "hide" } }));
+
+                    return reconnectDialog.open;
+                }
+                """).DefaultTimeout();
+
+            Assert.False(isOpenAfterHide);
+        });
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/ReconnectScriptTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ReconnectScriptTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class ReconnectScriptTests
+{
+    [Fact]
+    public void ReconnectScript_OpensReconnectDialogModelessly()
+    {
+        var script = ReadDashboardScript("app-reconnect.js");
+
+        Assert.DoesNotContain("showModal", script);
+        Assert.Contains("reconnectModal.show();", script);
+    }
+
+    private static string ReadDashboardScript(string scriptName)
+    {
+        var dashboardAssemblyDirectory = Path.GetDirectoryName(typeof(DashboardWebApplication).Assembly.Location);
+        Assert.NotNull(dashboardAssemblyDirectory);
+
+        var scriptPath = Path.Combine(dashboardAssemblyDirectory, "wwwroot", "js", scriptName);
+        Assert.True(File.Exists(scriptPath), $"Expected dashboard script to exist at '{scriptPath}'.");
+
+        return File.ReadAllText(scriptPath);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/ReconnectScriptTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ReconnectScriptTests.cs
@@ -13,6 +13,8 @@ public class ReconnectScriptTests
         var script = ReadDashboardScript("app-reconnect.js");
 
         Assert.DoesNotContain("showModal", script);
+        Assert.Contains("reconnectModal.addEventListener(\"cancel\"", script);
+        Assert.Contains("event.preventDefault();", script);
         Assert.Contains("reconnectModal.show();", script);
     }
 


### PR DESCRIPTION
## Description

Fixes #2514

This updates the Dashboard reconnect UI so it no longer blocks access to stale page content when the AppHost/server disconnects. The reconnect dialog is now opened modelessly and styled as a small fixed notice, so existing logs and Copilot chat content remain readable, scrollable, and copyable while the disconnected state is visible.

Changes:
- Open the reconnect dialog with guarded `show()`/`close()` helpers instead of `showModal()`.
- Restyle the reconnect UI as a non-blocking notice with no backdrop.
- Add fast script-level regression coverage and Playwright coverage that verifies the dialog is open but not `:modal`.

Validation:
- `dotnet test tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj -- --filter-method "*.ReconnectScript_OpensReconnectDialogModelessly" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build src/Aspire.Dashboard/Aspire.Dashboard.csproj /p:SkipNativeBuild=true`
- `dotnet test tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj -- --filter-method "*.ReconnectNotice_Shown_IsModeless" --filter-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
