### PR TITLE
Show AppHost SDK version in aspire ps

### DIFF
--- a/src/Aspire.Cli/Backchannel/IAppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/IAppHostAuxiliaryBackchannel.cs
@@ -42,6 +42,13 @@ internal interface IAppHostAuxiliaryBackchannel : IDisposable
     bool SupportsV2 { get; }
 
     /// <summary>
+    /// Gets AppHost information using the v2 API.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The AppHost information response.</returns>
+    Task<GetAppHostInfoResponse?> GetAppHostInfoV2Async(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the Dashboard URLs from the AppHost.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -13,6 +14,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Shared.Model.Serialization;
 using Microsoft.Extensions.Logging;
+using Semver;
 using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
@@ -235,18 +237,38 @@ internal sealed class PsCommand : BaseCommand
             return null;
         }
 
-        var plusIndex = sdkVersion.IndexOf('+');
-        if (plusIndex > 0)
+        if (SemVersion.TryParse(sdkVersion, SemVersionStyles.Strict, out var semVersion))
         {
-            sdkVersion = sdkVersion[..plusIndex];
+            return semVersion.WithoutMetadata().ToString();
         }
 
-        if (Version.TryParse(sdkVersion, out var version) && version.Revision == 0)
+        if (TryTrimTrailingZeroVersionSegment(sdkVersion, out var normalizedSdkVersion) &&
+            SemVersion.TryParse(normalizedSdkVersion, SemVersionStyles.Strict, out semVersion))
         {
-            return FormattableString.Invariant($"{version.Major}.{version.Minor}.{version.Build}");
+            return semVersion.WithoutMetadata().ToString();
         }
 
         return sdkVersion;
+    }
+
+    private static bool TryTrimTrailingZeroVersionSegment(string sdkVersion, [NotNullWhen(true)] out string? normalizedSdkVersion)
+    {
+        var suffixIndex = sdkVersion.IndexOfAny(['-', '+']);
+        var versionCore = suffixIndex >= 0 ? sdkVersion[..suffixIndex] : sdkVersion;
+        var suffix = suffixIndex >= 0 ? sdkVersion[suffixIndex..] : string.Empty;
+        var versionParts = versionCore.Split('.');
+
+        if (versionParts is [var major, var minor, var patch, "0"] &&
+            int.TryParse(major, NumberStyles.None, CultureInfo.InvariantCulture, out _) &&
+            int.TryParse(minor, NumberStyles.None, CultureInfo.InvariantCulture, out _) &&
+            int.TryParse(patch, NumberStyles.None, CultureInfo.InvariantCulture, out _))
+        {
+            normalizedSdkVersion = $"{major}.{minor}.{patch}{suffix}";
+            return true;
+        }
+
+        normalizedSdkVersion = null;
+        return false;
     }
 
     private void DisplayTable(List<AppHostDisplayInfo> appHosts)

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -25,6 +25,7 @@ internal sealed class AppHostDisplayInfo
 {
     public required string AppHostPath { get; init; }
     public required int AppHostPid { get; init; }
+    public string? SdkVersion { get; init; }
     public int? CliPid { get; init; }
     public string? DashboardUrl { get; init; }
 
@@ -158,6 +159,31 @@ internal sealed class PsCommand : BaseCommand
                 continue;
             }
 
