### PR TITLE
Run CLI dotnet tool smoke tests in daily smoke workflow

### DIFF
--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Run smoke tests against daily build
         env:
           ASPIRE_E2E_QUALITY: ${{ inputs.quality || 'dev' }}
+          ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR: ${{ github.workspace }}/testresults/cli-versions
         run: |
           dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
             --no-build \
@@ -91,67 +92,331 @@ jobs:
             dotnet "${summary_args[@]}"
           fi
 
+      - name: Add Aspire CLI version summary
+        if: always()
+        continue-on-error: true
+        run: |
+          versions_dir="${{ github.workspace }}/testresults/cli-versions"
+
+          escape_markdown() {
+            local value="${1:-}"
+            value="${value//$'\r'/}"
+            value="${value//$'\n'/ }"
+            local escaped=""
+            local char
+            local i
+
+            for ((i = 0; i < ${#value}; i++)); do
+              char="${value:i:1}"
+              case "$char" in
+                \\|\`|\*|_|"{"|"}"|"["|"]"|"("|")"|"#"|"+"|"-"|"."|"!"|\||"<"|">")
+                  escaped+="\\$char"
+                  ;;
+                *)
+                  escaped+="$char"
+                  ;;
+              esac
+            done
+
+            printf '%s' "$escaped"
+          }
+
+          format_code() {
+            local value="${1:-}"
+            value="${value//$'\r'/}"
+            value="${value//$'\n'/ }"
+            if [ -z "$value" ]; then
+              printf '-'
+            else
+              local max_run=0
+              local rest="$value"
+              while [ -n "$rest" ]; do
+                local prefix="${rest%%\`*}"
+                if [ "$prefix" = "$rest" ]; then
+                  break
+                fi
+
+                rest="${rest#"$prefix"}"
+                local ticks="${rest%%[!\`]*}"
+                if [ ${#ticks} -gt $max_run ]; then
+                  max_run=${#ticks}
+                fi
+                rest="${rest#"$ticks"}"
+              done
+
+              local delimiter=""
+              local i
+              for ((i = 0; i <= max_run; i++)); do
+                delimiter+="\`"
+              done
+
+              local padding=""
+              if [[ "$value" == \`* || "$value" == *\` ]]; then
+                padding=" "
+              fi
+
+              printf '%s%s%s%s%s' "$delimiter" "$padding" "$value" "$padding" "$delimiter"
+            fi
+          }
+
+          {
+            echo ""
+            echo "## Aspire CLI versions installed"
+            echo ""
+
+            if compgen -G "$versions_dir/*.env" > /dev/null; then
+              declare -A group_tests=()
+              declare -A group_routes=()
+              declare -A group_versions=()
+              groups=()
+
+              for version_file in "$versions_dir"/*.env; do
+                test_name=""
+                mode=""
+                strategy=""
+                version=""
+
+                while IFS='=' read -r key value; do
+                  case "$key" in
+                    test) test_name="$value" ;;
+                    mode) mode="$value" ;;
+                    strategy) strategy="$value" ;;
+                    version) version="$value" ;;
+                  esac
+                done < "$version_file"
+
+                route="${strategy:-$mode}"
+                group_key="${#route}:$route${#version}:$version"
+                if [ -z "${group_routes[$group_key]+set}" ]; then
+                  groups+=("$group_key")
+                  group_routes["$group_key"]="$route"
+                  group_versions["$group_key"]="$version"
+                fi
+
+                group_tests["$group_key"]+="$test_name"$'\n'
+              done
+
+              for group_key in "${groups[@]}"; do
+                echo "### $(escape_markdown "${group_routes[$group_key]}"): $(format_code "${group_versions[$group_key]}")"
+                echo ""
+
+                while IFS= read -r test_name; do
+                  if [ -n "$test_name" ]; then
+                    echo "- $(format_code "$test_name")"
+                  fi
+                done <<< "${group_tests[$group_key]}"
+
+                echo ""
+              done
+            else
+              echo "No Aspire CLI version records were produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   create-issue-on-failure:
     name: Create Issue on Failure
     needs: [smoke-test]
     runs-on: ubuntu-latest
     if: ${{ failure() && github.event_name == 'schedule' }}
     permissions:
+      actions: read
       issues: write
     steps:
+      - name: Download smoke test results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: smoke-test-results-${{ inputs.quality || 'dev' }}
+          path: smoke-test-results
+
       - name: Create GitHub Issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const quality = context.payload.inputs?.quality ?? 'dev';
             const date = new Date().toISOString().split('T')[0];
+            const cliVersionSummary = getCliVersionSummary(process.env.GITHUB_WORKSPACE, message => core.warning(message));
 
             const issueTitle = `[Daily Smoke] CLI smoke test failure - ${date}`;
-            const issueBody = `## Daily CLI Smoke Test Failure
+            const issueBody = [
+              '## Daily CLI Smoke Test Failure',
+              '',
+              `The daily CLI smoke tests failed on ${date}.`,
+              '',
+              `**Workflow Run:** ${runUrl}`,
+              `**Quality:** ${quality} (daily build)`,
+              '',
+              cliVersionSummary,
+              '',
+              '### Next Steps',
+              '1. Check the workflow run for detailed error logs',
+              '2. Download test recordings from artifacts',
+              '3. Compare with the latest daily build changes',
+              '4. Investigate and fix the regression',
+              '',
+              'This issue was automatically created by the daily CLI smoke test workflow.'
+            ].join('\n');
 
-            The daily CLI smoke tests failed on ${date}.
+            let todayIssue = null;
+            try {
+              const existingIssues = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: 'area-cli,failing-test',
+                per_page: 10
+              });
 
-            **Workflow Run:** ${runUrl}
-            **Quality:** dev (daily build)
-
-            ### Next Steps
-            1. Check the workflow run for detailed error logs
-            2. Download test recordings from artifacts
-            3. Compare with the latest daily build changes
-            4. Investigate and fix the regression
-
-            This issue was automatically created by the daily CLI smoke test workflow.
-            `;
-
-            // Check if a similar issue already exists (created today)
-            const existingIssues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'area-cli,failing-test',
-              per_page: 10
-            });
-
-            const todayIssue = existingIssues.data.find(issue =>
-              issue.title.includes(date) && issue.title.includes('[Daily Smoke]')
-            );
+              todayIssue = existingIssues.data.find(issue =>
+                issue.title.includes(date) && issue.title.includes('[Daily Smoke]')
+              );
+            }
+            catch (error) {
+              core.warning(`Could not query existing daily smoke issues; creating a new issue to avoid losing the failure report. ${getErrorMessage(error)}`);
+            }
 
             if (todayIssue) {
-              console.log(`Issue already exists for today: ${todayIssue.html_url}`);
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: todayIssue.number,
-                body: `Another failure occurred. See: ${runUrl}`
-              });
-            } else {
-              const issue = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: issueTitle,
-                body: issueBody,
-                labels: ['area-cli', 'failing-test']
-              });
-              console.log(`Created issue: ${issue.data.html_url}`);
+              core.info(`Issue already exists for today: ${todayIssue.html_url}`);
+              const body = [
+                `Another failure occurred. See: ${runUrl}`,
+                '',
+                cliVersionSummary
+              ].join('\n');
+
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: todayIssue.number,
+                  body
+                });
+                return;
+              }
+              catch (error) {
+                core.warning(`Failed to comment on the existing daily smoke issue; creating a new issue instead. ${getErrorMessage(error)}`);
+              }
+            }
+
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: issueTitle,
+              body: issueBody,
+              labels: ['area-cli', 'failing-test']
+            });
+
+            core.info(`Created issue: ${issue.data.html_url}`);
+
+            function getCliVersionSummary(workspace) {
+              const noVersionRecordsSummary = [
+                '### Aspire CLI versions tested',
+                '',
+                'No Aspire CLI version records were available in the uploaded smoke test artifact.'
+              ].join('\n');
+              const versionsDir = path.join(workspace, 'smoke-test-results', 'testresults', 'cli-versions');
+
+              try {
+                if (!fs.existsSync(versionsDir)) {
+                  return noVersionRecordsSummary;
+                }
+
+                const versionFiles = fs.readdirSync(versionsDir, { withFileTypes: true })
+                  .filter(entry => entry.isFile() && entry.name.endsWith('.env'))
+                  .map(entry => entry.name)
+                  .sort((left, right) => left.localeCompare(right));
+
+                if (versionFiles.length === 0) {
+                  return noVersionRecordsSummary;
+                }
+
+                const groups = new Map();
+                for (const versionFile of versionFiles) {
+                  const record = parseCliVersionRecord(path.join(versionsDir, versionFile));
+                  const route = record.strategy || record.mode || '(unknown install route)';
+                  const version = record.version || '(unknown version)';
+                  const key = `${route}\0${version}`;
+
+                  if (!groups.has(key)) {
+                    groups.set(key, { route, version, tests: [] });
+                  }
+
+                  groups.get(key).tests.push(record.test || '(unknown test)');
+                }
+
+                const lines = ['### Aspire CLI versions tested', ''];
+                for (const group of groups.values()) {
+                  lines.push(`#### ${escapeMarkdownText(group.route)}: ${formatInlineCode(group.version)}`);
+                  lines.push('');
+
+                  for (const testName of group.tests) {
+                    lines.push(`- ${formatInlineCode(testName)}`);
+                  }
+
+                  lines.push('');
+                }
+
+                return lines.join('\n').trimEnd();
+              }
+              catch (error) {
+                const message = `Unable to read Aspire CLI version records from the smoke test artifact: ${getErrorMessage(error)}`;
+                core.warning(message);
+                return [
+                  '### Aspire CLI versions tested',
+                  '',
+                  message
+                ].join('\n');
+              }
+            }
+
+            function parseCliVersionRecord(filePath) {
+              const record = {};
+              let content;
+              try {
+                content = fs.readFileSync(filePath, 'utf8');
+              }
+              catch (error) {
+                core.warning(`Unable to read Aspire CLI version record '${filePath}': ${getErrorMessage(error)}`);
+                return record;
+              }
+
+              for (const line of content.split(/\r?\n/)) {
+                const separatorIndex = line.indexOf('=');
+                if (separatorIndex < 0) {
+                  continue;
+                }
+
+                const key = line.slice(0, separatorIndex);
+                if (!key) {
+                  continue;
+                }
+
+                record[key] = line.slice(separatorIndex + 1);
+              }
+
+              return record;
+            }
+
+            function escapeMarkdownText(value) {
+              return String(value)
+                .replace(/\r?\n/g, ' ')
+                .replace(/([\\`*_{}\[\]()#+\-.!|<>])/g, '\\$1');
+            }
+
+            function formatInlineCode(value) {
+              const normalized = String(value).replace(/\r?\n/g, ' ');
+              const runs = normalized.match(/`+/g) ?? [];
+              const delimiterLength = Math.max(0, ...runs.map(run => run.length)) + 1;
+              const delimiter = '`'.repeat(delimiterLength);
+              const padding = normalized.startsWith('`') || normalized.endsWith('`') ? ' ' : '';
+
+              return `${delimiter}${padding}${normalized}${padding}${delimiter}`;
+            }
+
+            function getErrorMessage(error) {
+              return error instanceof Error ? error.message : String(error);
             }

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -50,20 +50,46 @@ jobs:
           dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj \
             --no-build \
             -- \
-            --filter-class "*.SmokeTests" \
+            --report-trx \
+            --report-trx-filename "DailyCliSmoke.trx" \
+            --results-directory ${{ github.workspace }}/testresults \
+            --filter-class "*SmokeTests" \
             --filter-not-trait "quarantined=true" \
             --filter-not-trait "outerloop=true" \
             --hangdump --hangdump-type none --hangdump-timeout 15m
 
-      - name: Upload test recordings
+      - name: Upload logs and test results
+        id: upload-logs
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: smoke-test-recordings-${{ inputs.quality || 'dev' }}
+          name: smoke-test-results-${{ inputs.quality || 'dev' }}
           path: |
-            testresults/recordings/*.cast
+            testresults/**
             **/TestResults/**/*.log
           if-no-files-found: ignore
+
+      - name: Generate test results summary
+        if: always()
+        continue-on-error: true
+        run: |
+          if [ -d "${{ github.workspace }}/testresults" ]; then
+            summary_args=(
+              run
+              --project
+              "${{ github.workspace }}/tools/GenerateTestSummary/GenerateTestSummary.csproj"
+              --
+              "${{ github.workspace }}/testresults"
+            )
+
+            artifact_url="${{ steps.upload-logs.outputs.artifact-url }}"
+            if [ -n "$artifact_url" ]; then
+              summary_args+=("-u" "$artifact_url")
+            fi
+
+            dotnet "${summary_args[@]}"
+          fi
 
   create-issue-on-failure:
     name: Create Issue on Failure

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Upload logs and test results
         id: upload-logs
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: smoke-test-results-${{ inputs.quality || 'dev' }}

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -22,6 +22,9 @@ on:
     # Run daily at 6 AM UTC
     - cron: '0 6 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test:
     name: CLI Smoke Test (${{ inputs.quality || 'dev' }})
@@ -31,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
@@ -74,6 +79,8 @@ jobs:
       - name: Generate test results summary
         if: always()
         continue-on-error: true
+        env:
+          SMOKE_TEST_RESULTS_ARTIFACT_URL: ${{ steps.upload-logs.outputs.artifact-url }}
         run: |
           if [ -d "${{ github.workspace }}/testresults" ]; then
             summary_args=(
@@ -84,7 +91,7 @@ jobs:
               "${{ github.workspace }}/testresults"
             )
 
-            artifact_url="${{ steps.upload-logs.outputs.artifact-url }}"
+            artifact_url="${SMOKE_TEST_RESULTS_ARTIFACT_URL:-}"
             if [ -n "$artifact_url" ]; then
               summary_args+=("-u" "$artifact_url")
             fi

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <!-- If the dotnet-public, dotnet9, or dotnet-libraries sources change, update tests/Shared/Docker/NuGet.DotnetTool.config for daily dotnet tool smoke tests. -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />

--- a/tests/Aspire.Cli.EndToEnd.Tests/DotnetToolSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DotnetToolSmokeTests.cs
@@ -18,7 +18,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// <list type="number">
 ///   <item><c>ASPIRE_E2E_DOTNET_TOOL_SOURCE</c> + <c>ASPIRE_E2E_VERSION</c> — install from local nupkg directory</item>
 ///   <item><c>BUILT_NUGETS_PATH</c> — auto-discover from CI-built nupkgs directory</item>
-///   <item>Published NuGet feed (optionally with <c>ASPIRE_E2E_VERSION</c> or prerelease packages when <c>ASPIRE_E2E_QUALITY</c> is <c>dev</c> or <c>staging</c>)</item>
+///   <item>Published NuGet feed when <c>ASPIRE_E2E_VERSION</c> or <c>ASPIRE_E2E_QUALITY</c> is set</item>
 /// </list>
 /// </para>
 /// </summary>
@@ -110,10 +110,10 @@ public sealed class DotnetToolSmokeTests(ITestOutputHelper output)
     /// <list type="number">
     ///   <item><c>ASPIRE_E2E_DOTNET_TOOL_SOURCE</c> + <c>ASPIRE_E2E_VERSION</c> — explicit local nupkg directory</item>
     ///   <item><c>BUILT_NUGETS_PATH</c> — auto-discover from CI-built nupkgs directory</item>
-    ///   <item>Published NuGet feed, including prerelease packages when <c>ASPIRE_E2E_QUALITY</c> is <c>dev</c> or <c>staging</c></item>
+    ///   <item>Published NuGet feed when <c>ASPIRE_E2E_VERSION</c> or <c>ASPIRE_E2E_QUALITY</c> is set</item>
     /// </list>
     /// </summary>
-    private static CliInstallStrategy GetDotnetToolStrategy()
+    internal static CliInstallStrategy GetDotnetToolStrategy()
     {
         // 1. Explicit local nupkg source (user-provided)
         var source = Environment.GetEnvironmentVariable("ASPIRE_E2E_DOTNET_TOOL_SOURCE");
@@ -155,10 +155,24 @@ public sealed class DotnetToolSmokeTests(ITestOutputHelper output)
             }
         }
 
-        // 3. Published NuGet feed. This test always validates dotnet tool installation; env only
-        //    selects the feed source/version behavior.
+        // 3. Published NuGet feed. Require an explicit selector so local dotnet test runs
+        //    don't silently install the latest package from the public feed.
         var requestedVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
+        if (string.IsNullOrWhiteSpace(requestedVersion))
+        {
+            requestedVersion = null;
+        }
+
         var quality = CliInstallStrategy.GetQualityFromEnvironment();
+        if (requestedVersion is null && quality is null)
+        {
+            throw new InvalidOperationException(
+                "Dotnet tool smoke tests require ASPIRE_E2E_QUALITY to select a daily published feed, " +
+                "ASPIRE_E2E_VERSION to install a specific published version, " +
+                "ASPIRE_E2E_DOTNET_TOOL_SOURCE with ASPIRE_E2E_VERSION to install from a local feed, " +
+                "or BUILT_NUGETS_PATH containing exactly one Aspire.Cli nupkg.");
+        }
+
         return CliInstallStrategy.FromPublishedDotnetToolFeed(requestedVersion, quality);
     }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DotnetToolSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DotnetToolSmokeTests.cs
