### PR TITLE
Route extension CLI logs to output channel

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -28,6 +28,9 @@
     <trans-unit id="aspire-vscode.strings.aspireOutputChannelName">
       <source xml:lang="en">Aspire Extension</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.aspireCliLogsChannelName">
+      <source xml:lang="en">Aspire Extension - CLI Logs</source>
+    </trans-unit>
     <trans-unit id="aspire-vscode.strings.aspireHostingSdkVersion">
       <source xml:lang="en">Aspire Hosting SDK Version: {0}.</source>
     </trans-unit>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -66,6 +66,7 @@
 	"aspire-vscode.strings.aspireTerminalName": "Aspire terminal",
 	"aspire-vscode.strings.rpcServerError": "RPC server error: {0}.",
 	"aspire-vscode.strings.aspireOutputChannelName": "Aspire Extension",
+	"aspire-vscode.strings.aspireCliLogsChannelName": "Aspire Extension - CLI Logs",
 	"aspire-vscode.strings.fieldRequired": "This field is required.",
   "aspire-vscode.strings.runProject": "Run {0}",
 	"aspire-vscode.strings.debugProject": "Debug {0}",

--- a/extension/src/debugger/languages/cli.ts
+++ b/extension/src/debugger/languages/cli.ts
@@ -1,6 +1,6 @@
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { EnvVar } from "../../dcp/types";
-import { extensionLogOutputChannel } from "../../utils/logging";
+import { cliLogsOutputChannel } from "../../utils/logging";
 import { AspireTerminalProvider } from "../../utils/AspireTerminalProvider";
 import * as readline from 'readline';
 import * as vscode from 'vscode';
@@ -16,6 +16,25 @@ export interface SpawnProcessOptions {
     debugSessionId?: string,
     noDebug?: boolean;
     noExtensionVariables?: boolean;
+    logToCliOutputChannel?: boolean;
+}
+
+export function withCliLogOutputChannelArgs(args: readonly string[] = []): string[] {
+    const delimiterIndex = args.indexOf('--');
+    const insertionIndex = delimiterIndex === -1 ? args.length : delimiterIndex;
+    const cliArgs = args.slice(0, insertionIndex);
+    const forwardedArgs = args.slice(insertionIndex);
+    const updatedArgs = [...cliArgs];
+
+    if (!cliArgs.includes('--debug')) {
+        updatedArgs.push('--debug');
+    }
+
+    if (!cliArgs.includes('--no-log-file')) {
+        updatedArgs.push('--no-log-file');
+    }
+
+    return [...updatedArgs, ...forwardedArgs];
 }
 
 export function spawnCliProcess(terminalProvider: AspireTerminalProvider, command: string, args?: string[], options?: SpawnProcessOptions): ChildProcessWithoutNullStreams {
@@ -25,6 +44,10 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
     Object.assign(env, terminalProvider.createEnvironment(options?.debugSessionId, options?.noDebug, options?.noExtensionVariables));
     if (options?.env) {
         Object.assign(env, Object.fromEntries(options.env.map(e => [e.name, e.value])));
+    }
+    if (options?.logToCliOutputChannel) {
+        args = withCliLogOutputChannelArgs(args);
+        cliLogsOutputChannel.appendLine(`Spawning CLI process with command: ${command} ${args.join(' ')} in directory: ${workingDirectory}`);
     }
 
     const child = spawn(command, args ?? [], {
@@ -45,14 +68,24 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
     });
 
     child.stderr.on("data", (data) => {
-        options?.stderrCallback?.(new String(data).toString());
+        const text = new String(data).toString();
+        options?.stderrCallback?.(text);
+        if (options?.logToCliOutputChannel) {
+            cliLogsOutputChannel.append(text);
+        }
     });
 
     child.on('error', (error) => {
+        if (options?.logToCliOutputChannel) {
+            cliLogsOutputChannel.appendLine(`CLI process error: ${error.message} (command: ${command} ${(args ?? []).join(' ')})`);
+        }
         options?.errorCallback?.(error);
     });
 
     child.on("close", (code) => {
+        if (options?.logToCliOutputChannel) {
+            cliLogsOutputChannel.appendLine(`CLI process exited with code ${code} (command: ${command} ${(args ?? []).join(' ')})`);
+        }
         options?.exitCallback?.(code);
     });
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -34,6 +34,7 @@ import { AspireCodeLensProvider } from './editor/AspireCodeLensProvider';
 import { AspireGutterDecorationProvider } from './editor/AspireGutterDecorationProvider';
 import { getSupportedLanguageIds } from './editor/parsers/AppHostResourceParser';
 import { readGitCommitSha } from './utils/versionInfo';
+import { clearCliPathCache } from './utils/cliPath';
 
 let aspireExtensionContext = new AspireExtensionContext();
 
@@ -120,6 +121,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Activate the data repository (starts workspace describe --follow; global polling begins when the panel is visible)
   dataRepository.activate();
+
+  context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
+    if (e.affectsConfiguration('aspire.aspireCliExecutablePath')) {
+      clearCliPathCache();
+    }
+  }));
 
   context.subscriptions.push(appHostTreeView, refreshRunningAppHostsRegistration, switchToGlobalViewRegistration, switchToWorkspaceViewRegistration, openDashboardRegistration, openAppHostSourceRegistration, stopAppHostRegistration, stopResourceRegistration, startResourceRegistration, restartResourceRegistration, viewResourceLogsRegistration, executeResourceCommandRegistration, copyEndpointUrlRegistration, openInExternalBrowserRegistration, openInIntegratedBrowserRegistration, copyResourceNameRegistration, copyPidRegistration, copyAppHostPathRegistration, expandAllRegistration, { dispose: () => { appHostTreeProvider.dispose(); dataRepository.dispose(); } });
 

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -21,6 +21,7 @@ export const aspireCliVersion = (version: string) => vscode.l10n.t('Aspire CLI V
 export const requiredCapability = (capability: string) => vscode.l10n.t('Required capability: {0}.', capability);
 export const aspireTerminalName = vscode.l10n.t('Aspire terminal');
 export const aspireOutputChannelName = vscode.l10n.t('Aspire Extension');
+export const aspireCliLogsChannelName = vscode.l10n.t('Aspire Extension - CLI Logs');
 export const fieldRequired = vscode.l10n.t('This field is required.');
 export const runProject = (projectName: string) => vscode.l10n.t('Run {0}', projectName);
 export const debugProject = (projectName: string) => vscode.l10n.t('Debug {0}', projectName);

--- a/extension/src/test/cli.test.ts
+++ b/extension/src/test/cli.test.ts
@@ -1,7 +1,17 @@
 import * as assert from 'assert';
-import { withCliLogOutputChannelArgs } from '../debugger/languages/cli';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { spawnCliProcess, withCliLogOutputChannelArgs } from '../debugger/languages/cli';
+import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+import { cliLogsOutputChannel } from '../utils/logging';
 
 suite('debugger/languages/cli tests', () => {
+    teardown(() => {
+        sinon.restore();
+    });
+
     test('adds logging args when none are provided', () => {
         assert.deepStrictEqual(withCliLogOutputChannelArgs(), ['--debug', '--no-log-file']);
     });
@@ -22,5 +32,56 @@ suite('debugger/languages/cli tests', () => {
         const args = ['run', '--debug', '--', '--applicationArg'];
 
         assert.deepStrictEqual(withCliLogOutputChannelArgs(args), ['run', '--debug', '--no-log-file', '--', '--applicationArg']);
+    });
+
+    test('routes stderr from logged CLI processes to the CLI logs output channel without logging stdout', async () => {
+        const append = sinon.stub(cliLogsOutputChannel, 'append');
+        const appendLine = sinon.stub(cliLogsOutputChannel, 'appendLine');
+        const terminalProvider = {
+            createEnvironment: () => ({ PATH: process.env.PATH ?? '' })
+        } as unknown as AspireTerminalProvider;
+        const stdout: string[] = [];
+        const stderr: string[] = [];
+        const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-cli-test-'));
+
+        try {
+            const scriptPath = path.join(tempDirectory, process.platform === 'win32' ? 'write-output.cmd' : 'write-output.sh');
+            fs.writeFileSync(
+                scriptPath,
+                process.platform === 'win32'
+                    ? '@echo off\r\nset /p dummy=stdout from cli<nul\r\nset /p dummy=stderr from cli<nul 1>&2\r\n'
+                    : "#!/bin/sh\nprintf 'stdout from cli'\nprintf 'stderr from cli' >&2\n");
+            fs.chmodSync(scriptPath, 0o755);
+            const command = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : '/bin/sh';
+            const args = process.platform === 'win32' ? ['/d', '/s', '/c', scriptPath] : [scriptPath];
+
+            const exitCode = await new Promise<number | null>((resolve, reject) => {
+                spawnCliProcess(
+                    terminalProvider,
+                    command,
+                    args,
+                    {
+                        workingDirectory: process.cwd(),
+                        logToCliOutputChannel: true,
+                        stdoutCallback: data => stdout.push(data),
+                        stderrCallback: data => stderr.push(data),
+                        exitCallback: resolve,
+                        errorCallback: reject,
+                    });
+            });
+
+            assert.strictEqual(exitCode, 0);
+            assert.strictEqual(stdout.join(''), 'stdout from cli');
+            assert.strictEqual(stderr.join(''), 'stderr from cli');
+            assert.ok(append.calledWith('stderr from cli'), 'should write stderr to the CLI logs output channel');
+            assert.ok(!append.getCalls().some(call => String(call.args[0]).includes('stdout from cli')), 'should not write stdout to the CLI logs output channel');
+
+            const outputLines = appendLine.getCalls().map(call => String(call.args[0]));
+            assert.ok(outputLines.some(line => line.includes('Spawning CLI process') && line.includes('--debug') && line.includes('--no-log-file')), 'should log the spawned CLI command with output-channel logging args');
+            assert.ok(outputLines.some(line => line.includes('CLI process exited with code 0')), 'should log the spawned CLI process exit');
+        }
+        finally {
+            fs.rmSync(tempDirectory, { recursive: true, force: true });
+        }
     });
 });

--- a/extension/src/test/cli.test.ts
+++ b/extension/src/test/cli.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+import { withCliLogOutputChannelArgs } from '../debugger/languages/cli';
+
+suite('debugger/languages/cli tests', () => {
+    test('adds logging args when none are provided', () => {
+        assert.deepStrictEqual(withCliLogOutputChannelArgs(), ['--debug', '--no-log-file']);
+    });
+
+    test('inserts logging args before the forwarded app args delimiter', () => {
+        const args = ['run', '--apphost', '/repo/AppHost.csproj', '--', '--applicationArg'];
+
+        assert.deepStrictEqual(withCliLogOutputChannelArgs(args), ['run', '--apphost', '/repo/AppHost.csproj', '--debug', '--no-log-file', '--', '--applicationArg']);
+    });
+
+    test('does not duplicate logging args that are already present before the delimiter', () => {
+        const args = ['run', '--debug', '--no-log-file', '--', '--applicationArg'];
+
+        assert.deepStrictEqual(withCliLogOutputChannelArgs(args), args);
+    });
+
+    test('adds only the missing logging arg before the delimiter', () => {
+        const args = ['run', '--debug', '--', '--applicationArg'];
+
+        assert.deepStrictEqual(withCliLogOutputChannelArgs(args), ['run', '--debug', '--no-log-file', '--', '--applicationArg']);
+    });
+});

--- a/extension/src/test/cli.test.ts
+++ b/extension/src/test/cli.test.ts
@@ -49,7 +49,7 @@ suite('debugger/languages/cli tests', () => {
             fs.writeFileSync(
                 scriptPath,
                 process.platform === 'win32'
-                    ? '@echo off\r\nset /p dummy=stdout from cli<nul\r\nset /p dummy=stderr from cli<nul 1>&2\r\n'
+                    ? '@echo off\r\nset /p dummy=stdout from cli<nul\r\nset /p dummy=stderr from cli<nul 1>&2\r\nexit /b 0\r\n'
                     : "#!/bin/sh\nprintf 'stdout from cli'\nprintf 'stderr from cli' >&2\n");
             fs.chmodSync(scriptPath, 0o755);
             const command = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : '/bin/sh';

--- a/extension/src/test/cliPath.test.ts
+++ b/extension/src/test/cliPath.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as os from 'os';
 import * as path from 'path';
-import { getDefaultCliInstallPaths, resolveCliPath, CliPathDependencies } from '../utils/cliPath';
+import { getDefaultCliInstallPaths, resolveCliPath, clearCliPathCache, CliPathDependencies } from '../utils/cliPath';
 
 const bundlePath = '/home/user/.aspire/bin/aspire';
 const globalToolPath = '/home/user/.dotnet/tools/aspire';
@@ -206,6 +206,41 @@ suite('utils/cliPath tests', () => {
             assert.strictEqual(result.source, 'default-install');
             assert.ok(setConfiguredPath.notCalled, 'should not re-set the path if it already matches');
         });
+
+        test('clearCliPathCache does not throw', () => {
+            clearCliPathCache();
+        });
+
+        test('coalesces concurrent resolutions for the same dependency set', async () => {
+            let releaseIsOnPath: (() => void) | undefined;
+            let signalIsOnPathStarted: (() => void) | undefined;
+            const isOnPathStarted = new Promise<void>(resolve => {
+                signalIsOnPathStarted = resolve;
+            });
+
+            const isOnPath = sinon.stub().callsFake(async () => {
+                signalIsOnPathStarted?.();
+                await new Promise<void>(resolveRelease => {
+                    releaseIsOnPath = resolveRelease;
+                });
+                return true;
+            });
+
+            const deps = createMockDeps({
+                isOnPath,
+            });
+
+            const firstResolution = resolveCliPath(deps);
+            await isOnPathStarted;
+            const secondResolution = resolveCliPath(deps);
+
+            assert.strictEqual(isOnPath.callCount, 1, 'should only run PATH probe once');
+            assert.ok(releaseIsOnPath, 'expected first resolution to be in progress');
+
+            releaseIsOnPath();
+
+            const [firstResult, secondResult] = await Promise.all([firstResolution, secondResolution]);
+            assert.deepStrictEqual(firstResult, secondResult);
+        });
     });
 });
