### PR TITLE
Disable dashboard AI for extension-hosted sessions

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -525,6 +525,13 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             }
         }
 
+        if (!context.EnvironmentVariables.ContainsKey(DashboardConfigNames.DashboardAIDisabledName.EnvVarName) &&
+            ShouldDisableDashboardAIForExtensionHost(configuration))
+        {
+            // VS Code extension sessions expose a debug endpoint, but don't currently serve GHCP endpoints.
+            context.EnvironmentVariables[DashboardConfigNames.DashboardAIDisabledName.EnvVarName] = "true";
+        }
+
         var options = dashboardOptions.Value;
 
         // Options should have been validated these should not be null
@@ -643,6 +650,11 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             context.EnvironmentVariables[DashboardConfigNames.DebugSessionTelemetryOptOutName.EnvVarName] = optOutValue;
         }
 
+    }
+
+    private static bool ShouldDisableDashboardAIForExtensionHost(IConfiguration configuration)
+    {
+        return configuration[KnownConfigNames.ExtensionEndpoint] is { Length: > 0 };
     }
 
     private static void PopulateDashboardUrls(EnvironmentCallbackContext context)

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -525,7 +525,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             }
         }
 
-        if (!context.EnvironmentVariables.ContainsKey(DashboardConfigNames.DashboardAIDisabledName.EnvVarName) &&
+        if (!HasDashboardAIDisabledConfigured(context.EnvironmentVariables) &&
             ShouldDisableDashboardAIForExtensionHost(configuration))
         {
             // VS Code extension sessions expose a debug endpoint, but don't currently serve GHCP endpoints.
@@ -655,6 +655,12 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
     private static bool ShouldDisableDashboardAIForExtensionHost(IConfiguration configuration)
     {
         return configuration[KnownConfigNames.ExtensionEndpoint] is { Length: > 0 };
+    }
+
+    private static bool HasDashboardAIDisabledConfigured(IDictionary<string, object> environmentVariables)
+    {
+        return environmentVariables.Keys.Any(key =>
+            string.Equals(key, DashboardConfigNames.DashboardAIDisabledName.EnvVarName, StringComparison.OrdinalIgnoreCase));
     }
 
     private static void PopulateDashboardUrls(EnvironmentCallbackContext context)

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -160,6 +160,7 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(debugSessionToken, environmentVariables.GetValueOrDefault(DashboardConfigNames.DebugSessionTokenName.EnvVarName));
         Assert.Equal(debugSessionCert, environmentVariables.GetValueOrDefault(DashboardConfigNames.DebugSessionServerCertificateName.EnvVarName));
         Assert.Equal(telemetryEnabled, bool.TryParse(environmentVariables.GetValueOrDefault(DashboardConfigNames.DebugSessionTelemetryOptOutName.EnvVarName), out var b) ? b : null);
+        Assert.Null(environmentVariables.GetValueOrDefault(DashboardConfigNames.DashboardAIDisabledName.EnvVarName));
     }
 
     [Fact]
@@ -191,6 +192,39 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
 
         // Assert
         Assert.Equal("true", envVars.Single(e => e.Key == "ASPIRE_DASHBOARD_PURPLE_MONKEY_DISHWASHER").Value);
+    }
+
+    [Fact]
+    public async Task ConfigureEnvironmentVariables_HasExtensionHostEnv_DisablesDashboardAI()
+    {
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+        var configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [KnownConfigNames.ExtensionEndpoint] = "https://localhost:1234",
+            [KnownConfigNames.ExtensionToken] = "extension-token",
+            [KnownConfigNames.ExtensionCert] = "extension-cert",
+            [KnownConfigNames.ExtensionPromptEnabled] = "true",
+            [KnownConfigNames.DebugSessionPort] = "localhost:5678",
+            [KnownConfigNames.DebugSessionToken] = "debug-token",
+            [KnownConfigNames.DebugSessionServerCertificate] = "debug-cert"
+        });
+        var configuration = configurationBuilder.Build();
+        var dashboardOptions = Options.Create(new DashboardOptions
+        {
+            DashboardPath = "test.dll",
+            DashboardUrl = "http://localhost:8080",
+            OtlpGrpcEndpointUrl = "http://localhost:4317",
+        });
+        var hook = CreateHook(resourceLoggerService, resourceNotificationService, configuration, dashboardOptions: dashboardOptions);
+
+        var envVars = new Dictionary<string, object>();
+        var dashboardResource = new ExecutableResource("aspire-dashboard", "dashboard.exe", ".");
+
+        await hook.ConfigureEnvironmentVariables(new EnvironmentCallbackContext(new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run), environmentVariables: envVars, resource: dashboardResource));
+
+        Assert.Equal("true", envVars.GetValueOrDefault(DashboardConfigNames.DashboardAIDisabledName.EnvVarName));
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -228,6 +228,38 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
+    [InlineData("ASPIRE_DASHBOARD_AI_DISABLED", "false")]
+    [InlineData("aspire_dashboard_ai_disabled", "false")]
+    [InlineData("ASPIRE_DASHBOARD_AI_DISABLED", "true")]
+    public async Task ConfigureEnvironmentVariables_HasExtensionHostEnv_RespectsExplicitDashboardAISetting(string key, string value)
+    {
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+        var configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [KnownConfigNames.ExtensionEndpoint] = "https://localhost:1234",
+            [key] = value
+        });
+        var configuration = configurationBuilder.Build();
+        var dashboardOptions = Options.Create(new DashboardOptions
+        {
+            DashboardPath = "test.dll",
+            DashboardUrl = "http://localhost:8080",
+            OtlpGrpcEndpointUrl = "http://localhost:4317",
+        });
+        var hook = CreateHook(resourceLoggerService, resourceNotificationService, configuration, dashboardOptions: dashboardOptions);
+
+        var envVars = new Dictionary<string, object>();
+        var dashboardResource = new ExecutableResource("aspire-dashboard", "dashboard.exe", ".");
+
+        await hook.ConfigureEnvironmentVariables(new EnvironmentCallbackContext(new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run), environmentVariables: envVars, resource: dashboardResource));
+
+        Assert.Equal(value, envVars.GetValueOrDefault(key));
+        Assert.Single(envVars, envVar => string.Equals(envVar.Key, DashboardConfigNames.DashboardAIDisabledName.EnvVarName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
     [InlineData("https://localhost:17131", "localhost", 9999, "https")]
     [InlineData("https://aspire-dashboard.dev.localhost:17131", "aspire-dashboard.dev.localhost", 9999, "https")]
     [InlineData("http://myapp.localhost:8080", "myapp.localhost", 5555, "http")]


### PR DESCRIPTION
## Description

Fixes #13695

Dashboards started from VS Code extension-hosted Aspire sessions now disable dashboard AI by default, preventing the Copilot chat entry from appearing when the extension debug endpoint does not serve GHCP endpoints.

Validation:
- `dotnet test tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-restore --verbosity quiet -- --filter-class "*.DashboardEventHandlersTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-restore --verbosity quiet -- --filter-method "*.Configuration_DisableAI_EnsureValueSetOnOptions" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