@@ -17,8 +17,8 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// The strategy is resolved from (in priority order):
 /// <list type="number">
 ///   <item><c>ASPIRE_E2E_DOTNET_TOOL_SOURCE</c> + <c>ASPIRE_E2E_VERSION</c> — install from local nupkg directory</item>
-///   <item><c>ASPIRE_E2E_DOTNET_TOOL=true</c> — install from published NuGet feed (optionally with <c>ASPIRE_E2E_VERSION</c>)</item>
 ///   <item><c>BUILT_NUGETS_PATH</c> — auto-discover from CI-built nupkgs directory</item>
+///   <item>Published NuGet feed (optionally with <c>ASPIRE_E2E_VERSION</c> or prerelease packages when <c>ASPIRE_E2E_QUALITY</c> is <c>dev</c> or <c>staging</c>)</item>
 /// </list>
 /// </para>
 /// </summary>
@@ -26,13 +26,9 @@ public sealed class DotnetToolSmokeTests(ITestOutputHelper output)
 {
     [CaptureWorkspaceOnFailure]
     [Fact]
-    public async Task DotnetToolInstall_CreateAndRunAspireStarterProject()
+    public async Task CreateAndRunAspireStarterProject()
     {
         var strategy = GetDotnetToolStrategy();
-
-        Assert.True(strategy is not null,
-            "DotnetToolSmokeTests requires one of: ASPIRE_E2E_DOTNET_TOOL_SOURCE + ASPIRE_E2E_VERSION, " +
-            "ASPIRE_E2E_DOTNET_TOOL=true, or BUILT_NUGETS_PATH containing Aspire.Cli nupkg.");
 
         output.WriteLine($"DotnetTool strategy resolved: {strategy}");
 
@@ -93,7 +89,8 @@ public sealed class DotnetToolSmokeTests(ITestOutputHelper output)
                     "This indicates multiple apphosts were incorrectly detected.");
             }
 
