### PR TITLE
Update VS Code walkthrough AppHost examples

### DIFF
--- a/extension/walkthrough/createProject.md
+++ b/extension/walkthrough/createProject.md
@@ -2,11 +2,13 @@
 
 [Create a new Aspire project](command:aspire-vscode.new) to scaffold a new solution from a starter template.
 The starter template gives you:
-- An **apphost** that orchestrates your services, connections, and startup order
+- An **AppHost** that orchestrates your services, connections, and startup order
 - A sample **API service** with health checks
 - A **web frontend** that references the API
 
-**The apphost** is the heart of your app — it defines everything in code:
+**The AppHost** is the heart of your app. It defines your application topology in code across supported stacks.
+
+### C# AppHost
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -14,16 +16,39 @@ var apiService = builder.AddProject<Projects.AspireApp_ApiService>("apiservice")
     .WithHttpHealthCheck("/health");
 builder.AddProject<Projects.AspireApp_Web>("webfrontend")
     .WithExternalHttpEndpoints()
-    .WithReference(apiService)    // web app can call the API
-    .WaitFor(apiService);         // start API first
+    .WithReference(apiService)
+    .WaitFor(apiService);
 builder.Build().Run();
 ```
 
-| Method | What it does |
+### TypeScript AppHost
+
+```typescript
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const api = await builder
+    .addNodeApp("api", "./api", "src/index.ts")
+    .withHttpEndpoint({ env: "PORT" })
+    .withHttpHealthCheck({ path: "/health" });
+
+await builder
+    .addViteApp("frontend", "./frontend")
+    .withExternalHttpEndpoints()
+    .withReference(api)
+    .waitFor(api);
+
+await builder.build().run();
+```
+
+The examples above start with C# and TypeScript. The Aspire extension also recognizes `apphost.js`, and this walkthrough can grow with additional language examples as more Aspire AppHost templates and docs are added.
+
+| Concept | What it does |
 |---|---|
-| `AddProject` | Registers a service |
-| `WithReference` | Connects services |
-| `WaitFor` | Controls startup order |
-| `WithHttpHealthCheck` | Monitors health |
+| Register a resource | Adds a service, app, container, database, or other resource to the AppHost |
+| Reference a resource | Connects one resource to another so connection details flow through the app model |
+| Wait for a resource | Controls startup order so dependencies are ready before dependents start |
+| Add a health check | Monitors whether a service is ready and healthy |
 
 Your application topology is defined in code, making it easy to understand, modify, and version control. [Learn more on aspire.dev](https://aspire.dev/get-started/first-app/)

--- a/extension/walkthrough/createProject.md
+++ b/extension/walkthrough/createProject.md
@@ -43,7 +43,6 @@ await builder
 await builder.build().run();
 ```
 
-The examples above show C# and TypeScript AppHosts. JavaScript AppHosts such as `apphost.js` use the same model and are also recognized by the Aspire extension.
 
 | Concept | What it does |
 |---|---|

--- a/extension/walkthrough/createProject.md
+++ b/extension/walkthrough/createProject.md
@@ -42,7 +42,7 @@ await builder
 await builder.build().run();
 ```
 
-The examples above start with C# and TypeScript. The Aspire extension also recognizes `apphost.js`, and this walkthrough can grow with additional language examples as more Aspire AppHost templates and docs are added.
+The examples above show example C# and TypeScript apphosts. The Aspire extension also recognizes `apphost.js`.
 
 | Concept | What it does |
 |---|---|

--- a/extension/walkthrough/createProject.md
+++ b/extension/walkthrough/createProject.md
@@ -43,7 +43,6 @@ await builder
 await builder.build().run();
 ```
 
-
 | Concept | What it does |
 |---|---|
 | Register a resource | Adds a service, app, container, database, or other resource to the AppHost |

