### PR TITLE
Hide inner Kubernetes environment for AKS

### DIFF
--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
@@ -57,25 +57,26 @@ public static class AzureKubernetesEnvironmentExtensions
         builder.Services.Configure<AzureProvisioningOptions>(
             o => o.SupportsTargetedRoleAssignments = true);
 
-        // Create the inner KubernetesEnvironmentResource via the public API.
-        // This registers the Kubernetes infrastructure pipeline step, creates the
-        // resource with Helm chart name/dashboard, adds it to the model, and sets up
-        // the default Helm deployment engine.
-        var k8sEnvBuilder = builder.AddKubernetesEnvironment($"{name}-k8s");
-
-        // Scope the Helm chart name to this AKS environment to avoid
-        // conflicts when multiple environments deploy to the same cluster
-        // or when re-deploying with different environment names.
-        k8sEnvBuilder.Resource.HelmChartName = $"{builder.Environment.ApplicationName}-{name}".ToHelmChartName();
-
         // Create the unified AKS environment resource
         var resource = new AzureKubernetesEnvironmentResource(name, ConfigureAksInfrastructure);
-        resource.KubernetesEnvironment = k8sEnvBuilder.Resource;
 
-        // Set the parent so KubernetesInfrastructure matches resources that use
-        // WithComputeEnvironment(aksEnv) — the inner K8s env checks both itself
-        // and its parent when filtering compute resources.
-        k8sEnvBuilder.Resource.OwningComputeEnvironment = resource;
+        // Create the inner KubernetesEnvironmentResource directly so it can hold
+        // Kubernetes-specific state without surfacing as a second environment in
+        // the application model.
+        builder.AddKubernetesInfrastructureCore();
+        var k8sEnvBuilder = builder.CreateResourceBuilder(new KubernetesEnvironmentResource(name)
+        {
+            // Scope the Helm chart name to this AKS environment to avoid
+            // conflicts when multiple environments deploy to the same cluster
+            // or when re-deploying with different environment names.
+            HelmChartName = $"{builder.Environment.ApplicationName}-{name}".ToHelmChartName(),
+            Dashboard = builder.CreateDashboard($"{name}-dashboard"),
+            OwningComputeEnvironment = resource
+        });
+        KubernetesEnvironmentExtensions.EnsureDefaultHelmEngine(k8sEnvBuilder);
+        resource.KubernetesEnvironment = k8sEnvBuilder.Resource;
+        resource.Annotations.Add(new KubernetesEnvironmentAnnotation());
+        AddKubernetesPipelineAnnotations(resource);
 
         if (builder.ExecutionContext.IsRunMode)
         {
@@ -88,6 +89,7 @@ public static class AzureKubernetesEnvironmentExtensions
         // registry for compute resources.
         var defaultRegistry = builder.AddAzureContainerRegistry($"{name}-acr");
         resource.DefaultContainerRegistry = defaultRegistry.Resource;
+        resource.Annotations.Add(new ContainerRegistryReferenceAnnotation(defaultRegistry.Resource));
         k8sEnvBuilder.WithAnnotation(new ContainerRegistryReferenceAnnotation(defaultRegistry.Resource));
 
         // Wire ACR name as a parameter on the AKS resource so the Bicep module
@@ -99,7 +101,7 @@ public static class AzureKubernetesEnvironmentExtensions
         // call registry.Endpoint.GetValueAsync() which awaits the BicepOutputReference
         // for loginServer — if the ACR hasn't been provisioned yet, this blocks.
         //
-        // NOTE: The standard push step dependency wiring (pushSteps.DependsOn(buildSteps) 
+        // NOTE: The standard push step dependency wiring (pushSteps.DependsOn(buildSteps)
         // and pushSteps.DependsOn(push-prereq)) from ProjectResource's PipelineConfigurationAnnotation
         // may not resolve correctly when using Kubernetes compute environments, because
         // context.GetSteps(resource, tag) may return empty if the resource reference doesn't
@@ -322,8 +324,10 @@ public static class AzureKubernetesEnvironmentExtensions
         }
 
         // Set the explicit registry via annotation on both the AKS environment
