### PR TITLE
Refactor CLI telemetry JSON output to match MCP tool format

### DIFF
--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -108,7 +108,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             return dashboardApi.ExitCode;
         }
 
-        return await FetchLogsAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, severity, limit, follow, format, dashboardOnly: dashboardUrl is not null, cancellationToken);
+        return await FetchLogsAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, severity, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, cancellationToken);
     }
 
     private async Task<int> FetchLogsAsync(
@@ -121,6 +121,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         bool follow,
         OutputFormat format,
         bool dashboardOnly,
+        string dashboardUrl,
         CancellationToken cancellationToken)
     {
         try
@@ -148,11 +149,11 @@ internal sealed class TelemetryLogsCommand : BaseCommand
 
             if (follow)
             {
-                return await StreamLogsAsync(client, url, format, allOtlpResources, baseUrl, cancellationToken);
+                return await StreamLogsAsync(client, url, format, allOtlpResources, dashboardUrl, cancellationToken);
             }
             else
             {
-                return await GetLogsSnapshotAsync(client, url, format, allOtlpResources, baseUrl, cancellationToken);
+                return await GetLogsSnapshotAsync(client, url, format, allOtlpResources, dashboardUrl, cancellationToken);
             }
         }
         catch (HttpRequestException ex)

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -148,11 +148,11 @@ internal sealed class TelemetryLogsCommand : BaseCommand
 
             if (follow)
             {
-                return await StreamLogsAsync(client, url, format, allOtlpResources, cancellationToken);
+                return await StreamLogsAsync(client, url, format, allOtlpResources, baseUrl, cancellationToken);
             }
             else
             {
-                return await GetLogsSnapshotAsync(client, url, format, allOtlpResources, cancellationToken);
+                return await GetLogsSnapshotAsync(client, url, format, allOtlpResources, baseUrl, cancellationToken);
             }
         }
         catch (HttpRequestException ex)
@@ -164,7 +164,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         }
     }
 
