### PR TITLE
Update Aspire skill monitoring output guidance

### DIFF
--- a/.agents/skills/aspire/SKILL.md
+++ b/.agents/skills/aspire/SKILL.md
@@ -33,7 +33,7 @@ Resources are typically defined in an AppHost such as, `AppHost.cs`, `apphost.ts
 1. Confirm that the workspace is an Aspire app and identify the AppHost.
 2. Start the app with `aspire start`. Use `--isolated` in git worktrees or whenever shared local state would be risky.
 3. Use `aspire wait <resource>` before interacting with a resource that needs to be healthy.
-4. Inspect state with `aspire describe`, then use `aspire otel logs`, `aspire logs`, `aspire otel traces`, and `aspire export` before making code changes.
+4. Inspect state with `aspire describe`, then use `aspire otel logs`, `aspire logs`, `aspire otel traces`, and `aspire export` before making code changes. Display returned data using the formatting rules in [references/monitoring.md](references/monitoring.md).
 5. Before adding an integration, introducing a custom dashboard/resource command, or using an unfamiliar AppHost API, use `aspire docs search <topic>` and `aspire docs get <slug>` for workflow guidance, then use `aspire docs api search <query> --language csharp|typescript` and `aspire docs api get <id>` when you need the API reference entry itself.
 6. Re-run `aspire start` after AppHost changes. In git worktrees, re-run `aspire start --isolated` instead of switching to `aspire run`.
 

--- a/.agents/skills/aspire/references/monitoring.md
+++ b/.agents/skills/aspire/references/monitoring.md
@@ -24,10 +24,10 @@ Keep these points in mind:
 Use these commands when the task is to diagnose behavior in the live app before making code changes.
 
 ```bash
-aspire otel logs [resource]
-aspire otel traces [resource]
-aspire otel spans [resource]
-aspire otel logs --trace-id <id>
+aspire otel logs [resource] --format Json
+aspire otel traces [resource] --format Json
+aspire otel spans [resource] --format Json
+aspire otel logs --trace-id <id> --format Json
 aspire logs [resource]
 ```
 
@@ -36,6 +36,8 @@ Keep these points in mind:
 - Prefer structured telemetry before raw console logs when possible.
 - Use `aspire logs` as a secondary console-output view after checking structured telemetry.
 - Use the trace-filtered log command when you already have a trace id and want the related log slice.
+- Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
+- `[resource]` is optional. Include it to filter results to a single resource; omit it to see all resources.
 
 ## Scenario: I Need A Sharable Diagnostics Bundle
 
@@ -48,3 +50,33 @@ aspire export [resource]
 Keep this point in mind:
 
 - Use `aspire export` when you need a sharable bundle of telemetry and resource state.
+
+## Dashboard Links
+
+Commands like `aspire describe`, `aspire otel logs`, `aspire otel traces`, and `aspire otel spans` may include dashboard URLs in their JSON output. Only use URLs that are explicitly returned by these commands — do not construct dashboard URLs yourself.
+
+When a dashboard link is returned alongside a resource or telemetry entry, make the resource name, trace ID, or span ID a clickable markdown link using the returned URL.
+
+## Displaying Resources
+
+When showing resource state to the user, display the state text with a circle emoji prefix:
+
+- 🟢 Running, healthy
+- 🟡 Starting, waiting
+- 🔴 Failed, error, unhealthy
+- ⚪ Stopped, exited
+
+Link resource names to their dashboard page when the dashboard URL is known.
+
+## Displaying Telemetry
+
+When showing structured logs, prefix each entry with an emoji matching the log level:
+
+- 🔴 Error / Critical
+- 🟡 Warning
+- 🔵 Information
+- ⚪ Debug / Trace
+
+Link resource names to their dashboard resource page. When trace IDs are present, display the first 7 characters and link that value to the full trace detail page.
+
+When showing traces or spans, use 🟢 for success/unset status and 🔴 for error status. Display only the first 7 characters of trace and span IDs, and link those values to their dashboard detail pages.


### PR DESCRIPTION
## Description

Designed to be used with improved JSON output in https://github.com/microsoft/aspire/pull/16523

Updates Aspire agent skill guidance for monitoring output formatting.

- In [.agents/skills/aspire/SKILL.md](.agents/skills/aspire/SKILL.md), step 4 now points to [references/monitoring.md](.agents/skills/aspire/references/monitoring.md) for display-formatting rules.
- In [.agents/skills/aspire/references/monitoring.md](.agents/skills/aspire/references/monitoring.md), telemetry command examples now include `--format Json`, and guidance was added for optional resource filters, dashboard link usage, and consistent resource/telemetry status display conventions.

No code behavior changes.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