-        // and the inner K8s environment (so KubernetesInfrastructure finds it)
-        builder.WithAnnotation(new ContainerRegistryReferenceAnnotation(registry.Resource));
+        // and the inner K8s environment so deployment target preparation finds it.
+        builder.WithAnnotation(
+            new ContainerRegistryReferenceAnnotation(registry.Resource),
+            ResourceAnnotationMutationBehavior.Replace);
 
         // Remove any stale container registry annotations from the inner K8s environment
         // before adding the new one (the default ACR annotation was added during
@@ -636,5 +640,35 @@ public static class AzureKubernetesEnvironmentExtensions
             };
             infrastructure.Add(fedCred);
         }
+    }
+
+    private static void AddKubernetesPipelineAnnotations(AzureKubernetesEnvironmentResource resource)
+    {
+        resource.Annotations.Add(new PipelineStepAnnotation(async factoryContext =>
+        {
+            var steps = new List<PipelineStep>();
+
+            foreach (var annotation in resource.KubernetesEnvironment.Annotations.OfType<PipelineStepAnnotation>())
+            {
+                var childFactoryContext = new PipelineStepFactoryContext
+                {
+                    PipelineContext = factoryContext.PipelineContext,
+                    Resource = resource.KubernetesEnvironment
+                };
+
+                var annotationSteps = await annotation.CreateStepsAsync(childFactoryContext).ConfigureAwait(false);
+                steps.AddRange(annotationSteps);
+            }
+
+            return steps;
+        }));
+
+        resource.Annotations.Add(new PipelineConfigurationAnnotation(async context =>
+        {
+            foreach (var annotation in resource.KubernetesEnvironment.Annotations.OfType<PipelineConfigurationAnnotation>())
+            {
+                await annotation.Callback(context).ConfigureAwait(false);
+            }
+        }));
     }
 }