-

--- a/extension/src/test/cliPath.test.ts
+++ b/extension/src/test/cliPath.test.ts
@@ -21,6 +21,10 @@ function createMockDeps(overrides: Partial<CliPathDependencies> = {}): CliPathDe
 }
 
 suite('utils/cliPath tests', () => {
+    teardown(() => {
+        clearCliPathCache();
+        sinon.restore();
+    });
 
     suite('getDefaultCliInstallPaths', () => {
         test('returns bundle path (~/.aspire/bin) as first entry', () => {
@@ -241,6 +245,99 @@ suite('utils/cliPath tests', () => {
 
             const [firstResult, secondResult] = await Promise.all([firstResolution, secondResolution]);
             assert.deepStrictEqual(firstResult, secondResult);
+        });
+
+        test('caches successful resolutions for the same dependency set', async () => {
+            const isOnPath = sinon.stub().resolves(true);
+            const deps = createMockDeps({
+                isOnPath,
+            });
+
+            const firstResult = await resolveCliPath(deps);
+            const secondResult = await resolveCliPath(deps);
+
+            assert.deepStrictEqual(firstResult, secondResult);
+            assert.strictEqual(isOnPath.callCount, 1, 'should reuse the cached CLI path resolution');
+        });
+
+        test('does not cache unavailable resolutions', async () => {
+            const isOnPath = sinon.stub();
+            isOnPath.onFirstCall().resolves(false);
+            isOnPath.onSecondCall().resolves(true);
+
+            const deps = createMockDeps({
+                isOnPath,
+                findAtDefaultPath: async () => undefined,
+            });
+
+            const unavailableResult = await resolveCliPath(deps);
+            const availableResult = await resolveCliPath(deps);
+
+            assert.strictEqual(unavailableResult.available, false);
+            assert.strictEqual(availableResult.available, true);
+            assert.strictEqual(availableResult.source, 'path');
+            assert.strictEqual(isOnPath.callCount, 2, 'should re-probe when the previous resolution was unavailable');
+        });
+
+        test('clearCliPathCache invalidates cached resolutions', async () => {
+            const isOnPath = sinon.stub();
+            isOnPath.onFirstCall().resolves(true);
+            isOnPath.onSecondCall().resolves(false);
+            const findAtDefaultPath = sinon.stub().resolves(bundlePath);
+
+            const deps = createMockDeps({
+                isOnPath,
+                findAtDefaultPath,
+            });
+
+            const firstResult = await resolveCliPath(deps);
+            const cachedResult = await resolveCliPath(deps);
+
+            assert.strictEqual(firstResult.source, 'path');
+            assert.strictEqual(cachedResult.source, 'path');
+            assert.strictEqual(isOnPath.callCount, 1, 'should use the cached result before invalidation');
+
+            clearCliPathCache();
+
+            const refreshedResult = await resolveCliPath(deps);
+
+            assert.strictEqual(refreshedResult.source, 'default-install');
+            assert.strictEqual(refreshedResult.cliPath, bundlePath);
+            assert.strictEqual(isOnPath.callCount, 2, 'should re-probe after cache invalidation');
+            assert.ok(findAtDefaultPath.calledOnce, 'should probe default paths after cache invalidation');
+        });
+
+        test('clearCliPathCache prevents stale in-flight resolutions from updating configuration', async () => {
+            let releaseFindAtDefaultPath: (() => void) | undefined;
+            let signalFindAtDefaultPathStarted: (() => void) | undefined;
+            const findAtDefaultPathStarted = new Promise<void>(resolve => {
+                signalFindAtDefaultPathStarted = resolve;
+            });
+            const setConfiguredPath = sinon.stub().resolves();
+
+            const deps = createMockDeps({
+                isOnPath: async () => false,
+                findAtDefaultPath: async () => {
+                    signalFindAtDefaultPathStarted?.();
+                    await new Promise<void>(resolveRelease => {
+                        releaseFindAtDefaultPath = resolveRelease;
+                    });
+                    return bundlePath;
+                },
+                setConfiguredPath,
+            });
+
+            const resolution = resolveCliPath(deps);
+            await findAtDefaultPathStarted;
+
+            clearCliPathCache();
+            assert.ok(releaseFindAtDefaultPath, 'expected CLI path resolution to be in progress');
+            releaseFindAtDefaultPath();
+
+            const result = await resolution;
+
+            assert.strictEqual(result.source, 'default-install');
+            assert.ok(setConfiguredPath.notCalled, 'should not update configuration from a stale resolution after cache invalidation');
         });
     });
 });

--- a/extension/src/utils/AspirePackageRestoreProvider.ts
+++ b/extension/src/utils/AspirePackageRestoreProvider.ts
@@ -189,6 +189,7 @@ export class AspirePackageRestoreProvider implements vscode.Disposable {
                 const proc = spawnCliProcess(this._terminalProvider, cliPath, ['restore'], {
                     workingDirectory: configDir,
                     noExtensionVariables: true,
+                    logToCliOutputChannel: true,
                     exitCallback: code => {
                         if (settled) { return; }
                         settled = true;

--- a/extension/src/utils/cliPath.ts
+++ b/extension/src/utils/cliPath.ts
@@ -9,6 +9,10 @@ import { extensionLogOutputChannel } from './logging';
 const execFileAsync = promisify(execFile);
 const fsAccessAsync = promisify(fs.access);
 
+let cachedCliPathResult: CliPathResolutionResult | undefined;
+const pendingCliPathResolutions = new WeakMap<CliPathDependencies, Promise<CliPathResolutionResult>>();
+let cliPathCacheGeneration = 0;
+
 /**
  * Gets the default installation paths for the Aspire CLI, in priority order.
  *
@@ -132,6 +136,71 @@ const defaultDependencies: CliPathDependencies = {
 };
 
 /**
+ * Clears the cached CLI path so the next resolveCliPath call re-probes.
+ */
+export function clearCliPathCache(): void {
+    cliPathCacheGeneration++;
+    cachedCliPathResult = undefined;
+    pendingCliPathResolutions.delete(defaultDependencies);
+}
+
+function shouldMutateConfiguration(useCache: boolean, cacheGeneration: number): boolean {
+    return !useCache || cacheGeneration === cliPathCacheGeneration;
+}
+
+function setCachedResultIfCurrent(result: CliPathResolutionResult, useCache: boolean, cacheGeneration: number): CliPathResolutionResult {
+    if (useCache && cacheGeneration === cliPathCacheGeneration) {
+        cachedCliPathResult = result;
+    }
+
+    return result;
+}
+
+async function resolveCliPathCore(deps: CliPathDependencies, useCache: boolean, cacheGeneration: number): Promise<CliPathResolutionResult> {
+    const configuredPath = deps.getConfiguredPath();
+    const defaultPaths = deps.getDefaultPaths();
+
+    // 1. Check if user has configured a custom path (not one of the defaults)
+    if (configuredPath && !defaultPaths.includes(configuredPath)) {
+        const isValid = await deps.tryExecute(configuredPath);
+        if (isValid) {
+            return setCachedResultIfCurrent({ cliPath: configuredPath, available: true, source: 'configured' }, useCache, cacheGeneration);
+        }
+
+        extensionLogOutputChannel.warn(`Configured CLI path is invalid: ${configuredPath}`);
+        // Continue to check other locations
+    }
+
+    // 2. Check if CLI is on PATH
+    const onPath = await deps.isOnPath();
+    if (onPath) {
+        // If we previously auto-set the path to a default install location, clear it
+        // since PATH is now working
+        if (defaultPaths.includes(configuredPath) && shouldMutateConfiguration(useCache, cacheGeneration)) {
+            extensionLogOutputChannel.info('Clearing aspireCliExecutablePath setting since CLI is on PATH');
+            await deps.setConfiguredPath('');
+        }
+
+        return setCachedResultIfCurrent({ cliPath: 'aspire', available: true, source: 'path' }, useCache, cacheGeneration);
+    }
+
+    // 3. Check default installation paths (~/.aspire/bin first, then ~/.dotnet/tools)
+    const foundPath = await deps.findAtDefaultPath();
+    if (foundPath) {
+        // Update the setting so future invocations use this path
+        if (configuredPath !== foundPath && shouldMutateConfiguration(useCache, cacheGeneration)) {
+            extensionLogOutputChannel.info('Updating aspireCliExecutablePath setting to use default install location');
+            await deps.setConfiguredPath(foundPath);
+        }
+
+        return setCachedResultIfCurrent({ cliPath: foundPath, available: true, source: 'default-install' }, useCache, cacheGeneration);
+    }
+
+    // 4. CLI not found anywhere. Don't cache so we re-probe next time.
+    return { cliPath: 'aspire', available: false, source: 'not-found' };
+}
+
+/**
  * Resolves the Aspire CLI path, checking multiple locations in order:
  * 1. User-configured path in VS Code settings
  * 2. System PATH
@@ -144,45 +213,28 @@ const defaultDependencies: CliPathDependencies = {
  * the setting is cleared to prefer PATH.
  */
 export async function resolveCliPath(deps: CliPathDependencies = defaultDependencies): Promise<CliPathResolutionResult> {
-    const configuredPath = deps.getConfiguredPath();
-    const defaultPaths = deps.getDefaultPaths();
+    const useCache = deps === defaultDependencies;
+    const cacheGeneration = cliPathCacheGeneration;
 
-    // 1. Check if user has configured a custom path (not one of the defaults)
-    if (configuredPath && !defaultPaths.includes(configuredPath)) {
-        const isValid = await deps.tryExecute(configuredPath);
-        if (isValid) {
-            return { cliPath: configuredPath, available: true, source: 'configured' };
-        }
-
-        extensionLogOutputChannel.warn(`Configured CLI path is invalid: ${configuredPath}`);
-        // Continue to check other locations
+    if (useCache && cachedCliPathResult) {
+        return cachedCliPathResult;
     }
 
-    // 2. Check if CLI is on PATH
-    const onPath = await deps.isOnPath();
-    if (onPath) {
-        // If we previously auto-set the path to a default install location, clear it
-        // since PATH is now working
-        if (defaultPaths.includes(configuredPath)) {
-            extensionLogOutputChannel.info('Clearing aspireCliExecutablePath setting since CLI is on PATH');
-            await deps.setConfiguredPath('');
-        }
-
-        return { cliPath: 'aspire', available: true, source: 'path' };
+    const pendingResolution = pendingCliPathResolutions.get(deps);
+    if (pendingResolution) {
+        return pendingResolution;
     }
 
-    // 3. Check default installation paths (~/.aspire/bin first, then ~/.dotnet/tools)
-    const foundPath = await deps.findAtDefaultPath();
-    if (foundPath) {
-        // Update the setting so future invocations use this path
-        if (configuredPath !== foundPath) {
-            extensionLogOutputChannel.info('Updating aspireCliExecutablePath setting to use default install location');
-            await deps.setConfiguredPath(foundPath);
+    const resolution = resolveCliPathCore(deps, useCache, cacheGeneration);
+    pendingCliPathResolutions.set(deps, resolution);
+
+    const clearPending = () => {
+        if (pendingCliPathResolutions.get(deps) === resolution) {
+            pendingCliPathResolutions.delete(deps);
         }
+    };
 
-        return { cliPath: foundPath, available: true, source: 'default-install' };
-    }
+    void resolution.then(clearPending, clearPending);
 
-    // 4. CLI not found anywhere
-    return { cliPath: 'aspire', available: false, source: 'not-found' };
+    return resolution;
 }

--- a/extension/src/utils/cliPath.ts
+++ b/extension/src/utils/cliPath.ts
@@ -9,8 +9,8 @@ import { extensionLogOutputChannel } from './logging';
 const execFileAsync = promisify(execFile);
 const fsAccessAsync = promisify(fs.access);
 
-let cachedCliPathResult: CliPathResolutionResult | undefined;
-const pendingCliPathResolutions = new WeakMap<CliPathDependencies, Promise<CliPathResolutionResult>>();
+let cachedCliPathResults = new WeakMap<CliPathDependencies, CliPathResolutionResult>();
+let pendingCliPathResolutions = new WeakMap<CliPathDependencies, Promise<CliPathResolutionResult>>();
 let cliPathCacheGeneration = 0;
 
 /**
@@ -140,23 +140,23 @@ const defaultDependencies: CliPathDependencies = {
  */
 export function clearCliPathCache(): void {
     cliPathCacheGeneration++;
-    cachedCliPathResult = undefined;
-    pendingCliPathResolutions.delete(defaultDependencies);
+    cachedCliPathResults = new WeakMap<CliPathDependencies, CliPathResolutionResult>();
+    pendingCliPathResolutions = new WeakMap<CliPathDependencies, Promise<CliPathResolutionResult>>();
 }
 
-function shouldMutateConfiguration(useCache: boolean, cacheGeneration: number): boolean {
-    return !useCache || cacheGeneration === cliPathCacheGeneration;
+function shouldMutateConfiguration(cacheGeneration: number): boolean {
+    return cacheGeneration === cliPathCacheGeneration;
 }
 
-function setCachedResultIfCurrent(result: CliPathResolutionResult, useCache: boolean, cacheGeneration: number): CliPathResolutionResult {
-    if (useCache && cacheGeneration === cliPathCacheGeneration) {
-        cachedCliPathResult = result;
+function setCachedResultIfCurrent(deps: CliPathDependencies, result: CliPathResolutionResult, cacheGeneration: number): CliPathResolutionResult {
+    if (cacheGeneration === cliPathCacheGeneration) {
+        cachedCliPathResults.set(deps, result);
     }
 
     return result;
 }
 
-async function resolveCliPathCore(deps: CliPathDependencies, useCache: boolean, cacheGeneration: number): Promise<CliPathResolutionResult> {
+async function resolveCliPathCore(deps: CliPathDependencies, cacheGeneration: number): Promise<CliPathResolutionResult> {
     const configuredPath = deps.getConfiguredPath();
     const defaultPaths = deps.getDefaultPaths();
 
@@ -164,7 +164,7 @@ async function resolveCliPathCore(deps: CliPathDependencies, useCache: boolean, 
     if (configuredPath && !defaultPaths.includes(configuredPath)) {
         const isValid = await deps.tryExecute(configuredPath);
         if (isValid) {
-            return setCachedResultIfCurrent({ cliPath: configuredPath, available: true, source: 'configured' }, useCache, cacheGeneration);
+            return setCachedResultIfCurrent(deps, { cliPath: configuredPath, available: true, source: 'configured' }, cacheGeneration);
         }
 
         extensionLogOutputChannel.warn(`Configured CLI path is invalid: ${configuredPath}`);
@@ -176,24 +176,24 @@ async function resolveCliPathCore(deps: CliPathDependencies, useCache: boolean, 
     if (onPath) {
         // If we previously auto-set the path to a default install location, clear it
         // since PATH is now working
-        if (defaultPaths.includes(configuredPath) && shouldMutateConfiguration(useCache, cacheGeneration)) {
+        if (defaultPaths.includes(configuredPath) && shouldMutateConfiguration(cacheGeneration)) {
             extensionLogOutputChannel.info('Clearing aspireCliExecutablePath setting since CLI is on PATH');
             await deps.setConfiguredPath('');
         }
 
-        return setCachedResultIfCurrent({ cliPath: 'aspire', available: true, source: 'path' }, useCache, cacheGeneration);
+        return setCachedResultIfCurrent(deps, { cliPath: 'aspire', available: true, source: 'path' }, cacheGeneration);
     }
 
     // 3. Check default installation paths (~/.aspire/bin first, then ~/.dotnet/tools)
     const foundPath = await deps.findAtDefaultPath();
     if (foundPath) {
         // Update the setting so future invocations use this path
-        if (configuredPath !== foundPath && shouldMutateConfiguration(useCache, cacheGeneration)) {
+        if (configuredPath !== foundPath && shouldMutateConfiguration(cacheGeneration)) {
             extensionLogOutputChannel.info('Updating aspireCliExecutablePath setting to use default install location');
             await deps.setConfiguredPath(foundPath);
         }
 
-        return setCachedResultIfCurrent({ cliPath: foundPath, available: true, source: 'default-install' }, useCache, cacheGeneration);
+        return setCachedResultIfCurrent(deps, { cliPath: foundPath, available: true, source: 'default-install' }, cacheGeneration);
     }
 
     // 4. CLI not found anywhere. Don't cache so we re-probe next time.
@@ -213,11 +213,11 @@ async function resolveCliPathCore(deps: CliPathDependencies, useCache: boolean, 
  * the setting is cleared to prefer PATH.
  */
 export async function resolveCliPath(deps: CliPathDependencies = defaultDependencies): Promise<CliPathResolutionResult> {
-    const useCache = deps === defaultDependencies;
     const cacheGeneration = cliPathCacheGeneration;
 
-    if (useCache && cachedCliPathResult) {
-        return cachedCliPathResult;
+    const cachedResult = cachedCliPathResults.get(deps);
+    if (cachedResult) {
+        return cachedResult;
     }
 
     const pendingResolution = pendingCliPathResolutions.get(deps);
@@ -225,7 +225,7 @@ export async function resolveCliPath(deps: CliPathDependencies = defaultDependen
         return pendingResolution;
     }
 
-    const resolution = resolveCliPathCore(deps, useCache, cacheGeneration);
+    const resolution = resolveCliPathCore(deps, cacheGeneration);
     pendingCliPathResolutions.set(deps, resolution);
 
     const clearPending = () => {

--- a/extension/src/utils/configInfoProvider.ts
+++ b/extension/src/utils/configInfoProvider.ts
@@ -45,7 +45,8 @@ export async function getConfigInfo(terminalProvider: AspireTerminalProvider): P
                 vscode.window.showErrorMessage(strings.errorGettingConfigInfo(error));
                 resolve(null);
             },
-            noExtensionVariables: true
+            noExtensionVariables: true,
+            logToCliOutputChannel: true
         });
     });
 }

--- a/extension/src/utils/logging.ts
+++ b/extension/src/utils/logging.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
-import { aspireOutputChannelName } from '../loc/strings';
+import { aspireCliLogsChannelName, aspireOutputChannelName } from '../loc/strings';
 
 export const extensionLogOutputChannel: vscode.LogOutputChannel = vscode.window.createOutputChannel(aspireOutputChannelName, { log: true });
+export const cliLogsOutputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(aspireCliLogsChannelName);
 
 export async function logAsyncOperation<T>(beforeMessage: string, afterMessage: (result: T) => string, operation: () => Promise<T>): Promise<T> {
     extensionLogOutputChannel.info( beforeMessage);

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -204,6 +204,7 @@ export async function checkForExistingAppHostPathInWorkspace(terminalProvider: A
                 }
             },
             noExtensionVariables: true,
+            logToCliOutputChannel: true,
             workingDirectory: rootFolder.uri.fsPath
         });
     })

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -223,6 +223,7 @@ export class AppHostDataRepository {
 
             this._getAppHostsProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                 noExtensionVariables: true,
+                logToCliOutputChannel: true,
                 workingDirectory: rootFolder.uri.fsPath,
                 lineCallback: (line) => {
                     try {
@@ -276,6 +277,7 @@ export class AppHostDataRepository {
             this._describeReceivedData = false;
             this._describeProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                 noExtensionVariables: true,
+                logToCliOutputChannel: true,
                 lineCallback: (line) => {
                     this._handleDescribeLine(line);
                 },
@@ -481,6 +483,7 @@ export class AppHostDataRepository {
 
         spawnCliProcess(this._terminalProvider, cliPath, args, {
             noExtensionVariables: true,
+            logToCliOutputChannel: true,
             stdoutCallback: (data) => { stdout += data; },
             stderrCallback: (data) => { stderr += data; },
             exitCallback: (code) => {

--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -5,7 +5,7 @@ using System.CommandLine;
 
 namespace Aspire.Cli;
 
-internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null)
+internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string? logFilePath, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null)
 {
     public DirectoryInfo WorkingDirectory { get; } = workingDirectory;
     public DirectoryInfo HivesDirectory { get; } = hivesDirectory;
@@ -24,9 +24,9 @@ internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, Direct
     public DirectoryInfo LogsDirectory { get; } = logsDirectory;
 
     /// <summary>
-    /// Gets the path to the current session's log file.
+    /// Gets the path to the current session's log file, or null when file logging is disabled.
     /// </summary>
-    public string LogFilePath { get; } = logFilePath;
+    public string? LogFilePath { get; } = logFilePath;
 
     public DirectoryInfo HomeDirectory { get; } = homeDirectory ?? new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
     public bool DebugMode { get; } = debugMode;

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -282,7 +282,11 @@ internal sealed class AddCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, ExitCodeConstants.FailedToAddPackage, ExecutionContext.LogFilePath));
+                InteractionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                    AddCommandStrings.PackageInstallationFailed,
+                    AddCommandStrings.PackageInstallationFailedWithoutLogFile,
+                    ExecutionContext.LogFilePath,
+                    ExitCodeConstants.FailedToAddPackage));
                 return ExitCodeConstants.FailedToAddPackage;
             }
 

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -368,7 +368,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         if (hasErrors)
         {
             _interactionService.DisplayMessage(KnownEmojis.Warning, AgentCommandStrings.ConfigurationCompletedWithErrors);
-            _interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
+            CommandInteractionHelpers.DisplaySeeLogsMessage(_interactionService, ExecutionContext.LogFilePath);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/CommandInteractionHelpers.cs
+++ b/src/Aspire.Cli/Commands/CommandInteractionHelpers.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+
+namespace Aspire.Cli.Commands;
+
+internal static class CommandInteractionHelpers
+{
+    internal static void DisplaySeeLogsMessage(IInteractionService interactionService, string? logFilePath)
+    {
+        if (logFilePath is not null)
+        {
+            interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, logFilePath));
+        }
+    }
+}

--- a/src/Aspire.Cli/Commands/CommandInteractionHelpers.cs
+++ b/src/Aspire.Cli/Commands/CommandInteractionHelpers.cs
@@ -9,6 +9,27 @@ namespace Aspire.Cli.Commands;
 
 internal static class CommandInteractionHelpers
 {
+    internal static string FormatMessageWithOptionalLogFile(string messageWithLogFile, string messageWithoutLogFile, string? logFilePath)
+    {
+        return logFilePath is null
+            ? messageWithoutLogFile
+            : string.Format(CultureInfo.CurrentCulture, messageWithLogFile, logFilePath);
+    }
+
+    internal static string FormatMessageWithOptionalLogFile(string messageWithLogFile, string messageWithoutLogFile, string? logFilePath, params object?[] args)
+    {
+        if (logFilePath is null)
+        {
+            return string.Format(CultureInfo.CurrentCulture, messageWithoutLogFile, args);
+        }
+
+        var argsWithLogFile = new object?[args.Length + 1];
+        args.CopyTo(argsWithLogFile, 0);
+        argsWithLogFile[^1] = logFilePath;
+
+        return string.Format(CultureInfo.CurrentCulture, messageWithLogFile, argsWithLogFile);
+    }
+
     internal static void DisplaySeeLogsMessage(IInteractionService interactionService, string? logFilePath)
     {
         if (logFilePath is not null)

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -306,7 +306,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         };
     }
 
-    private void RenderDashboardSummary(DashboardInfo info, string logFilePath)
+    private void RenderDashboardSummary(DashboardInfo info, string? logFilePath)
     {
         _interactionService.DisplayEmptyLine();
         var grid = new Grid();
@@ -343,9 +343,12 @@ internal sealed class DashboardRunCommand : BaseCommand
         grid.AddRow(Text.Empty, Text.Empty);
 
         // Logs row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(logFilePath));
+        if (logFilePath is not null)
+        {
+            grid.AddRow(
+                new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
+                new Text(logFilePath));
+        }
 
         var padder = new Padder(grid, new Padding(3, 0));
         _interactionService.DisplayRenderable(padder);

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -306,9 +306,9 @@ internal sealed class DashboardRunCommand : BaseCommand
         };
     }
 
-    private void RenderDashboardSummary(DashboardInfo info, string? logFilePath)
+    internal static int RenderDashboardSummary(IInteractionService interactionService, DashboardInfo info, string? logFilePath)
     {
-        _interactionService.DisplayEmptyLine();
+        interactionService.DisplayEmptyLine();
         var grid = new Grid();
         grid.AddColumn();
         grid.AddColumn();
@@ -318,7 +318,11 @@ internal sealed class DashboardRunCommand : BaseCommand
         var otlpHttpLabel = DashboardCommandStrings.OtlpHttpLabel;
         var logsLabel = DashboardCommandStrings.LogsLabel;
 
-        var labels = new List<string> { dashboardLabel, otlpGrpcLabel, otlpHttpLabel, logsLabel };
+        var labels = new List<string> { dashboardLabel, otlpGrpcLabel, otlpHttpLabel };
+        if (logFilePath is not null)
+        {
+            labels.Add(logsLabel);
+        }
 
         var longestLabelLength = labels.Max(s => s.Length) + 1; // +1 for colon
         grid.Columns[0].Width = longestLabelLength;
@@ -351,7 +355,8 @@ internal sealed class DashboardRunCommand : BaseCommand
         }
 
         var padder = new Padder(grid, new Padding(3, 0));
-        _interactionService.DisplayRenderable(padder);
+        interactionService.DisplayRenderable(padder);
+        return longestLabelLength;
     }
 
     private async Task<int> ExecuteForegroundAsync(string managedPath, List<string> dashboardArgs, DashboardInfo dashboardInfo, IDictionary<string, string>? environmentVariables, CancellationToken cancellationToken)
@@ -450,7 +455,7 @@ internal sealed class DashboardRunCommand : BaseCommand
                 : DashboardCommandStrings.DashboardStartTimedOut;
 
             _interactionService.DisplayError(exitMessage);
-            _interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
+            CommandInteractionHelpers.DisplaySeeLogsMessage(_interactionService, ExecutionContext.LogFilePath);
 
             if (!process.HasExited)
             {
@@ -461,7 +466,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         }
 
         // Dashboard is ready.
-        RenderDashboardSummary(dashboardInfo, ExecutionContext.LogFilePath);
+        RenderDashboardSummary(_interactionService, dashboardInfo, ExecutionContext.LogFilePath);
         _interactionService.DisplayEmptyLine();
 
         try

--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -243,7 +243,10 @@ internal class ExecCommand : BaseCommand
                 if (result != 0)
                 {
                     InteractionService.DisplayLines(runOutputCollector.GetLines());
-                    InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, RunCommandStrings.ProjectCouldNotBeRun, ExecutionContext.LogFilePath));
+                    InteractionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                        RunCommandStrings.ProjectCouldNotBeRun,
+                        RunCommandStrings.ProjectCouldNotBeRunWithoutLogFile,
+                        ExecutionContext.LogFilePath));
                     return result;
                 }
                 else
@@ -254,7 +257,10 @@ internal class ExecCommand : BaseCommand
             else
             {
                 InteractionService.DisplayLines(runOutputCollector.GetLines());
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, RunCommandStrings.ProjectCouldNotBeRun, ExecutionContext.LogFilePath));
+                InteractionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                    RunCommandStrings.ProjectCouldNotBeRun,
+                    RunCommandStrings.ProjectCouldNotBeRunWithoutLogFile,
+                    ExecutionContext.LogFilePath));
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
         }

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -158,7 +158,10 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             var polyglotResult = await CreatePolyglotAppHostAsync(languageInfo, cancellationToken);
             if (polyglotResult != 0)
             {
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
+                InteractionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                    InteractionServiceStrings.ProjectCouldNotBeCreated,
+                    InteractionServiceStrings.ProjectCouldNotBeCreatedWithoutLogFile,
+                    ExecutionContext.LogFilePath));
                 return polyglotResult;
             }
 
@@ -203,7 +206,10 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         if (initResult != 0)
         {
-            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
+            InteractionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                InteractionServiceStrings.ProjectCouldNotBeCreated,
+                InteractionServiceStrings.ProjectCouldNotBeCreatedWithoutLogFile,
+                ExecutionContext.LogFilePath));
             return initResult;
         }
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -394,7 +394,10 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             if (!resolveResult.Success)
             {
                 InteractionService.DisplayError(resolveResult.ErrorMessage);
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
+                InteractionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                    InteractionServiceStrings.ProjectCouldNotBeCreated,
+                    InteractionServiceStrings.ProjectCouldNotBeCreatedWithoutLogFile,
+                    ExecutionContext.LogFilePath));
                 return ExitCodeConstants.InvalidCommand;
             }
 

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -68,9 +68,19 @@ internal sealed class RootCommand : BaseRootCommand
         DefaultValueFactory = _ => false
     };
 