-            return s.ContainsText("Press CTRL+C to stop the AppHost and exit.");
+            // Dotnet tool smoke tests can run against older published packages that used different AppHost casing.
+            return s.GetScreenText().Contains("Press CTRL+C to stop the AppHost and exit.", StringComparison.OrdinalIgnoreCase);
         }, timeout: TimeSpan.FromMinutes(2), description: "Press CTRL+C message (aspire run started)");
 
         // Stop the running apphost with Ctrl+C
@@ -112,13 +109,11 @@ public sealed class DotnetToolSmokeTests(ITestOutputHelper output)
     /// Checks (in order):
     /// <list type="number">
     ///   <item><c>ASPIRE_E2E_DOTNET_TOOL_SOURCE</c> + <c>ASPIRE_E2E_VERSION</c> — explicit local nupkg directory</item>
-    ///   <item><c>ASPIRE_E2E_DOTNET_TOOL=true</c> — install from published NuGet feed</item>
     ///   <item><c>BUILT_NUGETS_PATH</c> — auto-discover from CI-built nupkgs directory</item>
+    ///   <item>Published NuGet feed, including prerelease packages when <c>ASPIRE_E2E_QUALITY</c> is <c>dev</c> or <c>staging</c></item>
     /// </list>
-    /// Returns <see langword="null"/> when none of the above are configured — callers should fail with
-    /// a clear message indicating the workflow is misconfigured.
     /// </summary>
