### PR TITLE
Show AppHost debug start errors in console

### DIFF
--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -180,7 +180,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
         },
         stderrCallback: (data) => {
           for (const line of trimMessage(data)) {
-            this.sendMessageWithEmoji("❌", line, false);
+            this.sendMessageWithEmoji("❌", line, false, 'stderr');
           }
         },
         errorCallback: (error) => {
@@ -316,9 +316,10 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       this._disposables.push(disposable);
     }
     catch (err) {
-      const errorMessage = String(err);
-      extensionLogOutputChannel.error(`Error starting AppHost debug session: ${errorMessage}`);
-      this.sendMessageWithEmoji("❌", errorMessage, true, 'stderr');
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      const errorDetails = err instanceof Error ? (err.stack ?? err.message) : String(err);
+      extensionLogOutputChannel.error(`Error starting AppHost debug session: ${errorDetails}`);
+      this.sendMessageWithEmoji("❌", errorDetails, true, 'stderr');
       vscode.window.showErrorMessage(errorMessage);
       this.dispose();
     }

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -316,8 +316,10 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       this._disposables.push(disposable);
     }
     catch (err) {
-      extensionLogOutputChannel.error(`Error starting AppHost debug session: ${err}`);
-      vscode.window.showErrorMessage(String(err));
+      const errorMessage = String(err);
+      extensionLogOutputChannel.error(`Error starting AppHost debug session: ${errorMessage}`);
+      this.sendMessageWithEmoji("❌", errorMessage, true, 'stderr');
+      vscode.window.showErrorMessage(errorMessage);
       this.dispose();
     }
   }
@@ -504,8 +506,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     this._onDidSendMessage.fire(event);
   }
 
-  sendMessageWithEmoji(emoji: string, message: string, addNewLine: boolean = true) {
-    this.sendMessage(`${emoji}  ${message}`, addNewLine);
+  sendMessageWithEmoji(emoji: string, message: string, addNewLine: boolean = true, category: 'stdout' | 'stderr' = 'stdout') {
+    this.sendMessage(`${emoji}  ${message}`, addNewLine, category);
   }
 
   sendMessage(message: string, addNewLine: boolean = true, category: 'stdout' | 'stderr' = 'stdout') {

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -79,12 +79,13 @@ suite('Dotnet Debugger Extension Tests', () => {
 
         await aspireDebugSession.startAppHost('/workspace/apphost.ts', ['node', 'apphost.ts'], [], true, { forceBuild: false });
 
-        assert.ok(showErrorMessageStub.calledWith(String(startError)));
+        assert.ok(showErrorMessageStub.calledWith(startError.message));
+        assert.ok(startError.stack);
         assert.ok(outputEvents.some(message =>
             message.type === 'event'
             && message.event === 'output'
             && message.body.category === 'stderr'
-            && message.body.output.includes(String(startError))));
+            && message.body.output.includes(startError.stack)));
 
         outputSubscription.dispose();
     });

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -51,6 +51,44 @@ suite('Dotnet Debugger Extension Tests', () => {
         const fakeDotNetService = new TestDotNetService(outputPath, rejectBuild, hasDevKit);
         return { dotNetService: fakeDotNetService, extension: createProjectDebuggerExtension(() => fakeDotNetService), doesFileExistStub: sinon.stub(io, 'doesFileExist').resolves(doesOutputFileExist) };
     }
+
+    test('failed AppHost start writes error to debug console', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: '/workspace/apphost.ts'
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub()
+        } as unknown as vscode.DebugSession;
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+        const outputEvents: any[] = [];
+        const outputSubscription = aspireDebugSession.onDidSendMessage(message => outputEvents.push(message));
+        const startError = new Error('AppHost build failed');
+
+        sinon.stub(aspireDebugSession, 'createDebugAdapterTrackerCore');
+        sinon.stub(aspireDebugSession, 'startAndGetDebugSession').rejects(startError);
+        const showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+
+        await aspireDebugSession.startAppHost('/workspace/apphost.ts', ['node', 'apphost.ts'], [], true, { forceBuild: false });
+
+        assert.ok(showErrorMessageStub.calledWith(String(startError)));
+        assert.ok(outputEvents.some(message =>
+            message.type === 'event'
+            && message.event === 'output'
+            && message.body.category === 'stderr'
+            && message.body.output.includes(String(startError))));
+
+        outputSubscription.dispose();
+    });
+
     test('project is built when C# dev kit is installed and executable not found', async () => {
         const outputPath = 'C:\\temp\\bin\\Debug\\net7.0\\TestProject.dll';
         const { extension, dotNetService } = createDebuggerExtension(outputPath, null, true, false);


### PR DESCRIPTION
## Description

Fixes #15578

When a VS Code AppHost debug launch fails before the child debug session starts, the extension now writes the failure details to the Debug Console as stderr before showing the existing error dialog.

Validation:
- `npm run compile-tests && npm run unit-test -- --grep "Dotnet Debugger Extension Tests" --timeout 10000`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
