### PR TITLE
Fix Kubernetes ATS duplicate capability exports

### DIFF
--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
@@ -276,7 +276,7 @@ public static class AzureKubernetesEnvironmentExtensions
     ///     .WithSubnet(gpuSubnet);
     /// </code>
     /// </example>
-    [AspireExport(Description = "Configures an AKS node pool to use a specific VNet subnet")]
+    [AspireExport("withNodePoolSubnet", MethodName = "withSubnet", Description = "Configures an AKS node pool to use a specific VNet subnet")]
     public static IResourceBuilder<AksNodePoolResource> WithSubnet(
         this IResourceBuilder<AksNodePoolResource> builder,
         IResourceBuilder<AzureSubnetResource> subnet)

--- a/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
+++ b/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
@@ -48,6 +48,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="namespace">A parameter resource builder for the namespace value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExport("withNamespaceFromParameter", MethodName = "withNamespaceFromParameter", Description = "Sets the target Kubernetes namespace for deployment using a parameter.")]
     public HelmChartOptions WithNamespace(IResourceBuilder<ParameterResource> @namespace)
     {
         ArgumentNullException.ThrowIfNull(@namespace);
@@ -77,6 +78,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="releaseName">A parameter resource builder for the release name value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExport("withReleaseNameFromParameter", MethodName = "withReleaseNameFromParameter", Description = "Sets the Helm release name for deployment using a parameter.")]
     public HelmChartOptions WithReleaseName(IResourceBuilder<ParameterResource> releaseName)
     {
         ArgumentNullException.ThrowIfNull(releaseName);
@@ -106,6 +108,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="version">A parameter resource builder for the chart version value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExport("withChartVersionFromParameter", MethodName = "withChartVersionFromParameter", Description = "Sets the Helm chart version for deployment using a parameter.")]
     public HelmChartOptions WithChartVersion(IResourceBuilder<ParameterResource> version)
     {
         ArgumentNullException.ThrowIfNull(version);

--- a/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
+++ b/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
@@ -33,6 +33,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="namespace">The namespace name.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withNamespace dispatcher export.")]
     public HelmChartOptions WithNamespace(string @namespace)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
@@ -48,7 +49,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="namespace">A parameter resource builder for the namespace value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
-    [AspireExport("HelmChartOptions.withNamespaceFromParameter", MethodName = "withNamespaceFromParameter", Description = "Sets the target Kubernetes namespace for deployment using a parameter.")]
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withNamespace dispatcher export.")]
     public HelmChartOptions WithNamespace(IResourceBuilder<ParameterResource> @namespace)
     {
         ArgumentNullException.ThrowIfNull(@namespace);
@@ -58,11 +59,25 @@ public sealed partial class HelmChartOptions
         return this;
     }
 
+    [AspireExport(MethodName = "withNamespace", Description = "Sets the target Kubernetes namespace for deployment.")]
+    internal HelmChartOptions WithNamespace([AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object @namespace)
+    {
+        ArgumentNullException.ThrowIfNull(@namespace);
+
+        return @namespace switch
+        {
+            string namespaceName => WithNamespace(namespaceName),
+            IResourceBuilder<ParameterResource> namespaceParameter => WithNamespace(namespaceParameter),
+            _ => throw new ArgumentException("Namespace must be a string or a parameter resource builder.", nameof(@namespace))
+        };
+    }
+
     /// <summary>
     /// Sets the Helm release name for deployment.
     /// </summary>
     /// <param name="releaseName">The release name.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withReleaseName dispatcher export.")]
     public HelmChartOptions WithReleaseName(string releaseName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(releaseName);
@@ -78,7 +93,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="releaseName">A parameter resource builder for the release name value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
-    [AspireExport("HelmChartOptions.withReleaseNameFromParameter", MethodName = "withReleaseNameFromParameter", Description = "Sets the Helm release name for deployment using a parameter.")]
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withReleaseName dispatcher export.")]
     public HelmChartOptions WithReleaseName(IResourceBuilder<ParameterResource> releaseName)
     {
         ArgumentNullException.ThrowIfNull(releaseName);
@@ -88,11 +103,25 @@ public sealed partial class HelmChartOptions
         return this;
     }
 
+    [AspireExport(MethodName = "withReleaseName", Description = "Sets the Helm release name for deployment.")]
+    internal HelmChartOptions WithReleaseName([AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object releaseName)
+    {
+        ArgumentNullException.ThrowIfNull(releaseName);
+
+        return releaseName switch
+        {
+            string releaseNameValue => WithReleaseName(releaseNameValue),
+            IResourceBuilder<ParameterResource> releaseNameParameter => WithReleaseName(releaseNameParameter),
+            _ => throw new ArgumentException("Release name must be a string or a parameter resource builder.", nameof(releaseName))
+        };
+    }
+
     /// <summary>
     /// Sets the Helm chart version for deployment.
     /// </summary>
     /// <param name="version">The chart version (e.g., "1.0.0").</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withChartVersion dispatcher export.")]
     public HelmChartOptions WithChartVersion(string version)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
@@ -108,7 +137,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="version">A parameter resource builder for the chart version value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
-    [AspireExport("HelmChartOptions.withChartVersionFromParameter", MethodName = "withChartVersionFromParameter", Description = "Sets the Helm chart version for deployment using a parameter.")]
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withChartVersion dispatcher export.")]
     public HelmChartOptions WithChartVersion(IResourceBuilder<ParameterResource> version)
     {
         ArgumentNullException.ThrowIfNull(version);
@@ -116,6 +145,19 @@ public sealed partial class HelmChartOptions
         var expression = ReferenceExpression.Create($"{version.Resource}");
         EnvironmentBuilder.WithAnnotation(new HelmChartVersionAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
         return this;
+    }
+
+    [AspireExport(MethodName = "withChartVersion", Description = "Sets the Helm chart version for deployment.")]
+    internal HelmChartOptions WithChartVersion([AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object version)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+
+        return version switch
+        {
+            string versionValue => WithChartVersion(versionValue),
+            IResourceBuilder<ParameterResource> versionParameter => WithChartVersion(versionParameter),
+            _ => throw new ArgumentException("Chart version must be a string or a parameter resource builder.", nameof(version))
+        };
     }
 
     private static void ValidateDnsLabel(string value, string target, int maxLength, string paramName)

--- a/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
+++ b/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
@@ -48,7 +48,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="namespace">A parameter resource builder for the namespace value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
-    [AspireExport("withNamespaceFromParameter", MethodName = "withNamespaceFromParameter", Description = "Sets the target Kubernetes namespace for deployment using a parameter.")]
+    [AspireExport("HelmChartOptions.withNamespaceFromParameter", MethodName = "withNamespaceFromParameter", Description = "Sets the target Kubernetes namespace for deployment using a parameter.")]
     public HelmChartOptions WithNamespace(IResourceBuilder<ParameterResource> @namespace)
     {
         ArgumentNullException.ThrowIfNull(@namespace);
@@ -78,7 +78,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="releaseName">A parameter resource builder for the release name value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
-    [AspireExport("withReleaseNameFromParameter", MethodName = "withReleaseNameFromParameter", Description = "Sets the Helm release name for deployment using a parameter.")]
+    [AspireExport("HelmChartOptions.withReleaseNameFromParameter", MethodName = "withReleaseNameFromParameter", Description = "Sets the Helm release name for deployment using a parameter.")]
     public HelmChartOptions WithReleaseName(IResourceBuilder<ParameterResource> releaseName)
     {
         ArgumentNullException.ThrowIfNull(releaseName);
@@ -108,7 +108,7 @@ public sealed partial class HelmChartOptions
     /// </summary>
     /// <param name="version">A parameter resource builder for the chart version value.</param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
-    [AspireExport("withChartVersionFromParameter", MethodName = "withChartVersionFromParameter", Description = "Sets the Helm chart version for deployment using a parameter.")]
+    [AspireExport("HelmChartOptions.withChartVersionFromParameter", MethodName = "withChartVersionFromParameter", Description = "Sets the Helm chart version for deployment using a parameter.")]
     public HelmChartOptions WithChartVersion(IResourceBuilder<ParameterResource> version)
     {
         ArgumentNullException.ThrowIfNull(version);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
@@ -10,9 +10,9 @@ void main() throws Exception {
             helm.withNamespace("validation-namespace");
             helm.withReleaseName("validation-release");
             helm.withChartVersion("1.2.3");
-            helm.withNamespaceFromParameter(helmNamespace);
-            helm.withReleaseNameFromParameter(helmReleaseName);
-            helm.withChartVersionFromParameter(helmChartVersion);
+            helm.withNamespace(helmNamespace);
+            helm.withReleaseName(helmReleaseName);
+            helm.withChartVersion(helmChartVersion);
         });
         kubernetes.withProperties((environment) -> {
             environment.setHelmChartName("validation-kubernetes");

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
@@ -2,7 +2,18 @@ import aspire.*;
 
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
+        var helmNamespace = builder.addParameter("helm-namespace");
+        var helmReleaseName = builder.addParameter("helm-release-name");
+        var helmChartVersion = builder.addParameter("helm-chart-version");
         var kubernetes = builder.addKubernetesEnvironment("kube");
+        kubernetes.withHelm((helm) -> {
+            helm.withNamespace("validation-namespace");
+            helm.withReleaseName("validation-release");
+            helm.withChartVersion("1.2.3");
+            helm.withNamespaceFromParameter(helmNamespace);
+            helm.withReleaseNameFromParameter(helmReleaseName);
+            helm.withChartVersionFromParameter(helmChartVersion);
+        });
         kubernetes.withProperties((environment) -> {
             environment.setHelmChartName("validation-kubernetes");
             var _configuredHelmChartName = environment.helmChartName();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
@@ -14,9 +14,9 @@ with create_builder() as builder:
         helm.with_namespace("validation-namespace")
         helm.with_release_name("validation-release")
         helm.with_chart_version("1.2.3")
-        helm.with_namespace_from_parameter(helm_namespace)
-        helm.with_release_name_from_parameter(helm_release_name)
-        helm.with_chart_version_from_parameter(helm_chart_version)
+        helm.with_namespace(helm_namespace)
+        helm.with_release_name(helm_release_name)
+        helm.with_chart_version(helm_chart_version)
 
     kubernetes.with_helm(configure_helm)
     kubernetes.with_properties()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
@@ -5,7 +5,20 @@ from aspire_app import create_builder
 
 
 with create_builder() as builder:
+    helm_namespace = builder.add_parameter("helm-namespace")
+    helm_release_name = builder.add_parameter("helm-release-name")
+    helm_chart_version = builder.add_parameter("helm-chart-version")
     kubernetes = builder.add_kubernetes_environment("resource")
+
+    def configure_helm(helm):
+        helm.with_namespace("validation-namespace")
+        helm.with_release_name("validation-release")
+        helm.with_chart_version("1.2.3")
+        helm.with_namespace_from_parameter(helm_namespace)
+        helm.with_release_name_from_parameter(helm_release_name)
+        helm.with_chart_version_from_parameter(helm_chart_version)
+
+    kubernetes.with_helm(configure_helm)
     kubernetes.with_properties()
     _resolved_helm_chart_name = kubernetes.helm_chart_name
     _resolved_default_storage_class_name = kubernetes.default_storage_class_name

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -13,9 +13,9 @@ await kubernetes.withHelm({
         await helm.withNamespace('validation-namespace');
         await helm.withReleaseName('validation-release');
         await helm.withChartVersion('1.2.3');
-        await helm.withNamespaceFromParameter(helmNamespace);
-        await helm.withReleaseNameFromParameter(helmReleaseName);
-        await helm.withChartVersionFromParameter(helmChartVersion);
+        await helm.withNamespace(helmNamespace);
+        await helm.withReleaseName(helmReleaseName);
+        await helm.withChartVersion(helmChartVersion);
     },
 });
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -8,13 +8,15 @@ const helmChartVersion = await builder.addParameter('helm-chart-version');
 
 const kubernetes = await builder.addKubernetesEnvironment('kube');
 
-await kubernetes.withHelm(async (helm) => {
-    await helm.withNamespace('validation-namespace');
-    await helm.withReleaseName('validation-release');
-    await helm.withChartVersion('1.2.3');
-    await helm.withNamespaceFromParameter(helmNamespace);
-    await helm.withReleaseNameFromParameter(helmReleaseName);
-    await helm.withChartVersionFromParameter(helmChartVersion);
+await kubernetes.withHelm({
+    configure: async (helm) => {
+        await helm.withNamespace('validation-namespace');
+        await helm.withReleaseName('validation-release');
+        await helm.withChartVersion('1.2.3');
+        await helm.withNamespaceFromParameter(helmNamespace);
+        await helm.withReleaseNameFromParameter(helmReleaseName);
+        await helm.withChartVersionFromParameter(helmChartVersion);
+    },
 });
 
 await kubernetes.withProperties(async (environment) => {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -2,7 +2,20 @@ import { createBuilder } from './.modules/aspire.js';
 
 const builder = await createBuilder();
 
+const helmNamespace = await builder.addParameter('helm-namespace');
+const helmReleaseName = await builder.addParameter('helm-release-name');
+const helmChartVersion = await builder.addParameter('helm-chart-version');
+
 const kubernetes = await builder.addKubernetesEnvironment('kube');
+
+await kubernetes.withHelm(async (helm) => {
+    await helm.withNamespace('validation-namespace');
+    await helm.withReleaseName('validation-release');
+    await helm.withChartVersion('1.2.3');
+    await helm.withNamespaceFromParameter(helmNamespace);
+    await helm.withReleaseNameFromParameter(helmReleaseName);
+    await helm.withChartVersionFromParameter(helmChartVersion);
+});
 
 await kubernetes.withProperties(async (environment) => {
     await environment.helmChartName.set('validation-kubernetes');


### PR DESCRIPTION
## Description

The scheduled Generate ATS Diffs workflow was failing because the Kubernetes and AKS integrations emitted ATS error diagnostics for duplicate capability IDs. This change gives the conflicting exports stable, explicit ATS IDs while preserving the intended guest method names where the target type disambiguates the call.

It also updates the Kubernetes polyglot apphost samples for TypeScript, Python, and Java to exercise the newly exposed Helm parameter overloads instead of adding generated-code shape tests.

Fixes #16300

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No