+    public static readonly Option<bool> NoLogFileOption = new(CommonOptionNames.NoLogFile)
+    {
+        Description = RootCommandStrings.NoLogFileArgumentDescription,
+        Recursive = true,
+        Hidden = true,
+        DefaultValueFactory = _ => false
+    };
+
     /// <summary>
     /// Global options that should be passed through to child CLI processes when spawning.
     /// Add new global options here to ensure they are forwarded during detached mode execution.
+    /// Options like <c>--no-log-file</c> are intentionally excluded because detached launches
+    /// always provision an explicit child log file for startup diagnostics.
     /// </summary>
     private static readonly (Option Option, Func<ParseResult, string[]?> GetArgs)[] s_childProcessOptions =
     [
@@ -181,6 +191,7 @@ internal sealed class RootCommand : BaseRootCommand
         Options.Add(BannerOption);
         Options.Add(WaitForDebuggerOption);
         Options.Add(CliWaitForDebuggerOption);
+        Options.Add(NoLogFileOption);
 
         // Handle standalone 'aspire' or 'aspire --banner' (no subcommand)
         this.SetAction((context, cancellationToken) =>

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -268,7 +268,10 @@ internal sealed class RunCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeBuilt, ExecutionContext.LogFilePath));
+                InteractionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                    InteractionServiceStrings.ProjectCouldNotBeBuilt,
+                    InteractionServiceStrings.ProjectCouldNotBeBuiltWithoutLogFile,
+                    ExecutionContext.LogFilePath));
                 return await pendingRun;
             }
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -423,8 +423,7 @@ internal sealed class RunCommand : BaseCommand
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ErrorConnectingToAppHost, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
-            // Don't display raw output - it's already in the log file
-            InteractionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
+            CommandInteractionHelpers.DisplaySeeLogsMessage(InteractionService, ExecutionContext.LogFilePath);
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
         catch (ConnectionLostException) when (isExtensionHost)
