### PR TITLE
Fix Windows AppHost path casing mismatch for backchannel hashing

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -128,8 +128,13 @@ internal sealed class AppHostLauncher(
             effectiveAppHostFile.FullName,
             executionContext.HomeDirectory.FullName);
         var expectedHash = AppHostHelper.ExtractHashFromSocketPath(expectedSocketPrefix)!;
+        var legacyHash = AppHostHelper.ComputeLegacyHash(effectiveAppHostFile.FullName);
 
         logger.LogDebug("Waiting for socket with prefix: {SocketPrefix}, Hash: {Hash}", expectedSocketPrefix, expectedHash);
+        if (legacyHash is not null)
+        {
+            logger.LogDebug("Also searching for legacy hash: {LegacyHash}", legacyHash);
+        }
 
         // If --wait-for-debugger is active, show a message so the user knows the AppHost
         // is paused. In detached mode we don't have the AppHost PID (stdout is suppressed),
@@ -144,7 +149,7 @@ internal sealed class AppHostLauncher(
         // Start the child process and wait for the backchannel
         var launchResult = await interactionService.ShowStatusAsync(
             RunCommandStrings.StartingAppHostInBackground,
-            () => LaunchAndWaitForBackchannelAsync(executablePath, childArgs, expectedHash, cancellationToken));
+            () => LaunchAndWaitForBackchannelAsync(executablePath, childArgs, expectedHash, legacyHash, cancellationToken));
 
         // Handle failure cases
         if (launchResult.Backchannel is null || launchResult.ChildProcess is null)
