### PR TITLE
Disambiguate VS Code AppHost path labels

### DIFF
--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -120,8 +120,8 @@ suite('shortenPaths', () => {
         const result = shortenPaths(paths);
 
         assert.deepStrictEqual(result, [
-            path.join('folder1', 'Project.csproj'),
-            path.join('folder2', 'Project.csproj'),
+            'folder1/Project.csproj',
+            'folder2/Project.csproj',
         ]);
     });
 
@@ -134,8 +134,8 @@ suite('shortenPaths', () => {
         const result = shortenPaths(paths);
 
         assert.deepStrictEqual(result, [
-            path.join('a', 'shared', 'Project.csproj'),
-            path.join('b', 'shared', 'Project.csproj'),
+            'a/shared/Project.csproj',
+            'b/shared/Project.csproj',
         ]);
     });
 
@@ -145,7 +145,7 @@ suite('shortenPaths', () => {
         const result = shortenPaths(paths);
 
         assert.deepStrictEqual(result, [
-            path.join('MyApp', 'AppHost.cs'),
+            'MyApp/AppHost.cs',
         ]);
     });
 
@@ -159,7 +159,7 @@ suite('shortenPaths', () => {
 
         assert.deepStrictEqual(result, [
             'App1.AppHost.csproj',
-            path.join('App2', 'AppHost.cs'),
+            'App2/AppHost.cs',
         ]);
     });
 

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1,9 +1,13 @@
 import * as assert from 'assert';
 import * as path from 'path';
-import { shortenPath } from '../views/AppHostDataRepository';
-import { getResourceContextValue, getResourceIcon, resolveAppHostSourcePath, buildResourceDescription } from '../views/AspireAppHostTreeProvider';
-import type { ResourceJson } from '../views/AppHostDataRepository';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as cliModule from '../debugger/languages/cli';
+import { AppHostDataRepository, shortenPath } from '../views/AppHostDataRepository';
+import { AspireAppHostTreeProvider, getResourceContextValue, getResourceIcon, resolveAppHostSourcePath, buildResourceDescription } from '../views/AspireAppHostTreeProvider';
+import type { AppHostDisplayInfo, ResourceJson, ViewMode } from '../views/AppHostDataRepository';
 import { ResourceState, HealthStatus, StateStyle } from '../editor/resourceConstants';