--- a/src/Aspire.Hosting.Kubernetes/Annotations/KubernetesEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Kubernetes/Annotations/KubernetesEnvironmentAnnotation.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Identifies a compute environment resource as being backed by a Kubernetes environment.
+/// </summary>
+public sealed class KubernetesEnvironmentAnnotation : IResourceAnnotation
+{
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
@@ -28,7 +28,8 @@ public static class KubernetesEnvironmentExtensions
         // The per-environment work (creating Kubernetes service resources and DeploymentTargetAnnotations)
         // is registered as a separate per-environment pipeline step on KubernetesEnvironmentResource.
         // This global step only validates that no resource has a PublishAsKubernetesService annotation
-        // when there are no KubernetesEnvironmentResource instances in the model.
+        // when there are no KubernetesEnvironmentResource instances or Kubernetes-backed
+        // compute environments in the model.
         if (builder.Services.All(d => d.ServiceType != typeof(KubernetesPipelineStepMarker)))
         {
             builder.Services.AddSingleton<KubernetesPipelineStepMarker>();
@@ -37,13 +38,17 @@ public static class KubernetesEnvironmentExtensions
                 name: KubernetesPipelineStepMarker.StepName,
                 action: ctx =>
                 {
-                    if (!ctx.Model.Resources.OfType<KubernetesEnvironmentResource>().Any())
+                    var hasKubernetesEnvironment = ctx.Model.Resources.OfType<KubernetesEnvironmentResource>().Any() ||
+                        ctx.Model.Resources.OfType<IComputeEnvironmentResource>()
+                            .Any(r => r.HasAnnotationOfType<KubernetesEnvironmentAnnotation>());
+
+                    if (!hasKubernetesEnvironment)
                     {
                         foreach (var r in ctx.Model.GetComputeResources())
                         {
                             if (r.HasAnnotationOfType<KubernetesServiceCustomizationAnnotation>())
                             {
-                                throw new InvalidOperationException($"Resource '{r.Name}' is configured to publish as a Kubernetes service, but there are no '{nameof(KubernetesEnvironmentResource)}' resources. Ensure you have added one by calling '{nameof(AddKubernetesEnvironment)}'.");
+                                throw new InvalidOperationException($"Resource '{r.Name}' is configured to publish as a Kubernetes service, but there are no '{nameof(KubernetesEnvironmentResource)}' resources or Kubernetes-backed compute environments. Ensure you have added one by calling '{nameof(AddKubernetesEnvironment)}'.");
                             }
                         }
                     }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -245,7 +245,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
             foreach (var computeResource in resources)
             {
-                var targetEnv = (IComputeEnvironmentResource?)environment.OwningComputeEnvironment ?? environment;
+                var targetEnv = environment.OwningComputeEnvironment ?? environment;
                 var deploymentTarget = computeResource.GetDeploymentTargetAnnotation(targetEnv)?.DeploymentTarget;
                 if (deploymentTarget is not null &&
                     deploymentTarget.TryGetAnnotationsOfType<PipelineStepAnnotation>(out var annotations))
@@ -282,7 +282,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
             foreach (var computeResource in resources)
             {
-                var targetEnv = (IComputeEnvironmentResource?)OwningComputeEnvironment ?? this;
+                var targetEnv = OwningComputeEnvironment ?? this;
                 var deploymentTarget = computeResource.GetDeploymentTargetAnnotation(targetEnv)?.DeploymentTarget;
                 if (deploymentTarget is null)
                 {
@@ -296,7 +296,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
                 // Push steps must complete before the helm deploy step
                 var pushSteps = context.GetSteps(computeResource, WellKnownPipelineTags.PushContainerImage);
-                var helmDeploySteps = context.GetSteps(this, "helm-deploy");
+                var helmDeploySteps = context.GetSteps(targetEnv, "helm-deploy");
                 helmDeploySteps.DependsOn(pushSteps);
 
                 // Print summary steps are on the deployment target and must run after helm deploy
@@ -349,6 +349,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         var environmentContext = new KubernetesEnvironmentContext(this, logger);
         var containerRegistry = GetContainerRegistry(this, appModel);
+        var targetComputeEnvironment = OwningComputeEnvironment ?? this;
 
         // Create a Kubernetes resource for the dashboard if enabled
         if (DashboardEnabled && Dashboard?.Resource is KubernetesAspireDashboardResource dashboard)
@@ -358,7 +359,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
             dashboard.Annotations.Add(new DeploymentTargetAnnotation(dashboardService)
             {
-                ComputeEnvironment = this,
+                ComputeEnvironment = targetComputeEnvironment,
                 ContainerRegistry = containerRegistry
             });
         }
@@ -390,7 +391,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             // Use the resource's actual compute environment (which may be a parent
             // like AzureKubernetesEnvironmentResource) so that GetDeploymentTargetAnnotation
             // can match it correctly during publish.
-            var computeEnvForAnnotation = resourceComputeEnvironment ?? (IComputeEnvironmentResource)this;
+            var computeEnvForAnnotation = resourceComputeEnvironment ?? targetComputeEnvironment;
             r.Annotations.Add(new DeploymentTargetAnnotation(serviceResource)
             {
                 ComputeEnvironment = computeEnvForAnnotation,

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -364,6 +364,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             });
         }
 
+        // Build deployment target lookup for endpoint resolution
+        var deploymentTargets = new Dictionary<IResource, KubernetesResource>();
+
         foreach (var r in appModel.GetComputeResources())
         {
             // Skip resources that are explicitly targeted to a different compute environment.
@@ -397,17 +400,8 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 ComputeEnvironment = computeEnvForAnnotation,
                 ContainerRegistry = containerRegistry
             });
-        }
 
-        // Build deployment target lookup for endpoint resolution
-        var targetEnv = (IComputeEnvironmentResource?)OwningComputeEnvironment ?? this;
-        var deploymentTargets = new Dictionary<IResource, KubernetesResource>();
-        foreach (var resource in appModel.Resources)
-        {
-            if (resource.GetDeploymentTargetAnnotation(targetEnv)?.DeploymentTarget is KubernetesResource k8sResource)
-            {
-                deploymentTargets[resource] = k8sResource;
-            }
+            deploymentTargets[r] = serviceResource;
         }
 
         // Process Ingress resources

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesEnvironmentExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesEnvironmentExtensionsTests.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Kubernetes;
 using Aspire.Hosting.Kubernetes;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -90,7 +91,40 @@ public class AzureKubernetesEnvironmentExtensionsTests
         var aks = builder.AddAzureKubernetesEnvironment("aks");
 
         Assert.NotNull(aks.Resource.KubernetesEnvironment);
-        Assert.Equal("aks-k8s", aks.Resource.KubernetesEnvironment.Name);
+        Assert.Equal("aks", aks.Resource.KubernetesEnvironment.Name);
+        Assert.True(aks.Resource.TryGetLastAnnotation<KubernetesEnvironmentAnnotation>(out var annotation));
+    }
+
+    [Fact]
+    public void AddAzureKubernetesEnvironment_AddsOnlyAksComputeEnvironmentToModel()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish);
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        Assert.DoesNotContain(model.Resources, r => r is KubernetesEnvironmentResource);
+
+        var computeEnvironment = Assert.Single(model.Resources.OfType<IComputeEnvironmentResource>());
+        Assert.Same(aks.Resource, computeEnvironment);
+    }
+
+    [Fact]
+    public async Task AddAzureKubernetesEnvironment_AllowsKubernetesServiceCustomizationWithoutVisibleKubernetesEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish);
+
+        builder.AddAzureKubernetesEnvironment("aks");
+        builder.AddContainer("api", "myimage")
+            .PublishAsKubernetesService(_ => { });
+
+        await using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
     }
 
     [Fact]
