### PR TITLE
Resolve AppHost paths case-insensitively

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -183,7 +183,14 @@ internal sealed class AppHostConnectionResolver(
         var normalizedAppHostPath = Path.GetFullPath(appHostPath);
         return backchannelMonitor.Connections.FirstOrDefault(c =>
             c.AppHostInfo?.AppHostPath is { } candidatePath &&
-            string.Equals(Path.GetFullPath(candidatePath), normalizedAppHostPath, StringComparison.OrdinalIgnoreCase));
+            string.Equals(Path.GetFullPath(candidatePath), normalizedAppHostPath, GetAppHostPathComparison()));
+    }
+
+    private static StringComparison GetAppHostPathComparison()
+    {
+        return OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -106,6 +106,16 @@ internal sealed class AppHostConnectionResolver(
                 }
             }
 
+            if (matchingSockets.Length == 0)
+            {
+                var matchingConnection = await FindMonitorConnectionByAppHostPathAsync(targetPath, cancellationToken).ConfigureAwait(false);
+                if (matchingConnection is not null)
+                {
+                    logger.LogDebug("Resolved AppHost by case-insensitive path comparison: {AppHostPath}", matchingConnection.AppHostInfo?.AppHostPath);
+                    return new AppHostConnectionResult { Connection = matchingConnection };
+                }
+            }
+
             return new AppHostConnectionResult { ErrorMessage = notFoundMessage };
         }
 
@@ -162,6 +172,18 @@ internal sealed class AppHostConnectionResolver(
         }
 
         return new AppHostConnectionResult { Connection = selectedConnection };
+    }
+
+    private async Task<IAppHostAuxiliaryBackchannel?> FindMonitorConnectionByAppHostPathAsync(
+        string appHostPath,
+        CancellationToken cancellationToken)
+    {
+        await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+
+        var normalizedAppHostPath = Path.GetFullPath(appHostPath);
+        return backchannelMonitor.Connections.FirstOrDefault(c =>
+            c.AppHostInfo?.AppHostPath is { } candidatePath &&
+            string.Equals(Path.GetFullPath(candidatePath), normalizedAppHostPath, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -10,7 +10,7 @@ namespace Aspire.Cli.Tests.Backchannel;
 public class AppHostConnectionResolverTests
 {
     [Fact]
-    public async Task ResolveConnectionAsync_FallsBackToCaseInsensitiveMonitorLookupWhenAppHostPathCasingDiffers()
+    public async Task ResolveConnectionAsync_FallsBackToPlatformPathComparisonWhenAppHostPathCasingDiffers()
     {
         var basePath = Path.Combine(Directory.GetCurrentDirectory(), "case-lookup-" + Guid.NewGuid().ToString("N"));
         var workingDirectory = new DirectoryInfo(Path.Combine(basePath, "repo"));
@@ -50,8 +50,17 @@ public class AppHostConnectionResolverTests
             "No AppHost found",
             CancellationToken.None);
 
-        Assert.True(result.Success, result.ErrorMessage);
-        Assert.Same(connection, result.Connection);
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+        {
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Same(connection, result.Connection);
+        }
+        else
+        {
+            Assert.False(result.Success);
+            Assert.Equal("No AppHost found", result.ErrorMessage);
+        }
+
         Assert.Equal(1, monitor.ScanCallCount);
     }
 }

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Tests.TestServices;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Backchannel;
+
+public class AppHostConnectionResolverTests
+{
+    [Fact]
+    public async Task ResolveConnectionAsync_FallsBackToCaseInsensitiveMonitorLookupWhenAppHostPathCasingDiffers()
+    {
+        var basePath = Path.Combine(Directory.GetCurrentDirectory(), "case-lookup-" + Guid.NewGuid().ToString("N"));
+        var workingDirectory = new DirectoryInfo(Path.Combine(basePath, "repo"));
+        var homeDirectory = new DirectoryInfo(Path.Combine(basePath, "home"));
+        var actualAppHostPath = Path.Combine(workingDirectory.FullName, "src", "MyApp.AppHost", "MyApp.AppHost.csproj");
+        var requestedAppHostPath = actualAppHostPath.Replace("MyApp.AppHost", "myapp.apphost", StringComparison.Ordinal);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = actualAppHostPath,
+                ProcessId = 1234
+            }
+        };
+        monitor.AddConnection("test-hash", "test-socket", connection);
+
+        var executionContext = new CliExecutionContext(
+            workingDirectory,
+            new DirectoryInfo(Path.Combine(basePath, "hives")),
+            new DirectoryInfo(Path.Combine(basePath, "cache")),
+            new DirectoryInfo(Path.Combine(basePath, "sdks")),
+            new DirectoryInfo(Path.Combine(basePath, "logs")),
+            Path.Combine(basePath, "logs", "test.log"),
+            homeDirectory: homeDirectory);
+        var resolver = new AppHostConnectionResolver(
+            monitor,
+            new TestInteractionService(),
+            executionContext,
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            new FileInfo(requestedAppHostPath),
+            "Scanning for AppHosts",
+            "Select an AppHost",
+            "No AppHost found",
+            CancellationToken.None);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Same(connection, result.Connection);
+        Assert.Equal(1, monitor.ScanCallCount);
+    }
+}


### PR DESCRIPTION
## Description

Fixes #15588

`aspire` now falls back to the auxiliary backchannel monitor when the socket fast path cannot find a running AppHost for the exact `--apphost` path casing. The fallback compares normalized AppHost paths case-insensitively, so VS Code resource commands can resolve a running AppHost even if the path casing differs from the path recorded by the running process.

Validation:
- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-restore --verbosity quiet -- --filter-class "*.AppHostConnectionResolverTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