-    private async Task<int> GetLogsSnapshotAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, CancellationToken cancellationToken)
+    private async Task<int> GetLogsSnapshotAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl, CancellationToken cancellationToken)
     {
         var response = await client.GetAsync(url, cancellationToken);
         TelemetryCommandHelpers.EnsureTelemetryApiResponse(response);
@@ -173,8 +173,10 @@ internal sealed class TelemetryLogsCommand : BaseCommand
 
         if (format == OutputFormat.Json)
         {
-            // Structured output always goes to stdout.
-            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
+            var apiResponse = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+            var resourceLogs = apiResponse?.Data?.ResourceLogs;
+            Func<IOtlpResource, string> getResourceName = s => OtlpHelpers.GetResourceName(s, allResources);
+            _interactionService.DisplayRawText(SharedAIHelpers.SerializeLogsToJson(resourceLogs, getResourceName, dashboardUrl), ConsoleOutput.Standard);
         }
         else
         {
@@ -184,7 +186,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         return ExitCodeConstants.Success;
     }
 
-    private async Task<int> StreamLogsAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, CancellationToken cancellationToken)
+    private async Task<int> StreamLogsAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl, CancellationToken cancellationToken)
     {
         using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         TelemetryCommandHelpers.EnsureTelemetryApiResponse(response);
@@ -196,8 +198,10 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         {
             if (format == OutputFormat.Json)
             {
-                // Structured output always goes to stdout.
-                _interactionService.DisplayRawText(line, ConsoleOutput.Standard);
+                var request = JsonSerializer.Deserialize(line, OtlpJsonSerializerContext.Default.OtlpExportLogsServiceRequestJson);
+                var resourceLogs = request?.ResourceLogs;
+                Func<IOtlpResource, string> getResourceName = s => OtlpHelpers.GetResourceName(s, allResources);
+                _interactionService.DisplayRawText(SharedAIHelpers.SerializeLogsToJson(resourceLogs, getResourceName, dashboardUrl), ConsoleOutput.Standard);
             }
             else
             {

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Utils;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Utils;
 using Aspire.Otlp.Serialization;
+using Aspire.Shared.ConsoleLogs;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -168,8 +169,10 @@ internal sealed class TelemetrySpansCommand : BaseCommand
 
         if (format == OutputFormat.Json)
         {
-            // Structured output always goes to stdout.
-            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
+            var apiResponse = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+            var resourceSpans = apiResponse?.Data?.ResourceSpans;
+            Func<IOtlpResource, string> getResourceName = s => OtlpHelpers.GetResourceName(s, allResources);
+            _interactionService.DisplayRawText(SharedAIHelpers.SerializeSpansToJson(resourceSpans, getResourceName, dashboardUrl), ConsoleOutput.Standard);
         }
         else
         {
@@ -191,8 +194,10 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         {
             if (format == OutputFormat.Json)
             {
-                // Structured output always goes to stdout.
-                _interactionService.DisplayRawText(line, ConsoleOutput.Standard);
+                var request = JsonSerializer.Deserialize(line, OtlpJsonSerializerContext.Default.OtlpExportTraceServiceRequestJson);
+                var resourceSpans = request?.ResourceSpans;
+                Func<IOtlpResource, string> getResourceName = s => OtlpHelpers.GetResourceName(s, allResources);
+                _interactionService.DisplayRawText(SharedAIHelpers.SerializeSpansToJson(resourceSpans, getResourceName, dashboardUrl), ConsoleOutput.Standard);
             }
             else
             {

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -13,6 +13,7 @@ using Aspire.Otlp.Serialization;
 using Aspire.Cli.Utils;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Utils;
+using Aspire.Shared.ConsoleLogs;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -153,8 +154,10 @@ internal sealed class TelemetryTracesCommand : BaseCommand
 
         if (format == OutputFormat.Json)
         {
-            // Structured output always goes to stdout.
-            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
+            var apiResponse = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+            var resourceSpans = apiResponse?.Data?.ResourceSpans;
+            Func<IOtlpResource, string> getResourceName = s => OtlpHelpers.GetResourceName(s, allOtlpResources);
+            _interactionService.DisplayRawText(SharedAIHelpers.SerializeTraceToJson(resourceSpans, getResourceName, dashboardUrl), ConsoleOutput.Standard);
         }
         else
         {
@@ -202,8 +205,10 @@ internal sealed class TelemetryTracesCommand : BaseCommand
 
         if (format == OutputFormat.Json)
         {
-            // Structured output always goes to stdout.
-            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
+            var apiResponse = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+            var resourceSpans = apiResponse?.Data?.ResourceSpans;
+            Func<IOtlpResource, string> getResourceName = s => OtlpHelpers.GetResourceName(s, allOtlpResources);
+            _interactionService.DisplayRawText(SharedAIHelpers.SerializeTracesToJson(resourceSpans, getResourceName, dashboardUrl), ConsoleOutput.Standard);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -156,8 +156,18 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         {
             var apiResponse = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
             var resourceSpans = apiResponse?.Data?.ResourceSpans;
-            Func<IOtlpResource, string> getResourceName = s => OtlpHelpers.GetResourceName(s, allOtlpResources);
-            _interactionService.DisplayRawText(SharedAIHelpers.SerializeTraceToJson(resourceSpans, getResourceName, dashboardUrl), ConsoleOutput.Standard);
+            var traces = SharedAIHelpers.GetTracesFromOtlpData(resourceSpans);
+            var trace = traces.FirstOrDefault();
+            if (trace is null)
+            {
+                // Shouldn't happen since API would return 404 if trace not found.
+                _interactionService.DisplayRawText("[]", ConsoleOutput.Standard);
+            }
+            else
+            {
+                Func<IOtlpResource, string> getResourceName = s => OtlpHelpers.GetResourceName(s, allOtlpResources);
+                _interactionService.DisplayRawText(SharedAIHelpers.SerializeTraceToJson(trace, getResourceName, dashboardUrl), ConsoleOutput.Standard);
+            }
         }
         else
         {

--- a/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
@@ -116,7 +116,7 @@ internal static class AIHelpers
 
             if (includeDashboardUrl && dashboardBaseUrl != null)
             {
-                resourceObj["dashboard_link"] = SharedAIHelpers.GetDashboardLinkObject(dashboardBaseUrl, DashboardUrls.ResourcesUrl(resource: resource.Name), resourceName);
+                resourceObj["dashboardUrl"] = DashboardUrls.CombineUrl(dashboardBaseUrl, DashboardUrls.ResourcesUrl(resource: resource.Name));
             }
 
             if (includeEnvironmentVariables)

--- a/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
@@ -69,7 +69,7 @@ internal static class AIHelpers
                 };
                 if (!string.IsNullOrEmpty(u.DisplayProperties.DisplayName))
                 {
-                    urlObj["display_name"] = u.DisplayProperties.DisplayName;
+                    urlObj["displayName"] = u.DisplayProperties.DisplayName;
                 }
                 endpointUrlsArray.Add(urlObj);
             }
@@ -80,15 +80,15 @@ internal static class AIHelpers
                 healthReportsArray.Add(new JsonObject
                 {
                     ["name"] = report.Name,
-                    ["health_status"] = GetReportHealthStatus(resource, report),
+                    ["healthStatus"] = GetReportHealthStatus(resource, report),
                     ["exception"] = report.ExceptionText
                 });
             }
 
             var healthObj = new JsonObject
             {
-                ["resource_health_status"] = GetResourceHealthStatus(resource),
-                ["health_reports"] = healthReportsArray
+                ["resourceHealthStatus"] = GetResourceHealthStatus(resource),
+                ["healthReports"] = healthReportsArray
             };
 
             var commandsArray = new JsonArray();
@@ -103,12 +103,12 @@ internal static class AIHelpers
 
             var resourceObj = new JsonObject
             {
-                ["resource_name"] = resourceName,
+                ["resourceName"] = resourceName,
                 ["type"] = resource.ResourceType,
                 ["state"] = resource.State,
-                ["state_description"] = ResourceStateViewModel.GetResourceStateTooltip(resource, s_columnsLoc),
+                ["stateDescription"] = ResourceStateViewModel.GetResourceStateTooltip(resource, s_columnsLoc),
                 ["relationships"] = GetResourceRelationshipsJson(resources, resource, getResourceName),
-                ["endpoint_urls"] = endpointUrlsArray,
+                ["endpointUrls"] = endpointUrlsArray,
                 ["health"] = healthObj,
                 ["source"] = ResourceSourceViewModel.GetSourceViewModel(resource)?.Value,
                 ["commands"] = commandsArray
@@ -126,7 +126,7 @@ internal static class AIHelpers
                 {
                     envVarsArray.Add(JsonValue.Create(e.Name));
                 }
-                resourceObj["environment_variables"] = envVarsArray;
+                resourceObj["environmentVariables"] = envVarsArray;
             }
 
             dataArray.Add(resourceObj);
@@ -149,8 +149,8 @@ internal static class AIHelpers
                 {
                     relationships.Add(new JsonObject
                     {
-                        ["resource_name"] = getResourceName?.Invoke(match) ?? match.Name,
-                        ["Types"] = relationship.Type
+                        ["resourceName"] = getResourceName?.Invoke(match) ?? match.Name,
+                        ["type"] = relationship.Type
                     });
                 }
             }

--- a/src/Shared/ConsoleLogs/PromptContext.cs
+++ b/src/Shared/ConsoleLogs/PromptContext.cs
@@ -10,9 +10,37 @@ internal sealed class PromptContext
 
     private readonly Dictionary<string, string> _promptValueMap = new Dictionary<string, string>();
 
+    /// <summary>
+    /// Gets whether values should be processed (duplicate lines removed, duplicate values replaced with references).
+    /// When <c>false</c>, <see cref="AddValue{T}"/> returns the input unchanged.
+    /// </summary>
+    public bool ProcessValues { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PromptContext"/>.
+    /// </summary>
+    /// <param name="processValues">
+    /// When <c>true</c> (the default), duplicate lines are removed and repeated values are replaced with
+    /// back-references to save tokens. Set to <c>false</c> to emit raw values without processing.
+    /// </param>
+    public PromptContext(bool processValues = true)
+    {
+        ProcessValues = processValues;
+    }
+
     public string? AddValue<T>(string? input, Func<T, string> getKey, T instance)
     {
-        if (string.IsNullOrEmpty(input) || input.Length < MinReferenceLength)
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        if (!ProcessValues)
+        {
+            return input;
+        }
+
+        if (input.Length < MinReferenceLength)
         {
             return input;
         }

--- a/src/Shared/ConsoleLogs/SharedAIHelpers.cs
+++ b/src/Shared/ConsoleLogs/SharedAIHelpers.cs
@@ -190,17 +190,15 @@ internal static class SharedAIHelpers
     }
 
     /// <summary>
-    /// Serializes a single trace from OTLP resource spans to a JSON string for CLI output.
+    /// Serializes a single trace DTO to JSON for CLI output.
     /// </summary>
     public static string SerializeTraceToJson(
-        IList<OtlpResourceSpansJson>? resourceSpans,
-        Func<IOtlpResource, string> getResourceName,
+        OtlpTraceDto traceDto,
+        Func<IOtlpResource, string>? getResourceName = null,
         string? dashboardBaseUrl = null)
     {
-        var traces = GetTracesFromOtlpData(resourceSpans);
-        var traceDto = traces.FirstOrDefault() ?? throw new InvalidOperationException("No trace found in OTLP data.");
         var context = new PromptContext(processValues: false);
-        return GetTraceDto(traceDto, context, getResourceName, dashboardBaseUrl)
+        return GetTraceDto(traceDto, context, getResourceName ?? (s => s.ResourceName), dashboardBaseUrl)
             .ToJsonString(s_jsonSerializerOptions);
     }
 

--- a/src/Shared/ConsoleLogs/SharedAIHelpers.cs
+++ b/src/Shared/ConsoleLogs/SharedAIHelpers.cs
@@ -25,7 +25,7 @@ internal static class SharedAIHelpers
     public const int MaximumListTokenLength = 8192;
     public const int MaximumStringLength = 2048;
 
-    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new JsonSerializerOptions
+    internal static readonly JsonSerializerOptions s_jsonSerializerOptions = new JsonSerializerOptions
     {
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
@@ -147,6 +147,177 @@ internal static class SharedAIHelpers
     }
 
     /// <summary>
+    /// Serializes OTLP resource spans to a JSON string of individual spans for CLI output.
+    /// Unlike <see cref="GetTracesJson"/>, which groups spans by trace ID, this returns a flat list.
+    /// </summary>
+    public static string SerializeSpansToJson(
+        IList<OtlpResourceSpansJson>? resourceSpans,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var spans = GetSpanDtosFromOtlpData(resourceSpans);
+        var context = new PromptContext(processValues: false);
+        var jsonArray = new JsonArray(spans.Select(s => GetSpanDto(s, context, getResourceName, dashboardBaseUrl)).ToArray<JsonNode>());
+        return jsonArray.ToJsonString(s_jsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// Serializes OTLP resource logs to a JSON string of log entries for CLI output.
+    /// </summary>
+    public static string SerializeLogsToJson(
+        IList<OtlpResourceLogsJson>? resourceLogs,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var logRecords = GetLogRecordsFromOtlpData(resourceLogs);
+        var context = new PromptContext(processValues: false);
+        var jsonArray = new JsonArray(logRecords.Select(l => GetLogEntryDto(l, context, getResourceName, dashboardBaseUrl)).ToArray<JsonNode>());
+        return jsonArray.ToJsonString(s_jsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// Serializes OTLP resource spans to a JSON string of traces for CLI output.
+    /// </summary>
+    public static string SerializeTracesToJson(
+        IList<OtlpResourceSpansJson>? resourceSpans,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var traces = GetTracesFromOtlpData(resourceSpans);
+        var context = new PromptContext(processValues: false);
+        var jsonArray = new JsonArray(traces.Select(t => GetTraceDto(t, context, getResourceName, dashboardBaseUrl)).ToArray<JsonNode>());
+        return jsonArray.ToJsonString(s_jsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// Serializes a single trace from OTLP resource spans to a JSON string for CLI output.
+    /// </summary>
+    public static string SerializeTraceToJson(
+        IList<OtlpResourceSpansJson>? resourceSpans,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var traces = GetTracesFromOtlpData(resourceSpans);
+        var traceDto = traces.FirstOrDefault() ?? throw new InvalidOperationException("No trace found in OTLP data.");
+        var context = new PromptContext(processValues: false);
+        return GetTraceDto(traceDto, context, getResourceName, dashboardBaseUrl)
+            .ToJsonString(s_jsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// Creates a JsonObject representing a single span for AI processing.
+    /// </summary>
+    public static JsonObject GetSpanDto(
+        OtlpSpanDto spanDto,
+        PromptContext context,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var span = spanDto.Span;
+        var spanId = span.SpanId ?? string.Empty;
+        var traceId = span.TraceId ?? string.Empty;
+
+        var attributesObj = new JsonObject();
+        if (span.Attributes is not null)
+        {
+            foreach (var attr in span.Attributes.Where(a => a.Key != OtlpHelpers.AspireDestinationNameAttribute))
+            {
+                var attrValue = MapOtelAttributeValue(attr);
+                attributesObj[attr.Key!] = context.AddValue(attrValue, id => $@"Duplicate of attribute ""{id.Key}"" for span {OtlpHelpers.ToShortenedId(id.SpanId)}", (SpanId: spanId, attr.Key));
+            }
+        }
+
+        JsonArray? linksArray = null;
+        if (span.Links is { Length: > 0 })
+        {
+            var linkObjects = span.Links.Select(link => (JsonNode)new JsonObject
+            {
+                ["traceId"] = link.TraceId ?? string.Empty,
+                ["spanId"] = link.SpanId ?? string.Empty
+            }).ToArray();
+            linksArray = new JsonArray(linkObjects);
+        }
+
+        var resourceName = getResourceName?.Invoke(spanDto.Resource) ?? spanDto.Resource.ResourceName;
+        var destination = GetAttributeStringValue(span.Attributes, OtlpHelpers.AspireDestinationNameAttribute);
+        var statusCode = span.Status?.Code;
+        var statusText = statusCode switch
+        {
+            1 => "Ok",
+            2 => "Error",
+            _ => null
+        };
+
+        var timestamp = span.StartTimeUnixNano is { } startNano
+            ? OtlpHelpers.UnixNanoSecondsToDateTime(startNano)
+            : (DateTime?)null;
+
+        var spanObj = new JsonObject
+        {
+            ["traceId"] = traceId,
+            ["spanId"] = spanId,
+            ["parentSpanId"] = span.ParentSpanId,
+            ["kind"] = GetSpanKindName(span.Kind),
+            ["name"] = context.AddValue(span.Name, sId => $@"Duplicate of ""name"" for span {OtlpHelpers.ToShortenedId(sId)}", spanId),
+            ["status"] = statusText,
+            ["statusMessage"] = context.AddValue(span.Status?.Message, sId => $@"Duplicate of ""statusMessage"" for span {OtlpHelpers.ToShortenedId(sId)}", spanId),
+            ["source"] = resourceName,
+            ["destination"] = destination,
+            ["durationMs"] = CalculateDurationMs(span.StartTimeUnixNano, span.EndTimeUnixNano),
+            ["timestamp"] = timestamp,
+            ["attributes"] = attributesObj,
+            ["links"] = linksArray
+        };
+
+        if (dashboardBaseUrl is not null)
+        {
+            spanObj["dashboardUrl"] = DashboardUrls.CombineUrl(dashboardBaseUrl, DashboardUrls.TraceDetailUrl(traceId, spanId: spanId));
+        }
+
+        return StripNullProperties(spanObj);
+    }
+
+    /// <summary>
+    /// Extracts individual spans from OTLP resource spans as a flat list.
+    /// </summary>
+    public static List<OtlpSpanDto> GetSpanDtosFromOtlpData(IList<OtlpResourceSpansJson>? resourceSpans)
+    {
+        var spans = new List<OtlpSpanDto>();
+
+        if (resourceSpans is null)
+        {
+            return spans;
+        }
+
+        foreach (var resourceSpan in resourceSpans)
+        {
+            var resource = CreateResourceFromOtlpJson(resourceSpan.Resource);
+
+            if (resourceSpan.ScopeSpans is null)
+            {
+                continue;
+            }
+
+            foreach (var scopeSpan in resourceSpan.ScopeSpans)
+            {
+                var scopeName = scopeSpan.Scope?.Name;
+
+                if (scopeSpan.Spans is null)
+                {
+                    continue;
+                }
+
+                foreach (var span in scopeSpan.Spans)
+                {
+                    spans.Add(new OtlpSpanDto(span, resource, scopeName));
+                }
+            }
+        }
+
+        return spans;
+    }
+
+    /// <summary>
     /// Extracts traces from OTLP resource spans, grouping spans by trace ID.
     /// </summary>
     public static List<OtlpTraceDto> GetTracesFromOtlpData(IList<OtlpResourceSpansJson>? resourceSpans)
@@ -212,59 +383,12 @@ internal static class SharedAIHelpers
         var spanObjects = new List<JsonNode>();
         foreach (var s in trace.Spans)
         {
-            var span = s.Span;
-            var spanId = span.SpanId ?? string.Empty;
-
-            var attributesObj = new JsonObject();
-            if (span.Attributes is not null)
-            {
-                foreach (var attr in span.Attributes.Where(a => a.Key != OtlpHelpers.AspireDestinationNameAttribute))
-                {
-                    var attrValue = MapOtelAttributeValue(attr);
-                    attributesObj[attr.Key!] = context.AddValue(attrValue, id => $@"Duplicate of attribute ""{id.Key}"" for span {OtlpHelpers.ToShortenedId(id.SpanId)}", (SpanId: spanId, attr.Key));
-                }
-            }
-
-            JsonArray? linksArray = null;
-            if (span.Links is { Length: > 0 })
-            {
-                var linkObjects = span.Links.Select(link => (JsonNode)new JsonObject
-                {
-                    ["trace_id"] = OtlpHelpers.ToShortenedId(link.TraceId ?? string.Empty),
-                    ["span_id"] = OtlpHelpers.ToShortenedId(link.SpanId ?? string.Empty)
-                }).ToArray();
-                linksArray = new JsonArray(linkObjects);
-            }
-
-            var resourceName = getResourceName?.Invoke(s.Resource) ?? s.Resource.ResourceName;
-            var destination = GetAttributeStringValue(span.Attributes, OtlpHelpers.AspireDestinationNameAttribute);
-            var statusCode = span.Status?.Code;
-            var statusText = statusCode switch
-            {
-                1 => "Ok",
-                2 => "Error",
-                _ => null
-            };
-
-            var spanObj = new JsonObject
-            {
-                ["span_id"] = OtlpHelpers.ToShortenedId(spanId),
-                ["parent_span_id"] = span.ParentSpanId is { } id ? OtlpHelpers.ToShortenedId(id) : null,
-                ["kind"] = GetSpanKindName(span.Kind),
-                ["name"] = context.AddValue(span.Name, sId => $@"Duplicate of ""name"" for span {OtlpHelpers.ToShortenedId(sId)}", spanId),
-                ["status"] = statusText,
-                ["status_message"] = context.AddValue(span.Status?.Message, sId => $@"Duplicate of ""status_message"" for span {OtlpHelpers.ToShortenedId(sId)}", spanId),
-                ["source"] = resourceName,
-                ["destination"] = destination,
-                ["duration_ms"] = CalculateDurationMs(span.StartTimeUnixNano, span.EndTimeUnixNano),
-                ["attributes"] = attributesObj,
-                ["links"] = linksArray
-            };
+            var spanObj = GetSpanDto(s, context, getResourceName, dashboardBaseUrl: null);
             spanObjects.Add(spanObj);
         }
 
         var spanArray = new JsonArray(spanObjects.ToArray());
-        var traceId = OtlpHelpers.ToShortenedId(trace.TraceId);
+        var traceId = trace.TraceId;
         var rootSpan = trace.Spans.FirstOrDefault(s => string.IsNullOrEmpty(s.Span.ParentSpanId)) ?? trace.Spans.FirstOrDefault();
         var hasError = trace.Spans.Any(s => s.Span.Status?.Code == 2);
         var timestamp = rootSpan?.Span.StartTimeUnixNano is { } startNano
@@ -273,20 +397,20 @@ internal static class SharedAIHelpers
 
         var traceData = new JsonObject
         {
-            ["trace_id"] = traceId,
-            ["duration_ms"] = CalculateTraceDurationMs(trace.Spans),
+            ["traceId"] = traceId,
+            ["durationMs"] = CalculateTraceDurationMs(trace.Spans),
             ["title"] = rootSpan?.Span.Name,
             ["spans"] = spanArray,
-            ["has_error"] = hasError,
+            ["hasError"] = hasError,
             ["timestamp"] = timestamp
         };
 
         if (dashboardBaseUrl is not null)
         {
-            traceData["dashboard_link"] = GetDashboardLinkObject(dashboardBaseUrl, DashboardUrls.TraceDetailUrl(traceId), traceId);
+            traceData["dashboardUrl"] = DashboardUrls.CombineUrl(dashboardBaseUrl, DashboardUrls.TraceDetailUrl(traceId));
         }
 
-        return traceData;
+        return StripNullProperties(traceData);
     }
 
     private static string MapOtelAttributeValue(OtlpKeyValueJson attribute)
@@ -381,6 +505,16 @@ internal static class SharedAIHelpers
             5 => "Consumer",
             _ => null
         };
+    }
+
+    private static JsonObject StripNullProperties(JsonObject obj)
+    {
+        foreach (var key in obj.Where(kvp => kvp.Value is null).Select(kvp => kvp.Key).ToList())
+        {
+            obj.Remove(key);
+        }
+
+        return obj;
     }
 
     private static int? CalculateDurationMs(ulong? startTimeUnixNano, ulong? endTimeUnixNano)
@@ -591,12 +725,12 @@ internal static class SharedAIHelpers
         var message = GetLogMessage(logEntry.LogRecord) ?? string.Empty;
         var log = new JsonObject
         {
-            ["log_id"] = logId,
-            ["span_id"] = OtlpHelpers.ToShortenedId(logEntry.LogRecord.SpanId ?? string.Empty),
-            ["trace_id"] = OtlpHelpers.ToShortenedId(logEntry.LogRecord.TraceId ?? string.Empty),
+            ["logId"] = logId,
+            ["spanId"] = logEntry.LogRecord.SpanId,
+            ["traceId"] = logEntry.LogRecord.TraceId,
             ["message"] = context.AddValue(message, id => $@"Duplicate of ""message"" for log entry {id}", logId),
             ["severity"] = logEntry.LogRecord.SeverityText ?? "Unknown",
-            ["resource_name"] = resourceName,
+            ["resourceName"] = resourceName,
             ["attributes"] = attributesObject,
             ["exception"] = context.AddValue(exceptionText, id => $@"Duplicate of ""exception"" for log entry {id}", logId),
             ["source"] = logEntry.ScopeName
@@ -604,19 +738,10 @@ internal static class SharedAIHelpers
 
         if (dashboardBaseUrl is not null && logId is not null)
         {
-            log["dashboard_link"] = GetDashboardLinkObject(dashboardBaseUrl, DashboardUrls.StructuredLogsUrl(logEntryId: logId), $"log_id: {logId}");
+            log["dashboardUrl"] = DashboardUrls.CombineUrl(dashboardBaseUrl, DashboardUrls.StructuredLogsUrl(logEntryId: logId));
         }
 
-        return log;
-    }
-
-    public static JsonObject? GetDashboardLinkObject(string dashboardBaseUrl, string path, string text)
-    {
-        return new JsonObject
-        {
-            ["url"] = DashboardUrls.CombineUrl(dashboardBaseUrl, path),
-            ["text"] = text
-        };
+        return StripNullProperties(log);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -568,4 +568,103 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(capturedBaseUrl);
         Assert.DoesNotContain("/login", capturedBaseUrl);
     }
+
+    [Fact]
+    public async Task TelemetryLogsCommand_JsonOutput_ProducesExpectedJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+
+        var resourceLogs = new OtlpResourceLogsJson[]
+        {
+            new()
+            {
+                Resource = TelemetryTestHelper.CreateOtlpResource("apiservice", null),
+                ScopeLogs =
+                [
+                    new OtlpScopeLogsJson
+                    {
+                        LogRecords =
+                        [
+                            new OtlpLogRecordJson
+                            {
+                                TimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime),
+                                SeverityNumber = 9,
+                                SeverityText = "Information",
+                                Body = new OtlpAnyValueJson { StringValue = "Request started" },
+                                Attributes =
+                                [
+                                    new OtlpKeyValueJson { Key = "aspire.log_id", Value = new OtlpAnyValueJson { StringValue = "42" } },
+                                    new OtlpKeyValueJson { Key = "http.method", Value = new OtlpAnyValueJson { StringValue = "GET" } }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var apiResponse = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceLogs = resourceLogs },
+            TotalCount = 1,
+            ReturnedCount = 1
+        };
+        var responseJson = JsonSerializer.Serialize(apiResponse, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            if (url.Contains("/api/telemetry/logs"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel logs --format json --dashboard-url http://localhost:18888");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
+        var formattedJson = TelemetryTestHelper.FormatJson(jsonLine);
+
+        var expected = """
+            [
+              {
+                "logId": 42,
+                "message": "Request started",
+                "severity": "Information",
+                "resourceName": "apiservice",
+                "attributes": {
+                  "http.method": "GET"
+                },
+                "dashboardUrl": "http://localhost:18888/structuredlogs?logEntryId=42"
+              }
+            ]
+            """;
+
+        Assert.Equal(expected, formattedJson, ignoreLineEndingDifferences: true);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
@@ -299,4 +299,109 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(string.Format(System.Globalization.CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, "http://localhost:18888"), errorMessage);
     }
+
+    [Fact]
+    public async Task TelemetrySpansCommand_JsonOutput_ProducesExpectedJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+
+        var resourceSpans = new OtlpResourceSpansJson[]
+        {
+            new()
+            {
+                Resource = TelemetryTestHelper.CreateOtlpResource("frontend", null),
+                ScopeSpans =
+                [
+                    new OtlpScopeSpansJson
+                    {
+                        Spans =
+                        [
+                            new OtlpSpanJson
+                            {
+                                TraceId = "abc1234567890def",
+                                SpanId = "span0017890abcde",
+                                Name = "GET /home",
+                                Kind = 2,
+                                StartTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime),
+                                EndTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime.AddMilliseconds(50)),
+                                Status = new OtlpSpanStatusJson { Code = 1 },
+                                Attributes =
+                                [
+                                    new OtlpKeyValueJson { Key = "http.method", Value = new OtlpAnyValueJson { StringValue = "GET" } }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var apiResponse = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceSpans = resourceSpans },
+            TotalCount = 1,
+            ReturnedCount = 1
+        };
+        var responseJson = JsonSerializer.Serialize(apiResponse, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            if (url.Contains("/api/telemetry/spans"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel spans --format json --dashboard-url http://localhost:18888");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
+        var formattedJson = TelemetryTestHelper.FormatJson(jsonLine);
+
+        var expected = """
+            [
+              {
+                "traceId": "abc1234567890def",
+                "spanId": "span0017890abcde",
+                "kind": "Server",
+                "name": "GET /home",
+                "status": "Ok",
+                "source": "frontend",
+                "durationMs": 50,
+                "timestamp": "1970-01-01T00:00:00Z",
+                "attributes": {
+                  "http.method": "GET"
+                },
+                "dashboardUrl": "http://localhost:18888/traces/detail/abc1234567890def?spanId=span0017890abcde"
+              }
+            ]
+            """;
+
+        Assert.Equal(expected, formattedJson, ignoreLineEndingDifferences: true);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
@@ -328,7 +328,8 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
                                 Status = new OtlpSpanStatusJson { Code = 1 },
                                 Attributes =
                                 [
-                                    new OtlpKeyValueJson { Key = "http.method", Value = new OtlpAnyValueJson { StringValue = "GET" } }
+                                    new OtlpKeyValueJson { Key = "http.method", Value = new OtlpAnyValueJson { StringValue = "GET" } },
+                                    new OtlpKeyValueJson { Key = "aspire.destination", Value = new OtlpAnyValueJson { StringValue = "backend" } }
                                 ]
                             }
                         ]
@@ -392,6 +393,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
                 "name": "GET /home",
                 "status": "Ok",
                 "source": "frontend",
+                "destination": "backend",
                 "durationMs": 50,
                 "timestamp": "1970-01-01T00:00:00Z",
                 "attributes": {

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTestHelper.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
@@ -124,5 +126,15 @@ internal static class TelemetryTestHelper
         services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
 
         return services.BuildServiceProvider();
+    }
+
+    internal static string FormatJson(string compactJson)
+    {
+        var node = JsonNode.Parse(compactJson);
+        return node!.ToJsonString(new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        });
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -307,4 +307,118 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(TelemetryCommandStrings.DashboardAuthFailed, errorMessage);
     }
+
+    [Fact]
+    public async Task TelemetryTracesCommand_JsonOutput_ProducesExpectedJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+
+        var resourceSpans = new OtlpResourceSpansJson[]
+        {
+            new()
+            {
+                Resource = TelemetryTestHelper.CreateOtlpResource("frontend", null),
+                ScopeSpans =
+                [
+                    new OtlpScopeSpansJson
+                    {
+                        Spans =
+                        [
+                            new OtlpSpanJson
+                            {
+                                TraceId = "abc1234567890def",
+                                SpanId = "span0017890abcde",
+                                Name = "GET /home",
+                                Kind = 2,
+                                StartTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime),
+                                EndTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime.AddMilliseconds(50)),
+                                Status = new OtlpSpanStatusJson { Code = 1 },
+                                Attributes =
+                                [
+                                    new OtlpKeyValueJson { Key = "http.method", Value = new OtlpAnyValueJson { StringValue = "GET" } }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var apiResponse = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceSpans = resourceSpans },
+            TotalCount = 1,
+            ReturnedCount = 1
+        };
+        var responseJson = JsonSerializer.Serialize(apiResponse, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            if (url.Contains("/api/telemetry/traces"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel traces --format json --dashboard-url http://localhost:18888");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
+        var formattedJson = TelemetryTestHelper.FormatJson(jsonLine);
+
+        var expected = """
+            [
+              {
+                "traceId": "abc1234567890def",
+                "durationMs": 50,
+                "title": "GET /home",
+                "spans": [
+                  {
+                    "traceId": "abc1234567890def",
+                    "spanId": "span0017890abcde",
+                    "kind": "Server",
+                    "name": "GET /home",
+                    "status": "Ok",
+                    "source": "frontend",
+                    "durationMs": 50,
+                    "timestamp": "1970-01-01T00:00:00Z",
+                    "attributes": {
+                      "http.method": "GET"
+                    }
+                  }
+                ],
+                "hasError": false,
+                "timestamp": "1970-01-01T00:00:00Z",
+                "dashboardUrl": "http://localhost:18888/traces/detail/abc1234567890def"
+              }
+            ]
+            """;
+
+        Assert.Equal(expected, formattedJson, ignoreLineEndingDifferences: true);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -421,4 +421,58 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(expected, formattedJson, ignoreLineEndingDifferences: true);
     }
+
+    [Fact]
+    public async Task TelemetryTracesCommand_JsonOutput_WithTraceIdAndNoTrace_ReturnsEmptyArray()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+
+        var apiResponse = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceSpans = [] },
+            TotalCount = 0,
+            ReturnedCount = 0
+        };
+        var responseJson = JsonSerializer.Serialize(apiResponse, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            if (url.Contains("/api/telemetry/traces/abc1234567890def"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel traces --trace-id abc1234567890def --format json --dashboard-url http://localhost:18888");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
+        Assert.Equal("[]", jsonLine);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Mcp/ListStructuredLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListStructuredLogsToolTests.cs
@@ -184,7 +184,7 @@ public class ListStructuredLogsToolTests
         var textContent = result.Content[0] as TextContentBlock;
         Assert.NotNull(textContent);
 
-        // Parse the JSON array from the response to verify log_id extraction and attribute filtering
+        // Parse the JSON array from the response to verify logId extraction and attribute filtering
         var jsonStartIndex = textContent.Text.IndexOf('[');
         var jsonEndIndex = textContent.Text.LastIndexOf(']') + 1;
         var jsonText = textContent.Text[jsonStartIndex..jsonEndIndex];
@@ -193,46 +193,37 @@ public class ListStructuredLogsToolTests
         Assert.NotNull(logsArray);
         Assert.Equal(3, logsArray.Count);
 
-        // Verify first log entry has correct resource_name, log_id extracted, and aspire.log_id not in attributes
+        // Verify first log entry has correct resourceName, logId extracted, and aspire.log_id not in attributes
         var firstLog = logsArray[0]?.AsObject();
         Assert.NotNull(firstLog);
-        Assert.Equal("api-service-instance-1", firstLog["resource_name"]?.GetValue<string>());
-        Assert.Equal(42, firstLog["log_id"]?.GetValue<long>());
+        Assert.Equal("api-service-instance-1", firstLog["resourceName"]?.GetValue<string>());
+        Assert.Equal(42, firstLog["logId"]?.GetValue<long>());
         var firstLogAttributes = firstLog["attributes"]?.AsObject();
         Assert.NotNull(firstLogAttributes);
         Assert.False(firstLogAttributes.ContainsKey(OtlpHelpers.AspireLogIdAttribute), "aspire.log_id should be filtered from attributes");
         Assert.True(firstLogAttributes.ContainsKey("custom.attr"), "custom.attr should be present in attributes");
 
-        // Verify dashboard_link is included for each log entry with correct URLs
-        var firstDashboardLink = firstLog["dashboard_link"]?.AsObject();
-        Assert.NotNull(firstDashboardLink);
-        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=42", firstDashboardLink["url"]?.GetValue<string>());
-        Assert.Equal("log_id: 42", firstDashboardLink["text"]?.GetValue<string>());
+        // Verify dashboardUrl is included for each log entry with correct URLs
+        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=42", firstLog["dashboardUrl"]?.GetValue<string>());
 
-        // Verify second log entry has correct resource_name (different instance), log_id extracted (from intValue)
+        // Verify second log entry has correct resourceName (different instance), logId extracted (from intValue)
         var secondLog = logsArray[1]?.AsObject();
         Assert.NotNull(secondLog);
-        Assert.Equal("api-service-instance-2", secondLog["resource_name"]?.GetValue<string>());
-        Assert.Equal(43, secondLog["log_id"]?.GetValue<long>());
+        Assert.Equal("api-service-instance-2", secondLog["resourceName"]?.GetValue<string>());
+        Assert.Equal(43, secondLog["logId"]?.GetValue<long>());
         var secondLogAttributes = secondLog["attributes"]?.AsObject();
         Assert.NotNull(secondLogAttributes);
         Assert.False(secondLogAttributes.ContainsKey(OtlpHelpers.AspireLogIdAttribute), "aspire.log_id should be filtered from attributes");
 
-        var secondDashboardLink = secondLog["dashboard_link"]?.AsObject();
-        Assert.NotNull(secondDashboardLink);
-        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=43", secondDashboardLink["url"]?.GetValue<string>());
-        Assert.Equal("log_id: 43", secondDashboardLink["text"]?.GetValue<string>());
+        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=43", secondLog["dashboardUrl"]?.GetValue<string>());
 
-        // Verify third log entry has correct resource_name (no instance ID)
+        // Verify third log entry has correct resourceName (no instance ID)
         var thirdLog = logsArray[2]?.AsObject();
         Assert.NotNull(thirdLog);
-        Assert.Equal("worker-service", thirdLog["resource_name"]?.GetValue<string>());
-        Assert.Equal(44, thirdLog["log_id"]?.GetValue<long>());
+        Assert.Equal("worker-service", thirdLog["resourceName"]?.GetValue<string>());
+        Assert.Equal(44, thirdLog["logId"]?.GetValue<long>());
 
-        var thirdDashboardLink = thirdLog["dashboard_link"]?.AsObject();
-        Assert.NotNull(thirdDashboardLink);
-        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=44", thirdDashboardLink["url"]?.GetValue<string>());
-        Assert.Equal("log_id: 44", thirdDashboardLink["text"]?.GetValue<string>());
+        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=44", thirdLog["dashboardUrl"]?.GetValue<string>());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Mcp/ListTracesToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListTracesToolTests.cs
@@ -163,24 +163,21 @@ public class ListTracesToolTests
         var tracesArray = JsonNode.Parse(jsonText)?.AsArray();
 
         Assert.NotNull(tracesArray);
-        // Should have 2 traces (grouped by trace_id)
+        // Should have 2 traces (grouped by traceId)
         Assert.Equal(2, tracesArray.Count);
 
-        // Verify first trace (trace_id is shortened to 7 characters)
+        // Verify first trace
         var firstTrace = tracesArray[0]?.AsObject();
         Assert.NotNull(firstTrace);
-        Assert.Equal("abc123d", firstTrace["trace_id"]?.GetValue<string>());
+        Assert.Equal("abc123def456789012345678901234567890", firstTrace["traceId"]?.GetValue<string>());
 
         // Verify spans in first trace have correct source and destination
         var spans = firstTrace["spans"]?.AsArray();
         Assert.NotNull(spans);
         Assert.Equal(2, spans.Count);
 
-        // Verify dashboard_link is included for each trace with correct URLs (trace_id is shortened to 7 chars in the URL)
-        var firstDashboardLink = firstTrace["dashboard_link"]?.AsObject();
-        Assert.NotNull(firstDashboardLink);
-        Assert.Equal("http://localhost:18888/traces/detail/abc123d", firstDashboardLink["url"]?.GetValue<string>());
-        Assert.Equal("abc123d", firstDashboardLink["text"]?.GetValue<string>());
+        // Verify dashboardUrl is included for each trace with correct URLs
+        Assert.Equal("http://localhost:18888/traces/detail/abc123def456789012345678901234567890", firstTrace["dashboardUrl"]?.GetValue<string>());
 
         // First span (server) should have source from resource name, no destination
         var serverSpan = spans.FirstOrDefault(s => s?["kind"]?.GetValue<string>() == "Server")?.AsObject();
@@ -197,12 +194,9 @@ public class ListTracesToolTests
         // Verify second trace
         var secondTrace = tracesArray[1]?.AsObject();
         Assert.NotNull(secondTrace);
-        Assert.Equal("xyz789a", secondTrace["trace_id"]?.GetValue<string>());
+        Assert.Equal("xyz789abc123456789012345678901234567890", secondTrace["traceId"]?.GetValue<string>());
 
-        var secondDashboardLink = secondTrace["dashboard_link"]?.AsObject();
-        Assert.NotNull(secondDashboardLink);
-        Assert.Equal("http://localhost:18888/traces/detail/xyz789a", secondDashboardLink["url"]?.GetValue<string>());
-        Assert.Equal("xyz789a", secondDashboardLink["text"]?.GetValue<string>());
+        Assert.Equal("http://localhost:18888/traces/detail/xyz789abc123456789012345678901234567890", secondTrace["dashboardUrl"]?.GetValue<string>());
 
         // Verify spans in second trace have correct source and destination
         var secondTraceSpans = secondTrace["spans"]?.AsArray();


### PR DESCRIPTION
## Description

The current JSON format matches OTLP/JSON. But that JSON is very verbose, doesn't include all information, and doesn't have a way to represent traces. New JSON should work better with AI agents.

---

Refactor CLI telemetry JSON output to align with the MCP tool format used by the dashboard AI helpers. This is a breaking change to JSON returned from telemetry commands.

### Changes

- **Shared serialization methods**: Added `SerializeSpansToJson`, `SerializeLogsToJson`, `SerializeTracesToJson`, and `SerializeTraceToJson` to `SharedAIHelpers` so CLI commands produce identical JSON to MCP tools
- **`PromptContext.ProcessValues` flag**: When `false`, `AddValue` returns input unchanged (CLI doesn't need AI token-limiting deduplication)
- **camelCase property names**: All JSON output properties use camelCase
- **Null property stripping**: `StripNullProperties` removes null-valued properties from JSON objects
- **`dashboardUrl` simplification**: Replaced `dashboardLink` object (`{url, text}`) with a direct `dashboardUrl` string in both `SharedAIHelpers` and `AIHelpers`
- **Full IDs**: `spanId` and `traceId` are no longer shortened via `ToShortenedId` in JSON output
- **`GetTraceDto` reuses `GetSpanDto`**: Eliminated duplicated span conversion logic; inner trace spans retain `traceId` and `timestamp`
- **Test helper consolidation**: Moved `FormatJson` to `TelemetryTestHelper`; added attributes to span/trace/log test data

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
