### PR TITLE
Make CLI confirmation prompts single-key

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -505,17 +505,42 @@ internal class ConsoleInteractionService : IInteractionService
         var yesChoice = defaultValue ? 'Y' : 'y';
         var noChoice = defaultValue ? 'n' : 'N';
 
-        var prompt = new ConfirmationPrompt(promptText)
-        {
-            Yes = yesChoice,
-            No = noChoice,
-            ShowDefaultValue = false,
-            DefaultValue = defaultValue,
-        };
-
-        var result = await MessageConsole.PromptAsync(prompt, cancellationToken);
+        var result = await PromptConfirmWithSingleKeyAsync(promptText, yesChoice, noChoice, defaultValue, cancellationToken);
         MessageLogger.LogInformation("Confirm result: {Result}", result);
         return result;
+    }
+
+    private async Task<bool> PromptConfirmWithSingleKeyAsync(string promptText, char yesChoice, char noChoice, bool defaultValue, CancellationToken cancellationToken)
+    {
+        MessageConsole.Markup(promptText);
+        MessageConsole.Write($" [{yesChoice}/{noChoice}] ");
+
+        while (true)
+        {
+            var key = await MessageConsole.Input.ReadKeyAsync(intercept: true, cancellationToken);
+            if (key is null)
+            {
+                continue;
+            }
+
+            if (key.Value.Key == ConsoleKey.Enter || key.Value.KeyChar is '\r' or '\n')
+            {
+                MessageConsole.WriteLine();
+                return defaultValue;
+            }
+
+            if (key.Value.Key == ConsoleKey.Y || key.Value.KeyChar is 'y' or 'Y')
+            {
+                MessageConsole.WriteLine("y");
+                return true;
+            }
+
+            if (key.Value.Key == ConsoleKey.N || key.Value.KeyChar is 'n' or 'N')
+            {
+                MessageConsole.WriteLine("n");
+                return false;
+            }
+        }
     }
 
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -520,7 +520,8 @@ internal class ConsoleInteractionService : IInteractionService
             var key = await MessageConsole.Input.ReadKeyAsync(intercept: true, cancellationToken);
             if (key is null)
             {
-                continue;
+                MessageConsole.WriteLine();
+                return defaultValue;
             }
 
             if (key.Value.Key == ConsoleKey.Enter || key.Value.KeyChar is '\r' or '\n')
@@ -531,13 +532,15 @@ internal class ConsoleInteractionService : IInteractionService
 
             if (key.Value.Key == ConsoleKey.Y || key.Value.KeyChar is 'y' or 'Y')
             {
-                MessageConsole.WriteLine("y");
+                var echoedChoice = key.Value.KeyChar is 'y' or 'Y' ? key.Value.KeyChar : yesChoice;
+                MessageConsole.WriteLine(echoedChoice.ToString());
                 return true;
             }
 
             if (key.Value.Key == ConsoleKey.N || key.Value.KeyChar is 'n' or 'N')
             {
-                MessageConsole.WriteLine("n");
+                var echoedChoice = key.Value.KeyChar is 'n' or 'N' ? key.Value.KeyChar : noChoice;
+                MessageConsole.WriteLine(echoedChoice.ToString());
                 return false;
             }
         }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
@@ -231,7 +231,6 @@ internal static class KubernetesDeployTestHelpers
         // Dismiss agent init prompt (same as DeclineAgentInitPromptAsync)
         await auto.WaitAsync(500);
         await auto.TypeAsync("n");
-        await auto.EnterAsync();
         await auto.WaitForAnyPromptAsync(counter);
 
         // Step 2: cd into the project

--- a/tests/Aspire.Cli.EndToEnd.Tests/NewWithAgentInitTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/NewWithAgentInitTests.cs
@@ -108,7 +108,6 @@ public sealed class NewWithAgentInitTests(ITestOutputHelper output)
             description: "agent init prompt after aspire new");
         await auto.WaitAsync(500);
         await auto.TypeAsync("y");