+            string? sdkVersion = null;
+            var appHostPath = info.AppHostPath;
+            var appHostPid = info.ProcessId;
+            var cliPid = info.CliProcessId;
+
+            try
+            {
+                var v2Info = await connection.GetAppHostInfoV2Async(cancellationToken).ConfigureAwait(false);
+                if (v2Info is not null)
+                {
+                    sdkVersion = NormalizeSdkVersion(v2Info.AspireHostVersion);
+                    appHostPath = string.IsNullOrWhiteSpace(v2Info.AppHostPath) ? appHostPath : v2Info.AppHostPath;
+                    cliPid = v2Info.CliProcessId ?? cliPid;
+
+                    if (int.TryParse(v2Info.Pid, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedPid))
+                    {
+                        appHostPid = parsedPid;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to get AppHost SDK version for {AppHostPath}", info.AppHostPath);
+            }
+
             string? dashboardUrl = null;
 
             try
@@ -186,15 +212,27 @@ internal sealed class PsCommand : BaseCommand
 
             appHostInfos.Add(new AppHostDisplayInfo
             {
-                AppHostPath = info.AppHostPath ?? PsCommandStrings.UnknownPath,
-                AppHostPid = info.ProcessId,
-                CliPid = info.CliProcessId,
+                AppHostPath = appHostPath ?? PsCommandStrings.UnknownPath,
+                AppHostPid = appHostPid,
+                SdkVersion = sdkVersion,
+                CliPid = cliPid,
                 DashboardUrl = dashboardUrl,
                 Resources = resources
             });
         }
 
         return appHostInfos;
+    }
+
+    private static string? NormalizeSdkVersion(string? sdkVersion)
+    {
+        if (string.IsNullOrWhiteSpace(sdkVersion) ||
+            string.Equals(sdkVersion, "unknown", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return sdkVersion;
     }
 
     private void DisplayTable(List<AppHostDisplayInfo> appHosts)
@@ -208,6 +246,7 @@ internal sealed class PsCommand : BaseCommand
 
         var table = new Table();
         table.AddBoldColumn(PsCommandStrings.HeaderPath);
+        table.AddBoldColumn(PsCommandStrings.HeaderSdk);
         table.AddBoldColumn(PsCommandStrings.HeaderPid);
         table.AddBoldColumn(PsCommandStrings.HeaderCliPid);
         table.AddBoldColumn(PsCommandStrings.HeaderDashboard);
@@ -231,6 +270,7 @@ internal sealed class PsCommand : BaseCommand
 
             table.AddRow(
                 Markup.Escape(shortPath),
+                Markup.Escape(appHost.SdkVersion ?? string.Empty),
                 appHost.AppHostPid.ToString(CultureInfo.InvariantCulture),
                 cliPid,
                 dashboard);

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -14,7 +13,6 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Shared.Model.Serialization;
 using Microsoft.Extensions.Logging;
-using Semver;
 using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
@@ -173,7 +171,7 @@ internal sealed class PsCommand : BaseCommand
                     var v2Info = await connection.GetAppHostInfoV2Async(cancellationToken).ConfigureAwait(false);
                     if (v2Info is not null)
                     {
-                        sdkVersion = NormalizeSdkVersion(v2Info.AspireHostVersion);
+                        sdkVersion = GetSdkVersion(v2Info.AspireHostVersion);
                         appHostPath = string.IsNullOrWhiteSpace(v2Info.AppHostPath) ? appHostPath : v2Info.AppHostPath;
                         cliPid = v2Info.CliProcessId ?? cliPid;
 
@@ -229,7 +227,7 @@ internal sealed class PsCommand : BaseCommand
         return appHostInfos;
     }
 
-    private static string? NormalizeSdkVersion(string? sdkVersion)
+    private static string? GetSdkVersion(string? sdkVersion)
     {
         if (string.IsNullOrWhiteSpace(sdkVersion) ||
             string.Equals(sdkVersion, "unknown", StringComparison.OrdinalIgnoreCase))
@@ -237,38 +235,7 @@ internal sealed class PsCommand : BaseCommand
             return null;
         }
 
-        if (SemVersion.TryParse(sdkVersion, SemVersionStyles.Strict, out var semVersion))
-        {
-            return semVersion.WithoutMetadata().ToString();
-        }
-
-        if (TryTrimTrailingZeroVersionSegment(sdkVersion, out var normalizedSdkVersion) &&
-            SemVersion.TryParse(normalizedSdkVersion, SemVersionStyles.Strict, out semVersion))
-        {
-            return semVersion.WithoutMetadata().ToString();
-        }
-
         return sdkVersion;
-    }
-
-    private static bool TryTrimTrailingZeroVersionSegment(string sdkVersion, [NotNullWhen(true)] out string? normalizedSdkVersion)
-    {
-        var suffixIndex = sdkVersion.IndexOfAny(['-', '+']);
-        var versionCore = suffixIndex >= 0 ? sdkVersion[..suffixIndex] : sdkVersion;
-        var suffix = suffixIndex >= 0 ? sdkVersion[suffixIndex..] : string.Empty;
-        var versionParts = versionCore.Split('.');
-
-        if (versionParts is [var major, var minor, var patch, "0"] &&
-            int.TryParse(major, NumberStyles.None, CultureInfo.InvariantCulture, out _) &&
-            int.TryParse(minor, NumberStyles.None, CultureInfo.InvariantCulture, out _) &&
-            int.TryParse(patch, NumberStyles.None, CultureInfo.InvariantCulture, out _))
-        {
-            normalizedSdkVersion = $"{major}.{minor}.{patch}{suffix}";
-            return true;
-        }
-
-        normalizedSdkVersion = null;
-        return false;
     }
 
     private void DisplayTable(List<AppHostDisplayInfo> appHosts)

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -166,16 +166,19 @@ internal sealed class PsCommand : BaseCommand
 
             try
             {
-                var v2Info = await connection.GetAppHostInfoV2Async(cancellationToken).ConfigureAwait(false);
-                if (v2Info is not null)
+                if (connection.SupportsV2)
                 {
-                    sdkVersion = NormalizeSdkVersion(v2Info.AspireHostVersion);
-                    appHostPath = string.IsNullOrWhiteSpace(v2Info.AppHostPath) ? appHostPath : v2Info.AppHostPath;
-                    cliPid = v2Info.CliProcessId ?? cliPid;
-
-                    if (int.TryParse(v2Info.Pid, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedPid))
+                    var v2Info = await connection.GetAppHostInfoV2Async(cancellationToken).ConfigureAwait(false);
+                    if (v2Info is not null)
                     {
-                        appHostPid = parsedPid;
+                        sdkVersion = NormalizeSdkVersion(v2Info.AspireHostVersion);
+                        appHostPath = string.IsNullOrWhiteSpace(v2Info.AppHostPath) ? appHostPath : v2Info.AppHostPath;
+                        cliPid = v2Info.CliProcessId ?? cliPid;
+
+                        if (int.TryParse(v2Info.Pid, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedPid))
+                        {
+                            appHostPid = parsedPid;
+                        }
                     }
                 }
             }
@@ -270,7 +273,7 @@ internal sealed class PsCommand : BaseCommand
 
             table.AddRow(
                 Markup.Escape(shortPath),
-                Markup.Escape(appHost.SdkVersion ?? string.Empty),
+                Markup.Escape(appHost.SdkVersion ?? "-"),
                 appHost.AppHostPid.ToString(CultureInfo.InvariantCulture),
                 cliPid,
                 dashboard);

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -235,6 +235,17 @@ internal sealed class PsCommand : BaseCommand
             return null;
         }
 