@@ -439,8 +438,7 @@ internal sealed class RunCommand : BaseCommand
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
-            // Don't display raw output - it's already in the log file
-            InteractionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
+            CommandInteractionHelpers.DisplaySeeLogsMessage(InteractionService, ExecutionContext.LogFilePath);
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
         finally
@@ -502,10 +500,14 @@ internal sealed class RunCommand : BaseCommand
         var pidLabel = RunCommandStrings.ProcessId;
 
         // Calculate column width based on labels that will actually be displayed
-        var labels = new List<string> { appHostLabel, logsLabel };
+        var labels = new List<string> { appHostLabel };
         if (!isExtensionHost)
         {
             labels.Add(dashboardLabel);
+        }
+        if (logFilePath is not null)
+        {
+            labels.Add(logsLabel);
         }
         if (pid.HasValue)
         {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -478,7 +478,7 @@ internal sealed class RunCommand : BaseCommand
     /// <param name="appHostRelativePath">The relative path to the AppHost file.</param>
     /// <param name="dashboardUrl">The dashboard URL with login token, or null if not available.</param>
     /// <param name="codespacesUrl">The codespaces URL with login token, or null if not in codespaces.</param>
-    /// <param name="logFilePath">The full path to the log file.</param>
+    /// <param name="logFilePath">The full path to the log file, or <see langword="null"/> to omit the logs row.</param>
     /// <param name="pid">The process ID to display, or null to omit the PID row.</param>
     /// <param name="isExtensionHost">Whether the AppHost is running in the Aspire extension.</param>
     /// <returns>The column width used, for subsequent grid additions.</returns>
@@ -487,7 +487,7 @@ internal sealed class RunCommand : BaseCommand
         string appHostRelativePath,
         string? dashboardUrl,
         string? codespacesUrl,
-        string logFilePath,
+        string? logFilePath,
         bool isExtensionHost,
         int? pid = null)
     {
@@ -546,9 +546,12 @@ internal sealed class RunCommand : BaseCommand
         }
 
         // Logs row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(logFilePath));