@@ -246,6 +251,7 @@ internal sealed class AppHostLauncher(
         string executablePath,
         List<string> childArgs,
         string expectedHash,
+        string? legacyHash,
         CancellationToken cancellationToken)
     {
         Process childProcess;
@@ -283,7 +289,8 @@ internal sealed class AppHostLauncher(
 
             await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
 
-            var connection = backchannelMonitor.GetConnectionsByHash(expectedHash).FirstOrDefault();
+            var connection = backchannelMonitor.GetConnectionsByHash(expectedHash).FirstOrDefault()
+                ?? (legacyHash is not null ? backchannelMonitor.GetConnectionsByHash(legacyHash).FirstOrDefault() : null);
             if (connection is not null)
             {
                 DashboardUrlsState? dashboardUrls = null;

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -353,6 +353,24 @@ internal sealed class ProjectLocator(
                     }
                 }
             }
+            else if (File.Exists(projectFile.FullName))
+            {
+                // A project file was directly specified.
+                //
+                // Resolve to the filesystem-canonical path so the path used for backchannel socket
+                // hash computation matches.
+                var resolvedProjectPath = PathNormalizer.ResolveToFilesystemPath(projectFile.FullName);
+
+                if (!string.Equals(resolvedProjectPath, projectFile.FullName, StringComparison.Ordinal))
+                {
+                    logger.LogDebug(
+                        "Canonicalized explicit AppHost path from '{OriginalPath}' to '{ResolvedPath}'.",
+                        projectFile.FullName,
+                        resolvedProjectPath);
+
+                    projectFile = new FileInfo(resolvedProjectPath);
+                }
+            }
 
             if (projectFile is not null)
             {

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -95,6 +95,14 @@ internal static class AppHostHelper
         => BackchannelConstants.ComputeSocketPrefix(appHostPath, homeDirectory);
 
     /// <summary>
+    /// Computes the legacy (pre-normalization) hash for backward compatibility with older AppHosts.
+    /// </summary>
+    /// <param name="appHostPath">The full path to the AppHost project file or assembly.</param>
+    /// <returns>The legacy hash, or <c>null</c> if it is identical to the current hash.</returns>
+    internal static string? ComputeLegacyHash(string appHostPath)
+        => BackchannelConstants.ComputeLegacyHash(appHostPath);
+
+    /// <summary>
     /// Finds all socket files matching the given AppHost path.
     /// </summary>
     /// <param name="appHostPath">The full path to the AppHost project file or assembly.</param>

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -135,6 +135,7 @@ internal static class BackchannelConstants
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
     /// <returns>A 16-character lowercase hex string, or <c>null</c> if it matches the current hash.</returns>
+    // TODO: Remove legacy hash support once all supported AppHost versions use normalized hashing.
     public static string? ComputeLegacyHash(string appHostPath)
     {
         var normalizedPath = NormalizePath(appHostPath);
@@ -209,20 +210,43 @@ internal static class BackchannelConstants
     /// <returns>An array of socket file paths, or empty if none found.</returns>
     public static string[] FindMatchingSockets(string appHostPath, string homeDirectory)
     {
-        var prefix = ComputeSocketPrefix(appHostPath, homeDirectory);
-        var dir = Path.GetDirectoryName(prefix);
-        var prefixFileName = Path.GetFileName(prefix);
+        var dir = GetBackchannelsDirectory(homeDirectory);
 
-        if (dir is null || !Directory.Exists(dir))
+        if (!Directory.Exists(dir))
         {
             return [];
         }
 
+        var hash = ComputeHash(appHostPath);
+        var prefixFileName = $"{SocketPrefix}.{hash}";
+        var results = FindSocketsByPrefix(dir, prefixFileName);
+
+        // Also search for sockets created by older AppHosts that used the raw (unnormalized) path hash.
+        var legacyHash = ComputeLegacyHash(appHostPath);
+        if (legacyHash is not null)
+        {
+            var legacyPrefixFileName = $"{SocketPrefix}.{legacyHash}";
+            var legacyResults = FindSocketsByPrefix(dir, legacyPrefixFileName);
+            if (legacyResults.Length > 0)
+            {
+                results = [.. results, .. legacyResults];
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Finds socket files in <paramref name="directory"/> whose names match
+    /// <paramref name="prefixFileName"/> in any of the supported socket name formats.
+    /// </summary>
+    private static string[] FindSocketsByPrefix(string directory, string prefixFileName)
+    {
         // Match old format (auxi.sock.{hash}), previous format (auxi.sock.{hash}.{pid}),
         // and current format (auxi.sock.{hash}.{instanceHash}.{pid})
         // Use pattern with "*" to match optional PID suffix
-        var allMatches = Directory.GetFiles(dir, prefixFileName + "*");
-        
+        var allMatches = Directory.GetFiles(directory, prefixFileName + "*");
+
         // Filter to only include exact match (old format), .{pid} suffix (previous format),
         // or .{instanceHash}.{pid} suffix (current format). This avoids matching
         // auxi.sock.{hash}abc (different hash that starts with same chars) and files

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -138,6 +138,11 @@ internal static class BackchannelConstants
     // TODO: Remove legacy hash support once all supported AppHost versions use normalized hashing.
     public static string? ComputeLegacyHash(string appHostPath)
     {
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
         var currentHash = ComputeHash(appHostPath);
         var legacyHash = ComputeStableIdentifier(appHostPath, HashLength);
 
@@ -149,7 +154,7 @@ internal static class BackchannelConstants
         // If the input path was already normalized (for example, an uppercase drive letter on Windows),
         // also try the opposite drive-letter casing to preserve compatibility with older AppHosts that
         // may have hashed the same path with a lowercase drive letter from MSBuild metadata.
-        if (OperatingSystem.IsWindows() && appHostPath.Length >= 2 && appHostPath[1] == ':' && char.IsLetter(appHostPath[0]))
+        if (appHostPath.Length >= 2 && appHostPath[1] == ':' && char.IsLetter(appHostPath[0]))
         {
             var alternateDriveLetter = char.IsUpper(appHostPath[0])
                 ? char.ToLowerInvariant(appHostPath[0])

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -113,9 +113,9 @@ internal static class BackchannelConstants
     /// Computes the hash portion of the socket name from an AppHost path.
     /// </summary>
     /// <remarks>
-    /// On case-insensitive file systems (Windows, macOS), the path is normalized to uppercase
-    /// before hashing so that "C:\App\MyApp.csproj" and "c:\app\myapp.csproj" produce the
-    /// same hash. Without this, the CLI and AppHost can derive different drive-letter casings
+    /// On Windows the drive letter is normalized to uppercase before hashing so that
+    /// "C:\App\MyApp.csproj" and "c:\App\MyApp.csproj" produce the same hash.
+    /// Without this, the CLI and AppHost can derive different drive-letter casings
     /// (e.g. <c>FileInfo.FullName</c> vs MSBuild metadata) and fail to match sockets.
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
@@ -149,13 +149,16 @@ internal static class BackchannelConstants
     }
 
     /// <summary>
-    /// Normalizes the path for consistent hashing on case-insensitive file systems.
+    /// Normalizes the path for consistent hashing by uppercasing the Windows drive letter.
     /// </summary>
     private static string NormalizePath(string path)
     {
-        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+        // On Windows, the drive letter casing can differ between callers
+        // (e.g. FileInfo.FullName produces "C:\..." while MSBuild metadata may produce "c:\...").
+        // Uppercase only the drive letter so both sides hash identically.
+        if (OperatingSystem.IsWindows() && path.Length >= 2 && path[1] == ':')
         {
-            return path.ToUpperInvariant();
+            return char.ToUpperInvariant(path[0]) + path[1..];
         }
 
         return path;

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -138,14 +138,32 @@ internal static class BackchannelConstants
     // TODO: Remove legacy hash support once all supported AppHost versions use normalized hashing.
     public static string? ComputeLegacyHash(string appHostPath)
     {
-        var normalizedPath = NormalizePath(appHostPath);
-        if (string.Equals(appHostPath, normalizedPath, StringComparison.Ordinal))
+        var currentHash = ComputeHash(appHostPath);
+        var legacyHash = ComputeStableIdentifier(appHostPath, HashLength);
+
+        if (!string.Equals(legacyHash, currentHash, StringComparison.Ordinal))
         {
-            // Path didn't change after normalization, so legacy hash is identical.
-            return null;
+            return legacyHash;
         }
 
-        return ComputeStableIdentifier(appHostPath, HashLength);
+        // If the input path was already normalized (for example, an uppercase drive letter on Windows),
+        // also try the opposite drive-letter casing to preserve compatibility with older AppHosts that
+        // may have hashed the same path with a lowercase drive letter from MSBuild metadata.
+        if (OperatingSystem.IsWindows() && appHostPath.Length >= 2 && appHostPath[1] == ':' && char.IsLetter(appHostPath[0]))
+        {
+            var alternateDriveLetter = char.IsUpper(appHostPath[0])
+                ? char.ToLowerInvariant(appHostPath[0])
+                : char.ToUpperInvariant(appHostPath[0]);
+            var alternatePath = alternateDriveLetter + appHostPath[1..];
+            var alternateLegacyHash = ComputeStableIdentifier(alternatePath, HashLength);
+
+            if (!string.Equals(alternateLegacyHash, currentHash, StringComparison.Ordinal))
+            {
+                return alternateLegacyHash;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -113,16 +113,51 @@ internal static class BackchannelConstants
     /// Computes the hash portion of the socket name from an AppHost path.
     /// </summary>
     /// <remarks>
-    /// The hash is case-sensitive. On case-insensitive file systems (Windows, macOS with default settings),
-    /// "C:\App\MyApp.csproj" and "C:\app\myapp.csproj" will produce different hashes even though they
-    /// reference the same file. This is acceptable because the CLI typically uses the exact path provided
-    /// by MSBuild or the user, which should be consistent within a session.
+    /// On case-insensitive file systems (Windows, macOS), the path is normalized to uppercase
+    /// before hashing so that "C:\App\MyApp.csproj" and "c:\app\myapp.csproj" produce the
+    /// same hash. Without this, the CLI and AppHost can derive different drive-letter casings
+    /// (e.g. <c>FileInfo.FullName</c> vs MSBuild metadata) and fail to match sockets.
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
     /// <returns>A 16-character lowercase hex string.</returns>
     public static string ComputeHash(string appHostPath)
     {
+        return ComputeStableIdentifier(NormalizePath(appHostPath), HashLength);
+    }
+
+    /// <summary>
+    /// Computes the legacy (pre-normalization) hash for backward compatibility.
+    /// </summary>
+    /// <remarks>
+    /// Older AppHost versions hashed the raw path without case normalization.
+    /// The CLI uses this to find sockets created by older AppHosts.
+    /// Returns <c>null</c> when the legacy hash would be identical to <see cref="ComputeHash"/>.
+    /// </remarks>
+    /// <param name="appHostPath">The full path to the AppHost project file.</param>
+    /// <returns>A 16-character lowercase hex string, or <c>null</c> if it matches the current hash.</returns>
+    public static string? ComputeLegacyHash(string appHostPath)
+    {
+        var normalizedPath = NormalizePath(appHostPath);
+        if (string.Equals(appHostPath, normalizedPath, StringComparison.Ordinal))
+        {
+            // Path didn't change after normalization, so legacy hash is identical.
+            return null;
+        }
+
         return ComputeStableIdentifier(appHostPath, HashLength);
+    }
+
+    /// <summary>
+    /// Normalizes the path for consistent hashing on case-insensitive file systems.
+    /// </summary>
+    private static string NormalizePath(string path)
+    {
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+        {
+            return path.ToUpperInvariant();
+        }
+
+        return path;
     }
 
     /// <summary>

--- a/src/Shared/PathNormalizer.cs
+++ b/src/Shared/PathNormalizer.cs
@@ -26,4 +26,62 @@ internal static class PathNormalizer
     {
         return path.Replace('\\', '/');
     }
+
+    /// <summary>
+    /// On Windows, resolves a path to its filesystem-canonical form by querying the OS for
+    /// the actual casing of each path component. On other platforms this is a no-op because
+    /// the file system is case-sensitive and there is no casing ambiguity.
+    /// </summary>
+    /// <remarks>
+    /// Use this when the path needs to match what MSBuild reports for the same file.
+    /// MSBuild always uses the true filesystem casing; a user who types
+    /// <c>--apphost c:\FOO\bar.csproj</c> will get back <c>C:\foo\bar.csproj</c>
+    /// if that is the on-disk casing, making the hash agree with the AppHost side.
+    /// </remarks>
+    /// <param name="path">An absolute path to a file that exists on disk.</param>
+    /// <returns>
+    /// The path with OS-canonical casing, or <paramref name="path"/> unchanged if it
+    /// cannot be resolved (file does not exist, UNC path, etc.).
+    /// </returns>
+    public static string ResolveToFilesystemPath(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return path;
+        }
+
+        // Only handle standard drive-letter paths (e.g. C:\...).
+        // UNC paths (\\server\share\...) are not common for project files and are left unchanged.
+        if (path.Length < 3 || path[1] != ':' || path[2] != Path.DirectorySeparatorChar)
+        {
+            return path;
+        }
+
+        // Uppercase the drive letter and use it as the starting root (e.g. "C:\").
+        var current = char.ToUpperInvariant(path[0]) + ":" + Path.DirectorySeparatorChar;
+
+        // Walk each component after the root ("X:\") to resolve its real casing.
+        var parts = path[3..].Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (i == parts.Length - 1)
+            {
+                // Final component: find the file with its real name.
+                var files = Directory.GetFiles(current, parts[i]);
+                return files.Length == 1 ? files[0] : Path.Combine(current, parts[i]);
+            }
+
+            // Intermediate component: find the directory with its real name.
+            var dirs = Directory.GetDirectories(current, parts[i]);
+            current = dirs.Length == 1 ? dirs[0] : Path.Combine(current, parts[i]);
+
+            if (!current.EndsWith(Path.DirectorySeparatorChar))
+            {
+                current += Path.DirectorySeparatorChar;
+            }
+        }
+
+        return path;
+    }
 }

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -333,6 +333,38 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UseOrFindAppHostProjectFileResultUsesOnDiskCasingForExplicitPath()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "On-disk path casing normalization is only required on Windows.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectDirectory = workspace.WorkspaceRoot.CreateSubdirectory("MyAppHost");
+        var onDiskProjectFile = new FileInfo(Path.Combine(projectDirectory.FullName, "MyAppHost.csproj"));
+        await File.WriteAllTextAsync(onDiskProjectFile.FullName, "Not a real project file.");
+
+        static string ToggleCase(string path)
+            => string.Concat(path.Select(c => char.IsLetter(c)
+                ? (char.IsUpper(c) ? char.ToLowerInvariant(c) : char.ToUpperInvariant(c))
+                : c));
+
+        var mismatchedCasePath = ToggleCase(onDiskProjectFile.FullName);
+        Assert.False(string.Equals(onDiskProjectFile.FullName, mismatchedCasePath, StringComparison.Ordinal));
+        Assert.True(File.Exists(mismatchedCasePath));
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext);
+
+        var result = await projectLocator.UseOrFindAppHostProjectFileAsync(
+            new FileInfo(mismatchedCasePath),
+            MultipleAppHostProjectsFoundBehavior.Throw,
+            createSettingsFile: false,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.NotNull(result.SelectedProjectFile);
+        Assert.Equal(onDiskProjectFile.FullName, result.SelectedProjectFile!.FullName);
+    }
+
+    [Fact]
     public async Task UseOrFindAppHostProjectFileReturnsProjectFileInDirectoryIfNotExplicitlyProvided()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -412,11 +412,15 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
         Directory.CreateDirectory(backchannelsDir);
 
-        // Simulate paths with different drive letter casing, as can happen when
+        // Simulate paths with different casing, as can happen when
         // the CLI resolves via FileInfo.FullName (uppercase) and the AppHost resolves
         // via MSBuild metadata (lowercase).
-        var upperCasePath = @"C:\Development\MyApp\MyApp.AppHost.csproj";
-        var lowerCasePath = @"c:\development\myapp\myapp.apphost.csproj";
+        var upperCasePath = OperatingSystem.IsWindows()
+            ? @"C:\Development\MyApp\MyApp.AppHost.csproj"
+            : "/Users/Dev/MyApp/MyApp.AppHost.csproj";
+        var lowerCasePath = OperatingSystem.IsWindows()
+            ? @"c:\development\myapp\myapp.apphost.csproj"
+            : "/users/dev/myapp/myapp.apphost.csproj";
 
         // Both casings should produce the same hash (current behavior after normalization)
         var upperPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(upperCasePath, workspace.WorkspaceRoot.FullName);
@@ -450,7 +454,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Directory.CreateDirectory(backchannelsDir);
 
         // A mixed-case path produces a legacy hash that differs from the normalized hash
-        var appHostPath = @"c:\Development\MyApp\MyApp.AppHost.csproj";
+        var appHostPath = OperatingSystem.IsWindows()
+            ? @"c:\Development\MyApp\MyApp.AppHost.csproj"
+            : "/users/Dev/MyApp/MyApp.AppHost.csproj";
         var legacyHash = AppHostHelper.ComputeLegacyHash(appHostPath);
         Assert.NotNull(legacyHash);
 
@@ -458,18 +464,14 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var legacySocket = Path.Combine(backchannelsDir, $"auxi.sock.{legacyHash}.a1b2c3d4e5f6.99999");
         File.WriteAllText(legacySocket, "");
 
-        // The current normalized hash should NOT find the legacy socket
+        // The current normalized hash differs from the legacy hash
         var currentPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
         var currentHash = Path.GetFileName(currentPrefix)["auxi.sock.".Length..];
         Assert.NotEqual(currentHash, legacyHash);
 
-        var foundByCurrentHash = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
-        Assert.Empty(foundByCurrentHash);
-
-        // But the legacy hash lets us locate it via directory scan
-        var legacyPrefix = Path.Combine(backchannelsDir, $"auxi.sock.{legacyHash}");
-        var legacyMatches = Directory.GetFiles(backchannelsDir, Path.GetFileName(legacyPrefix) + "*");
-        Assert.Single(legacyMatches);
-        Assert.Contains(legacySocket, legacyMatches);
+        // FindMatchingSockets should still find the legacy socket via fallback
+        var found = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        Assert.Single(found);
+        Assert.Contains(legacySocket, found);
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -387,4 +387,89 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Assert.Equal(expectedCompatible, isCompatible);
         Assert.Equal(aspireVersion, returnedVersion);
     }
+
+    [Fact]
+    public void ComputeLegacyHash_ReturnsNullWhenPathUnchangedByNormalization()
+    {
+        // On Linux, normalization is a no-op so the legacy hash is always null.
+        // On Windows/macOS, a path that is already fully uppercase won't change either.
+        var appHostPath = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? @"C:\PATH\TO\MYAPP.APPHOST.CSPROJ"
+            : "/path/to/MyApp.AppHost.csproj";
+
+        var legacyHash = AppHostHelper.ComputeLegacyHash(appHostPath);
+
+        Assert.Null(legacyHash);
+    }
+
+    [Fact]
+    public void FindMatchingSockets_FindsSocketsCreatedWithDifferentPathCasing()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS(),
+            "Path case normalization only applies on case-insensitive file systems (Windows/macOS).");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        Directory.CreateDirectory(backchannelsDir);
+
+        // Simulate paths with different drive letter casing, as can happen when
+        // the CLI resolves via FileInfo.FullName (uppercase) and the AppHost resolves
+        // via MSBuild metadata (lowercase).
+        var upperCasePath = @"C:\Development\MyApp\MyApp.AppHost.csproj";
+        var lowerCasePath = @"c:\development\myapp\myapp.apphost.csproj";
+
+        // Both casings should produce the same hash (current behavior after normalization)
+        var upperPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(upperCasePath, workspace.WorkspaceRoot.FullName);
+        var lowerPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(lowerCasePath, workspace.WorkspaceRoot.FullName);
+        Assert.Equal(upperPrefix, lowerPrefix);
+
+        var hash = Path.GetFileName(upperPrefix)["auxi.sock.".Length..];
+
+        // Create a socket file using the normalized hash (simulates a new AppHost)
+        var socket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.a1b2c3d4e5f6.12345");
+        File.WriteAllText(socket, "");
+
+        // Both path casings should find the socket
+        var fromUpper = AppHostHelper.FindMatchingSockets(upperCasePath, workspace.WorkspaceRoot.FullName);
+        var fromLower = AppHostHelper.FindMatchingSockets(lowerCasePath, workspace.WorkspaceRoot.FullName);
+
+        Assert.Single(fromUpper);
+        Assert.Single(fromLower);
+        Assert.Contains(socket, fromUpper);
+        Assert.Contains(socket, fromLower);
+    }
+
+    [Fact]
+    public void FindMatchingSockets_LegacyHashFindsSocketsFromOlderAppHost()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS(),
+            "Legacy hash divergence only occurs on case-insensitive file systems (Windows/macOS).");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        Directory.CreateDirectory(backchannelsDir);
+
+        // A mixed-case path produces a legacy hash that differs from the normalized hash
+        var appHostPath = @"c:\Development\MyApp\MyApp.AppHost.csproj";
+        var legacyHash = AppHostHelper.ComputeLegacyHash(appHostPath);
+        Assert.NotNull(legacyHash);
+
+        // Create a socket using the legacy (pre-normalization) hash, as an older AppHost would
+        var legacySocket = Path.Combine(backchannelsDir, $"auxi.sock.{legacyHash}.a1b2c3d4e5f6.99999");
+        File.WriteAllText(legacySocket, "");
+
+        // The current normalized hash should NOT find the legacy socket
+        var currentPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
+        var currentHash = Path.GetFileName(currentPrefix)["auxi.sock.".Length..];
+        Assert.NotEqual(currentHash, legacyHash);
+
+        var foundByCurrentHash = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        Assert.Empty(foundByCurrentHash);
+
+        // But the legacy hash lets us locate it via directory scan
+        var legacyPrefix = Path.Combine(backchannelsDir, $"auxi.sock.{legacyHash}");
+        var legacyMatches = Directory.GetFiles(backchannelsDir, Path.GetFileName(legacyPrefix) + "*");
+        Assert.Single(legacyMatches);
+        Assert.Contains(legacySocket, legacyMatches);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -389,14 +389,33 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void ComputeLegacyHash_ReturnsNullWhenPathUnchangedByNormalization()
+    public void ComputeLegacyHash_WhenUppercaseDrivePathOnWindows_ReturnsLowercaseDriveLegacyHash()
     {
-        // Normalization only uppercases the Windows drive letter.
-        // A path whose drive letter is already uppercase (or any non-Windows path) is unchanged.
-        var appHostPath = OperatingSystem.IsWindows()
-            ? @"C:\Path\To\MyApp.AppHost.csproj"
-            : "/path/to/MyApp.AppHost.csproj";
+        Assert.SkipWhen(!OperatingSystem.IsWindows(),
+            "Drive-letter legacy fallback behavior only applies on Windows.");
 
+        var upperDrivePath = @"C:\Path\To\MyApp.AppHost.csproj";
+        var lowerDrivePath = @"c:\Path\To\MyApp.AppHost.csproj";
+
+        var upperLegacyHash = AppHostHelper.ComputeLegacyHash(upperDrivePath);
+        var lowerLegacyHash = AppHostHelper.ComputeLegacyHash(lowerDrivePath);
+
+        Assert.NotNull(upperLegacyHash);
+        Assert.NotNull(lowerLegacyHash);
+        Assert.Equal(lowerLegacyHash, upperLegacyHash);
+
+        var currentPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(upperDrivePath, Path.GetTempPath());
+        var currentHash = Path.GetFileName(currentPrefix)["auxi.sock.".Length..];
+        Assert.NotEqual(currentHash, upperLegacyHash);
+    }
+
+    [Fact]
+    public void ComputeLegacyHash_ReturnsNullOnNonWindowsWhenPathUnchanged()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(),
+            "Non-Windows behavior is validated by this test.");
+
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
         var legacyHash = AppHostHelper.ComputeLegacyHash(appHostPath);
 
         Assert.Null(legacyHash);

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -391,10 +391,10 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ComputeLegacyHash_ReturnsNullWhenPathUnchangedByNormalization()
     {
-        // On Linux, normalization is a no-op so the legacy hash is always null.
-        // On Windows/macOS, a path that is already fully uppercase won't change either.
-        var appHostPath = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
-            ? @"C:\PATH\TO\MYAPP.APPHOST.CSPROJ"
+        // Normalization only uppercases the Windows drive letter.
+        // A path whose drive letter is already uppercase (or any non-Windows path) is unchanged.
+        var appHostPath = OperatingSystem.IsWindows()
+            ? @"C:\Path\To\MyApp.AppHost.csproj"
             : "/path/to/MyApp.AppHost.csproj";
 
         var legacyHash = AppHostHelper.ComputeLegacyHash(appHostPath);
@@ -403,28 +403,24 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void FindMatchingSockets_FindsSocketsCreatedWithDifferentPathCasing()
+    public void FindMatchingSockets_FindsSocketsCreatedWithDifferentDriveLetterCasing()
     {
-        Assert.SkipWhen(!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS(),
-            "Path case normalization only applies on case-insensitive file systems (Windows/macOS).");
+        Assert.SkipWhen(!OperatingSystem.IsWindows(),
+            "Drive letter normalization only applies on Windows.");
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
         Directory.CreateDirectory(backchannelsDir);
 
-        // Simulate paths with different casing, as can happen when
-        // the CLI resolves via FileInfo.FullName (uppercase) and the AppHost resolves
-        // via MSBuild metadata (lowercase).
-        var upperCasePath = OperatingSystem.IsWindows()
-            ? @"C:\Development\MyApp\MyApp.AppHost.csproj"
-            : "/Users/Dev/MyApp/MyApp.AppHost.csproj";
-        var lowerCasePath = OperatingSystem.IsWindows()
-            ? @"c:\development\myapp\myapp.apphost.csproj"
-            : "/users/dev/myapp/myapp.apphost.csproj";
+        // Simulate the real-world mismatch: FileInfo.FullName yields an uppercase drive letter
+        // (e.g. "C:\...") while MSBuild metadata may yield a lowercase one (e.g. "c:\...").
+        // Only the drive letter casing differs; the rest of the path is identical.
+        var upperDrivePath = @"C:\Development\MyApp\MyApp.AppHost.csproj";
+        var lowerDrivePath = @"c:\Development\MyApp\MyApp.AppHost.csproj";
 
-        // Both casings should produce the same hash (current behavior after normalization)
-        var upperPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(upperCasePath, workspace.WorkspaceRoot.FullName);
-        var lowerPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(lowerCasePath, workspace.WorkspaceRoot.FullName);
+        // Both should produce the same hash after drive-letter normalization.
+        var upperPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(upperDrivePath, workspace.WorkspaceRoot.FullName);
+        var lowerPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(lowerDrivePath, workspace.WorkspaceRoot.FullName);
         Assert.Equal(upperPrefix, lowerPrefix);
 
         var hash = Path.GetFileName(upperPrefix)["auxi.sock.".Length..];
@@ -433,9 +429,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var socket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.a1b2c3d4e5f6.12345");
         File.WriteAllText(socket, "");
 
-        // Both path casings should find the socket
-        var fromUpper = AppHostHelper.FindMatchingSockets(upperCasePath, workspace.WorkspaceRoot.FullName);
-        var fromLower = AppHostHelper.FindMatchingSockets(lowerCasePath, workspace.WorkspaceRoot.FullName);
+        // Both path variants should find the socket
+        var fromUpper = AppHostHelper.FindMatchingSockets(upperDrivePath, workspace.WorkspaceRoot.FullName);
+        var fromLower = AppHostHelper.FindMatchingSockets(lowerDrivePath, workspace.WorkspaceRoot.FullName);
 
         Assert.Single(fromUpper);
         Assert.Single(fromLower);
@@ -446,17 +442,16 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void FindMatchingSockets_LegacyHashFindsSocketsFromOlderAppHost()
     {
-        Assert.SkipWhen(!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS(),
-            "Legacy hash divergence only occurs on case-insensitive file systems (Windows/macOS).");
+        Assert.SkipWhen(!OperatingSystem.IsWindows(),
+            "Legacy hash divergence only occurs on Windows where drive-letter casing is normalized.");
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
         Directory.CreateDirectory(backchannelsDir);
 
-        // A mixed-case path produces a legacy hash that differs from the normalized hash
-        var appHostPath = OperatingSystem.IsWindows()
-            ? @"c:\Development\MyApp\MyApp.AppHost.csproj"
-            : "/users/Dev/MyApp/MyApp.AppHost.csproj";
+        // A path with a lowercase drive letter produces a legacy hash that differs from the
+        // normalized hash (which has an uppercase drive letter).
+        var appHostPath = @"c:\Development\MyApp\MyApp.AppHost.csproj";
         var legacyHash = AppHostHelper.ComputeLegacyHash(appHostPath);
         Assert.NotNull(legacyHash);
 


### PR DESCRIPTION
## Description

Fix `aspire start` timing out on Windows due to a backchannel socket hash mismatch caused by AppHost path casing differences.

**Root cause:**
The CLI and AppHost independently compute a hash of the AppHost project path to name/find the backchannel socket. On Windows, callers can provide different path casing for the same file (for example `C:\...` vs `c:\...`), and the AppHost path can also come from MSBuild metadata with different casing. Hashing those raw strings can produce different socket hashes.

**Fix:**
- Normalize **only the Windows drive letter** in `BackchannelConstants.ComputeHash` before hashing.
- Keep `ComputeLegacyHash` and legacy-socket fallback so a newer CLI can still connect to sockets from older AppHosts.
- When `--apphost` is explicitly provided, resolve it to the filesystem-canonical path (`PathNormalizer.ResolveToFilesystemPath`) before project selection, so `SelectedProjectFile` and hash inputs use on-disk casing.
- Add `LogDebug` output when explicit `--apphost` canonicalization changes the incoming path.
- Add/update unit tests for drive-letter normalization, legacy hash fallback, and `ProjectLocator` explicit-path casing behavior.

**Backward compatibility:**
| | Old AppHost | New AppHost |
|---|---|---|
| **Old CLI** | Works (unchanged) | Breaks (requires CLI update) |
| **New CLI** | Works (legacy fallback) | Works (normalized hash) |

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Fixes https://github.com/microsoft/aspire/issues/15588
