### PR TITLE
Forward VS Code debug output to dashboard logs, apphost errors show in Aspire debug session console

### DIFF
--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { EventEmitter } from "vscode";
 import * as fs from "fs";
-import { createDebugAdapterTracker, AppHostRestartHandler } from "./adapterTracker";
+import { createDebugAdapterTracker, AppHostOutputHandler, AppHostRestartHandler } from "./adapterTracker";
 import { AspireResourceExtendedDebugConfiguration, AspireResourceDebugSession, EnvVar, AspireExtendedDebugConfiguration, NodeLaunchConfiguration, ProjectLaunchConfiguration, StartAppHostOptions } from "../dcp/types";
 import { extensionLogOutputChannel } from "../utils/logging";
 import AspireDcpServer, { generateDcpIdPrefix } from "../dcp/AspireDcpServer";
@@ -180,7 +180,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
         },
         stderrCallback: (data) => {
           for (const line of trimMessage(data)) {
-            this.sendMessageWithEmoji("❌", line, false);
+            this.sendMessageWithEmoji("❌", line, false, 'stderr');
           }
         },
         errorCallback: (error) => {
@@ -217,13 +217,13 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     }
   }
 
-  createDebugAdapterTrackerCore(debugAdapter: string, onAppHostRestartRequested?: AppHostRestartHandler) {
+  createDebugAdapterTrackerCore(debugAdapter: string, onAppHostRestartRequested?: AppHostRestartHandler, onAppHostOutput?: AppHostOutputHandler) {
     if (this._trackedDebugAdapters.includes(debugAdapter)) {
       return;
     }
 
     this._trackedDebugAdapters.push(debugAdapter);
-    this._disposables.push(createDebugAdapterTracker(this._dcpServer, debugAdapter, onAppHostRestartRequested));
+    this._disposables.push(createDebugAdapterTracker(this._dcpServer, debugAdapter, onAppHostRestartRequested, onAppHostOutput));
   }
 
   private static readonly _nodeAppHostExtensions = ['.js', '.ts', '.mjs', '.mts', '.cjs', '.cts'];
@@ -249,7 +249,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
             return true; // suppress VS Code's child restart
           }
           return false;
-        }
+        },
+        (output, category) => this.sendMessage(output, false, category)
       );
 
       let appHostArgs: string[];
@@ -316,8 +317,13 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       this._disposables.push(disposable);
     }
     catch (err) {
-      extensionLogOutputChannel.error(`Error starting AppHost debug session: ${err}`);
-      vscode.window.showErrorMessage(String(err));
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      const errorDetails = err instanceof Error ? (err.stack ?? err.message) : String(err);
+      extensionLogOutputChannel.error(`Error starting AppHost debug session: ${errorDetails}`);
+      if (!isErrorWithStreamedDebugConsoleOutput(err)) {
+        this.sendMessageWithEmoji("❌", errorDetails, true, 'stderr');
+      }
+      vscode.window.showErrorMessage(errorMessage);
       this.dispose();
     }
   }
@@ -504,8 +510,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     this._onDidSendMessage.fire(event);
   }
 