-        await auto.EnterAsync();
 
         // Agent init: skill location - select Claude Code
         await auto.WaitUntilAsync(

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -881,6 +881,36 @@ public class ConsoleInteractionServiceTests
         Assert.Equal(defaultValue, result);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ConfirmAsync_WhenUserPressesYWithoutEnter_ReturnsTrue(bool defaultValue)
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "y");
+        var interactionService = CreateInteractionService(console);
+
+        var result = await interactionService.PromptConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
+
+        Assert.True(result);
+        Assert.EndsWith("y\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ConfirmAsync_WhenUserPressesNWithoutEnter_ReturnsFalse(bool defaultValue)
+    {
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "n");
+        var interactionService = CreateInteractionService(console);
+
+        var result = await interactionService.PromptConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
+
+        Assert.False(result);
+        Assert.EndsWith("n\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+
     [Fact]
     public async Task PromptForStringAsync_CliProvidedValue_RunsValidator()
     {

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -882,33 +882,37 @@ public class ConsoleInteractionServiceTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ConfirmAsync_WhenUserPressesYWithoutEnter_ReturnsTrue(bool defaultValue)
+    [InlineData(true, "y")]
+    [InlineData(true, "Y")]
+    [InlineData(false, "y")]
+    [InlineData(false, "Y")]
+    public async Task ConfirmAsync_WhenUserPressesYWithoutEnter_ReturnsTrue(bool defaultValue, string input)
     {
         var output = new StringBuilder();
-        var console = CreateInteractiveConsoleWithInput(output, "y");
+        var console = CreateInteractiveConsoleWithInput(output, input);
         var interactionService = CreateInteractionService(console);
 
         var result = await interactionService.PromptConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
 
         Assert.True(result);
-        Assert.EndsWith("y\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        Assert.EndsWith($"{input}\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ConfirmAsync_WhenUserPressesNWithoutEnter_ReturnsFalse(bool defaultValue)
+    [InlineData(true, "n")]
+    [InlineData(true, "N")]
+    [InlineData(false, "n")]
+    [InlineData(false, "N")]
+    public async Task ConfirmAsync_WhenUserPressesNWithoutEnter_ReturnsFalse(bool defaultValue, string input)
     {
         var output = new StringBuilder();
-        var console = CreateInteractiveConsoleWithInput(output, "n");
+        var console = CreateInteractiveConsoleWithInput(output, input);
         var interactionService = CreateInteractionService(console);
 
         var result = await interactionService.PromptConfirmAsync("Proceed?", PromptBinding.CreateDefault(defaultValue), cancellationToken: CancellationToken.None);
 
         Assert.False(result);
-        Assert.EndsWith("n\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        Assert.EndsWith($"{input}\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -482,7 +482,6 @@ internal static class Hex1bAutomatorTestHelpers
 
         await auto.WaitAsync(500);
         await auto.TypeAsync("n");
-        await auto.EnterAsync();
 
         await auto.WaitUntilAsync(s =>
         {

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -307,8 +307,7 @@ internal static class Hex1bTestHelpers
         return builder
             .WaitUntil(s => agentInitPrompt.Search(s).Count > 0, timeout ?? TimeSpan.FromSeconds(120))
             .Wait(500)
-            .Type("n")
-            .Enter();
+            .Type("n");
     }
 
     /// <summary>
@@ -332,8 +331,6 @@ internal static class Hex1bTestHelpers
         var agentInitPrompt = new CellPatternSearcher()
             .Find("configure AI agent environments");
 
-        var agentInitFound = false;
-
         return builder
             // Wait for either the agent init prompt (new CLI) or the success prompt (old CLI).
             // Uses the full timeout since aspire new project creation can take minutes.
@@ -341,7 +338,6 @@ internal static class Hex1bTestHelpers
             {
                 if (agentInitPrompt.Search(s).Count > 0)
                 {
-                    agentInitFound = true;
                     return true;
                 }
                 var successSearcher = new CellPatternSearcher()
@@ -350,11 +346,10 @@ internal static class Hex1bTestHelpers
                 return successSearcher.Search(s).Count > 0;
             }, effectiveTimeout)
             .Wait(500)
-            // Type 'n' + Enter unconditionally:
+            // Type 'n' unconditionally:
             // - Agent init: declines the prompt, CLI exits, success prompt appears
-            // - No agent init: 'n' runs at bash (command not found), produces error prompt
+            // - No agent init: 'n' is typed at bash but not submitted; the existing success prompt remains and Ctrl+U clears the pending input
             .Type("n")
-            .Enter()
             // Wait for the aspire command's success prompt (already on screen or appears after decline)
             .WaitUntil(s =>
             {
@@ -363,15 +358,12 @@ internal static class Hex1bTestHelpers
                     .RightText(" OK] $ ");
                 return successSearcher.Search(s).Count > 0;
             }, effectiveTimeout)
+            .Ctrl().Key(Hex1bKey.U)
             // Increment counter correctly for both cases:
             // - Agent init: one increment for the aspire command
-            // - No agent init: two increments (aspire command + the 'n' error command)
+            // - No agent init: one increment for the aspire command
             .WaitUntil(_ =>
             {
-                if (!agentInitFound)
-                {
-                    counter.Increment();
-                }
                 counter.Increment();
                 return true;
             }, TimeSpan.FromSeconds(1));


### PR DESCRIPTION
## Description

CLI yes/no prompts currently require users to press Enter even after typing `y` or `n`, which makes flows like `aspire init` and `aspire new` feel slower than expected. This updates the shared CLI confirmation prompt so `y` and `n` answer immediately with a single key, while preserving the existing `[Y/n]` / `[y/N]` display and Enter-to-default behavior.

The change is centralized in `ConsoleInteractionService.PromptConfirmAsync`, so the AI agent environment prompt and other CLI confirmation prompts use the same behavior. Focused interaction tests cover `y`, `n`, and Enter handling.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