-    private static CliInstallStrategy? GetDotnetToolStrategy()
+    private static CliInstallStrategy GetDotnetToolStrategy()
     {
         // 1. Explicit local nupkg source (user-provided)
         var source = Environment.GetEnvironmentVariable("ASPIRE_E2E_DOTNET_TOOL_SOURCE");
@@ -136,17 +131,7 @@ public sealed class DotnetToolSmokeTests(ITestOutputHelper output)
             return CliInstallStrategy.FromDotnetToolLocalSource(source, version);
         }
 
-        // 2. Published NuGet feed
-        var dotnetTool = Environment.GetEnvironmentVariable("ASPIRE_E2E_DOTNET_TOOL");
-
-        if (string.Equals(dotnetTool, "true", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(dotnetTool, "1", StringComparison.OrdinalIgnoreCase))
-        {
-            var version = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
-            return CliInstallStrategy.FromDotnetTool(version);
-        }
-
-        // 3. Auto-discover from CI-built nupkgs (BUILT_NUGETS_PATH contains the tool nupkg
+        // 2. Auto-discover from CI-built nupkgs (BUILT_NUGETS_PATH contains the tool nupkg
         //    directly since the dotnet tool is built as part of the normal package build)
         var builtNugetsPath = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
 
@@ -170,7 +155,11 @@ public sealed class DotnetToolSmokeTests(ITestOutputHelper output)
             }
         }
 
-        return null;
+        // 3. Published NuGet feed. This test always validates dotnet tool installation; env only
+        //    selects the feed source/version behavior.
+        var requestedVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
+        var quality = CliInstallStrategy.GetQualityFromEnvironment();
+        return CliInstallStrategy.FromPublishedDotnetToolFeed(requestedVersion, quality);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -246,6 +246,7 @@ internal static class CliE2EAutomatorHelpers
         SequenceCounter counter)
     {
         var expectedVersion = strategy.ExpectedVersion;
+        var recordVersionCommand = GetRecordAspireCliVersionCommand(strategy, "VER", "BASE_VER");
 
         if (expectedVersion is null)
         {
@@ -258,7 +259,10 @@ internal static class CliE2EAutomatorHelpers
             }
 
             // No version to verify — just log for diagnostics
-            await auto.LogAspireCliVersionAsync(counter);
+            await auto.TypeAsync(
+                $"VER=$(aspire --version 2>/dev/null) && BASE_VER=${{VER%%+*}} && echo \"$VER\" && {recordVersionCommand}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
             return;
         }
 
@@ -267,7 +271,8 @@ internal static class CliE2EAutomatorHelpers
             $"VER=$(aspire --version 2>/dev/null) && BASE_VER=${{VER%%+*}} && " +
             $"[ \"$BASE_VER\" = \"{expectedVersion}\" ] && " +
             $"echo \"CLI_VERSION_EXACT:$VER\" || " +
-            $"echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"");
+            $"echo \"CLI_VERSION_MISMATCH:expected={expectedVersion} actual=$VER\"; " +
+            recordVersionCommand);
         await auto.EnterAsync();
 
         var foundExact = false;
@@ -290,6 +295,39 @@ internal static class CliE2EAutomatorHelpers
         Assert.True(foundExact,
             $"Aspire CLI version mismatch. Expected '{expectedVersion}' (from {strategy.Mode}) " +
             "but got a different version. This may indicate the wrong CLI binary was installed.");
