### PR TITLE
Add CLI stable AppHost compatibility smoke tests

### DIFF
--- a/src/Aspire.Cli/Scaffolding/IScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/IScaffoldingService.cs
@@ -11,10 +11,14 @@ namespace Aspire.Cli.Scaffolding;
 /// <param name="Language">The language to scaffold.</param>
 /// <param name="TargetDirectory">The directory to scaffold into.</param>
 /// <param name="ProjectName">Optional project name.</param>
+/// <param name="SdkVersion">Optional Aspire SDK version to use for scaffolding.</param>
+/// <param name="Channel">Optional Aspire channel to use for scaffolding.</param>
 internal record ScaffoldContext(
     LanguageInfo Language,
     DirectoryInfo TargetDirectory,
-    string? ProjectName = null);
+    string? ProjectName = null,
+    string? SdkVersion = null,
+    string? Channel = null);
 
 /// <summary>
 /// Service for scaffolding new AppHost projects.

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -52,9 +52,25 @@ internal sealed class ScaffoldingService : IScaffoldingService
         var language = context.Language;
 
         // Step 1: Resolve SDK and package strategy
-        var sdkVersion = VersionHelper.GetDefaultSdkVersion();
+        var sdkVersion = string.IsNullOrWhiteSpace(context.SdkVersion)
+            ? VersionHelper.GetDefaultSdkVersion()
+            : context.SdkVersion;
         var config = AspireConfigFile.LoadOrCreate(directory.FullName, sdkVersion);
+        if (!string.IsNullOrWhiteSpace(context.SdkVersion))
+        {
+            config.SdkVersion = context.SdkVersion;
+        }
+        if (!string.IsNullOrWhiteSpace(context.Channel))
+        {
+            config.Channel = context.Channel;
+        }
+
         PreAddJavaScriptHostingForBrownfieldTypeScript(config, directory, language, sdkVersion);
