### PR TITLE
Use internal feed for extension Yarn tarballs

### DIFF
--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -4481,7 +4481,7 @@ pluralize@^8.0.0:
 
 postcss@8.5.10, postcss@^7.0.16:
   version "8.5.10"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/postcss/-/postcss-8.5.10.tgz"
   integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
   dependencies:
     nanoid "^3.3.11"
@@ -5676,7 +5676,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
 
 uuid@14.0.0, uuid@^8.3.0:
   version "14.0.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-14.0.0.tgz"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 v8-compile-cache-lib@^3.0.1:


### PR DESCRIPTION
## Description

PR #16489 correctly added Yarn `resolutions` for `postcss@8.5.10` and `uuid@14.0.0`, but the regenerated `extension/yarn.lock` pinned those two tarballs to `https://registry.npmjs.org/` while the extension's `.npmrc` and `.yarnrc` point installs at the internal dotnet-public npm feed.

This updates the two new `extension/yarn.lock` `resolved` URLs to use `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/`, matching the rest of the extension Yarn lockfile. This prevents Yarn v1 from bypassing the internal feed during package fetches.

Validation:

- Verified `extension/yarn.lock` was the only Yarn lockfile with `registry.npmjs.org` tarball URLs, and those were the `postcss` and `uuid` entries introduced by PR #16489.
- Verified no `resolved "https://registry.npmjs.org/` entries remain in repository `yarn.lock` files.
- Ran `YARN_CACHE_FOLDER=... yarn install --frozen-lockfile --non-interactive --ignore-scripts` from `extension/`.

**Only approve and merge after https://dev.azure.com/dnceng/internal/_build/results?buildId=2961968&view=results succeeds**

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No (lockfile URL-only change; validation is via lockfile invariant and frozen Yarn install)
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