+        var plusIndex = sdkVersion.IndexOf('+');
+        if (plusIndex > 0)
+        {
+            sdkVersion = sdkVersion[..plusIndex];
+        }
+
+        if (Version.TryParse(sdkVersion, out var version) && version.Revision == 0)
+        {
+            return FormattableString.Invariant($"{version.Major}.{version.Minor}.{version.Build}");
+        }
+
         return sdkVersion;
     }
 

--- a/src/Aspire.Cli/Resources/PsCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/PsCommandStrings.Designer.cs
@@ -63,6 +63,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string HeaderSdk {
+            get {
+                return ResourceManager.GetString("HeaderSdk", resourceCulture);
+            }
+        }
+
         public static string HeaderPid {
             get {
                 return ResourceManager.GetString("HeaderPid", resourceCulture);

--- a/src/Aspire.Cli/Resources/PsCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/PsCommandStrings.resx
@@ -126,6 +126,9 @@
   <data name="HeaderPath" xml:space="preserve">
     <value>Path</value>
   </data>
+  <data name="HeaderSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
   <data name="HeaderPid" xml:space="preserve">
     <value>PID</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Výstup ve formátu JSON</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Ausgabe im JSON-Format.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Salida en formato JSON.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Sortie au format JSON.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Output in formato JSON.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">JSON 形式で出力します。</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">JSON 형식의 출력입니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Identyfikator PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Wynik w formacie JSON.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Saída no formato JSON.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Вывод в формате JSON.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">Çıkışı JSON biçiminde oluşturun.</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">以 JSON 格式输出。</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">PID</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderSdk">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>
         <target state="needs-review-translation">以 JSON 格式輸出。</target>

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -71,8 +71,35 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
 
     private static string GetAspireHostVersion()
     {
-        return typeof(AuxiliaryBackchannelRpcTarget).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+        return GetDisplayVersion(typeof(AuxiliaryBackchannelRpcTarget).Assembly) ?? "unknown";
+    }
+
+    internal static string? GetDisplayVersion(Assembly assembly)
+    {
+        // The package version is stamped into the assembly's AssemblyInformationalVersionAttribute at build time, followed by a '+' and
+        // the commit hash, e.g.:
+        // [assembly: AssemblyInformationalVersion("8.0.0-preview.2.23604.7+e7762a46d31842884a0bc72c92e07ba700c99bf5")]
+
+        var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        if (version is not null)
+        {
+            var plusIndex = version.IndexOf('+');
+
+            if (plusIndex > 0)
+            {
+                return version[..plusIndex];
+            }
+
+            return version;
+        }
+
+        // Fallback to the file version, which is based on the CI build number, and then fallback to the assembly version, which is
+        // product stable version, e.g. 8.0.0.0
+        version = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version
+            ?? assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version;
+
+        return version;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Channels;
@@ -61,11 +62,17 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         return new GetAppHostInfoResponse
         {
             Pid = legacyInfo.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            AspireHostVersion = typeof(AuxiliaryBackchannelRpcTarget).Assembly.GetName().Version?.ToString() ?? "unknown",
+            AspireHostVersion = GetAspireHostVersion(),
             AppHostPath = legacyInfo.AppHostPath,
             CliProcessId = legacyInfo.CliProcessId,
             StartedAt = legacyInfo.StartedAt
         };
+    }
+
+    private static string GetAspireHostVersion()
+    {
+        return typeof(AuxiliaryBackchannelRpcTarget).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -169,13 +169,17 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             });
     }
 