+        if (!string.IsNullOrWhiteSpace(context.SdkVersion) ||
+            !string.IsNullOrWhiteSpace(context.Channel))
+        {
+            config.Save(directory.FullName);
+        }
 
         // Include the code generation package for scaffolding and code gen
         var codeGenPackage = await _languageDiscovery.GetPackageForLanguageAsync(language.LanguageId, cancellationToken);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -74,7 +74,12 @@ internal sealed partial class CliTemplateFactory
                     else
                     {
                         _logger.LogDebug("Using scaffolding service for language '{LanguageDisplayName}' in '{OutputPath}'.", language.DisplayName, outputPath);
-                        var context = new ScaffoldContext(language, new DirectoryInfo(outputPath), projectName);
+                        var context = new ScaffoldContext(
+                            language,
+                            new DirectoryInfo(outputPath),
+                            projectName,
+                            SdkVersion: inputs.Version,
+                            Channel: inputs.Channel);
                         if (!await _scaffoldingService.ScaffoldAsync(context, cancellationToken))
                         {
                             return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -151,25 +151,87 @@ internal static class CliE2EAutomatorHelpers
         TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromMinutes(2);
+        var command = BuildAspireNewEmptyAppHostCommand(
+            "aspire-empty",
+            projectName,
+            outputPath,
+            channel,
+            useLocalhostTld);
+
+        await auto.TypeAsync(command);
+        await auto.EnterAsync();
+        await auto.WaitForAspireNewEmptyAppHostCompletionAsync(
+            projectName,
+            "C#",
+            counter,
+            AppHostLanguagePromptSelection.DefaultCSharp,
+            effectiveTimeout);
+    }
+
+    /// <summary>
+    /// Creates a TypeScript empty AppHost using the direct <c>aspire new aspire-ts-empty</c> command.
+    /// </summary>
+    internal static async Task AspireNewTypeScriptEmptyAppHostAsync(
+        this Hex1bTerminalAutomator auto,
+        string projectName,
+        SequenceCounter counter,
+        string? outputPath = null,
+        string? channel = null,
+        bool useLocalhostTld = false,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromMinutes(2);
+        var command = BuildAspireNewEmptyAppHostCommand(
+            "aspire-ts-empty",
+            projectName,
+            outputPath,
+            channel,
+            useLocalhostTld);
+
+        await auto.TypeAsync(command);
+        await auto.EnterAsync();
+        await auto.WaitForAspireNewEmptyAppHostCompletionAsync(
+            projectName,
+            "TypeScript",
+            counter,
+            AppHostLanguagePromptSelection.TypeScript,
+            effectiveTimeout);
+    }
+
+    private static string BuildAspireNewEmptyAppHostCommand(
+        string templateName,
+        string projectName,
+        string? outputPath,
+        string? channel,
+        bool useLocalhostTld)
+    {
         var output = string.IsNullOrWhiteSpace(outputPath) ? projectName : outputPath;
         var channelArgument = string.IsNullOrWhiteSpace(channel)
             ? string.Empty
             : $" --channel {AspireCliShellCommandHelpers.QuoteBashArg(channel)}";
         var localhostTldValue = useLocalhostTld ? "true" : "false";
-        var command =
-            $"aspire new aspire-empty --name {AspireCliShellCommandHelpers.QuoteBashArg(projectName)} " +
+
+        return
+            $"aspire new {AspireCliShellCommandHelpers.QuoteBashArg(templateName)} " +
+            $"--name {AspireCliShellCommandHelpers.QuoteBashArg(projectName)} " +
             $"--output {AspireCliShellCommandHelpers.QuoteBashArg(output)}" +
             $"{channelArgument} --localhost-tld {localhostTldValue}";
+    }
 
-        await auto.TypeAsync(command);
-        await auto.EnterAsync();
-
+    private static async Task WaitForAspireNewEmptyAppHostCompletionAsync(
+        this Hex1bTerminalAutomator auto,
+        string projectName,
+        string languageDisplayName,
+        SequenceCounter counter,
+        AppHostLanguagePromptSelection languagePromptSelection,
+        TimeSpan effectiveTimeout)
+    {
         var languagePrompt = new CellPatternSearcher()
             .Find("Which language would you like to use?");
         var agentInitPrompt = new CellPatternSearcher()
             .Find("configure AI agent environments");
-
         var result = AspireNewEmptyAppHostResult.None;
+
         await auto.WaitUntilAsync(snapshot =>
         {
             if (languagePrompt.Search(snapshot).Count > 0)
@@ -203,12 +265,12 @@ internal static class CliE2EAutomatorHelpers
             }
 
             return false;
-        }, timeout: effectiveTimeout, description: "C# empty AppHost creation prompt or completion");
+        }, timeout: effectiveTimeout, description: $"{languageDisplayName} empty AppHost creation prompt or completion");
 
         switch (result)
         {
             case AspireNewEmptyAppHostResult.LanguagePrompt:
-                await auto.EnterAsync();
+                await auto.SelectAppHostLanguageAsync(languagePromptSelection);
                 await auto.DeclineAgentInitPromptAsync(counter, effectiveTimeout);
                 return;
 
@@ -221,10 +283,34 @@ internal static class CliE2EAutomatorHelpers
                 return;
 
             case AspireNewEmptyAppHostResult.ErrorPrompt:
-                throw new InvalidOperationException($"aspire new failed while creating C# empty AppHost project '{projectName}'.");
+                throw new InvalidOperationException($"aspire new failed while creating {languageDisplayName} empty AppHost project '{projectName}'.");
 
             default:
-                throw new InvalidOperationException($"Unexpected aspire new result while creating C# empty AppHost project '{projectName}': {result}.");
+                throw new InvalidOperationException($"Unexpected aspire new result while creating {languageDisplayName} empty AppHost project '{projectName}': {result}.");
+        }
+    }
+
+    private static async Task SelectAppHostLanguageAsync(
+        this Hex1bTerminalAutomator auto,
+        AppHostLanguagePromptSelection languagePromptSelection)
+    {
+        switch (languagePromptSelection)
+        {
+            case AppHostLanguagePromptSelection.DefaultCSharp:
+                await auto.EnterAsync();
+                return;
+
+            case AppHostLanguagePromptSelection.TypeScript:
+                await auto.DownAsync();
+                await auto.WaitUntilAsync(
+                    s => new CellPatternSearcher().Find("> TypeScript (Node.js)").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(5),
+                    description: "TypeScript AppHost language selected");
+                await auto.EnterAsync();
+                return;
+
+            default:
+                throw new InvalidOperationException($"Unexpected AppHost language prompt selection: {languagePromptSelection}.");
         }
     }
 