+        if (logFilePath is not null)
+        {
+            grid.AddRow(
+                new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
+                new Text(logFilePath));
+        }
 
         // PID row (if provided)
         if (pid.HasValue)

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -324,10 +324,7 @@ internal static class TelemetryCommandHelpers
             interactionService.DisplayMessage(KnownEmojis.Information, hint);
         }
 
-        if (logFilePath is not null)
-        {
-            interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, logFilePath));
-        }
+        CommandInteractionHelpers.DisplaySeeLogsMessage(interactionService, logFilePath);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -176,7 +176,7 @@ internal static class TelemetryCommandHelpers
     /// When <c>true</c>, a missing Dashboard API is a hard error.
     /// When <c>false</c>, a missing Dashboard API is non-fatal and the method returns success with <c>null</c> base URL and token.
     /// </param>
-    /// <param name="logFilePath">The path to the current session's log file, displayed alongside errors.</param>
+    /// <param name="logFilePath">The path to the current session's log file, displayed alongside errors when available.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="DashboardApiResult"/> with the resolved connection and dashboard API info.</returns>
     public static async Task<DashboardApiResult> GetDashboardApiAsync(
@@ -188,7 +188,7 @@ internal static class TelemetryCommandHelpers
         string? dashboardUrl,
         string? apiKey,
         bool requireDashboard,
-        string logFilePath,
+        string? logFilePath,
         CancellationToken cancellationToken)
     {
         // Validate mutual exclusivity of --apphost and --dashboard-url
@@ -315,7 +315,7 @@ internal static class TelemetryCommandHelpers
     public static void DisplayTelemetryError(
         IInteractionService interactionService,
         TelemetryErrorInfo errorInfo,
-        string logFilePath)
+        string? logFilePath)
     {
         interactionService.DisplayError(errorInfo.Error);
 
@@ -324,7 +324,10 @@ internal static class TelemetryCommandHelpers
             interactionService.DisplayMessage(KnownEmojis.Information, hint);
         }
 
-        interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, logFilePath));
+        if (logFilePath is not null)
+        {
+            interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, logFilePath));
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Cli/CommonOptionNames.cs
+++ b/src/Aspire.Cli/CommonOptionNames.cs
@@ -20,6 +20,7 @@ internal static class CommonOptionNames
     public const string NonInteractive = "--non-interactive";
     public const string WaitForDebugger = "--wait-for-debugger";
     public const string CliWaitForDebugger = "--cli-wait-for-debugger";
+    public const string NoLogFile = "--no-log-file";
 
     /// <summary>
     /// Options that represent informational commands (e.g. --version, --help) which should