-    [Fact]
-    public async Task PsCommand_JsonFormat_IncludesSdkVersionFromV2AppHostInfo()
+    [Theory]
+    [InlineData("9.9.9", "9.9.9")]
+    [InlineData("13.2.4.0", "13.2.4")]
+    [InlineData("13.2.4.0+e7762a46d31842884a0bc72c92e07ba700c99bf5", "13.2.4")]
+    [InlineData("13.3.0-pr.16502.g809f606f+e7762a46d31842884a0bc72c92e07ba700c99bf5", "13.3.0-pr.16502.g809f606f")]
+    public async Task PsCommand_JsonFormat_NormalizesSdkVersionFromV2AppHostInfo(string sdkVersion, string expectedSdkVersion)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var textWriter = new TestOutputTextWriter(outputHelper);
         var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
-        using var server = TestAppHostBackchannelServer.Start(appHostPath, processId: 1234, sdkVersion: "9.9.9");
+        using var server = TestAppHostBackchannelServer.Start(appHostPath, processId: 1234, sdkVersion: sdkVersion);
         using var connection = await server.ConnectAsync().DefaultTimeout();
 
         var monitor = new TestAuxiliaryBackchannelMonitor();
@@ -198,7 +202,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
         using var document = JsonDocument.Parse(jsonOutput);
         Assert.Equal(1, document.RootElement.GetArrayLength());
-        Assert.Equal("9.9.9", document.RootElement[0].GetProperty("sdkVersion").GetString());
+        Assert.Equal(expectedSdkVersion, document.RootElement[0].GetProperty("sdkVersion").GetString());
     }
 
     [Fact]
@@ -379,7 +383,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var textWriter = new TestOutputTextWriter(outputHelper);
         var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
-        using var server = TestAppHostBackchannelServer.Start(appHostPath, processId: 1234, sdkVersion: "9.9.9");
+        using var server = TestAppHostBackchannelServer.Start(appHostPath, processId: 1234, sdkVersion: "13.2.4.0");
         using var connection = await server.ConnectAsync().DefaultTimeout();
 
         var monitor = new TestAuxiliaryBackchannelMonitor();
@@ -403,7 +407,8 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var output = string.Join(Environment.NewLine, textWriter.Logs);
         var normalizedOutput = output.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
         Assert.Contains("SDK", normalizedOutput, StringComparison.Ordinal);