+    }
+
+    private static string GetRecordAspireCliVersionCommand(
+        CliInstallStrategy strategy,
+        string versionVariableName,
+        string baseVersionVariableName)
+    {
+        var requestedVersion = strategy.ExpectedVersion ?? strategy.Version ?? "";
+        var testName = GetCurrentTestName();
+
+        return
+            "if [ -n \"${ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR:-}\" ]; then " +
+            "mkdir -p \"$ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR\" && " +
+            "CLI_VERSION_RECORD=\"$ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR/$(date +%s%N)-$$.env\" && " +
+            "{ " +
+            $"printf '%s\\n' {AspireCliShellCommandHelpers.QuoteBashArg($"test={testName}")}; " +
+            $"printf '%s\\n' {AspireCliShellCommandHelpers.QuoteBashArg($"mode={strategy.Mode}")}; " +
+            $"printf '%s\\n' {AspireCliShellCommandHelpers.QuoteBashArg($"strategy={strategy}")}; " +
+            $"printf '%s\\n' {AspireCliShellCommandHelpers.QuoteBashArg($"expected={requestedVersion}")}; " +
+            $"printf 'version=%s\\n' \"${versionVariableName}\"; " +
+            $"printf 'baseVersion=%s\\n' \"${baseVersionVariableName}\"; " +
+            "} > \"$CLI_VERSION_RECORD\" && " +
+            "echo \"CLI_VERSION_RECORDED:$CLI_VERSION_RECORD\"; " +
+            "fi";
+    }
+
+    private static string GetCurrentTestName()
+    {
+        var testCase = TestContext.Current.TestCase;
+
+        return testCase is null
+            ? "unknown"
+            : $"{testCase.TestClassName}.{testCase.TestMethodName}";
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -297,7 +297,7 @@ internal static class CliE2EAutomatorHelpers
             "but got a different version. This may indicate the wrong CLI binary was installed.");
     }
 
-    private static string GetRecordAspireCliVersionCommand(
+    internal static string GetRecordAspireCliVersionCommand(
         CliInstallStrategy strategy,
         string versionVariableName,
         string baseVersionVariableName)
@@ -307,7 +307,7 @@ internal static class CliE2EAutomatorHelpers
 
         return
             "if [ -n \"${ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR:-}\" ]; then " +
-            "mkdir -p \"$ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR\" && " +
+            "if mkdir -p \"$ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR\" && " +
             "CLI_VERSION_RECORD=\"$ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR/$(date +%s%N)-$$.env\" && " +
             "{ " +
             $"printf '%s\\n' {AspireCliShellCommandHelpers.QuoteBashArg($"test={testName}")}; " +
@@ -316,8 +316,11 @@ internal static class CliE2EAutomatorHelpers
             $"printf '%s\\n' {AspireCliShellCommandHelpers.QuoteBashArg($"expected={requestedVersion}")}; " +
             $"printf 'version=%s\\n' \"${versionVariableName}\"; " +
             $"printf 'baseVersion=%s\\n' \"${baseVersionVariableName}\"; " +
-            "} > \"$CLI_VERSION_RECORD\" && " +
+            "} > \"$CLI_VERSION_RECORD\"; then " +
             "echo \"CLI_VERSION_RECORDED:$CLI_VERSION_RECORD\"; " +
+            "else " +
+            "echo \"CLI_VERSION_RECORD_FAILED:$ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR\"; " +
+            "fi; " +
             "fi";
     }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -18,6 +18,8 @@ namespace Aspire.Cli.EndToEnd.Tests.Helpers;
 internal static class CliE2ETestHelpers
 {
     internal const string CliArchiveDirEnvironmentVariableName = CliInstallStrategy.CliArchiveDirEnvironmentVariableName;
+    internal const string CliVersionOutputDirEnvironmentVariableName = "ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR";
+    internal const string ContainerCliVersionOutputDir = "/tmp/aspire-cli-versions";
     private static readonly Regex s_commitShaPattern = new("^[0-9a-fA-F]{40}$", RegexOptions.Compiled);
 
     /// <summary>
@@ -198,6 +200,14 @@ internal static class CliE2ETestHelpers
                 if (workspace is not null)
                 {
                     c.Volumes.Add($"{workspace.WorkspaceRoot.FullName}:/workspace/{workspace.WorkspaceRoot.Name}");
+                }
+
+                var cliVersionOutputDir = Environment.GetEnvironmentVariable(CliVersionOutputDirEnvironmentVariableName);
+                if (!string.IsNullOrEmpty(cliVersionOutputDir))
+                {
+                    Directory.CreateDirectory(cliVersionOutputDir);
+                    c.Volumes.Add($"{cliVersionOutputDir}:{ContainerCliVersionOutputDir}");
+                    c.Environment[CliVersionOutputDirEnvironmentVariableName] = ContainerCliVersionOutputDir;
                 }
 
                 if (additionalVolumes is not null)

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
@@ -348,6 +348,52 @@ public class CliInstallStrategyTests
     }
 
     [Fact]
+    public void DotnetToolSmokeTests_ThrowsWhenPublishedFeedFallbackHasNoSelector()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("BUILT_NUGETS_PATH", null),
+            ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_QUALITY", null));
+
+        var exception = Assert.Throws<InvalidOperationException>(DotnetToolSmokeTests.GetDotnetToolStrategy);
+
+        Assert.Contains("ASPIRE_E2E_QUALITY", exception.Message);
+    }
+
+    [Fact]
+    public void DotnetToolSmokeTests_UsesPublishedFeedWhenQualityIsSet()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("BUILT_NUGETS_PATH", null),
+            ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_QUALITY", "staging"));
+
+        var strategy = DotnetToolSmokeTests.GetDotnetToolStrategy();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+        Assert.True(strategy.IncludePrerelease);
+        Assert.Null(strategy.Version);
+    }
+
+    [Fact]
+    public void DotnetToolSmokeTests_UsesPublishedFeedWhenVersionIsSet()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("BUILT_NUGETS_PATH", null),
+            ("ASPIRE_E2E_VERSION", "13.3.0"),
+            ("ASPIRE_E2E_QUALITY", null));
+
+        var strategy = DotnetToolSmokeTests.GetDotnetToolStrategy();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+        Assert.Equal("13.3.0", strategy.Version);
+        Assert.False(strategy.IncludePrerelease);
+    }
+
+    [Fact]
     public void ConfigureContainer_MountsNupkgSourceForDotnetToolLocalSource()
     {
         var tempDir = Directory.CreateTempSubdirectory("aspire-test-nupkg-");

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
@@ -23,6 +23,17 @@ public class CliInstallStrategyTests
     }
 
     [Fact]