--- a/extension/walkthrough/createProject.md
+++ b/extension/walkthrough/createProject.md
@@ -42,7 +42,7 @@ await builder
 await builder.build().run();
 ```
 
-The examples above show example C# and TypeScript apphosts. The Aspire extension also recognizes `apphost.js`.
+The examples above show C# and TypeScript AppHosts. The Aspire extension also recognizes `apphost.js`.
 
 | Concept | What it does |
 |---|---|

--- a/extension/walkthrough/createProject.md
+++ b/extension/walkthrough/createProject.md
@@ -13,12 +13,15 @@ The starter template gives you:
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
+
 var apiService = builder.AddProject<Projects.AspireApp_ApiService>("apiservice")
     .WithHttpHealthCheck("/health");
+
 builder.AddProject<Projects.AspireApp_Web>("webfrontend")
     .WithExternalHttpEndpoints()
     .WithReference(apiService)
     .WaitFor(apiService);
+
 builder.Build().Run();
 ```
 

--- a/extension/walkthrough/createProject.md
+++ b/extension/walkthrough/createProject.md
@@ -1,7 +1,8 @@
 # Create your first Aspire app
 
-[Create a new Aspire project](command:aspire-vscode.new) to scaffold a new solution from a starter template.
+[Create a new Aspire project](command:aspire-vscode.new) to scaffold a new Aspire application from a starter template.
 The starter template gives you:
+
 - An **AppHost** that orchestrates your services, connections, and startup order
 - A sample **API service** with health checks
 - A **web frontend** that references the API