@@ -934,5 +1020,11 @@ internal static class CliE2EAutomatorHelpers
         AgentInitPrompt,
         SuccessPrompt,
         ErrorPrompt
+    }
+
+    private enum AppHostLanguagePromptSelection
+    {
+        DefaultCSharp,
+        TypeScript
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -138,6 +138,97 @@ internal static class CliE2EAutomatorHelpers
     }
 
     /// <summary>
+    /// Creates a C# empty AppHost using the direct <c>aspire new aspire-empty</c> command.
+    /// Handles CLI versions where C# is implicit and newer versions that prompt for the AppHost language.
+    /// </summary>
+    internal static async Task AspireNewCSharpEmptyAppHostAsync(
+        this Hex1bTerminalAutomator auto,
+        string projectName,
+        SequenceCounter counter,
+        string? outputPath = null,
+        string? channel = null,
+        bool useLocalhostTld = false,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromMinutes(2);
+        var output = string.IsNullOrWhiteSpace(outputPath) ? projectName : outputPath;
+        var channelArgument = string.IsNullOrWhiteSpace(channel)
+            ? string.Empty
+            : $" --channel {AspireCliShellCommandHelpers.QuoteBashArg(channel)}";
+        var localhostTldValue = useLocalhostTld ? "true" : "false";
+        var command =
+            $"aspire new aspire-empty --name {AspireCliShellCommandHelpers.QuoteBashArg(projectName)} " +
+            $"--output {AspireCliShellCommandHelpers.QuoteBashArg(output)}" +
+            $"{channelArgument} --localhost-tld {localhostTldValue}";
+
+        await auto.TypeAsync(command);
+        await auto.EnterAsync();
+
+        var languagePrompt = new CellPatternSearcher()
+            .Find("Which language would you like to use?");
+        var agentInitPrompt = new CellPatternSearcher()
+            .Find("configure AI agent environments");
+
+        var result = AspireNewEmptyAppHostResult.None;
+        await auto.WaitUntilAsync(snapshot =>
+        {
+            if (languagePrompt.Search(snapshot).Count > 0)
+            {
+                result = AspireNewEmptyAppHostResult.LanguagePrompt;
+                return true;
+            }
+
+            if (agentInitPrompt.Search(snapshot).Count > 0)
+            {
+                result = AspireNewEmptyAppHostResult.AgentInitPrompt;
+                return true;
+            }
+
+            var successPrompt = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+            if (successPrompt.Search(snapshot).Count > 0)
+            {
+                result = AspireNewEmptyAppHostResult.SuccessPrompt;
+                return true;
+            }
+
+            var errorPrompt = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" ERR:");
+            if (errorPrompt.Search(snapshot).Count > 0)
+            {
+                result = AspireNewEmptyAppHostResult.ErrorPrompt;
+                return true;
+            }
+
+            return false;
+        }, timeout: effectiveTimeout, description: "C# empty AppHost creation prompt or completion");
+
+        switch (result)
+        {
+            case AspireNewEmptyAppHostResult.LanguagePrompt:
+                await auto.EnterAsync();
+                await auto.DeclineAgentInitPromptAsync(counter, effectiveTimeout);
+                return;
+
+            case AspireNewEmptyAppHostResult.AgentInitPrompt:
+                await auto.DeclineAgentInitPromptAsync(counter, effectiveTimeout);
+                return;
+
+            case AspireNewEmptyAppHostResult.SuccessPrompt:
+                counter.Increment();
+                return;
+
+            case AspireNewEmptyAppHostResult.ErrorPrompt:
+                throw new InvalidOperationException($"aspire new failed while creating C# empty AppHost project '{projectName}'.");
+
+            default:
+                throw new InvalidOperationException($"Unexpected aspire new result while creating C# empty AppHost project '{projectName}': {result}.");
+        }
+    }
+
+    /// <summary>
     /// Handles <c>aspire add</c> completing directly or stopping on a version selection prompt.
     /// </summary>
     internal static async Task WaitForAspireAddSuccessAsync(
@@ -834,5 +925,14 @@ internal static class CliE2EAutomatorHelpers
     private static bool ShouldCaptureWorkspaceDiagnostics()
     {
         return CliE2ETestHelpers.IsRunningInCI || ShouldPreserveLocalWorkspace();
+    }
+
+    private enum AspireNewEmptyAppHostResult
+    {
+        None,
+        LanguagePrompt,
+        AgentInitPrompt,
+        SuccessPrompt,
+        ErrorPrompt
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.RegularExpressions;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
@@ -67,5 +68,61 @@ public sealed class SmokeTests(ITestOutputHelper output)
         await auto.EnterAsync();
 
         await pendingRun;
+    }
+
+    [CaptureWorkspaceOnFailure]
+    [Fact]
+    public async Task LatestCliCanStartStableChannelAppHost()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect();
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        const string projectName = "StableAppHost";
+        await auto.AspireNewCSharpEmptyAppHostAsync(projectName, counter, channel: "stable");
+
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName, "apphost.cs");
+        var appHostSdkVersion = GetAppHostSdkVersion(appHostPath);
+        if (appHostSdkVersion.Contains('-', StringComparison.Ordinal) ||
+            appHostSdkVersion.Contains('+', StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected stable Aspire.AppHost.Sdk version, got '{appHostSdkVersion}' in {appHostPath}.");
+        }
+
+        output.WriteLine($"Stable AppHost SDK version: {appHostSdkVersion}");
+
+        await auto.RunCommandFailFastAsync($"cd {projectName}", counter);
+        await auto.AspireStartAsync(counter);
+        await auto.AspireStopAsync(counter);
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
+    private static string GetAppHostSdkVersion(string appHostPath)
+    {
+        if (!File.Exists(appHostPath))
+        {
+            throw new FileNotFoundException($"Expected AppHost file to exist: {appHostPath}", appHostPath);
+        }
+
+        var appHostContent = File.ReadAllText(appHostPath);
+        var match = Regex.Match(appHostContent, @"(?m)^#:\s*sdk\s+Aspire\.AppHost\.Sdk@(?<version>\S+)\s*$");
+        return match.Success
+            ? match.Groups["version"].Value
+            : throw new InvalidOperationException($"Could not find Aspire.AppHost.Sdk directive in {appHostPath}.");
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
@@ -112,6 +113,48 @@ public sealed class SmokeTests(ITestOutputHelper output)
         await pendingRun;
     }
 
+    [CaptureWorkspaceOnFailure]
+    [Fact]
+    public async Task LatestCliCanStartStableChannelTypeScriptAppHost()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect();
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        const string projectName = "StableTypeScriptAppHost";
+        await auto.AspireNewTypeScriptEmptyAppHostAsync(projectName, counter, channel: "stable");
+
+        var projectPath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+        var appHostPath = Path.Combine(projectPath, "apphost.ts");
+        if (!File.Exists(appHostPath))
+        {
+            throw new FileNotFoundException($"Expected TypeScript AppHost file to exist: {appHostPath}", appHostPath);
+        }
+
+        AssertStableTypeScriptAppHostConfig(Path.Combine(projectPath, "aspire.config.json"));
+        output.WriteLine("Stable TypeScript AppHost config verified.");
+
+        await auto.RunCommandFailFastAsync($"cd {projectName}", counter);
+        await auto.AspireStartAsync(counter);
+        await auto.AspireStopAsync(counter);
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
     private static string GetAppHostSdkVersion(string appHostPath)
     {
         if (!File.Exists(appHostPath))
@@ -124,5 +167,61 @@ public sealed class SmokeTests(ITestOutputHelper output)
         return match.Success
             ? match.Groups["version"].Value
             : throw new InvalidOperationException($"Could not find Aspire.AppHost.Sdk directive in {appHostPath}.");
+    }
+
+    private static void AssertStableTypeScriptAppHostConfig(string configPath)
+    {
+        if (!File.Exists(configPath))
+        {
+            throw new FileNotFoundException($"Expected Aspire config file to exist: {configPath}", configPath);
+        }
+
+        // Expected shape: { "appHost": { "path": "apphost.ts", "language": "typescript/nodejs" }, "sdk": { "version": "13.2.0" }, "channel": "stable" }
+        using var config = JsonDocument.Parse(File.ReadAllText(configPath));
+        var root = config.RootElement;
+        AssertJsonStringProperty(root, "channel", "stable", configPath);
+        var sdk = GetRequiredJsonObjectProperty(root, "sdk", configPath);
+        var sdkVersion = GetRequiredJsonStringProperty(sdk, "version", configPath);
+        if (sdkVersion.Contains('-', StringComparison.Ordinal) ||
+            sdkVersion.Contains('+', StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected stable Aspire SDK version, got '{sdkVersion}' in {configPath}.");
+        }
+
+        var appHost = GetRequiredJsonObjectProperty(root, "appHost", configPath);
+        AssertJsonStringProperty(appHost, "path", "apphost.ts", configPath);
+        AssertJsonStringProperty(appHost, "language", "typescript/nodejs", configPath);
+    }
+
+    private static JsonElement GetRequiredJsonObjectProperty(JsonElement element, string propertyName, string configPath)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException($"Expected JSON object property '{propertyName}' in {configPath}.");
+        }
+
+        return property;
+    }
+
+    private static void AssertJsonStringProperty(JsonElement element, string propertyName, string expectedValue, string configPath)
+    {
+        var actualValue = GetRequiredJsonStringProperty(element, propertyName, configPath);
+        if (!string.Equals(actualValue, expectedValue, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected JSON property '{propertyName}' in {configPath} to be '{expectedValue}', got '{actualValue}'.");
+        }
+    }
+
+    private static string GetRequiredJsonStringProperty(JsonElement element, string propertyName, string configPath)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidOperationException($"Expected JSON string property '{propertyName}' in {configPath}.");
+        }
+
+        return property.GetString()
+            ?? throw new InvalidOperationException($"Expected JSON string property '{propertyName}' in {configPath} to be non-null.");
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -76,7 +76,7 @@ public sealed class SmokeTests(ITestOutputHelper output)
     public async Task LatestCliCanStartStableChannelAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -118,7 +118,7 @@ public sealed class SmokeTests(ITestOutputHelper output)
     public async Task LatestCliCanStartStableChannelTypeScriptAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
         var workspace = TemporaryWorkspace.Create(output);
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -990,6 +990,55 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithTypeScriptEmptyTemplatePassesResolvedVersionAndChannelToScaffolding()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? scaffoldSdkVersion = null;
+        string? scaffoldChannel = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.PackagingServiceFactory = (sp) =>
+            {
+                var packagingService = new TestPackagingService();
+                packagingService.GetChannelsAsyncCallback = (ct) =>
+                {
+                    var stableCache = new FakeNuGetPackageCache();
+                    stableCache.GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
+                    {
+                        var package = new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = "9.2.0" };
+                        return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
+                    };
+
+                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], stableCache);
+                    return Task.FromResult<IEnumerable<PackageChannel>>([stableChannel]);
+                };
+
+                return packagingService;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                scaffoldSdkVersion = context.SdkVersion;
+                scaffoldChannel = context.Channel;
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("new aspire-ts-empty --name TestApp --output . --channel stable --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal("9.2.0", scaffoldSdkVersion);
+        Assert.Equal("stable", scaffoldChannel);
+    }
+
+    [Fact]
     public async Task NewCommandWithEmptyTemplateNormalizesDefaultOutputPath()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -459,6 +459,7 @@ internal static class Hex1bAutomatorTestHelpers
             .Find("configure AI agent environments");
 
         var agentInitFound = false;