+    public void GetRecordAspireCliVersionCommand_IsBestEffort()
+    {
+        var strategy = CliInstallStrategy.FromDotnetTool(includePrerelease: true);
+
+        var command = CliE2EAutomatorHelpers.GetRecordAspireCliVersionCommand(strategy, "VER", "BASE_VER");
+
+        Assert.Contains("if mkdir -p \"$ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR\" && ", command);
+        Assert.Contains("} > \"$CLI_VERSION_RECORD\"; then echo \"CLI_VERSION_RECORDED:$CLI_VERSION_RECORD\"; else echo \"CLI_VERSION_RECORD_FAILED:$ASPIRE_E2E_CLI_VERSION_OUTPUT_DIR\"; fi; fi", command);
+    }
+
+    [Fact]
     public void Detect_ReturnsLocalArchive_WhenArchiveDirIsSet()
     {
         var tempDir = Directory.CreateTempSubdirectory("cli-archives-test");

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
@@ -167,6 +167,7 @@ public class CliInstallStrategyTests
         Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
         Assert.Null(strategy.Version);
         Assert.Null(strategy.NupkgSourcePath);
+        Assert.False(strategy.IncludePrerelease);
     }
 
     [Fact]
@@ -189,6 +190,7 @@ public class CliInstallStrategyTests
         Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
         Assert.Equal("9.5.0", strategy.Version);
         Assert.Null(strategy.NupkgSourcePath);
+        Assert.False(strategy.IncludePrerelease);
     }
 
     [Fact]
@@ -267,6 +269,71 @@ public class CliInstallStrategyTests
         var strategy = CliInstallStrategy.Detect();
 
         Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+        Assert.True(strategy.IncludePrerelease);
+    }
+
+    [Fact]
+    public void Detect_DotnetTool_IncludesPrereleaseForStagingQuality()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", "true"),
+            ("ASPIRE_E2E_QUALITY", "staging"),
+            ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_PREINSTALLED", null),
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", null));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+        Assert.True(strategy.IncludePrerelease);
+    }
+
+    [Fact]
+    public void Detect_DotnetTool_DoesNotIncludePrereleaseForReleaseQuality()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", "true"),
+            ("ASPIRE_E2E_QUALITY", "release"),
+            ("ASPIRE_E2E_VERSION", null),
+            ("ASPIRE_E2E_PREINSTALLED", null),
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", null));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+        Assert.False(strategy.IncludePrerelease);
+    }
+
+    [Fact]
+    public void Detect_DotnetTool_DoesNotIncludePrereleaseWhenVersionIsSpecified()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("ASPIRE_E2E_ARCHIVE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL_SOURCE", null),
+            ("ASPIRE_E2E_DOTNET_TOOL", "true"),
+            ("ASPIRE_E2E_QUALITY", "dev"),
+            ("ASPIRE_E2E_VERSION", "13.3.0-preview.1.25175.1"),
+            ("ASPIRE_E2E_PREINSTALLED", null),
+            ("GITHUB_PR_NUMBER", null),
+            ("GITHUB_PR_HEAD_SHA", null),
+            ("CI", null),
+            ("GITHUB_ACTIONS", null));
+
+        var strategy = CliInstallStrategy.Detect();
+
+        Assert.Equal(CliInstallMode.DotnetTool, strategy.Mode);
+        Assert.Equal("13.3.0-preview.1.25175.1", strategy.Version);
+        Assert.False(strategy.IncludePrerelease);
     }
 
     [Fact]
@@ -310,6 +377,15 @@ public class CliInstallStrategyTests
     }
 
     [Fact]
+    public void GetDotnetToolInstallCommandInDocker_WithPrereleaseVersion()
+    {
+        var strategy = CliInstallStrategy.FromDotnetTool("13.3.0-preview.1.25175.1");
+        var command = AspireCliShellCommandHelpers.GetDotnetToolInstallCommandInDocker(strategy);
+
+        Assert.Equal("dotnet tool install --global Aspire.Cli --version 13.3.0-preview.1.25175.1 --configfile '/opt/aspire-scripts/NuGet.config'", command);
+    }
+
+    [Fact]
     public void GetDotnetToolInstallCommandInDocker_WithLocalSource()
     {
         var tempDir = Directory.CreateTempSubdirectory("aspire-test-nupkg-");
@@ -319,7 +395,7 @@ public class CliInstallStrategyTests
             var strategy = CliInstallStrategy.FromDotnetToolLocalSource(tempDir.FullName, "13.3.0");
             var command = AspireCliShellCommandHelpers.GetDotnetToolInstallCommandInDocker(strategy);
 
-            Assert.Equal("dotnet tool install --global Aspire.Cli --version 13.3.0 --add-source /tmp/aspire-nupkg-source", command);
+            Assert.Equal("dotnet tool install --global Aspire.Cli --version 13.3.0 --add-source '/tmp/aspire-nupkg-source'", command);
         }
         finally
         {
@@ -334,6 +410,15 @@ public class CliInstallStrategyTests
         var command = AspireCliShellCommandHelpers.GetDotnetToolInstallCommandInDocker(strategy);
 
         Assert.Equal("dotnet tool install --global Aspire.Cli", command);
+    }
+
+    [Fact]
+    public void GetDotnetToolInstallCommandInDocker_WithPrerelease()
+    {
+        var strategy = CliInstallStrategy.FromDotnetTool(includePrerelease: true);
+        var command = AspireCliShellCommandHelpers.GetDotnetToolInstallCommandInDocker(strategy);
+
+        Assert.Equal("dotnet tool install --global Aspire.Cli --prerelease --configfile '/opt/aspire-scripts/NuGet.config'", command);
     }
 
     [Fact]