@@ -292,7 +326,9 @@ public class AzureKubernetesEnvironmentExtensionsTests
         await using var app = builder.Build();
         await ExecuteBeforeStartHooksAsync(app, default);
 
-        // The inner K8s environment should have the registry annotation
+        Assert.True(aks.Resource.TryGetLastAnnotation<ContainerRegistryReferenceAnnotation>(out var aksAnnotation));
+        Assert.Same(aks.Resource.DefaultContainerRegistry, aksAnnotation.Registry);
+
         Assert.True(aks.Resource.KubernetesEnvironment
             .TryGetLastAnnotation<ContainerRegistryReferenceAnnotation>(out var annotation));
         Assert.Same(aks.Resource.DefaultContainerRegistry, annotation.Registry);

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -139,8 +139,8 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
         // OwningComputeEnvironment should be set
         Assert.Same(enva.Resource, enva.Resource.KubernetesEnvironment.OwningComputeEnvironment);
         Assert.Same(envb.Resource, envb.Resource.KubernetesEnvironment.OwningComputeEnvironment);
-        Assert.True(enva.Resource.TryGetLastAnnotation<KubernetesEnvironmentAnnotation>(out var envaKubernetesEnvironment));
-        Assert.True(envb.Resource.TryGetLastAnnotation<KubernetesEnvironmentAnnotation>(out var envbKubernetesEnvironment));
+        Assert.True(enva.Resource.TryGetLastAnnotation<KubernetesEnvironmentAnnotation>(out var _));
+        Assert.True(envb.Resource.TryGetLastAnnotation<KubernetesEnvironmentAnnotation>(out var _));
 
         await using var app = builder.Build();
         await ExecuteBeforeStartHooksAsync(app, default);

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -2,16 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREAZURE003
+#pragma warning disable ASPIREPIPELINES001
+#pragma warning disable ASPIREPIPELINES003
 
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Kubernetes;
 using Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Pipelines;
+using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Tests;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Azure.Tests;
 
-public class AzureKubernetesInfrastructureTests
+public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
 {
     [Fact]
     public async Task NoUserPool_CreatesDefaultWorkloadPool()
@@ -96,13 +102,10 @@ public class AzureKubernetesInfrastructureTests
         await using var app = builder.Build();
         await ExecuteBeforeStartHooksAsync(app, default);
 
-        // DeploymentTargetAnnotation comes from KubernetesInfrastructure (via the inner
-        // KubernetesEnvironmentResource), not from AzureKubernetesInfrastructure.
         Assert.True(container.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target));
         Assert.NotNull(target.DeploymentTarget);
 
-        // The compute environment should be the inner K8s environment
-        Assert.Same(aks.Resource.KubernetesEnvironment, target.ComputeEnvironment);
+        Assert.Same(aks.Resource, target.ComputeEnvironment);
 
         // CRITICAL: ContainerRegistry must be set on the DeploymentTargetAnnotation
         // so that push steps can resolve the registry endpoint