+        var errorPromptFound = false;
 
         // Wait for either the agent init prompt (new CLI) or the success prompt (old CLI).
         await auto.WaitUntilAsync(s =>
@@ -471,8 +472,22 @@ internal static class Hex1bAutomatorTestHelpers
             var successSearcher = new CellPatternSearcher()
                 .FindPattern(counter.Value.ToString())
                 .RightText(" OK] $ ");
-            return successSearcher.Search(s).Count > 0;
+            if (successSearcher.Search(s).Count > 0)
+            {
+                return true;
+            }
+
+            var errorSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" ERR:");
+            errorPromptFound = errorSearcher.Search(s).Count > 0;
+            return errorPromptFound;
         }, timeout: effectiveTimeout, description: $"agent init prompt or success prompt [{counter.Value} OK] $");
+
+        if (errorPromptFound)
+        {
+            throw new InvalidOperationException($"Command failed while waiting for agent init prompt or success prompt [{counter.Value} OK].");
+        }
 
         if (!agentInitFound)
         {
@@ -482,16 +497,8 @@ internal static class Hex1bAutomatorTestHelpers
 
         await auto.WaitAsync(500);
         await auto.TypeAsync("n");
-
-        await auto.WaitUntilAsync(s =>
-        {
-            var successSearcher = new CellPatternSearcher()
-                .FindPattern(counter.Value.ToString())
-                .RightText(" OK] $ ");
-            return successSearcher.Search(s).Count > 0;
-        }, timeout: effectiveTimeout, description: $"success prompt [{counter.Value} OK] $ after agent init");
-
-        counter.Increment();
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, effectiveTimeout);
     }
 
     /// <summary>

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -459,6 +459,7 @@ internal static class Hex1bAutomatorTestHelpers
             .Find("configure AI agent environments");
 
         var agentInitFound = false;