--- a/tests/Shared/CliInstallStrategy.cs
+++ b/tests/Shared/CliInstallStrategy.cs
@@ -59,6 +59,7 @@ internal static class AspireCliShellCommandHelpers
     internal const string AspireCliVersionCommand = "aspire --version";
     internal const string DockerInstallScriptCommandPrefix = "/opt/aspire-scripts/get-aspire-cli.sh";
     internal const string DockerPullRequestInstallCommandPrefix = "/opt/aspire-scripts/get-aspire-cli-pr.sh";
+    internal const string DockerNuGetConfigPath = "/opt/aspire-scripts/NuGet.config";
     internal const string MainInstallScriptCommandPrefix = "curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli.sh | bash -s --";
     internal const string MainPullRequestInstallCommandPrefix = "curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s --";
     internal const string AkaMsInstallScriptCommandPrefix = "curl -fsSL https://aka.ms/aspire/get/install.sh | bash -s --";
@@ -149,22 +150,18 @@ internal static class AspireCliShellCommandHelpers
 
     internal static string GetDotnetToolInstallCommand(CliInstallStrategy strategy)
     {
-        var args = "--global Aspire.Cli";
-
-        if (strategy.Version is not null)
-        {
-            args += $" --version {strategy.Version}";
-        }
-
-        if (strategy.NupkgSourcePath is not null)
-        {
-            args += $" --add-source {QuoteBashArg(strategy.NupkgSourcePath)}";
-        }
-
-        return $"dotnet tool install {args}";
+        return $"dotnet tool install {GetDotnetToolInstallArgs(strategy, strategy.NupkgSourcePath)}";
     }
 
     internal static string GetDotnetToolInstallCommandInDocker(CliInstallStrategy strategy)
+    {
+        var nupkgSourcePath = strategy.NupkgSourcePath is not null ? "/tmp/aspire-nupkg-source" : null;
+        var nuGetConfigPath = strategy.RequiresDotnetToolNuGetConfig ? DockerNuGetConfigPath : null;
+
+        return $"dotnet tool install {GetDotnetToolInstallArgs(strategy, nupkgSourcePath, nuGetConfigPath)}";
+    }
+
+    private static string GetDotnetToolInstallArgs(CliInstallStrategy strategy, string? nupkgSourcePath, string? nuGetConfigPath = null)
     {
         var args = "--global Aspire.Cli";
 
@@ -172,14 +169,22 @@ internal static class AspireCliShellCommandHelpers
         {
             args += $" --version {strategy.Version}";
         }
-
-        if (strategy.NupkgSourcePath is not null)
+        else if (strategy.IncludePrerelease)
         {
-            // In Docker, local nupkg source is mounted at /tmp/aspire-nupkg-source
-            args += " --add-source /tmp/aspire-nupkg-source";
+            args += " --prerelease";
         }
 
-        return $"dotnet tool install {args}";
+        if (nupkgSourcePath is not null)
+        {
+            args += $" --add-source {QuoteBashArg(nupkgSourcePath)}";
+        }
+
+        if (nuGetConfigPath is not null)
+        {
+            args += $" --configfile {QuoteBashArg(nuGetConfigPath)}";
+        }
+
+        return args;
     }
 }
 
@@ -240,13 +245,26 @@ internal sealed class CliInstallStrategy
     public string? NupkgSourcePath { get; }
 
     /// <summary>
+    /// For DotnetTool: include prerelease package versions when installing the latest available version.
+    /// </summary>
+    public bool IncludePrerelease { get; }
+
+    /// <summary>
     /// The expected CLI version after installation, when known.
     /// Set automatically for modes where the version is deterministic (LocalArchive, DotnetTool local source, explicit version).
     /// Used by post-install verification to assert the correct CLI binary was installed.
     /// </summary>
     public string? ExpectedVersion { get; }
 
-    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, CliInstallQuality? quality = null, string? version = null, string? archiveDir = null, string? nupkgSourcePath = null, string? expectedVersion = null)
+    /// <summary>
+    /// Gets whether the Docker dotnet tool install command needs the generated NuGet.config for internal/prerelease feeds.
+    /// </summary>
+    public bool RequiresDotnetToolNuGetConfig =>
+        Mode is CliInstallMode.DotnetTool &&
+        NupkgSourcePath is null &&
+        (IncludePrerelease || IsPrereleaseVersion(Version));
+
+    private CliInstallStrategy(CliInstallMode mode, string? archivePath = null, CliInstallQuality? quality = null, string? version = null, string? archiveDir = null, string? nupkgSourcePath = null, bool includePrerelease = false, string? expectedVersion = null)
     {
         Mode = mode;
         ArchivePath = archivePath;
@@ -254,6 +272,7 @@ internal sealed class CliInstallStrategy
         Version = version;
         ArchiveDir = archiveDir;
         NupkgSourcePath = nupkgSourcePath;
+        IncludePrerelease = includePrerelease;
         ExpectedVersion = expectedVersion;
     }
 
@@ -341,14 +360,23 @@ internal sealed class CliInstallStrategy
     /// <summary>
     /// Creates a DotnetTool strategy to install from a published NuGet feed.
     /// </summary>
-    public static CliInstallStrategy FromDotnetTool(string? version = null)
+    public static CliInstallStrategy FromDotnetTool(string? version = null, bool includePrerelease = false)
     {
         if (version is not null && !s_versionPattern.IsMatch(version))
         {
             throw new ArgumentException($"Invalid version format: '{version}'. Must contain only alphanumeric characters, dots, and dashes.", nameof(version));
         }
 
-        return new CliInstallStrategy(CliInstallMode.DotnetTool, version: version);
+        return new CliInstallStrategy(CliInstallMode.DotnetTool, version: version, includePrerelease: version is null && includePrerelease);
+    }
+
+    /// <summary>
+    /// Creates a DotnetTool strategy for a published NuGet feed.
+    /// </summary>
+    public static CliInstallStrategy FromPublishedDotnetToolFeed(string? version, CliInstallQuality? quality)
+    {
+        var includePrerelease = ShouldIncludePrereleaseForPublishedDotnetTool(version, quality);
+        return FromDotnetTool(version, includePrerelease);
     }
 
     /// <summary>
