### PR TITLE
Clarify AppHost language in starter templates

### DIFF
--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -115,15 +115,6 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to React (Vite) &amp; FastAPI starter.
-        /// </summary>
-        public static string AspirePyStarter_Description {
-            get {
-                return ResourceManager.GetString("AspirePyStarter_Description", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Service defaults.
         /// </summary>
         public static string AspireServiceDefaults_Description {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -124,7 +124,7 @@
     <value>Starter App (ASP.NET Core/Blazor)</value>
   </data>
   <data name="AspireJsFrontendStarter_Description" xml:space="preserve">
-    <value>Starter App (ASP.NET Core/React)</value>
+    <value>Starter App (ASP.NET Core/React, C# AppHost)</value>
   </data>
   <data name="AspireJavaStarter_Description" xml:space="preserve">
     <value>Starter App (Java AppHost/Express/React)</value>
@@ -142,7 +142,7 @@
     <value>Service defaults</value>
   </data>
   <data name="AspirePyStarter_Description" xml:space="preserve">
-    <value>Starter App (FastAPI/React)</value>
+    <value>Starter App (FastAPI/React, TypeScript AppHost)</value>
   </data>
   <data name="AspireAppHostSingleFile_Description" xml:space="preserve">
     <value>Empty AppHost</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -141,9 +141,6 @@
   <data name="AspireServiceDefaults_Description" xml:space="preserve">
     <value>Service defaults</value>
   </data>
-  <data name="AspirePyStarter_Description" xml:space="preserve">
-    <value>Starter App (FastAPI/React, TypeScript AppHost)</value>
-  </data>
   <data name="AspireAppHostSingleFile_Description" xml:space="preserve">
     <value>Empty AppHost</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Úvodní aplikace (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Úvodní aplikace (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">Úvodní aplikace (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">Úvodní aplikace (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">Úvodní aplikace (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Výchozí hodnoty služby</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">Starter-App (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Dienststandardwerte</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Starter-App (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Starter-App (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">Starter-App (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">Starter-App (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Aplicación de inicio (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Aplicación de inicio (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">Aplicación de inicio (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">Aplicación de inicio (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">Aplicación de inicio (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Valores predeterminados del servicio</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Application de démarrage (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Application de démarrage (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">Application de démarrage (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">Application de démarrage (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">Application de démarrage (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Paramètres par défaut du service</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Starter App (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Starter App (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">App Starter (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">App Starter (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">App Starter (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Impostazioni predefinite del servizio</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">スターター アプリ (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">サービスの既定値</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">スターター アプリ (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">スターター アプリ (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">スターター アプリ (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">スターター アプリ (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">시작 앱(FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">서비스 기본값</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">시작 앱(ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">시작 앱(ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">시작 앱(FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">시작 앱(FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Aplikacja startowa (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Aplikacja startowa (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">Aplikacja startowa (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">Aplikacja startowa (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">Aplikacja startowa (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Wartości domyślne usługi</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Aplicativo inicial (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Aplicativo inicial (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">Aplicativo inicial (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">Aplicativo inicial (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">Aplicativo inicial (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Padrões de serviço</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">Начальное приложение (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Значения по умолчанию для службы</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Начальное приложение (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Начальное приложение (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">Начальное приложение (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">Начальное приложение (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">Başlangıç Uygulaması (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">Hizmet varsayılanları</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">Başlangıç Uygulaması (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">Başlangıç Uygulaması (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">Başlangıç Uygulaması (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">Başlangıç Uygulaması (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">入门应用(FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">服务默认值</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">入门应用(ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">入门应用(ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">入门应用(FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">入门应用(FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -37,11 +37,6 @@
         <target state="translated">NUnit</target>
         <note />
       </trans-unit>
-      <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
-        <target state="needs-review-translation">入門應用程式 (FastAPI/React)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
         <source>Service defaults</source>
         <target state="translated">服務預設值</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireJsFrontendStarter_Description">
-        <source>Starter App (ASP.NET Core/React)</source>
-        <target state="translated">入門應用程式 (ASP.NET Core/React)</target>
+        <source>Starter App (ASP.NET Core/React, C# AppHost)</source>
+        <target state="needs-review-translation">入門應用程式 (ASP.NET Core/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AspirePyStarter_Description">
-        <source>Starter App (FastAPI/React)</source>
-        <target state="translated">入門應用程式 (FastAPI/React)</target>
+        <source>Starter App (FastAPI/React, TypeScript AppHost)</source>
+        <target state="needs-review-translation">入門應用程式 (FastAPI/React)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -95,7 +95,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
         [
             new CallbackTemplate(
                 KnownTemplateId.TypeScriptStarter,
-                "Starter App (Express/React)",
+                "Starter App (Express/React, TypeScript AppHost)",
                 projectName => $"./{projectName}",
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyTypeScriptStarterTemplateAsync,
@@ -139,7 +139,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
 
             new CallbackTemplate(
                 KnownTemplateId.PythonStarter,
-                "Starter App (FastAPI/React)",
+                "Starter App (FastAPI/React, TypeScript AppHost)",
                 projectName => $"./{projectName}",
                 cmd =>
                 {

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -139,7 +139,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
 
             new CallbackTemplate(
                 KnownTemplateId.PythonStarter,
-                "Starter App (FastAPI/React, TypeScript AppHost)",
+                TemplatingStrings.AspirePyStarter_Description,
                 projectName => $"./{projectName}",
                 cmd =>
                 {

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -139,7 +139,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
 
             new CallbackTemplate(
                 KnownTemplateId.PythonStarter,
-                TemplatingStrings.AspirePyStarter_Description,
+                "Starter App (FastAPI/React, TypeScript AppHost)",
                 projectName => $"./{projectName}",
                 cmd =>
                 {

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.cs.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Úvodní aplikace Aspire (ASP.NET Core/React)",
+  "name": "Úvodní aplikace Aspire (ASP.NET Core/React, C# AppHost)",
   "description": "Šablona projektu pro vytvoření aplikace Aspire s front-endem React a back-endovou službou minimálního rozhraní API jazyka C# s volitelným ukládáním do mezipaměti Redis",
   "symbols/Framework/description": "Cílová architektura pro projekt.",
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.de.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aspire Starter-App (ASP.NET Core/React)",
+  "name": "Aspire Starter-App (ASP.NET Core/React, C# AppHost)",
   "description": "Eine Projektvorlage zum Erstellen einer Aspire-App mit einem React-Front-End und einem C# Minimal-API-Back-End-Dienst, optional mit Redis-Zwischenspeicherung.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aspire Starter App (ASP.NET Core/React)",
+  "name": "Aspire Starter App (ASP.NET Core/React, C# AppHost)",
   "description": "A project template for creating an Aspire app with a React frontend and a C# Minimal API backend service, with optional Redis caching.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.es.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aplicación starter de Starter (ASP.NET Core/React)",
+  "name": "Aplicación starter de Starter (ASP.NET Core/React, C# AppHost)",
   "description": "Plantilla de proyecto para crear una aplicación Desi con un front-end de React y un servicio back-end de API mínimo de C#, con almacenamiento en caché de Redis opcional.",
   "symbols/Framework/description": "Marco de destino del proyecto.",
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.fr.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Application de démarrage Aspire (ASP.NET Core/React)",
+  "name": "Application de démarrage Aspire (ASP.NET Core/React, C# AppHost)",
   "description": "Modèle de projet pour créer une application Aspire avec un front-end React et un service backend d’API Minimal en C#, avec une mise en cache Redis optionnelle.",
   "symbols/Framework/description": "Infrastructure cible du projet.",
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.it.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "App Starter Aspire (ASP.NET Core/React)",
+  "name": "App Starter Aspire (ASP.NET Core/React, C# AppHost)",
   "description": "Modello di progetto per la creazione di un'app Aspire con front-end React e servizio back-end Minimal API in C#, con cache Redis opzionale.",
   "symbols/Framework/description": "Il framework di destinazione per il progetto.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ja.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aspire スターター アプリ (ASP.NET Core/React)",
+  "name": "Aspire スターター アプリ (ASP.NET Core/React, C# AppHost)",
   "description": "React フロントエンドと C# MInimal API バックエンド サービスを使用して Aspire アプリを作成するためのプロジェクト テンプレート。必要に応じて、Redis キャッシュを使用します。",
   "symbols/Framework/description": "プロジェクトのターゲット フレームワーク。",
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ko.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aspire Starter 앱(ASP.NET Core/React)",
+  "name": "Aspire Starter 앱(ASP.NET Core/React, C# AppHost)",
   "description": "선택적 Redis 캐싱을 사용하여 React 프런트 엔드와 C# 최소 API 백 엔드 서비스로 Aspire 앱을 만들기 위한 프로젝트 템플릿입니다.",
   "symbols/Framework/description": "프로젝트에 대한 대상 프레임워크입니다.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.pl.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aplikacja startowa Aspire (ASP.NET Core/React)",
+  "name": "Aplikacja startowa Aspire (ASP.NET Core/React, C# AppHost)",
   "description": "Szablon projektu do tworzenia aplikacji Aspire z frontonem React i minimalną usługą zaplecza interfejsu API w języku C#, z opcjonalnym buforowaniem Redis.",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.pt-BR.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aplicativo Inicial Aspire (ASP.NET Core/React)",
+  "name": "Aplicativo Inicial Aspire (ASP.NET Core/React, C# AppHost)",
   "description": "Um modelo de projeto para criar um aplicativo Aspire com front-end React e serviço de back-end C# com API Mínima, com cache Redis opcional.",
   "symbols/Framework/description": "A estrutura de destino para o projeto.",
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ru.json
@@ -1,6 +1,6 @@
 {
   "author": "Майкрософт",
-  "name": "Начальное приложение Aspire (ASP.NET Core/React)",
+  "name": "Начальное приложение Aspire (ASP.NET Core/React, C# AppHost)",
   "description": "Шаблон проекта для создания приложения Aspire с интерфейсной частью React и серверной службой минимального API на C# с необязательным кэшированием Redis.",
   "symbols/Framework/description": "Целевая платформа для проекта.",
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.tr.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aspire Başlangıç Uygulaması (ASP.NET Core/React)",
+  "name": "Aspire Başlangıç Uygulaması (ASP.NET Core/React, C# AppHost)",
   "description": "İsteğe bağlı Redis önbelleğiyle bir React ön uç ve C# Minimal API arka uç hizmetini içeren bir Aspire uygulaması oluşturmak için proje şablonu.",
   "symbols/Framework/description": "Projenin hedef çerçevesi.",
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aspire 入门应用(ASP.NET Core/React)",
+  "name": "Aspire 入门应用(ASP.NET Core/React, C# AppHost)",
   "description": "用于使用 React 前端和 C# Minimal API 后端服务创建 Aspire 应用的项目模板，可选择使用 Redis 缓存。",
   "symbols/Framework/description": "项目的目标框架。",
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Aspire 入門應用程式 (ASP.NET Core/React)",
+  "name": "Aspire 入門應用程式 (ASP.NET Core/React, C# AppHost)",
   "description": "用於建立 Aspire 應用程式的專案範本，其中包含 React 前端與 C# Minimal API 後端服務，並可選用 Redis 快取功能。",
   "symbols/Framework/description": "專案的目標架構。",
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/template.json
@@ -13,7 +13,7 @@
     "TypeScript",
     "React"
   ],
-  "name": "Aspire Starter App (ASP.NET Core/React)",
+  "name": "Aspire Starter App (ASP.NET Core/React, C# AppHost)",
   "defaultName": "AspireApp",
   "description": "A project template for creating an Aspire app with a React frontend and a C# Minimal API backend service, with optional Redis caching.",
   "shortName": "aspire-ts-cs-starter",

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -799,7 +799,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(promptedTemplates);
         Assert.Contains((KnownTemplateId.CSharpEmptyAppHost, "Empty AppHost"), promptedTemplates);
         Assert.Contains((KnownTemplateId.TypeScriptEmptyAppHost, "Empty (TypeScript AppHost)"), promptedTemplates);
-        Assert.Contains((KnownTemplateId.TypeScriptStarter, "Starter App (Express/React)"), promptedTemplates);
+        Assert.Contains((KnownTemplateId.TypeScriptStarter, "Starter App (Express/React, TypeScript AppHost)"), promptedTemplates);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
     }
 
@@ -1850,4 +1850,3 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.True(File.Exists(skillPath));
     }
 }
-

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -569,7 +569,7 @@ internal static class Hex1bAutomatorTestHelpers
                 break;
 
             case AspireTemplate.TypeScriptEmptyAppHost:
-                await auto.TypeAsync("TypeScript");
+                await auto.TypeAsync("Empty (TypeScript");
                 await auto.WaitUntilAsync(
                     s => new CellPatternSearcher().Find("> Empty (TypeScript AppHost)").Search(s).Count > 0,
                     timeout: TimeSpan.FromSeconds(5),

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -525,7 +525,7 @@ internal static class Hex1bAutomatorTestHelpers
             case AspireTemplate.JsReact:
                 await auto.DownAsync();
                 await auto.WaitUntilAsync(
-                    s => new CellPatternSearcher().Find("> Starter App (ASP.NET Core/React)").Search(s).Count > 0,
+                    s => new CellPatternSearcher().Find("> Starter App (ASP.NET Core/React, C# AppHost)").Search(s).Count > 0,
                     timeout: TimeSpan.FromSeconds(5),
                     description: "JS React template selected");
                 await auto.EnterAsync();
@@ -535,7 +535,7 @@ internal static class Hex1bAutomatorTestHelpers
                 await auto.DownAsync();
                 await auto.DownAsync();
                 await auto.WaitUntilAsync(
-                    s => new CellPatternSearcher().Find("> Starter App (Express/React)").Search(s).Count > 0,
+                    s => new CellPatternSearcher().Find("> Starter App (Express/React, TypeScript AppHost)").Search(s).Count > 0,
                     timeout: TimeSpan.FromSeconds(5),
                     description: "Express React template selected");
                 await auto.EnterAsync();
@@ -546,7 +546,7 @@ internal static class Hex1bAutomatorTestHelpers
                 await auto.DownAsync();
                 await auto.DownAsync();
                 await auto.WaitUntilAsync(
-                    s => new CellPatternSearcher().Find("> Starter App (FastAPI/React)").Search(s).Count > 0,
+                    s => new CellPatternSearcher().Find("> Starter App (FastAPI/React, TypeScript AppHost)").Search(s).Count > 0,
                     timeout: TimeSpan.FromSeconds(5),
                     description: "Python React template selected");
                 await auto.EnterAsync();

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -33,19 +33,19 @@ internal enum AspireTemplate
     Starter,
 
     /// <summary>
-    /// Starter App (ASP.NET Core/React).
+    /// Starter App (ASP.NET Core/React, C# AppHost).
     /// Prompts: template, project name, output path, URLs, Redis. No test project prompt.
     /// </summary>
     JsReact,
 
     /// <summary>
-    /// Starter App (Express/React).
+    /// Starter App (Express/React, TypeScript AppHost).
     /// Prompts: template, project name, output path, URLs. No Redis or test project prompt.
     /// </summary>
     ExpressReact,
 
     /// <summary>
-    /// Starter App (FastAPI/React).
+    /// Starter App (FastAPI/React, TypeScript AppHost).
     /// Prompts: template, project name, output path, URLs, Redis. No test project prompt.
     /// </summary>
     PythonReact,
@@ -431,7 +431,7 @@ internal static class Hex1bTestHelpers
 
             case AspireTemplate.JsReact:
                 var jsReactSelected = new CellPatternSearcher()
-                    .Find("> Starter App (ASP.NET Core/React)");
+                    .Find("> Starter App (ASP.NET Core/React, C# AppHost)");
                 builder.Key(Hex1bKey.DownArrow)
                     .WaitUntil(s => jsReactSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
                     .Enter();
@@ -439,7 +439,7 @@ internal static class Hex1bTestHelpers
 
             case AspireTemplate.ExpressReact:
                 var expressReactSelected = new CellPatternSearcher()
-                    .Find("> Starter App (Express/React)");
+                    .Find("> Starter App (Express/React, TypeScript AppHost)");
                 builder.Key(Hex1bKey.DownArrow)
                     .Key(Hex1bKey.DownArrow)
                     .WaitUntil(s => expressReactSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
@@ -448,7 +448,7 @@ internal static class Hex1bTestHelpers
 
             case AspireTemplate.PythonReact:
                 var pythonReactSelected = new CellPatternSearcher()
-                    .Find("> Starter App (FastAPI/React)");
+                    .Find("> Starter App (FastAPI/React, TypeScript AppHost)");
                 builder.Key(Hex1bKey.DownArrow)
                     .Key(Hex1bKey.DownArrow)
                     .Key(Hex1bKey.DownArrow)

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -466,7 +466,7 @@ internal static class Hex1bTestHelpers
             case AspireTemplate.TypeScriptEmptyAppHost:
                 var typeScriptEmptyAppHostSelected = new CellPatternSearcher()
                     .Find("> Empty (TypeScript AppHost)");
-                builder.Type("TypeScript")
+                builder.Type("Empty (TypeScript")
                     .WaitUntil(s => typeScriptEmptyAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
                     .Enter();
                 break;


### PR DESCRIPTION
## Description

The Aspire CLI template picker had starter app entries where the frontend/backend stack was visible but the AppHost language was not. This clarifies the affected labels so users can tell whether a starter creates a C# or TypeScript AppHost before selecting it.

This updates the ASP.NET Core/React, Express/React, and FastAPI/React starter descriptions used by the CLI prompt and keeps localized resource metadata in sync for the resource-backed descriptions. Shared terminal test helpers and the relevant `NewCommand` expectation were updated for the new labels.

Fixes #15550

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