@@ -135,6 +138,8 @@ public class AzureKubernetesInfrastructureTests
         // OwningComputeEnvironment should be set
         Assert.Same(enva.Resource, enva.Resource.KubernetesEnvironment.OwningComputeEnvironment);
         Assert.Same(envb.Resource, envb.Resource.KubernetesEnvironment.OwningComputeEnvironment);
+        Assert.True(enva.Resource.TryGetLastAnnotation<KubernetesEnvironmentAnnotation>(out var envaKubernetesEnvironment));
+        Assert.True(envb.Resource.TryGetLastAnnotation<KubernetesEnvironmentAnnotation>(out var envbKubernetesEnvironment));
 
         await using var app = builder.Build();
         await ExecuteBeforeStartHooksAsync(app, default);
@@ -152,5 +157,37 @@ public class AzureKubernetesInfrastructureTests
         Assert.True(other.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var otherTarget),
             "other should have DeploymentTargetAnnotation");
         Assert.Same(envb.Resource, otherTarget.ComputeEnvironment);
+    }
+
+    [Fact]
+    public async Task KubernetesPipelineStepsFlowThroughAksEnvironment()
+    {
+        using var tempDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            tempDir.Path,
+            step: WellKnownPipelineSteps.Diagnostics);
+
+        var reporter = new TestPipelineActivityReporter(output);
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+        builder.Services.AddSingleton<IPipelineActivityReporter>(reporter);
+
+        builder.AddAzureKubernetesEnvironment("aks");
+        builder.AddContainer("api", "myimage")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        await using var app = builder.Build();
+        await app.RunAsync();
+
+        var logs = reporter.LoggedMessages
+            .Where(s => s.StepTitle == "diagnostics")
+            .Select(s => s.Message)
+            .ToList();
+
+        Assert.Contains(logs, msg => msg.Contains("publish-aks"));
+        Assert.Contains(logs, msg => msg.Contains("prepare-aks"));
+        Assert.Contains(logs, msg => msg.Contains("helm-deploy-aks"));
+        Assert.Contains(logs, msg => msg.Contains("aks-get-credentials-aks"));
+        Assert.DoesNotContain(logs, msg => msg.Contains("aks-k8s"));
     }
 }

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -105,6 +105,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
         Assert.True(container.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target));
         Assert.NotNull(target.DeploymentTarget);
 
+        // The compute environment should be the Azure K8s environment
         Assert.Same(aks.Resource, target.ComputeEnvironment);
 
         // CRITICAL: ContainerRegistry must be set on the DeploymentTargetAnnotation

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesIngressTests.cs
@@ -10,10 +10,6 @@ namespace Aspire.Hosting.Azure.Tests;
 
 public class AzureKubernetesIngressTests
 {
-    // With AKS, there are two compute environments (AKS + inner K8s),
-    // so the Helm chart output goes to {outputDir}/{k8sEnvName}/...
-    private const string K8sEnvSubdir = "aks-k8s";
-
     [Fact]
     public async Task AksAddIngress_WithRoute_GeneratesIngressInHelmOutput()
     {
@@ -33,7 +29,7 @@ public class AzureKubernetesIngressTests
         app.Run();
 
         // With AKS, the Helm output goes to the inner K8S env subdirectory
-        var ingressPath = Path.Combine(tempDir.Path, K8sEnvSubdir, "templates", "public", "public.yaml");
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
         Assert.True(File.Exists(ingressPath), $"Expected ingress YAML at {ingressPath}");
 
         var content = await File.ReadAllTextAsync(ingressPath);


### PR DESCRIPTION
## Description

Keep the KubernetesEnvironmentResource used by AKS as an implementation detail instead of adding it to the application model. Delegate Kubernetes pipeline steps through the AKS environment resource and ensure deployment target annotations point at AKS.

This is needed so we can validation that when you have multiple compute environments, that compute resources are explicitly assigned to an evironment. See #16411

Add tests for the single visible compute environment, AKS deployment targets, and delegated Kubernetes pipeline steps.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