-  sendMessageWithEmoji(emoji: string, message: string, addNewLine: boolean = true) {
-    this.sendMessage(`${emoji}  ${message}`, addNewLine);
+  sendMessageWithEmoji(emoji: string, message: string, addNewLine: boolean = true, category: 'stdout' | 'stderr' = 'stdout') {
+    this.sendMessage(`${emoji}  ${message}`, addNewLine, category);
   }
 
   sendMessage(message: string, addNewLine: boolean = true, category: 'stdout' | 'stderr' = 'stdout') {
@@ -523,4 +529,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
   notifyAppHostStartupCompleted() {
     extensionLogOutputChannel.info(`AppHost startup completed and dashboard is running.`);
   }
+}
+
+function isErrorWithStreamedDebugConsoleOutput(err: unknown): boolean {
+  return err instanceof Error && (err as Error & { debugConsoleOutputAlreadyWritten?: boolean }).debugConsoleOutputAlreadyWritten === true;
 }

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -10,8 +10,9 @@ import { dcpServerNotInitialized } from '../loc/strings';
  * Return `true` to suppress VS Code's automatic child session restart.
  */
 export type AppHostRestartHandler = (debugSessionId: string) => boolean;
+export type AppHostOutputHandler = (output: string, category: 'stdout' | 'stderr') => void;
 
-export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapter: string, onAppHostRestartRequested?: AppHostRestartHandler): vscode.Disposable {
+export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapter: string, onAppHostRestartRequested?: AppHostRestartHandler, onAppHostOutput?: AppHostOutputHandler): vscode.Disposable {
     return vscode.debug.registerDebugAdapterTrackerFactory(debugAdapter, {
         createDebugAdapterTracker(session: vscode.DebugSession) {
                 return {
@@ -44,6 +45,10 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
 
                             const { category, output } = message.body;
                             if (typeof output === 'string' && category !== 'telemetry') {
+                                if (session.configuration.isApphost && onAppHostOutput) {
+                                    onAppHostOutput(output, category === 'stderr' ? 'stderr' : 'stdout');
+                                }
+
                                 const notification: ServiceLogsNotification = {
                                     notification_type: 'serviceLogs',
                                     session_id: session.configuration.runId,

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -45,8 +45,9 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
 
                             const { category, output } = message.body;
                             if (typeof output === 'string' && category !== 'telemetry') {
-                                if (session.configuration.isApphost && onAppHostOutput) {
-                                    onAppHostOutput(output, category === 'stderr' ? 'stderr' : 'stdout');
+                                if (session.configuration.isApphost) {
+                                    onAppHostOutput?.(output, category === 'stderr' ? 'stderr' : 'stdout');
+                                    return;
                                 }
 
                                 const notification: ServiceLogsNotification = {

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -43,7 +43,7 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                             }
 
                             const { category, output } = message.body;
-                            if (category === 'stdout' || category === 'stderr') {
+                            if (typeof output === 'string' && category !== 'telemetry') {
                                 const notification: ServiceLogsNotification = {
                                     notification_type: 'serviceLogs',
                                     session_id: session.configuration.runId,

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -90,12 +90,12 @@ class DotNetService implements IDotNetService {
                 if (code === 0) {
                     // if build succeeds, simply return. otherwise throw to trigger error handling
                     if (stderrOutput) {
-                        reject(new Error(stderrOutput));
+                        reject(createErrorWithStreamedDebugConsoleOutput(stderrOutput));
                     } else {
                         resolve();
                     }
                 } else {
-                    reject(new Error(buildFailedForProjectWithError(projectFile, stdoutOutput || stderrOutput || `Exit code ${code}`)));
+                    reject(createErrorWithStreamedDebugConsoleOutput(buildFailedForProjectWithError(projectFile, stdoutOutput || stderrOutput || `Exit code ${code}`)));
                 }
             });
         });
@@ -189,6 +189,13 @@ function getRunApiConfigFromOutput(runApiOutput: string): RunApiOutput {
         executablePath: parsed.ExecutablePath,
         env: parsed.EnvironmentVariables
     };
+}
+
+function createErrorWithStreamedDebugConsoleOutput(message: string): Error {
+    const error = new Error(message) as Error & { debugConsoleOutputAlreadyWritten?: boolean };
+    error.debugConsoleOutputAlreadyWritten = true;
+
+    return error;
 }
 
 export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSession: AspireDebugSession) => IDotNetService): ResourceDebuggerExtension {

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -192,6 +192,7 @@ function getRunApiConfigFromOutput(runApiOutput: string): RunApiOutput {
 }
 
 function createErrorWithStreamedDebugConsoleOutput(message: string): Error {
+    // Mark build errors whose output was already streamed to avoid replaying the transcript in AppHost startup handling.
     const error = new Error(message) as Error & { debugConsoleOutputAlreadyWritten?: boolean };
     error.debugConsoleOutputAlreadyWritten = true;
 

--- a/extension/src/debugger/languages/node.ts
+++ b/extension/src/debugger/languages/node.ts
@@ -16,7 +16,7 @@ function getProjectFile(launchConfig: ExecutableLaunchConfiguration): string {
 
 export const nodeDebuggerExtension: ResourceDebuggerExtension = {
     resourceType: 'node',
-    debugAdapter: 'node',
+    debugAdapter: 'pwa-node',
     extensionId: null,
     getDisplayName: (launchConfiguration: ExecutableLaunchConfiguration) => {
         if (isNodeLaunchConfiguration(launchConfiguration)) {
@@ -33,7 +33,8 @@ export const nodeDebuggerExtension: ResourceDebuggerExtension = {
             throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
         }
 
-        debugConfiguration.type = 'node';
+        debugConfiguration.type = 'pwa-node';
+        debugConfiguration.outputCapture = 'std';
 
         // Use working_directory for cwd if available
         if (launchConfig.working_directory) {

--- a/extension/src/debugger/languages/node.ts
+++ b/extension/src/debugger/languages/node.ts
@@ -16,6 +16,7 @@ function getProjectFile(launchConfig: ExecutableLaunchConfiguration): string {
 
 export const nodeDebuggerExtension: ResourceDebuggerExtension = {
     resourceType: 'node',
+    // Use js-debug's pwa-node adapter so outputCapture emits stdout/stderr DAP output events for dashboard log forwarding.
     debugAdapter: 'pwa-node',
     extensionId: null,
     getDisplayName: (launchConfiguration: ExecutableLaunchConfiguration) => {

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -245,6 +245,54 @@ suite('Debug Adapter Tracker Tests', () => {
         disposable.dispose();
     });
 
+    test('apphost output events are mirrored to output callback', async () => {
+        const outputCallback = sinon.stub();
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'pwa-node', undefined, outputCallback);
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker({
+            ...debugSession,
+            configuration: {
+                ...debugSession.configuration,
+                isApphost: true
+            }
+        });
+
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'output',
+            body: {
+                category: 'stderr',
+                output: 'tsx compile error\n'
+            }
+        });
+
+        assert.strictEqual(outputCallback.calledOnceWith('tsx compile error\n', 'stderr'), true);
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+
+        disposable.dispose();
+    });
+
+    test('resource output events are not mirrored to output callback', async () => {
+        const outputCallback = sinon.stub();
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'pwa-node', undefined, outputCallback);
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'output',
+            body: {
+                category: 'stderr',
+                output: 'resource error\n'
+            }
+        });
+
+        assert.strictEqual(outputCallback.called, false);
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+
+        disposable.dispose();
+    });
+
     test('does not send notification if debug session lacks runId', async () => {
         // Create session without proper configuration
         const invalidSession = {

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -245,7 +245,7 @@ suite('Debug Adapter Tracker Tests', () => {
         disposable.dispose();
     });
 
-    test('apphost output events are mirrored to output callback', async () => {
+    test('apphost output events are mirrored to output callback without service log notification', async () => {
         const outputCallback = sinon.stub();
         const disposable = createDebugAdapterTracker(dcpServer as any, 'pwa-node', undefined, outputCallback);
         const factory = registerFactoryStub.lastCall.args[1];
@@ -267,7 +267,7 @@ suite('Debug Adapter Tracker Tests', () => {
         });
 
         assert.strictEqual(outputCallback.calledOnceWith('tsx compile error\n', 'stderr'), true);
-        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+        assert.strictEqual(dcpServer.sendNotification.called, false);
 
         disposable.dispose();
     });

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { createDebugAdapterTracker } from '../debugger/adapterTracker';
 import AspireDcpServer from '../dcp/AspireDcpServer';
-import { AspireResourceExtendedDebugConfiguration, SessionTerminatedNotification } from '../dcp/types';
+import { AspireResourceExtendedDebugConfiguration, ServiceLogsNotification, SessionTerminatedNotification } from '../dcp/types';
 
 suite('Debug Adapter Tracker Tests', () => {
     let dcpServer: sinon.SinonStubbedInstance<AspireDcpServer>;
@@ -184,6 +184,63 @@ suite('Debug Adapter Tracker Tests', () => {
         assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
         const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
         assert.strictEqual(notification.exit_code, 0);
+
+        disposable.dispose();
+    });
+
+    test('non-telemetry output events are sent as service logs', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'node');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        const testCases: { category?: string, output: string, expectedIsStdErr: boolean, expectedLogMessage: string }[] = [
+            { category: 'stdout', output: 'stdout line\n', expectedIsStdErr: false, expectedLogMessage: 'stdout line' },
+            { category: 'stderr', output: 'stderr line\n', expectedIsStdErr: true, expectedLogMessage: 'stderr line' },
+            { category: 'console', output: 'VITE ready\n', expectedIsStdErr: false, expectedLogMessage: 'VITE ready' },
+            { category: 'important', output: 'important line\n', expectedIsStdErr: false, expectedLogMessage: 'important line' },
+            { category: 'debug', output: 'debug line\n', expectedIsStdErr: false, expectedLogMessage: 'debug line' },
+            { output: 'default console line\n', expectedIsStdErr: false, expectedLogMessage: 'default console line' }
+        ];
+
+        for (const testCase of testCases) {
+            dcpServer.sendNotification.resetHistory();
+
+            tracker.onDidSendMessage({
+                type: 'event',
+                event: 'output',
+                body: {
+                    category: testCase.category,
+                    output: testCase.output
+                }
+            });
+
+            assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+            const notification = dcpServer.sendNotification.firstCall.args[0] as ServiceLogsNotification;
+            assert.strictEqual(notification.notification_type, 'serviceLogs');
+            assert.strictEqual(notification.session_id, 'run-123');
+            assert.strictEqual(notification.dcp_id, 'debug-456');
+            assert.strictEqual(notification.is_std_err, testCase.expectedIsStdErr);
+            assert.strictEqual(notification.log_message, testCase.expectedLogMessage);
+        }
+
+        disposable.dispose();
+    });
+
+    test('telemetry output event is not sent as service log', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'node');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'output',
+            body: {
+                category: 'telemetry',
+                output: '{"eventName":"nodeTelemetry"}'
+            }
+        });
+
+        assert.strictEqual(dcpServer.sendNotification.called, false);
 
         disposable.dispose();
     });

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -51,6 +51,82 @@ suite('Dotnet Debugger Extension Tests', () => {
         const fakeDotNetService = new TestDotNetService(outputPath, rejectBuild, hasDevKit);
         return { dotNetService: fakeDotNetService, extension: createProjectDebuggerExtension(() => fakeDotNetService), doesFileExistStub: sinon.stub(io, 'doesFileExist').resolves(doesOutputFileExist) };
     }
+
+    test('failed AppHost start writes error to debug console', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: '/workspace/apphost.ts'
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub()
+        } as unknown as vscode.DebugSession;
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+        const outputEvents: any[] = [];
+        const outputSubscription = aspireDebugSession.onDidSendMessage(message => outputEvents.push(message));
+        const startError = new Error('AppHost build failed');
+
+        sinon.stub(aspireDebugSession, 'createDebugAdapterTrackerCore');
+        sinon.stub(aspireDebugSession, 'startAndGetDebugSession').rejects(startError);
+        const showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+
+        await aspireDebugSession.startAppHost('/workspace/apphost.ts', ['node', 'apphost.ts'], [], true, { forceBuild: false });
+
+        assert.ok(showErrorMessageStub.calledWith(startError.message));
+        assert.ok(startError.stack);
+        assert.ok(outputEvents.some(message =>
+            message.type === 'event'
+            && message.event === 'output'
+            && message.body.category === 'stderr'
+            && message.body.output.includes(startError.stack)));
+
+        outputSubscription.dispose();
+    });
+
+    test('failed AppHost start does not duplicate already streamed build output', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: '/workspace/apphost.ts'
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub()
+        } as unknown as vscode.DebugSession;
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+        const outputEvents: any[] = [];
+        const outputSubscription = aspireDebugSession.onDidSendMessage(message => outputEvents.push(message));
+        const startError = new Error('Build FAILED.');
+        (startError as Error & { debugConsoleOutputAlreadyWritten?: boolean }).debugConsoleOutputAlreadyWritten = true;
+
+        sinon.stub(aspireDebugSession, 'createDebugAdapterTrackerCore');
+        sinon.stub(aspireDebugSession, 'startAndGetDebugSession').rejects(startError);
+        const showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+
+        await aspireDebugSession.startAppHost('/workspace/apphost.ts', ['node', 'apphost.ts'], [], true, { forceBuild: false });
+
+        assert.ok(showErrorMessageStub.calledWith(startError.message));
+        assert.strictEqual(outputEvents.some(message =>
+            message.type === 'event'
+            && message.event === 'output'
+            && message.body.output.includes(startError.message)), false);
+
+        outputSubscription.dispose();
+    });
+
     test('project is built when C# dev kit is installed and executable not found', async () => {
         const outputPath = 'C:\\temp\\bin\\Debug\\net7.0\\TestProject.dll';
         const { extension, dotNetService } = createDebuggerExtension(outputPath, null, true, false);

--- a/extension/src/test/nodeDebugger.test.ts
+++ b/extension/src/test/nodeDebugger.test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert';
+import { AspireDebugSession } from '../debugger/AspireDebugSession';
+import { nodeDebuggerExtension } from '../debugger/languages/node';
+import { AspireResourceExtendedDebugConfiguration, NodeLaunchConfiguration } from '../dcp/types';
+
+suite('Node Debugger Tests', () => {
+    const fakeAspireDebugSession = {} as AspireDebugSession;
+
+    test('configures js-debug to capture process stdout and stderr', async () => {
+        const launchConfig: NodeLaunchConfiguration = {
+            type: 'node',
+            script_path: '/workspace/app/server.js',
+            working_directory: '/workspace/app'
+        };
+        const debugConfig = createDebugConfig();
+
+        await nodeDebuggerExtension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+        assert.strictEqual(debugConfig.type, 'pwa-node');
+        assert.strictEqual(debugConfig.outputCapture, 'std');
+        assert.strictEqual(debugConfig.cwd, '/workspace/app');
+    });
+
+    test('uses runtime arguments for package manager launches', async () => {
+        const launchConfig: NodeLaunchConfiguration = {
+            type: 'node',
+            runtime_executable: 'npm',
+            working_directory: '/workspace/app'
+        };
+        const debugConfig = createDebugConfig();
+
+        await nodeDebuggerExtension.createDebugSessionConfigurationCallback!(launchConfig, ['run', 'dev'], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+        assert.strictEqual(debugConfig.type, 'pwa-node');
+        assert.strictEqual(debugConfig.outputCapture, 'std');
+        assert.strictEqual(debugConfig.runtimeExecutable, 'npm');
+        assert.deepStrictEqual(debugConfig.runtimeArgs, ['run', 'dev']);
+        assert.strictEqual(debugConfig.program, undefined);
+        assert.strictEqual(debugConfig.args, undefined);
+    });
+});
+
+function createDebugConfig(): AspireResourceExtendedDebugConfiguration {
+    return {
+        runId: '1',
+        debugSessionId: '1',
+        type: 'node',
+        name: 'Node',
+        request: 'launch',
+        program: '/workspace/app/server.js',
+        args: []
+    };
+}


### PR DESCRIPTION
## Description

Forward non-telemetry VS Code debug adapter output events to DCP service logs so output shown in the VS Code Debug Console also appears in Aspire Dashboard console logs.

This fixes JavaScript resource logs by launching Node resources through VS Code js-debug's `pwa-node` adapter with `outputCapture: "std"`, which is required for package-manager and Vite stdout/stderr to be emitted as Debug Adapter Protocol output events. The tracker forwards those output events to DCP as `serviceLogs`.

This also incorporates and supersedes the AppHost startup failure reporting from #16516. This is because pwa-node tracking would also be required to get ts AppHost stderr. AppHost failures that happen before the child debug session starts now write details to the Debug Console as stderr instead of only showing a dialog. Build failures whose output was already streamed are not replayed a second time, and AppHost child debug output is mirrored back to the parent Aspire Debug Console so TypeScript AppHost runtime/startup errors are visible in the same place as C# AppHost errors.

Fixes #16468
Fixes #15578

Validation:

- `npm run compile-tests`
- `npm run unit-test -- --grep "Node Debugger Tests|Debug Adapter Tracker Tests|failed AppHost start"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No