--- a/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
+++ b/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
@@ -19,16 +19,31 @@ internal sealed class FileLoggerProvider : ILoggerProvider
 {
     private const int MaxQueuedMessages = 1024;
 
-    private readonly string _logFilePath;
+    private readonly string? _logFilePath;
     private readonly StreamWriter? _writer;
     private readonly Channel<string>? _channel;
     private readonly Task? _writerTask;
     private bool _disposed;
 
     /// <summary>
-    /// Gets the path to the log file.
+    /// Gets the path to the log file, or null when file logging is disabled.
     /// </summary>
-    public string LogFilePath => _logFilePath;
+    public string? LogFilePath => _logFilePath;
+
+    /// <summary>
+    /// Creates a no-op <see cref="FileLoggerProvider"/> that does not create or write to any file.
+    /// </summary>
+    internal static FileLoggerProvider CreateNull()
+    {
+        return new FileLoggerProvider();
+    }
+
+    private FileLoggerProvider()
+    {
+        _logFilePath = null;
+        _writer = null;
+        _channel = null;
+    }
 
     /// <summary>
     /// Generates a unique, chronologically-sortable log file name.

--- a/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
+++ b/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
@@ -32,10 +32,10 @@ internal interface IStartupErrorWriter : IDisposable
 internal sealed class StartupErrorWriter : IStartupErrorWriter
 {
     private readonly IAnsiConsole _errorConsole;
-    private readonly string _logFilePath;
+    private readonly string? _logFilePath;
     private bool _hasOutput;
 
-    public StartupErrorWriter(string logFilePath)
+    public StartupErrorWriter(string? logFilePath)
     {
         _logFilePath = logFilePath;
         _errorConsole = AnsiConsole.Create(new AnsiConsoleSettings
@@ -58,7 +58,7 @@ internal sealed class StartupErrorWriter : IStartupErrorWriter
 
     public void Dispose()
     {
-        if (!_hasOutput || !File.Exists(_logFilePath))
+        if (!_hasOutput || _logFilePath is null || !File.Exists(_logFilePath))
         {
             return;
         }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -64,8 +64,9 @@ public class Program
     /// <param name="ConsoleLogLevel">The console log level if specified via --log-level or --debug.</param>
     /// <param name="DebugMode">Whether --debug or -d was specified.</param>
     /// <param name="LogsDirectory">The directory where log files are stored.</param>
-    /// <param name="LogFilePath">The full path to the current session's log file.</param>
-    internal record CliLoggingOptions(LogLevel? ConsoleLogLevel, bool DebugMode, string LogsDirectory, string LogFilePath);
+    /// <param name="LogFilePath">The full path to the current session's log file, or null when file logging is disabled.</param>
+    /// <param name="NoLogFile">Whether --no-log-file was specified to disable file logging.</param>
+    internal record CliLoggingOptions(LogLevel? ConsoleLogLevel, bool DebugMode, string LogsDirectory, string? LogFilePath, bool NoLogFile);
 
     /// <summary>
     /// Holds the objects created during early CLI startup, before DI is available.
@@ -121,9 +122,12 @@ public class Program
         }
 
         var logsDirectory = Path.Combine(GetUsersAspirePath(), "logs");
-        var logFilePath = ParseLogFileOption(args) ?? FileLoggerProvider.GenerateLogFilePath(logsDirectory, TimeProvider.System);
+        var noLogFile = HasNoLogFileOption(args);
+        var logFilePath = noLogFile
+            ? null
+            : ParseLogFileOption(args) ?? FileLoggerProvider.GenerateLogFilePath(logsDirectory, TimeProvider.System);
 
-        return new CliLoggingOptions(logLevel, debugMode, logsDirectory, logFilePath);
+        return new CliLoggingOptions(logLevel, debugMode, logsDirectory, logFilePath, noLogFile);
     }
 
     /// <summary>
@@ -151,6 +155,32 @@ public class Program
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Returns whether <c>--no-log-file</c> appears before the command delimiter (<c>--</c>).
+    /// </summary>
+    private static bool HasNoLogFileOption(string[]? args)
+    {
+        if (args is null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--")
+            {
+                break;
+            }
+
+            if (args[i] == CommonOptionNames.NoLogFile)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string GetGlobalSettingsPath(ILogger logger)
@@ -201,7 +231,7 @@ public class Program
     /// Sets up OpenTelemetry logging, file logging, console logging, log-level filters,
     /// and MCP console logging based on command-line arguments.
     /// </summary>
-    /// <returns>A tuple containing the configured <see cref="ILoggerFactory"/> and the <see cref="FileLoggerProvider"/> used for file logging.</returns>
+    /// <returns>A tuple containing the configured <see cref="ILoggerFactory"/> and the <see cref="FileLoggerProvider"/>.</returns>
     internal static (ILoggerFactory LoggerFactory, FileLoggerProvider FileLoggerProvider) CreateLoggerFactory(string[] args, CliLoggingOptions loggingOptions, IStartupErrorWriter errorWriter)
     {
         var consoleLogLevel = loggingOptions.ConsoleLogLevel;
@@ -211,8 +241,12 @@ public class Program
 
         var extensionEndpoint = Environment.GetEnvironmentVariable(KnownConfigNames.ExtensionEndpoint);
 
-        // Create file logger provider from pre-computed path info
-        var fileLoggerProvider = new FileLoggerProvider(loggingOptions.LogFilePath, errorWriter);
+        var fileLoggerProvider = loggingOptions switch
+        {
+            { NoLogFile: true } => FileLoggerProvider.CreateNull(),
+            { LogFilePath: { } logFilePath } => new FileLoggerProvider(logFilePath, errorWriter),
+            _ => throw new InvalidOperationException("A log file path is required when file logging is enabled.")
+        };
 
         var factory = LoggerFactory.Create(builder =>
         {
@@ -223,7 +257,7 @@ public class Program
                 logging.IncludeScopes = true;
             });
 
-            // Always capture complete CLI session details to disk for diagnostics
+            // Capture complete CLI session details when file logging is enabled.
             builder.AddProvider(fileLoggerProvider);
 
             // Configure log-level filters based on --log-level or --debug
@@ -552,7 +586,7 @@ public class Program
         return new DirectoryInfo(sdksPath);
     }
 
-    private static CliExecutionContext BuildCliExecutionContext(bool debugMode, string logsDirectory, string logFilePath)
+    private static CliExecutionContext BuildCliExecutionContext(bool debugMode, string logsDirectory, string? logFilePath)
     {
         var workingDirectory = new DirectoryInfo(Environment.CurrentDirectory);
         var hivesDirectory = GetHivesDirectory();

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -99,11 +99,16 @@ public class Program
         if (args is not null && args.Length > 0)
         {
             // Check for --debug or -d (backward compatibility)
-            debugMode = args.Any(a => a == "--debug" || a == "-d");
+            debugMode = args.TakeWhile(a => a != "--").Any(a => a == "--debug" || a == "-d");
 
             // Check for --log-level or -l
             for (var i = 0; i < args.Length; i++)
             {
+                if (args[i] == "--")
+                {
+                    break;
+                }
+
                 if ((args[i] == "--log-level" || args[i] == "-l") && i + 1 < args.Length)
                 {
                     if (Enum.TryParse<LogLevel>(args[i + 1], ignoreCase: true, out var parsedLevel))

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -149,6 +149,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string PackageInstallationFailedWithoutLogFile
+        {
+            get
+            {
+                return ResourceManager.GetString("PackageInstallationFailedWithoutLogFile", resourceCulture);
+            }
+        }
+
         public static string PackageAddedSuccessfully
         {
             get

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -155,6 +155,10 @@
     <value>The package installation failed with exit code {0}. See logs at {1}</value>
     <comment>{0} is a number, {1} is the log file path</comment>
   </data>
+  <data name="PackageInstallationFailedWithoutLogFile" xml:space="preserve">
+    <value>The package installation failed with exit code {0}.</value>
+    <comment>{0} is a number</comment>
+  </data>
   <data name="PackageAddedSuccessfully" xml:space="preserve">
     <value>The package {0}::{1} was added successfully.</value>
     <comment>{0} is the package name, {1} is the version.</comment>

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -173,6 +173,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string ProjectCouldNotBeAnalyzedWithoutLogFile
+        {
+            get
+            {
+                return ResourceManager.GetString("ProjectCouldNotBeAnalyzedWithoutLogFile", resourceCulture);
+            }
+        }
+
         public static string ProjectIsNotAppHost
         {
             get

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -165,6 +165,9 @@
   <data name="ProjectCouldNotBeAnalyzed" xml:space="preserve">
     <value>The project could not be analyzed due to a build error. See logs at {0}</value>
   </data>
+  <data name="ProjectCouldNotBeAnalyzedWithoutLogFile" xml:space="preserve">
+    <value>The project could not be analyzed due to a build error.</value>
+  </data>
   <data name="ProjectIsNotAppHost" xml:space="preserve">
     <value>The project does not contain an Aspire AppHost.</value>
   </data>

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -295,11 +295,29 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The project could not be built..
+        /// </summary>
+        public static string ProjectCouldNotBeBuiltWithoutLogFile {
+            get {
+                return ResourceManager.GetString("ProjectCouldNotBeBuiltWithoutLogFile", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The app could not be created. See logs at {0}.
         /// </summary>
         public static string ProjectCouldNotBeCreated {
             get {
                 return ResourceManager.GetString("ProjectCouldNotBeCreated", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The app could not be created..
+        /// </summary>
+        public static string ProjectCouldNotBeCreatedWithoutLogFile {
+            get {
+                return ResourceManager.GetString("ProjectCouldNotBeCreatedWithoutLogFile", resourceCulture);
             }
         }
         

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -188,8 +188,14 @@
   <data name="ProjectCouldNotBeBuilt" xml:space="preserve">
     <value>The project could not be built. See logs at {0}</value>
   </data>
+  <data name="ProjectCouldNotBeBuiltWithoutLogFile" xml:space="preserve">
+    <value>The project could not be built.</value>
+  </data>
   <data name="ProjectCouldNotBeCreated" xml:space="preserve">
     <value>The app could not be created. See logs at {0}</value>
+  </data>
+  <data name="ProjectCouldNotBeCreatedWithoutLogFile" xml:space="preserve">
+    <value>The app could not be created.</value>
   </data>
   <data name="OperationCancelled" xml:space="preserve">
     <value>The operation was canceled.</value>

--- a/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
@@ -147,6 +147,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Disable writing CLI logs to a file..
+        /// </summary>
+        public static string NoLogFileArgumentDescription {
+            get {
+                return ResourceManager.GetString("NoLogFileArgumentDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Run the command in non-interactive mode, disabling all interactive prompts and spinners..
         /// </summary>
         public static string NonInteractiveArgumentDescription {

--- a/src/Aspire.Cli/Resources/RootCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.resx
@@ -138,6 +138,9 @@
   <data name="NoLogoArgumentDescription" xml:space="preserve">
     <value>Suppress the startup banner and telemetry notice</value>
   </data>
+  <data name="NoLogFileArgumentDescription" xml:space="preserve">
+    <value>Disable writing CLI logs to a file</value>
+  </data>
   <data name="WaitForDebuggerArgumentDescription" xml:space="preserve">
     <value>Wait for a debugger to attach before executing the command</value>
   </data>

--- a/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
@@ -134,6 +134,12 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ProjectCouldNotBeRun", resourceCulture);
             }
         }
+
+        public static string ProjectCouldNotBeRunWithoutLogFile {
+            get {
+                return ResourceManager.GetString("ProjectCouldNotBeRunWithoutLogFile", resourceCulture);
+            }
+        }
         
         public static string Dashboard {
             get {

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -172,6 +172,9 @@
   <data name="ProjectCouldNotBeRun" xml:space="preserve">
     <value>The project could not be run. See logs at {0}</value>
   </data>
+  <data name="ProjectCouldNotBeRunWithoutLogFile" xml:space="preserve">
+    <value>The project could not be run.</value>
+  </data>
   <data name="Dashboard" xml:space="preserve">
     <value>Dashboard</value>
   </data>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -331,6 +331,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Project creation failed with exit code {0}..
+        /// </summary>
+        public static string ProjectCreationFailedWithoutLogFile {
+            get {
+                return ResourceManager.GetString("ProjectCreationFailedWithoutLogFile", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Select a test framework.
         /// </summary>
         public static string PromptForTFM_Prompt {
@@ -381,6 +390,15 @@ namespace Aspire.Cli.Resources {
         public static string TemplateInstallationFailed {
             get {
                 return ResourceManager.GetString("TemplateInstallationFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The template installation failed with exit code {0}..
+        /// </summary>
+        public static string TemplateInstallationFailedWithoutLogFile {
+            get {
+                return ResourceManager.GetString("TemplateInstallationFailedWithoutLogFile", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -208,6 +208,10 @@
     <value>The template installation failed with exit code {0}. See logs at {1}</value>
     <comment>{0} is a number, {1} is the log file path</comment>
   </data>
+  <data name="TemplateInstallationFailedWithoutLogFile" xml:space="preserve">
+    <value>The template installation failed with exit code {0}.</value>
+    <comment>{0} is a number</comment>
+  </data>
   <data name="UsingProjectTemplatesVersion" xml:space="preserve">
     <value>Using project templates version: {0}</value>
   </data>
@@ -217,6 +221,10 @@
   <data name="ProjectCreationFailed" xml:space="preserve">
     <value>Project creation failed with exit code {0}. See logs at {1}</value>
     <comment>{0} is a number, {1} is the log file path</comment>
+  </data>
+  <data name="ProjectCreationFailedWithoutLogFile" xml:space="preserve">
+    <value>Project creation failed with exit code {0}.</value>
+    <comment>{0} is a number</comment>
   </data>
   <data name="ProjectCreatedSuccessfully" xml:space="preserve">
     <value>Project created successfully in {0}.</value>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Instalace balíčku se nezdařila s ukončovacím kódem {0}. Protokoly najdete na {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">Cesta k souboru projektu, do které se má integrace přidat</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Die Paketinstallation ist mit dem Exitcode {0} fehlgeschlagen. Protokolle unter {1} anzeigen.</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">Der Pfad zur Projektdatei, der die Integration hinzugefügt werden soll.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">La instalación del paquete falló con el código de salida {0}. Consulte los registros en {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">La ruta al archivo del proyecto al que se agregará la integración.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">L’installation du package a échoué avec le code de sortie {0}. Consultez les journaux à l’emplacement {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">Chemin du fichier projet auquel ajouter l’intégration.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">L'installazione del pacchetto non è riuscita con codice di uscita {0}. Consultare i log in {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">Percorso del file di progetto a cui aggiungere l'integrazione.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">パッケージのインストールが終了コード {0} で失敗しました。{1} でログを表示する</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">統合を追加するプロジェクト ファイルへのパス。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">패키지 설치에 실패했습니다(종료 코드: {0}). {1}에서 로그 보기</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">통합을 추가할 프로젝트 파일의 경로입니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Instalacja pakietu nie powiodła się z kodem zakończenia {0}. Zobacz dzienniki pod adresem {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu, do którego ma zostać dodana integracja.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">A instalação do pacote falhou com o código de saída {0}. Ver logs em {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto ao qual adicionar a integração.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Не удалось установить пакет. Код завершения: {0}. См. журналы по адресу {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">Путь к файлу проекта, в который необходимо добавить интеграцию.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Paket yüklemesi {0} çıkış koduyla başarısız oldu. {1} adresinde günlüklere bakın</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">Tümleştirmenin ekleneceği proje dosyasının yolu.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">包安装失败，退出代码为 {0}。请参阅 {1} 处的日志</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">要将集成添加到的项目文件的路径。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">套件安裝失敗，結束代碼為 {0}。請參閱 {1} 中的記錄</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="PackageInstallationFailedWithoutLogFile">
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file to add the integration to</source>
         <target state="needs-review-translation">要新增整合的專案檔路徑。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Projekt se nepodařilo analyzovat kvůli chybě sestavení. Protokoly najdete na {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Soubor projektu neexistuje.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Das Projekt konnte aufgrund eines Buildfehlers nicht analysiert werden. Protokolle unter {0} anzeigen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Die Projektdatei ist nicht vorhanden.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -172,6 +172,11 @@
         <target state="translated">No se pudo analizar el proyecto debido a un error de compilación. Consulte los registros en {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">El archivo de proyecto no existe.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Impossible d’analyser le projet en raison d’une erreur de build. Consultez les journaux à l’emplacement {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Le fichier projet de bot n’existe pas.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Non è possibile analizzare il progetto a causa di un errore di compilazione. Consultare i log in {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Il file di progetto non esiste.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -172,6 +172,11 @@
         <target state="translated">ビルド エラーのため、プロジェクトを分析できませんでした。{0} でログを表示する</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">プロジェクト ファイルが存在しません。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -172,6 +172,11 @@
         <target state="translated">빌드 오류로 인해 프로젝트를 분석할 수 없습니다. {0}에서 로그 보기</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">프로젝트 파일이 없습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Nie można przeanalizować projektu z powodu błędu kompilacji. Zobacz dzienniki pod adresem {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Plik projektu nie istnieje.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Não foi possível analisar o projeto devido a um erro de compilação. Ver logs em {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">O arquivo de projeto não existe.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Не удалось проанализировать проект из-за ошибки сборки. См. журналы по адресу {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Файл проекта не существует.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Proje bir derleme hatası nedeniyle analiz edilemedi. {0} adresinde günlüklere bakın</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">Proje dosyası mevcut değil.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -172,6 +172,11 @@
         <target state="translated">由于生成错误，无法分析项目。请参阅 {0} 处的日志</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">项目文件不存在。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -172,6 +172,11 @@
         <target state="translated">因為組建錯誤，無法分析專案。請參閱 {0} 中的記錄</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeAnalyzedWithoutLogFile">
+        <source>The project could not be analyzed due to a build error.</source>
+        <target state="new">The project could not be analyzed due to a build error.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">
         <source>Project file does not exist.</source>
         <target state="translated">專案檔案不存在。</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -127,9 +127,19 @@
         <target state="translated">Projekt se nepovedlo sestavit. Protokoly najdete na {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -127,9 +127,19 @@
         <target state="translated">Das Projekt konnte nicht erstellt werden. Protokolle unter {0} anzeigen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -127,9 +127,19 @@
         <target state="translated">No se pudo compilar el proyecto. Consulte los registros en {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -127,9 +127,19 @@
         <target state="translated">Désolé, le projet n’a pas pu être généré. Consultez les journaux à l’emplacement {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -127,9 +127,19 @@
         <target state="translated">Non è possibile compilare il progetto. Consultare i log in {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -127,9 +127,19 @@
         <target state="translated">プロジェクトを構築できませんでした。{0} でログを表示する</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -127,9 +127,19 @@
         <target state="translated">프로젝트를 빌드할 수 없습니다. {0}에서 로그 보기</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -127,9 +127,19 @@
         <target state="translated">Nie można skompilować projektu. Zobacz dzienniki pod adresem {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -127,9 +127,19 @@
         <target state="translated">O projeto não pôde ser compilado. Ver logs em {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -127,9 +127,19 @@
         <target state="translated">Не удалось выполнить сборку проекта. См. журналы по адресу {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -127,9 +127,19 @@
         <target state="translated">Proje oluşturulamadı. {0} adresinde günlüklere bakın</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -127,9 +127,19 @@
         <target state="translated">无法生成项目。请参阅 {0} 处的日志</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -127,9 +127,19 @@
         <target state="translated">無法建置專案。請參閱 {0} 中的記錄</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeBuiltWithoutLogFile">
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
         <source>The app could not be created. See logs at {0}</source>
         <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreatedWithoutLogFile">
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Umožňuje potlačit banner spuštění a oznámení o telemetrii.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Unterdrücken Sie das Startupbanner und den Telemetriehinweis.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Suprima el banner de inicio y el aviso de telemetría.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Supprimer la bannière de démarrage et la notification de télémétrie.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Consente di disabilitare il banner di avvio e l'avviso di telemetria.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">スタートアップ バナーとテレメトリ通知を非表示にします。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">시작 배너 및 원격 분석 알림을 표시하지 않습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Wstrzymaj baner startowy i powiadomienie o telemetrii.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Suprima a faixa de inicialização e o aviso de telemetria.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Отключить баннер запуска и уведомление о телеметрии.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Başlangıç başlığını ve telemetri bildirimini gizle.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">抑制显示启动横幅和遥测通知。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
@@ -52,6 +52,11 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
+      <trans-unit id="NoLogFileArgumentDescription">
+        <source>Disable writing CLI logs to a file</source>
+        <target state="new">Disable writing CLI logs to a file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">抑制啟動橫幅與遙測通知。</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Projekt nelze spustit. Protokoly najdete na {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Prostředek</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Das Projekt konnte nicht ausgeführt werden. Protokolle unter {0} anzeigen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Ressource</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -162,6 +162,11 @@
         <target state="translated">No se pudo ejecutar el proyecto. Consulte los registros en {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Recurso</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Désolé, le projet n’a pas pu être exécuté. Consultez les journaux à l’emplacement {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Ressource</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Non è possibile eseguire il progetto. Consultare i log in {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Risorsa</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -162,6 +162,11 @@
         <target state="translated">プロジェクトを実行できませんでした。{0} でログを表示する</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">リソース</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -162,6 +162,11 @@
         <target state="translated">프로젝트를 실행할 수 없습니다. {0}에서 로그 보기</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">리소스</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Nie można uruchomić projektu. Zobacz dzienniki pod adresem {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Zasób</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Não foi possível executar o projeto. Ver logs em {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Recurso</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Не удалось запустить проект. См. журналы по адресу {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Ресурс</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Proje çalıştırılamadı. {0} adresinde günlüklere bakın</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">Kaynak</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -162,6 +162,11 @@
         <target state="translated">无法运行该项目。请参阅 {0} 处的日志</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">资源</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -162,6 +162,11 @@
         <target state="translated">無法執行專案。請參閱 {0} 中的記錄</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeRunWithoutLogFile">
+        <source>The project could not be run.</source>
+        <target state="new">The project could not be run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Resource">
         <source>Resource</source>
         <target state="translated">資源</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Vytvoření projektu se nezdařilo s ukončovacím kódem {0}. Protokoly najdete na {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">Konfiguruje, jestli se má vytvořit projekt pro testy integrace pomocí MSTest, NUnit nebo xUnit.net.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">Instalace balíčku se nezdařila s ukončovacím kódem {0}. Protokoly najdete na {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Die Projekterstellung ist mit dem Exitcode {0} fehlgeschlagen. Protokolle unter {1} anzeigen.</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">Konfiguriert, ob ein Projekt für Integrationstests mit MSTest, NUnit oder xUnit.net erstellt werden soll.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">Die Vorlageninstallation ist mit dem Exitcode {0} fehlgeschlagen. Protokolle unter {1} anzeigen.</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Error al crear el proyecto con el código de salida {0}. Consulte los registros en {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">Configura si se va a crear un proyecto para las pruebas de integración mediante MSTest, NUnit o xUnit.net.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">La instalación de la plantilla falló con el código de salida {0}. Consulte los registros en {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Désolé, échec de la création du projet avec le code de sortie {0}. Consultez les journaux à l’emplacement {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">Configure s’il faut créer un projet pour les tests d’intégration à l’aide de MSTest, NUnit ou xUnit.net.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">L’installation du modèle a échoué avec le code de sortie {0}. Consultez les journaux à l’emplacement {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Creazione del progetto non riuscita con codice di uscita {0}. Consultare i log in {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">Consente di configurare se creare un progetto per i test di integrazione usando MSTest, NUnit o xUnit.net.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">L'installazione del modello non è riuscita con codice di uscita {0}. Consultare i log in {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -147,6 +147,11 @@
         <target state="translated">プロジェクトの作成が、終了コード {0} で失敗しました。{1} でログを表示する</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">MSTest、NUnit、または xUnit.net を使用して統合テスト用のプロジェクトを作成するかどうかを構成します。</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">テンプレートのインストールが、終了コード {0} で失敗しました。{1} でログを表示する</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -147,6 +147,11 @@
         <target state="translated">{0} 종료 코드를 이용하여 프로젝트 만들기에 실패했습니다. {1}에서 로그 보기</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">MSTest, NUnit, xUnit.net을 사용하여 통합 테스트용 프로젝트를 만들지 여부를 구성합니다.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">{0} 종료 코드를 이용한 템플릿 설치에 실패했습니다. {1}에서 로그 보기</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Tworzenie projektu nie powiodło się z kodem zakończenia {0}. Zobacz dzienniki pod adresem {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">Konfiguruje, czy utworzyć projekt na potrzeby testów integracji przy użyciu narzędzia MSTest, NUnit lub xUnit.net.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">Instalacja szablonu nie powiodła się z kodem zakończenia {0}. Zobacz dzienniki pod adresem {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Falha na criação do projeto com código de saída {0}. Ver logs em {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">Configura se será criado um projeto para testes de integração usando MSTest, NUnit ou xUnit.net.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">A instalação do modelo falhou com o código de saída {0}. Ver logs em {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Не удалось создать проект. Код завершения: {0}. См. журналы по адресу {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">Указывает, с помощью какого средства создавать проект для интеграционных тестов: MSTest, NUnit или xUnit.net.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">Не удалось установить шаблон. Код завершения: {0}. См. журналы по адресу {1}</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -147,6 +147,11 @@
         <target state="translated">Proje oluşturma başarısız oldu, çıkış kodu {0}. {1} adresinde günlüklere bakın</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">MSTest, NUnit veya xUnit.net kullanarak tümleştirme testleri için bir proje oluşturulup oluşturulmayacağını yapılandırır.</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">Şablon yüklemesi {0} çıkış koduyla başarısız oldu. {1} adresinde günlüklere bakın</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -147,6 +147,11 @@
         <target state="translated">项目创建失败，退出代码为 {0}。请参阅 {1} 处的日志</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">配置是使用 MSTest、NUnit 还是 xUnit.net 来创建集成测试的项目。</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">模板安装失败，退出代码为 {0}。请参阅 {1} 处的日志</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -147,6 +147,11 @@
         <target state="translated">專案建立失敗，結束代碼為 {0}。請參閱 {1} 中的記錄</target>
         <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
+      <trans-unit id="ProjectCreationFailedWithoutLogFile">
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
+      </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
         <target state="translated">設定是否要使用 MSTest、NUnit、或 xUnit.net 專案為整合測試建立專案。</target>
@@ -176,6 +181,11 @@
         <source>The template installation failed with exit code {0}. See logs at {1}</source>
         <target state="translated">範本安裝失敗，結束代碼為 {0}。請參閱 {1} 中的記錄</target>
         <note>{0} is a number, {1} is the log file path</note>
+      </trans-unit>
+      <trans-unit id="TemplateInstallationFailedWithoutLogFile">
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -501,7 +501,11 @@ internal class DotNetTemplateFactory(
             if (templateInstallResult.ExitCode != 0)
             {
                 interactionService.DisplayLines(templateInstallCollector.GetLines());
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, templateInstallResult.ExitCode, executionContext.LogFilePath));
+                interactionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                    TemplatingStrings.TemplateInstallationFailed,
+                    TemplatingStrings.TemplateInstallationFailedWithoutLogFile,
+                    executionContext.LogFilePath,
+                    templateInstallResult.ExitCode));
                 return new TemplateResult(ExitCodeConstants.FailedToInstallTemplates);
             }
 
@@ -540,7 +544,11 @@ internal class DotNetTemplateFactory(
                 }
 
                 interactionService.DisplayLines(newProjectCollector.GetLines());
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, newProjectExitCode, executionContext.LogFilePath));
+                interactionService.DisplayError(CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+                    TemplatingStrings.ProjectCreationFailed,
+                    TemplatingStrings.ProjectCreationFailedWithoutLogFile,
+                    executionContext.LogFilePath,
+                    newProjectExitCode));
                 return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
             }
 

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -14,13 +14,20 @@ namespace Aspire.Cli.Utils;
 
 internal static class AppHostHelper
 {
-    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, string logFilePath, CancellationToken cancellationToken)
+    internal static string GetProjectCouldNotBeAnalyzedMessage(string? logFilePath)
+    {
+        return logFilePath is { Length: > 0 }
+            ? string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectCouldNotBeAnalyzed, logFilePath)
+            : ErrorStrings.ProjectCouldNotBeAnalyzedWithoutLogFile;
+    }
+
+    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, string? logFilePath, CancellationToken cancellationToken)
     {
         var appHostInformation = await GetAppHostInformationAsync(runner, interactionService, projectFile, telemetry, workingDirectory, cancellationToken);
 
         if (appHostInformation.ExitCode != 0)
         {
-            interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectCouldNotBeAnalyzed, logFilePath));
+            interactionService.DisplayError(GetProjectCouldNotBeAnalyzedMessage(logFilePath));
             return (false, false, null);
         }
 

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -87,6 +87,27 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void RenderDashboardSummary_ExcludesLogsLabelFromWidth_WhenLogFilePathIsNull()
+    {
+        var interactionService = new TestInteractionService();
+        var dashboardInfo = new DashboardRunCommand.DashboardInfo(
+            DashboardUrl: "http://localhost:18888",
+            OtlpGrpcUrl: "http://localhost:4317",
+            OtlpHttpUrl: "http://localhost:4318");
+
+        var width = DashboardRunCommand.RenderDashboardSummary(interactionService, dashboardInfo, logFilePath: null);
+
+        Assert.Equal(
+            new[]
+            {
+                DashboardCommandStrings.DashboardLabel,
+                DashboardCommandStrings.OtlpGrpcLabel,
+                DashboardCommandStrings.OtlpHttpLabel
+            }.Max(s => s.Length) + 1,
+            width);
+    }
+
+    [Fact]
     public void DashboardRunCommand_SkipsDefaultWhenEnvVarIsSet()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
@@ -1513,6 +1514,44 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         Assert.Empty(result.Errors);
         Assert.Contains("--custom-arg", result.UnmatchedTokens);
         Assert.Contains("value", result.UnmatchedTokens);
+    }
+
+    [Fact]
+    public void DisplaySeeLogsMessage_DisplaysMessage_WhenLogFilePathIsAvailable()
+    {
+        var interactionService = new TestInteractionService();
+
+        CommandInteractionHelpers.DisplaySeeLogsMessage(interactionService, "aspire.log");
+
+        var message = Assert.Single(interactionService.DisplayedMessages);
+        Assert.Equal(KnownEmojis.PageFacingUp, message.Emoji);
+        Assert.Contains("aspire.log", message.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DisplaySeeLogsMessage_DoesNotDisplayMessage_WhenLogFilePathIsNull()
+    {
+        var interactionService = new TestInteractionService();
+
+        CommandInteractionHelpers.DisplaySeeLogsMessage(interactionService, logFilePath: null);
+
+        Assert.Empty(interactionService.DisplayedMessages);
+    }
+
+    [Fact]
+    public void RenderAppHostSummary_ExcludesLogsLabelFromWidth_WhenLogFilePathIsNull()
+    {
+        var interactionService = new TestInteractionService();
+
+        var width = RunCommand.RenderAppHostSummary(
+            interactionService,
+            appHostRelativePath: "AppHost.csproj",
+            dashboardUrl: null,
+            codespacesUrl: null,
+            logFilePath: null,
+            isExtensionHost: true);
+
+        Assert.Equal(RunCommandStrings.AppHost.Length + 1, width);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1539,6 +1539,42 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void FormatMessageWithOptionalLogFile_UsesLogFileMessage_WhenLogFilePathIsAvailable()
+    {
+        var message = CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+            InteractionServiceStrings.ProjectCouldNotBeBuilt,
+            InteractionServiceStrings.ProjectCouldNotBeBuiltWithoutLogFile,
+            logFilePath: "aspire.log");
+
+        Assert.Equal("The project could not be built. See logs at aspire.log", message);
+    }
+
+    [Fact]
+    public void FormatMessageWithOptionalLogFile_UsesNoLogFileMessage_WhenLogFilePathIsNull()
+    {
+        var message = CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+            InteractionServiceStrings.ProjectCouldNotBeBuilt,
+            InteractionServiceStrings.ProjectCouldNotBeBuiltWithoutLogFile,
+            logFilePath: null);
+
+        Assert.Equal("The project could not be built.", message);
+        Assert.DoesNotContain("See logs", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatMessageWithOptionalLogFile_PreservesOtherFormatArguments_WhenLogFilePathIsNull()
+    {
+        var message = CommandInteractionHelpers.FormatMessageWithOptionalLogFile(
+            AddCommandStrings.PackageInstallationFailed,
+            AddCommandStrings.PackageInstallationFailedWithoutLogFile,
+            logFilePath: null,
+            ExitCodeConstants.FailedToAddPackage);
+
+        Assert.Equal($"The package installation failed with exit code {ExitCodeConstants.FailedToAddPackage}.", message);
+        Assert.DoesNotContain("See logs", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderAppHostSummary_ExcludesLogsLabelFromWidth_WhenLogFilePathIsNull()
     {
         var interactionService = new TestInteractionService();

--- a/tests/Aspire.Cli.Tests/ProgramTests.cs
+++ b/tests/Aspire.Cli.Tests/ProgramTests.cs
@@ -40,6 +40,24 @@ public class ProgramTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void ParseLoggingOptions_NoLogFile_DoesNotUseLogFilePath()
+    {
+        var options = Program.ParseLoggingOptions(["describe", "--debug", "--no-log-file"]);
+
+        Assert.True(options.DebugMode);
+        Assert.Null(options.LogFilePath);
+    }
+
+    [Fact]
+    public void ParseLoggingOptions_IgnoresNoLogFileAfterDelimiter()
+    {
+        var options = Program.ParseLoggingOptions(["run", "--", "--no-log-file"]);
+
+        Assert.NotNull(options.LogFilePath);
+        Assert.EndsWith(".log", options.LogFilePath);
+    }
+
+    [Fact]
     public void BuildAnsiConsole_DoesNotReenablePlaygroundFormatting_WhenHostDisablesAnsi()
     {
         var services = new ServiceCollection();

--- a/tests/Aspire.Cli.Tests/ProgramTests.cs
+++ b/tests/Aspire.Cli.Tests/ProgramTests.cs
@@ -58,6 +58,23 @@ public class ProgramTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void ParseLoggingOptions_IgnoresDebugAfterDelimiter()
+    {
+        var options = Program.ParseLoggingOptions(["run", "--", "--debug"]);
+
+        Assert.False(options.DebugMode);
+        Assert.Null(options.ConsoleLogLevel);
+    }
+
+    [Fact]
+    public void ParseLoggingOptions_IgnoresLogLevelAfterDelimiter()
+    {
+        var options = Program.ParseLoggingOptions(["run", "--", "--log-level", "Debug"]);
+
+        Assert.Null(options.ConsoleLogLevel);
+    }
+
+    [Fact]
     public void BuildAnsiConsole_DoesNotReenablePlaygroundFormatting_WhenHostDisablesAnsi()
     {
         var services = new ServiceCollection();

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils;
@@ -27,6 +29,22 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var dir = Path.GetDirectoryName(socketPrefix);
         Assert.NotNull(dir);
         Assert.EndsWith("backchannels", dir);
+    }
+
+    [Fact]
+    public void GetProjectCouldNotBeAnalyzedMessage_UsesLogPathWhenAvailable()
+    {
+        var message = AppHostHelper.GetProjectCouldNotBeAnalyzedMessage("/tmp/cli.log");
+
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectCouldNotBeAnalyzed, "/tmp/cli.log"), message);
+    }
+
+    [Fact]
+    public void GetProjectCouldNotBeAnalyzedMessage_UsesNoLogFileMessageWhenLogPathMissing()
+    {
+        var message = AppHostHelper.GetProjectCouldNotBeAnalyzedMessage(null);
+
+        Assert.Equal(ErrorStrings.ProjectCouldNotBeAnalyzedWithoutLogFile, message);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -92,7 +92,7 @@ internal static class CliTestHelper
         var testLogsDirectory = Path.Combine(options.WorkingDirectory.FullName, ".aspire", "logs");
         var testLogFilePath = FileLoggerProvider.GenerateLogFilePath(testLogsDirectory, TimeProvider.System);
         services.AddSingleton(sp => new FileLoggerProvider(testLogFilePath, new TestStartupErrorWriter()));
-        services.AddSingleton(new Program.CliLoggingOptions(ConsoleLogLevel: null, DebugMode: false, LogsDirectory: testLogsDirectory, LogFilePath: testLogFilePath));
+        services.AddSingleton(new Program.CliLoggingOptions(ConsoleLogLevel: null, DebugMode: false, LogsDirectory: testLogsDirectory, LogFilePath: testLogFilePath, NoLogFile: false));
 
         services.AddMemoryCache();
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelperTests.cs
@@ -21,7 +21,7 @@ public class CliTestHelperTests(ITestOutputHelper outputHelper)
             using (var provider = services.BuildServiceProvider())
             {
                 var fileLoggerProvider = provider.GetRequiredService<FileLoggerProvider>();
-                logFilePath = fileLoggerProvider.LogFilePath;
+                logFilePath = Assert.IsType<string>(fileLoggerProvider.LogFilePath);
 
                 Assert.True(File.Exists(logFilePath), $"Log file should exist at {logFilePath}");
                 Assert.StartsWith(Path.Combine(workspacePath, ".aspire", "logs"), logFilePath);


### PR DESCRIPTION
## Description

Ports the requested CLI/extension logging and CLI availability cache pieces from draft PR https://github.com/microsoft/aspire/pull/15963.

- Adds hidden `--no-log-file` support to the Aspire CLI so extension-spawned processes can emit debug logs without creating CLI log files.
- Routes stderr/debug output for extension-spawned Aspire CLI processes to a dedicated `Aspire Extension - CLI Logs` output channel.
- Adds an Aspire CLI path availability cache with concurrent resolution coalescing and invalidation when `aspire.aspireCliExecutablePath` changes.

Validation:

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `cd extension && npm run compile && npm run lint && npm run compile-tests -- --pretty false && npm run unit-test`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