-        Assert.Contains("9.9.9", normalizedOutput, StringComparison.Ordinal);
+        Assert.Contains("13.2.4", normalizedOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("13.2.4.0", normalizedOutput, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -171,11 +171,10 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
     [Theory]
     [InlineData("9.9.9", "9.9.9")]
-    [InlineData("13.2.4.0", "13.2.4")]
-    [InlineData("13.2.4.0+e7762a46d31842884a0bc72c92e07ba700c99bf5", "13.2.4")]
-    [InlineData("13.3.0-pr.16502.g809f606f+e7762a46d31842884a0bc72c92e07ba700c99bf5", "13.3.0-pr.16502.g809f606f")]
-    [InlineData("13.2.4.0-preview.1+e7762a46d31842884a0bc72c92e07ba700c99bf5", "13.2.4-preview.1")]
-    public async Task PsCommand_JsonFormat_NormalizesSdkVersionFromV2AppHostInfo(string sdkVersion, string expectedSdkVersion)
+    [InlineData("13.2.4", "13.2.4")]
+    [InlineData("13.3.0-pr.16502.g809f606f", "13.3.0-pr.16502.g809f606f")]
+    [InlineData("13.2.4-preview.1", "13.2.4-preview.1")]
+    public async Task PsCommand_JsonFormat_DisplaysSdkVersionFromV2AppHostInfo(string sdkVersion, string expectedSdkVersion)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var textWriter = new TestOutputTextWriter(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -407,8 +407,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var output = string.Join(Environment.NewLine, textWriter.Logs);
         var normalizedOutput = output.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
         Assert.Contains("SDK", normalizedOutput, StringComparison.Ordinal);
-        Assert.Contains("13.2.4", normalizedOutput, StringComparison.Ordinal);
-        Assert.DoesNotContain("13.2.4.0", normalizedOutput, StringComparison.Ordinal);
+        Assert.Contains("13.2.4.0", normalizedOutput, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -174,6 +174,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     [InlineData("13.2.4.0", "13.2.4")]
     [InlineData("13.2.4.0+e7762a46d31842884a0bc72c92e07ba700c99bf5", "13.2.4")]
     [InlineData("13.3.0-pr.16502.g809f606f+e7762a46d31842884a0bc72c92e07ba700c99bf5", "13.3.0-pr.16502.g809f606f")]
+    [InlineData("13.2.4.0-preview.1+e7762a46d31842884a0bc72c92e07ba700c99bf5", "13.2.4-preview.1")]
     public async Task PsCommand_JsonFormat_NormalizesSdkVersionFromV2AppHostInfo(string sdkVersion, string expectedSdkVersion)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using StreamJsonRpc;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -167,6 +170,77 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PsCommand_JsonFormat_IncludesSdkVersionFromV2AppHostInfo()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
+        using var server = TestAppHostBackchannelServer.Start(appHostPath, processId: 1234, sdkVersion: "9.9.9");
+        using var connection = await server.ConnectAsync().DefaultTimeout();
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = string.Join(string.Empty, textWriter.Logs);
+        using var document = JsonDocument.Parse(jsonOutput);
+        Assert.Equal(1, document.RootElement.GetArrayLength());
+        Assert.Equal("9.9.9", document.RootElement[0].GetProperty("sdkVersion").GetString());
+    }
+
+    [Fact]
+    public async Task PsCommand_JsonFormat_UsesNullSdkVersionWhenUnknown()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = string.Join(string.Empty, textWriter.Logs);
+        using var document = JsonDocument.Parse(jsonOutput);
+        Assert.Equal(1, document.RootElement.GetArrayLength());
+        Assert.True(document.RootElement[0].TryGetProperty("sdkVersion", out var sdkVersion));
+        Assert.Equal(JsonValueKind.Null, sdkVersion.ValueKind);
+    }
+
+    [Fact]
     public async Task PsCommand_JsonFormat_ReturnsAnonymousDashboardUrl()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -252,6 +326,39 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var normalizedOutput = output.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
         var expectedDashboardUrl = new Uri("http://localhost:18888/login?t=abc123").AbsoluteUri;
         Assert.Contains(expectedDashboardUrl, normalizedOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PsCommand_TableFormat_IncludesSdkVersionFromV2AppHostInfo()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
+        using var server = TestAppHostBackchannelServer.Start(appHostPath, processId: 1234, sdkVersion: "9.9.9");
+        using var connection = await server.ConnectAsync().DefaultTimeout();
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.DisableAnsi = true;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var output = string.Join(Environment.NewLine, textWriter.Logs);
+        var normalizedOutput = output.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
+        Assert.Contains("SDK", normalizedOutput, StringComparison.Ordinal);
+        Assert.Contains("9.9.9", normalizedOutput, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -454,5 +561,101 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(resourcesFetched, "Resources should not be fetched when output format is table");
+    }
+
+    private sealed class TestAppHostBackchannelServer : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly TestAppHostRpcTarget _target;
+        private readonly List<IDisposable> _disposables = [];
+
+        private TestAppHostBackchannelServer(string appHostPath, int processId, string sdkVersion)
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _target = new TestAppHostRpcTarget(appHostPath, processId, sdkVersion);
+        }
+
+        public static TestAppHostBackchannelServer Start(string appHostPath, int processId, string sdkVersion)
+        {
+            var server = new TestAppHostBackchannelServer(appHostPath, processId, sdkVersion);
+            server._listener.Start();
+
+            return server;
+        }
+
+        public async Task<AppHostAuxiliaryBackchannel> ConnectAsync()
+        {
+            var clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var acceptTask = _listener.AcceptSocketAsync();
+            await clientSocket.ConnectAsync((IPEndPoint)_listener.LocalEndpoint).DefaultTimeout();
+            var serverSocket = await acceptTask.DefaultTimeout();
+            var serverStream = new NetworkStream(serverSocket, ownsSocket: true);
+            var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(serverStream, serverStream, BackchannelJsonSerializerContext.CreateRpcMessageFormatter()), _target);
+            rpc.StartListening();
+            _disposables.Add(rpc);
+
+            return await AppHostAuxiliaryBackchannel.CreateFromSocketAsync("hash1", "socket.hash1", isInScope: true, clientSocket).DefaultTimeout();
+        }
+
+        public void Dispose()
+        {
+            foreach (var disposable in _disposables)
+            {
+                disposable.Dispose();
+            }
+
+            _listener.Stop();
+        }
+    }
+
+    private sealed class TestAppHostRpcTarget(string appHostPath, int processId, string sdkVersion)
+    {
+        public Task<AppHostInformation> GetAppHostInformationAsync(CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+
+            return Task.FromResult(new AppHostInformation
+            {
+                AppHostPath = appHostPath,
+                ProcessId = processId
+            });
+        }
+
+        public Task<GetCapabilitiesResponse> GetCapabilitiesAsync(GetCapabilitiesRequest? request = null, CancellationToken cancellationToken = default)
+        {
+            _ = request;
+            _ = cancellationToken;
+            string[] capabilities = string.IsNullOrEmpty(sdkVersion)
+                ? [AuxiliaryBackchannelCapabilities.V1]
+                : [AuxiliaryBackchannelCapabilities.V1, AuxiliaryBackchannelCapabilities.V2];
+
+            return Task.FromResult(new GetCapabilitiesResponse
+            {
+                Capabilities = capabilities
+            });
+        }
+
+        public Task<GetAppHostInfoResponse> GetAppHostInfoAsync(GetAppHostInfoRequest? request = null, CancellationToken cancellationToken = default)
+        {
+            _ = request;
+            _ = cancellationToken;
+
+            return Task.FromResult(new GetAppHostInfoResponse
+            {
+                Pid = processId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                AspireHostVersion = sdkVersion,
+                AppHostPath = appHostPath
+            });
+        }
+
+        public Task<DashboardUrlsState> GetDashboardUrlsAsync(CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+
+            return Task.FromResult(new DashboardUrlsState
+            {
+                DashboardHealthy = !string.IsNullOrEmpty(appHostPath)
+            });
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -241,6 +241,51 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PsCommand_JsonFormat_DoesNotFetchSdkVersionFromV1Connection()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            SupportsV2 = false,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234
+            },
+            AppHostInfoResponse = new GetAppHostInfoResponse
+            {
+                Pid = "1234",
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                AspireHostVersion = "9.9.9"
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = string.Join(string.Empty, textWriter.Logs);
+        using var document = JsonDocument.Parse(jsonOutput);
+        Assert.Equal(1, document.RootElement.GetArrayLength());
+        Assert.Equal(JsonValueKind.Null, document.RootElement[0].GetProperty("sdkVersion").ValueKind);
+    }
+
+    [Fact]
     public async Task PsCommand_JsonFormat_ReturnsAnonymousDashboardUrl()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -359,6 +404,46 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var normalizedOutput = output.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
         Assert.Contains("SDK", normalizedOutput, StringComparison.Ordinal);
         Assert.Contains("9.9.9", normalizedOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PsCommand_TableFormat_DisplaysDashWhenSdkVersionIsUnavailable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            SupportsV2 = false,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = appHostPath,
+                ProcessId = 1234
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.DisableAnsi = true;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var output = string.Join(Environment.NewLine, textWriter.Logs);
+        Assert.Contains("SDK", output, StringComparison.Ordinal);
+        Assert.Contains(" - ", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -590,9 +675,12 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             await clientSocket.ConnectAsync((IPEndPoint)_listener.LocalEndpoint).DefaultTimeout();
             var serverSocket = await acceptTask.DefaultTimeout();
             var serverStream = new NetworkStream(serverSocket, ownsSocket: true);
-            var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(serverStream, serverStream, BackchannelJsonSerializerContext.CreateRpcMessageFormatter()), _target);
+            var messageHandler = new HeaderDelimitedMessageHandler(serverStream, serverStream, BackchannelJsonSerializerContext.CreateRpcMessageFormatter());
+            var rpc = new JsonRpc(messageHandler, _target);
             rpc.StartListening();
             _disposables.Add(rpc);
+            _disposables.Add(messageHandler);
+            _disposables.Add(serverStream);
 
             return await AppHostAuxiliaryBackchannel.CreateFromSocketAsync("hash1", "socket.hash1", isInScope: true, clientSocket).DefaultTimeout();
         }

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostAuxiliaryBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostAuxiliaryBackchannel.cs
@@ -31,6 +31,11 @@ internal sealed class TestAppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackcha
     public DashboardUrlsState? DashboardUrlsState { get; set; }
 
     /// <summary>
+    /// Gets or sets the AppHost info response to return from GetAppHostInfoV2Async.
+    /// </summary>
+    public GetAppHostInfoResponse? AppHostInfoResponse { get; set; }
+
+    /// <summary>
     /// Gets or sets the log lines to return from GetResourceLogsAsync.
     /// </summary>
     public List<ResourceLogLine> LogLines { get; set; } = [];
@@ -66,6 +71,30 @@ internal sealed class TestAppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackcha
     public Task<DashboardUrlsState?> GetDashboardUrlsAsync(CancellationToken cancellationToken = default)
     {
         return Task.FromResult(DashboardUrlsState);
+    }
+
+    public Task<GetAppHostInfoResponse?> GetAppHostInfoV2Async(CancellationToken cancellationToken = default)
+    {
+        _ = cancellationToken;
+
+        if (AppHostInfoResponse is not null)
+        {
+            return Task.FromResult<GetAppHostInfoResponse?>(AppHostInfoResponse);
+        }
+
+        if (AppHostInfo is null)
+        {
+            return Task.FromResult<GetAppHostInfoResponse?>(null);
+        }
+
+        return Task.FromResult<GetAppHostInfoResponse?>(new GetAppHostInfoResponse
+        {
+            Pid = AppHostInfo.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            AspireHostVersion = "unknown",
+            AppHostPath = AppHostInfo.AppHostPath,
+            CliProcessId = AppHostInfo.CliProcessId,
+            StartedAt = AppHostInfo.StartedAt
+        });
     }
 
     public Task<List<ResourceSnapshot>> GetResourceSnapshotsAsync(bool includeHidden, CancellationToken cancellationToken = default)

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using System.Reflection.Emit;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
@@ -14,8 +15,56 @@ namespace Aspire.Hosting.Backchannel;
 [Trait("Partition", "4")]
 public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 {
+    [Theory]
+    [InlineData("8.0.0-preview.1", "8.0.0-preview.1")]
+    [InlineData("8.0.0-preview.1+asdlkjfdijee", "8.0.0-preview.1")]
+    [InlineData("8.0.0-preview.1+asdlkjfdijee+someothersuffix", "8.0.0-preview.1")]
+    [InlineData("+asdlkjfdijee", "+asdlkjfdijee")]
+    [InlineData("Plain old text", "Plain old text")]
+    [InlineData("", "")]
+    public void GetDisplayVersionUsesDashboardDisplayVersionImplementation(string informationalVersion, string expectedDisplayVersion)
+    {
+        var assembly = CreateAssembly(CreateAttribute<AssemblyInformationalVersionAttribute>(informationalVersion));
+
+        var actualDisplayVersion = AuxiliaryBackchannelRpcTarget.GetDisplayVersion(assembly);
+
+        Assert.Equal(expectedDisplayVersion, actualDisplayVersion);
+    }
+
     [Fact]
-    public async Task GetAppHostInfoAsync_ReturnsAssemblyInformationalVersion()
+    public void GetDisplayVersionUsesFileVersionWhenInformationalVersionIsMissing()
+    {
+        var assembly = CreateAssembly(
+            CreateAttribute<AssemblyFileVersionAttribute>("42.42.42.42424"),
+            CreateAttribute<AssemblyVersionAttribute>("8.0.0.0"));
+
+        var actualDisplayVersion = AuxiliaryBackchannelRpcTarget.GetDisplayVersion(assembly);
+
+        Assert.Equal("42.42.42.42424", actualDisplayVersion);
+    }
+
+    [Fact]
+    public void GetDisplayVersionUsesAssemblyVersionWhenInformationalAndFileVersionsAreMissing()
+    {
+        var assembly = CreateAssembly(CreateAttribute<AssemblyVersionAttribute>("8.0.0.0"));
+
+        var actualDisplayVersion = AuxiliaryBackchannelRpcTarget.GetDisplayVersion(assembly);
+
+        Assert.Equal("8.0.0.0", actualDisplayVersion);
+    }
+
+    [Fact]
+    public void GetDisplayVersionReturnsNullWhenVersionAttributesAreMissing()
+    {
+        var assembly = CreateAssembly();
+
+        var actualDisplayVersion = AuxiliaryBackchannelRpcTarget.GetDisplayVersion(assembly);
+
+        Assert.Null(actualDisplayVersion);
+    }
+
+    [Fact]
+    public async Task GetAppHostInfoAsync_ReturnsAssemblyDisplayVersion()
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -34,9 +83,38 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 
         var result = await target.GetAppHostInfoAsync().DefaultTimeout();
         var expectedVersion = typeof(AuxiliaryBackchannelRpcTarget).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var plusIndex = expectedVersion?.IndexOf('+') ?? -1;
+        if (plusIndex > 0)
+        {
+            expectedVersion = expectedVersion![..plusIndex];
+        }
+        expectedVersion ??= typeof(AuxiliaryBackchannelRpcTarget).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version
+            ?? typeof(AuxiliaryBackchannelRpcTarget).Assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version
+            ?? "unknown";
 
         Assert.Equal(expectedVersion, result.AspireHostVersion);
+    }
+
+    private static AssemblyBuilder CreateAssembly(params CustomAttributeBuilder[] attributes)
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName($"TestAssembly{Guid.NewGuid():N}"), AssemblyBuilderAccess.Run);
+
+        foreach (var attribute in attributes)
+        {
+            assembly.SetCustomAttribute(attribute);
+        }
+
+        return assembly;
+    }
+
+    private static CustomAttributeBuilder CreateAttribute<TAttribute>(string value)
+        where TAttribute : Attribute
+    {
+        var constructor = typeof(TAttribute).GetConstructor([typeof(string)]);
+        Assert.NotNull(constructor);
+
+        return new CustomAttributeBuilder(constructor, [value]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -12,6 +14,31 @@ namespace Aspire.Hosting.Backchannel;
 [Trait("Partition", "4")]
 public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 {
+    [Fact]
+    public async Task GetAppHostInfoAsync_ReturnsAssemblyInformationalVersion()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppHost:Path"] = "/path/to/apphost.csproj"
+            })
+            .Build();
+
+        using var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .BuildServiceProvider();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            services);
+
+        var result = await target.GetAppHostInfoAsync().DefaultTimeout();
+        var expectedVersion = typeof(AuxiliaryBackchannelRpcTarget).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+
+        Assert.Equal(expectedVersion, result.AspireHostVersion);
+    }
+
     [Fact]
     public async Task GetResourceSnapshotsAsync_EnumeratesResources()
     {


### PR DESCRIPTION
## Description

Fixes #16292

`aspire ps` now surfaces the AppHost SDK version from the v2 auxiliary backchannel in table output and JSON output as `sdkVersion`, with unknown values rendered as blank/null.

<img width="2494" height="238" alt="image" src="https://github.com/user-attachments/assets/91e57017-ed54-420b-92e5-c39fdfc903c9" />


Validation:
- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-restore --verbosity quiet -- --filter-class "*.PsCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