@@ -42,7 +43,7 @@ await builder
 await builder.build().run();
 ```
 
-The examples above show C# and TypeScript AppHosts. The Aspire extension also recognizes `apphost.js`.
+The examples above show C# and TypeScript AppHosts. JavaScript AppHosts such as `apphost.js` use the same model and are also recognized by the Aspire extension.
 
 | Concept | What it does |
 |---|---|

--- a/extension/walkthrough/runApp.md
+++ b/extension/walkthrough/runApp.md
@@ -1,26 +1,27 @@
 # Run your app
 
-Use the **Run AppHost** or **Debug AppHost** buttons in the sidebar, or run the commands from the Command Palette. You can also right-click an AppHost in the Aspire view.
+Use the **Run AppHost** or **Debug AppHost** buttons in the sidebar, run the commands from the Command Palette, or right-click an AppHost in the Aspire view.
 
-When you run, the extension:
-1. Discovers the AppHost project in your workspace
-2. Builds your solution
+When you run your app, the extension:
+
+1. Discovers the AppHost in your workspace
+2. Builds the app when needed
 3. Launches all services in the correct order
 4. Opens the **Aspire Dashboard** for real-time monitoring
 
 ### Debugging
-When you **debug** instead of run, the extension attaches debuggers to your services automatically — set breakpoints in any project and they'll be hit as requests flow through your app.
+When you **debug** instead of run, the extension attaches debuggers to supported services automatically. Set breakpoints in your code and they'll be hit as requests flow through your app.
 
 ### Editor indicators
 While your app is running, the extension shows live resource status directly in your AppHost source file:
 
-- **Gutter icons** — distinct shapes in the editor gutter next to each resource definition show state at a glance: a green **✓** checkmark for running healthy, a yellow **⚠** triangle for unhealthy or degraded, a red **✕** for errors, a blue **⌛** hourglass for starting or waiting, and a grey **○** circle for not yet started.
-- **Code lens** — inline labels above each resource show the current state and health (e.g. "Running - (Unhealthy 0/1)", "Not Started", "Waiting") along with quick actions like Restart, Stop, Start, and Logs.
+- **Gutter icons** — distinct shapes in the editor gutter next to each resource definition show state at a glance: a green **✓** checkmark for running and healthy, a yellow **⚠** triangle for unhealthy or degraded, a red **✕** for errors, a blue **⌛** hourglass for starting or waiting, and a grey **○** circle for not yet started.
+- **CodeLens** — inline labels above each resource show the current state and health (e.g. "Running - (Unhealthy 0/1)", "Not Started", "Waiting") along with quick actions like Restart, Stop, Start, and Logs.
 
-![Editor showing gutter icons and code lens labels for resources in different states](../resources/editor-indicators-dark.png)
+![Editor showing gutter icons and CodeLens labels for resources in different states](../resources/editor-indicators-dark.png)
 
 ### The dashboard
-Once running, the dashboard shows all your resources, endpoints, logs, traces, and metrics in one place:
+Once your app is running, the dashboard shows all your resources, endpoints, logs, traces, and metrics in one place:
 
 ![Aspire dashboard showing running resources](../resources/aspire-dashboard-dark.png)
 

--- a/extension/walkthrough/runApp.md
+++ b/extension/walkthrough/runApp.md
@@ -1,9 +1,9 @@
 # Run your app
 
-Use the **Run apphost** or **Debug apphost** buttons in the sidebar, or run the commands from the Command Palette. You can also right-click an apphost in the Aspire view.
+Use the **Run AppHost** or **Debug AppHost** buttons in the sidebar, or run the commands from the Command Palette. You can also right-click an AppHost in the Aspire view.
 
 When you run, the extension:
-1. Discovers the apphost project in your workspace
+1. Discovers the AppHost project in your workspace
 2. Builds your solution
 3. Launches all services in the correct order
 4. Opens the **Aspire Dashboard** for real-time monitoring
@@ -12,7 +12,7 @@ When you run, the extension:
 When you **debug** instead of run, the extension attaches debuggers to your services automatically — set breakpoints in any project and they'll be hit as requests flow through your app.
 
 ### Editor indicators
-While your app is running, the extension shows live resource status directly in your apphost source file:
+While your app is running, the extension shows live resource status directly in your AppHost source file:
 
 - **Gutter icons** — distinct shapes in the editor gutter next to each resource definition show state at a glance: a green **✓** checkmark for running healthy, a yellow **⚠** triangle for unhealthy or degraded, a red **✕** for errors, a blue **⌛** hourglass for starting or waiting, and a grey **○** circle for not yet started.
 - **Code lens** — inline labels above each resource show the current state and health (e.g. "Running - (Unhealthy 0/1)", "Not Started", "Waiting") along with quick actions like Restart, Stop, Start, and Logs.

--- a/extension/walkthrough/welcome.md
+++ b/extension/walkthrough/welcome.md
@@ -1,6 +1,6 @@
 # Welcome to Aspire
 
-Aspire streamlines building, running, debugging, and deploying distributed apps. Define your services, databases, and frontends in code — then launch and debug everything with a single command.
+Aspire streamlines building, running, debugging, and deploying distributed apps. Define your services, databases, and front ends in code — then launch and debug everything with a single command.
 
 ### Key benefits
 
@@ -12,7 +12,7 @@ Aspire streamlines building, running, debugging, and deploying distributed apps.
 
 ### How it works
 
-1. Define your services and their connections in an **AppHost** project
+1. Define your services and their connections in an **AppHost**
 2. Run everything locally with a single command
 3. Monitor it all through the **Aspire Dashboard**
 4. Deploy the same architecture definition to production

--- a/extension/walkthrough/welcome.md
+++ b/extension/walkthrough/welcome.md
@@ -12,7 +12,7 @@ Aspire streamlines building, running, debugging, and deploying distributed apps.
 
 ### How it works
 
-1. Define your services and their connections in an **apphost** project
+1. Define your services and their connections in an **AppHost** project
 2. Run everything locally with a single command
 3. Monitor it all through the **Aspire Dashboard**
 4. Deploy the same architecture definition to production


### PR DESCRIPTION
## Description

Updates the VS Code extension walkthrough so the first-app flow matches Aspire's polyglot positioning instead of reading as C#-only.

Summary:

- Keeps the C# AppHost example, but labels it explicitly.
- Adds a TypeScript AppHost example using the generated TypeScript API shape.
- Notes JavaScript AppHost support through `apphost.js` without making the listed examples sound final.
- Replaces the C# method-name table with language-neutral AppHost concepts.
- Polishes walkthrough copy for AppHost casing, CodeLens terminology, Markdown list formatting, and less C#-centric wording.

Validation:

- Ran `git diff --check microsoft/main...HEAD -- extension/walkthrough`
- Reviewed all walkthrough Markdown pages for grammar, terminology, and polyglot consistency

Fixes #16256

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