+import type { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 
 function makeResource(overrides: Partial<ResourceJson> = {}): ResourceJson {
     const base: ResourceJson = {
@@ -25,6 +29,43 @@ function makeResource(overrides: Partial<ResourceJson> = {}): ResourceJson {
 
 function buildPath(...segments: string[]): string {
     return path.join(...segments);
+}
+
+function makeAppHost(overrides: Partial<AppHostDisplayInfo> = {}): AppHostDisplayInfo {
+    return {
+        appHostPath: '/test/AppHost.csproj',
+        appHostPid: 1234,
+        cliPid: null,
+        dashboardUrl: null,
+        resources: null,
+        ...overrides,
+    };
+}
+
+function makeTerminalProvider(): AspireTerminalProvider {
+    return {
+        getAspireCliExecutablePath: async () => 'aspire',
+        createEnvironment: () => ({}),
+        sendAspireCommandToAspireTerminal: () => { },
+    } as unknown as AspireTerminalProvider;
+}
+
+function makeTreeProvider(appHosts: readonly AppHostDisplayInfo[], viewMode: ViewMode = 'global'): AspireAppHostTreeProvider {
+    const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+    const repository = {
+        viewMode,
+        appHosts,
+        workspaceResources: [],
+        workspaceAppHostPath: undefined,
+        workspaceAppHostName: undefined,
+        onDidChangeData,
+    } as unknown as AppHostDataRepository;
+
+    return new AspireAppHostTreeProvider(repository, makeTerminalProvider());
+}
+
+async function flushPromises(): Promise<void> {
+    await new Promise(resolve => setImmediate(resolve));
 }
 
 suite('shortenPath', () => {
@@ -50,6 +91,120 @@ suite('shortenPath', () => {
 
     test('two segments returns parent/filename', () => {
         assert.strictEqual(shortenPath('MyApp/AppHost.cs'), 'MyApp/AppHost.cs');
+    });
+});
+
+suite('AspireAppHostTreeProvider', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('global apphost labels add enough parent folders to disambiguate duplicate filenames', () => {
+        const appHosts = [
+            makeAppHost({
+                appHostPath: '/workspace/apps/Store/AppHost.csproj',
+                appHostPid: 1,
+            }),
+            makeAppHost({
+                appHostPath: '/workspace/samples/Store/AppHost.csproj',
+                appHostPid: 2,
+            }),
+        ];
+        const provider = makeTreeProvider(appHosts);
+
+        const labels = provider.getChildren().map(item => item.label);
+
+        assert.deepStrictEqual(labels, [
+            'apps/Store/AppHost.csproj',
+            'samples/Store/AppHost.csproj',
+        ]);
+    });
+
+    test('global apphost labels keep single-path shortening behavior', () => {
+        const provider = makeTreeProvider([
+            makeAppHost({
+                appHostPath: '/workspace/apps/Store/AppHost.cs',
+                appHostPid: 1,
+            }),
+        ]);
+
+        const [item] = provider.getChildren();
+
+        assert.strictEqual(item.label, 'Store/AppHost.cs');
+    });
+
+    test('dashboard quick pick labels add enough parent folders to disambiguate duplicate filenames', async () => {
+        const appHosts = [
+            makeAppHost({
+                appHostPath: '/workspace/apps/Store/AppHost.csproj',
+                appHostPid: 1,
+                dashboardUrl: 'http://localhost:1001',
+            }),
+            makeAppHost({
+                appHostPath: '/workspace/samples/Store/AppHost.csproj',
+                appHostPid: 2,
+                dashboardUrl: 'http://localhost:1002',
+            }),
+        ];
+        const provider = makeTreeProvider(appHosts);
+        const showQuickPickStub = sandbox.stub(vscode.window, 'showQuickPick').resolves(undefined);
+
+        await provider.openDashboard();
+
+        const items = showQuickPickStub.getCall(0).args[0] as readonly vscode.QuickPickItem[];
+        assert.deepStrictEqual(items.map(item => item.label), [
+            'apps/Store/AppHost.csproj',
+            'samples/Store/AppHost.csproj',
+        ]);
+    });
+});
+
+suite('AppHostDataRepository', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('workspace apphost name uses all candidates to disambiguate duplicate filenames', async () => {
+        let lineCallback: ((line: string) => void) | undefined;
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([{
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        }]);
+        sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+            lineCallback = options?.lineCallback;
+            return { kill: () => { } } as any;
+        });
+        const repository = new AppHostDataRepository(makeTerminalProvider());
+
+        try {
+            await flushPromises();
+            assert.ok(lineCallback);
+
+            lineCallback(JSON.stringify({
+                selected_project_file: '/workspace/apps/Store/AppHost.csproj',
+                all_project_file_candidates: [
+                    '/workspace/apps/Store/AppHost.csproj',
+                    '/workspace/samples/Store/AppHost.csproj',
+                ],
+            }));
+
+            assert.strictEqual(repository.workspaceAppHostName, 'apps/Store/AppHost.csproj');
+        } finally {
+            repository.dispose();
+        }
     });
 });
 

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as cliModule from '../debugger/languages/cli';
-import { AppHostDataRepository, shortenPath } from '../views/AppHostDataRepository';
+import { AppHostDataRepository, shortenPath, shortenPaths } from '../views/AppHostDataRepository';
 import { AspireAppHostTreeProvider, getResourceContextValue, getResourceIcon, resolveAppHostSourcePath, buildResourceDescription } from '../views/AspireAppHostTreeProvider';
 import type { AppHostDisplayInfo, ResourceJson, ViewMode } from '../views/AppHostDataRepository';
 import { ResourceState, HealthStatus, StateStyle } from '../editor/resourceConstants';
@@ -91,6 +91,101 @@ suite('shortenPath', () => {
 
     test('two segments returns parent/filename', () => {
         assert.strictEqual(shortenPath('MyApp/AppHost.cs'), 'MyApp/AppHost.cs');
+    });
+});
+
+suite('shortenPaths', () => {
+    test('unique project filenames return just the filename', () => {
+        const paths = [
+            '/home/user/folder1/App1.AppHost.csproj',
+            '/home/user/folder2/App2.AppHost.fsproj',
+            '/home/user/folder3/App3.AppHost.vbproj',
+        ];
+
+        const result = shortenPaths(paths);
+
+        assert.deepStrictEqual(result, [
+            'App1.AppHost.csproj',
+            'App2.AppHost.fsproj',
+            'App3.AppHost.vbproj',
+        ]);
+    });
+
+    test('duplicate filenames add parent directory to disambiguate', () => {
+        const paths = [
+            '/home/user/folder1/Project.csproj',
+            '/home/user/folder2/Project.csproj',
+        ];
+
+        const result = shortenPaths(paths);
+
+        assert.deepStrictEqual(result, [
+            path.join('folder1', 'Project.csproj'),
+            path.join('folder2', 'Project.csproj'),
+        ]);
+    });
+
+    test('duplicate filenames with same parent add more segments', () => {
+        const paths = [
+            '/home/a/shared/Project.csproj',
+            '/home/b/shared/Project.csproj',
+        ];
+
+        const result = shortenPaths(paths);
+
+        assert.deepStrictEqual(result, [
+            path.join('a', 'shared', 'Project.csproj'),
+            path.join('b', 'shared', 'Project.csproj'),
+        ]);
+    });
+
+    test('single non-project file returns parent and filename', () => {
+        const paths = ['/home/user/repos/MyApp/AppHost.cs'];
+
+        const result = shortenPaths(paths);
+
+        assert.deepStrictEqual(result, [
+            path.join('MyApp', 'AppHost.cs'),
+        ]);
+    });
+
+    test('mixed project and non-project files use project-aware minimum depth', () => {
+        const paths = [
+            '/home/user/App1/App1.AppHost.csproj',
+            '/home/user/App2/AppHost.cs',
+        ];
+
+        const result = shortenPaths(paths);
+
+        assert.deepStrictEqual(result, [
+            'App1.AppHost.csproj',
+            path.join('App2', 'AppHost.cs'),
+        ]);
+    });
+
+    test('duplicate filenames exhaust segments and return full path', () => {
+        const paths = [
+            'C:\\folder\\Project.csproj',
+            'D:\\folder\\Project.csproj',
+        ];
+
+        const result = shortenPaths(paths);
+
+        assert.deepStrictEqual(result, paths);
+    });
+
+    test('duplicate paths return the same shortened label for each occurrence', () => {
+        const paths = [
+            '/home/user/folder1/Project.csproj',
+            '/home/user/folder1/Project.csproj',
+        ];
+
+        const result = shortenPaths(paths);
+
+        assert.deepStrictEqual(result, [
+            'Project.csproj',
+            'Project.csproj',
+        ]);
     });
 });
 

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -570,7 +570,7 @@ function createShortenedPathState(filePath: string): ShortenedPathState {
         originalPath: filePath,
         segments,
         depth,
-        label: depth >= 2 ? path.join(...segments.slice(-depth)) : fileName,
+        label: depth >= 2 ? joinPathSegments(segments.slice(-depth)) : fileName,
     };
 }
 
@@ -589,7 +589,11 @@ function expandShortenedPathState(state: ShortenedPathState): void {
         return;
     }
 
-    state.label = path.join(...state.segments.slice(firstCandidateIndex));
+    state.label = joinPathSegments(state.segments.slice(firstCandidateIndex));
+}
+
+function joinPathSegments(segments: readonly string[]): string {
+    return segments.join('/');
 }
 
 function isWindowsDriveSegment(segment: string): boolean {

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -228,11 +228,14 @@ export class AppHostDataRepository {
                     try {
                         const parsed = JSON.parse(line);
                         if (parsed && (typeof parsed.selected_project_file === 'string' || parsed.selected_project_file === null) && Array.isArray(parsed.all_project_file_candidates)) {
+                            const appHostCandidates = parsed.all_project_file_candidates.filter((candidate: unknown): candidate is string => typeof candidate === 'string');
                             const appHostPath = parsed.selected_project_file
-                                ?? (parsed.all_project_file_candidates.length === 1 ? parsed.all_project_file_candidates[0] : null);
+                                ?? (appHostCandidates.length === 1 ? appHostCandidates[0] : null);
                             if (appHostPath) {
                                 this._workspaceAppHostPath = appHostPath;
-                                this._workspaceAppHostName = shortenPath(appHostPath);
+                                const appHostLabels = shortenPaths(appHostCandidates);
+                                const candidateIndex = appHostCandidates.indexOf(appHostPath);
+                                this._workspaceAppHostName = candidateIndex >= 0 ? appHostLabels[candidateIndex] : shortenPath(appHostPath);
                                 extensionLogOutputChannel.info(`Workspace apphost resolved: ${appHostPath}`);
                                 this._onDidChangeData.fire();
                             }
@@ -501,17 +504,103 @@ export class AppHostDataRepository {
 }
 
 export function shortenPath(filePath: string): string {
-    const fileName = filePath.split(/[/\\]/).pop() ?? filePath;
+    return shortenPaths([filePath])[0] ?? filePath;
+}
+
+export function shortenPaths(filePaths: readonly string[]): string[] {
+    const states: ShortenedPathState[] = [];
+    const stateByPath = new Map<string, ShortenedPathState>();
+
+    for (const filePath of filePaths) {
+        const pathKey = getComparisonKey(filePath);
+        let state = stateByPath.get(pathKey);
+        if (!state) {
+            state = createShortenedPathState(filePath);
+            stateByPath.set(pathKey, state);
+            states.push(state);
+        }
+    }
+
+    while (true) {
+        const duplicateLabels = new Set<string>();
+        const seenLabels = new Set<string>();
+
+        for (const state of states) {
+            const labelKey = getComparisonKey(state.label);
+            if (seenLabels.has(labelKey)) {
+                duplicateLabels.add(labelKey);
+            } else {
+                seenLabels.add(labelKey);
+            }
+        }
+
+        if (duplicateLabels.size === 0) {
+            break;
+        }
+
+        for (const state of states) {
+            if (duplicateLabels.has(getComparisonKey(state.label))) {
+                expandShortenedPathState(state);
+            }
+        }
+    }
+
+    return filePaths.map(filePath => stateByPath.get(getComparisonKey(filePath))?.label ?? filePath);
+}
+
+interface ShortenedPathState {
+    originalPath: string;
+    segments: string[];
+    depth: number;
+    label: string;
+}
+
+function createShortenedPathState(filePath: string): ShortenedPathState {
+    const normalized = filePath.replace(/\\/g, '/').replace(/\/+$/, '');
+    const segments = normalized.split('/');
+    const fileName = segments[segments.length - 1] || filePath;
 
     if (fileName.endsWith('.csproj')) {
-        return fileName;
+        return {
+            originalPath: filePath,
+            segments,
+            depth: 1,
+            label: fileName,
+        };
     }
 
-    // For single-file AppHosts (.cs), show parent/filename
-    const parts = filePath.split(/[/\\]/);
-    if (parts.length >= 2) {
-        return `${parts[parts.length - 2]}/${fileName}`;
+    const depth = segments.length >= 2 ? 2 : 1;
+
+    return {
+        originalPath: filePath,
+        segments,
+        depth,
+        label: segments.slice(-depth).join('/'),
+    };
+}
+
+function expandShortenedPathState(state: ShortenedPathState): void {
+    state.depth++;
+
+    if (state.depth >= state.segments.length) {
+        state.label = state.originalPath;
+        return;
     }
 
-    return fileName;
+    const firstCandidateIndex = state.segments.length - state.depth;
+    const firstCandidateSegment = state.segments[firstCandidateIndex];
+    if (firstCandidateSegment.length === 0 || isWindowsDriveSegment(firstCandidateSegment)) {
+        state.label = state.originalPath;
+        return;
+    }
+
+    state.label = state.segments.slice(firstCandidateIndex).join('/');
+}
+
+function isWindowsDriveSegment(segment: string): boolean {
+    return /^[a-zA-Z]:$/.test(segment);
+}
+
+function getComparisonKey(value: string): string {
+    return process.platform === 'win32' ? value.toLowerCase() : value;
 }

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { ChildProcessWithoutNullStreams } from 'child_process';
 import { spawnCliProcess } from '../debugger/languages/cli';
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
@@ -507,6 +508,8 @@ export function shortenPath(filePath: string): string {
     return shortenPaths([filePath])[0] ?? filePath;
 }
 
+const projectFileExtensions = new Set(['.csproj', '.fsproj', '.vbproj']);
+
 export function shortenPaths(filePaths: readonly string[]): string[] {
     const states: ShortenedPathState[] = [];
     const stateByPath = new Map<string, ShortenedPathState>();
@@ -559,23 +562,15 @@ function createShortenedPathState(filePath: string): ShortenedPathState {
     const normalized = filePath.replace(/\\/g, '/').replace(/\/+$/, '');
     const segments = normalized.split('/');
     const fileName = segments[segments.length - 1] || filePath;
-
-    if (fileName.endsWith('.csproj')) {
-        return {
-            originalPath: filePath,
-            segments,
-            depth: 1,
-            label: fileName,
-        };
-    }
-
-    const depth = segments.length >= 2 ? 2 : 1;
+    const extension = path.extname(fileName).toLowerCase();
+    const isProjectFile = projectFileExtensions.has(extension);
+    const depth = !isProjectFile && segments.length >= 2 ? 2 : 1;
 
     return {
         originalPath: filePath,
         segments,
         depth,
-        label: segments.slice(-depth).join('/'),
+        label: depth >= 2 ? path.join(...segments.slice(-depth)) : fileName,
     };
 }
 
@@ -594,7 +589,7 @@ function expandShortenedPathState(state: ShortenedPathState): void {
         return;
     }
 
-    state.label = state.segments.slice(firstCandidateIndex).join('/');
+    state.label = path.join(...state.segments.slice(firstCandidateIndex));
 }
 
 function isWindowsDriveSegment(segment: string): boolean {

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -31,7 +31,7 @@ import {
     AppHostDisplayInfo,
     ResourceJson,
     ViewMode,
-    shortenPath,
+    shortenPaths,
 } from './AppHostDataRepository';
 
 type TreeElement = AppHostItem | PidItem | EndpointUrlItem | ResourcesGroupItem | ResourceItem | WorkspaceResourcesItem | HealthChecksGroupItem | HealthCheckItem;
@@ -55,9 +55,8 @@ function stripResourceSuffix(url: string): string {
 }
 
 class AppHostItem extends vscode.TreeItem {
-    constructor(public readonly appHost: AppHostDisplayInfo) {
-        const name = shortenPath(appHost.appHostPath);
-        super(name, vscode.TreeItemCollapsibleState.Expanded);
+    constructor(public readonly appHost: AppHostDisplayInfo, label: string) {
+        super(label, vscode.TreeItemCollapsibleState.Expanded);
         this.id = `apphost:${appHost.appHostPid}`;
         this.description = pidDescription(appHost.appHostPid);
         this.iconPath = appHostIcon(appHost.appHostPath);
@@ -453,7 +452,9 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
 
     private _getGlobalChildren(element?: TreeElement): TreeElement[] {
         if (!element) {
-            return this._repository.appHosts.map(appHost => new AppHostItem(appHost));
+            const appHosts = this._repository.appHosts;
+            const labels = shortenPaths(appHosts.map(appHost => appHost.appHostPath));
+            return appHosts.map((appHost, index) => new AppHostItem(appHost, labels[index]));
         }
 
         if (element instanceof AppHostItem) {
@@ -571,8 +572,9 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
                 if (appHosts.length === 1) {
                     url = appHosts[0].dashboardUrl;
                 } else if (appHosts.length > 1) {
-                    const items = appHosts.map(a => ({
-                        label: shortenPath(a.appHostPath),
+                    const labels = shortenPaths(appHosts.map(a => a.appHostPath));
+                    const items = appHosts.map((a, index) => ({
+                        label: labels[index],
                         description: pidDescription(a.appHostPid),
                         dashboardUrl: a.dashboardUrl!,
                     }));


### PR DESCRIPTION
## Description

Fixes #16200

The VS Code extension now shortens AppHost paths as a batch so duplicate filenames gain enough parent segments to be unique in the tree, dashboard quick pick, and workspace AppHost label.

Validation:
- `npm run compile-tests && npm run unit-test -- --grep "shortenPath|AspireAppHostTreeProvider|AppHostDataRepository" --timeout 10000`


Before:
<img width="746" height="188" alt="image" src="https://github.com/user-attachments/assets/8b6986ad-d595-4c95-9b2a-0374239de393" />

After:
<img width="842" height="216" alt="image" src="https://github.com/user-attachments/assets/3872c896-54cf-401c-ac36-67439af02f47" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