+        var agentInitPromptRequiresEnter = false;
         var errorPromptFound = false;
 
         // Wait for either the agent init prompt (new CLI) or the success prompt (old CLI).
@@ -467,6 +468,10 @@ internal static class Hex1bAutomatorTestHelpers
             if (agentInitPrompt.Search(s).Count > 0)
             {
                 agentInitFound = true;
+                agentInitPromptRequiresEnter = new CellPatternSearcher()
+                    .Find("[Y/n]")
+                    .RightText(": ")
+                    .Search(s).Count > 0;
                 return true;
             }
             var successSearcher = new CellPatternSearcher()
@@ -497,7 +502,11 @@ internal static class Hex1bAutomatorTestHelpers
 
         await auto.WaitAsync(500);
         await auto.TypeAsync("n");
-        await auto.EnterAsync();
+        if (agentInitPromptRequiresEnter)
+        {
+            await auto.EnterAsync();
+        }
+
         await auto.WaitForSuccessPromptFailFastAsync(counter, effectiveTimeout);
     }
 

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -487,11 +487,11 @@ internal static class Hex1bAutomatorTestHelpers
                 .RightText(" ERR:");
             errorPromptFound = errorSearcher.Search(s).Count > 0;
             return errorPromptFound;
-        }, timeout: effectiveTimeout, description: $"agent init prompt or success prompt [{counter.Value} OK] $");
+        }, timeout: effectiveTimeout, description: $"agent init prompt, success prompt [{counter.Value} OK] $, or error prompt [{counter.Value} ERR:*] $");
 
         if (errorPromptFound)
         {
-            throw new InvalidOperationException($"Command failed while waiting for agent init prompt or success prompt [{counter.Value} OK].");
+            throw new InvalidOperationException($"Command failed with error prompt [{counter.Value} ERR:*] while waiting for the agent init prompt or success prompt.");
         }
 
         if (!agentInitFound)