@@ -449,20 +477,18 @@ internal sealed class CliInstallStrategy
             string.Equals(dotnetTool, "1", StringComparison.OrdinalIgnoreCase))
         {
             var toolVersion = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
-            log?.Invoke($"  → Selected: DotnetTool published feed (ASPIRE_E2E_DOTNET_TOOL={dotnetTool}, version={toolVersion ?? "(latest)"})");
-            return FromDotnetTool(toolVersion);
+            var quality = GetQualityFromEnvironment();
+            var strategy = FromPublishedDotnetToolFeed(toolVersion, quality);
+            var versionDescription = toolVersion ?? (strategy.IncludePrerelease ? "(latest prerelease)" : "(latest stable)");
+            log?.Invoke($"  → Selected: DotnetTool published feed (ASPIRE_E2E_DOTNET_TOOL={dotnetTool}, version={versionDescription})");
+            return strategy;
         }
 
-        var qualityStr = Environment.GetEnvironmentVariable("ASPIRE_E2E_QUALITY");
-        if (!string.IsNullOrEmpty(qualityStr))
+        var qualityStr = GetQualityFromEnvironment();
+        if (qualityStr is not null)
         {
-            if (!Enum.TryParse<CliInstallQuality>(qualityStr, ignoreCase: true, out var quality))
-            {
-                throw new ArgumentException($"Invalid ASPIRE_E2E_QUALITY value: '{qualityStr}'. Must be one of: {string.Join(", ", Enum.GetNames<CliInstallQuality>())}");
-            }
-
-            log?.Invoke($"  → Selected: InstallScript quality={quality}");
-            return FromQuality(quality);
+            log?.Invoke($"  → Selected: InstallScript quality={qualityStr}");
+            return FromQuality(qualityStr.Value);
         }
 
         var version = Environment.GetEnvironmentVariable("ASPIRE_E2E_VERSION");
@@ -574,6 +600,7 @@ internal sealed class CliInstallStrategy
             CliInstallMode.InstallScript => "InstallScript (latest GA)",
             CliInstallMode.DotnetTool when NupkgSourcePath is not null => $"DotnetTool (local: {NupkgSourcePath}, --version {Version})",
             CliInstallMode.DotnetTool when Version is not null => $"DotnetTool (--version {Version})",
+            CliInstallMode.DotnetTool when IncludePrerelease => "DotnetTool (latest prerelease)",
             CliInstallMode.DotnetTool => "DotnetTool (latest)",
             _ => Mode.ToString(),
         };
@@ -581,5 +608,31 @@ internal sealed class CliInstallStrategy
         return ExpectedVersion is not null
             ? $"{description} [expected={ExpectedVersion}]"
             : description;
+    }
+
+    internal static CliInstallQuality? GetQualityFromEnvironment()
+    {
+        var qualityStr = Environment.GetEnvironmentVariable("ASPIRE_E2E_QUALITY");
+        if (string.IsNullOrEmpty(qualityStr))
+        {
+            return null;
+        }
+
+        if (Enum.TryParse<CliInstallQuality>(qualityStr, ignoreCase: true, out var quality))
+        {
+            return quality;
+        }
+
+        throw new ArgumentException($"Invalid ASPIRE_E2E_QUALITY value: '{qualityStr}'. Must be one of: {string.Join(", ", Enum.GetNames<CliInstallQuality>())}");
+    }
+
+    private static bool ShouldIncludePrereleaseForPublishedDotnetTool(string? version, CliInstallQuality? quality)
+    {
+        return string.IsNullOrEmpty(version) && quality is CliInstallQuality.Dev or CliInstallQuality.Staging;
+    }
+
+    private static bool IsPrereleaseVersion(string? version)
+    {
+        return version?.Contains('-', StringComparison.Ordinal) == true;
     }
 }

--- a/tests/Shared/Docker/Dockerfile.e2e
+++ b/tests/Shared/Docker/Dockerfile.e2e
@@ -87,6 +87,7 @@ RUN apt-get update -qq && \
 # Copy the install scripts.
 COPY eng/scripts/get-aspire-cli.sh /opt/aspire-scripts/
 COPY eng/scripts/get-aspire-cli-pr.sh /opt/aspire-scripts/
+COPY tests/Shared/Docker/NuGet.DotnetTool.config /opt/aspire-scripts/NuGet.config
 RUN chmod +x /opt/aspire-scripts/*.sh
 
 # Copy the bundle directory from the build stage.

--- a/tests/Shared/Docker/NuGet.DotnetTool.config
+++ b/tests/Shared/Docker/NuGet.DotnetTool.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="dotnet9">
+      <package pattern="Aspire.*" />
+    </packageSource>
+    <packageSource key="dotnet-libraries">
+      <package pattern="Microsoft.DeveloperControlPlane*" />
+    </packageSource>
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
## Description

Runs the CLI smoke suite through the .NET tool install path in the daily smoke workflow, alongside the existing install-script coverage. This verifies the published `Aspire.Cli` package can be installed with `dotnet tool install`, create a starter project, and run the generated AppHost.

The daily workflow now runs all CLI smoke test classes matching `*SmokeTests`, adding dotnet-tool install coverage and bundle smoke coverage alongside the existing install-script smoke path.

Also improves daily smoke diagnostics by:

- selecting prerelease tool packages for `dev` and `staging` quality runs while keeping `release` on stable packages
- using an internal NuGet.config for prerelease/internal package feeds in the Docker smoke environment
- recording the installed CLI version for each smoke test and including it in the workflow summary and auto-created failure issue
- keeping artifact upload, summary generation, and failure issue reporting from masking the actual smoke test result
- validating local archive/package version detection so the smoke tests fail clearly when artifacts are missing, malformed, or ambiguous

<img width="1421" height="398" alt="Screenshot 2026-04-28 at 05 44 30" src="https://github.com/user-attachments/assets/fa6da1dd-4bea-410f-8d71-592c7ae53f62"/>