### PR DESCRIPTION
## Description

Adds CLI E2E smoke coverage that verifies the latest CLI can create, start, and stop stable-channel empty AppHosts for both C# and TypeScript. This covers the daily CLI compatibility scenario for testing a current CLI against the latest stable AppHost.

The change also adds reusable direct `aspire new` helpers for C# and TypeScript empty AppHosts. While adding TypeScript coverage, this exposed that guest-language scaffolding was preparing its temporary AppHost server before persisting the resolved template SDK/channel inputs; that meant `--channel stable` could be overwritten by the current/global CLI channel. The scaffolding context now carries the resolved SDK/channel and persists them before preparation so TypeScript AppHosts use the requested stable SDK.

Validation:
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.NewCommandWithTypeScriptEmptyTemplatePassesResolvedVersionAndChannelToScaffolding" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true" --hangdump --hangdump-timeout 5m`
- `./localhive.sh -o /tmp/aspire-e2e-cli-compat -r linux-arm64 --archive`
- `ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e-cli-compat.tar.gz dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj --no-launch-profile -- --filter-method "*.LatestCliCanStartStableChannelTypeScriptAppHost" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true" --hangdump --hangdump-timeout 15m`
- `ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e-cli-compat.tar.gz dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj --no-launch-profile -- --filter-method "*.LatestCliCanStartStableChannelAppHost" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true" --hangdump --hangdump-timeout 15m`
- `git diff --check`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
