### PR TITLE
Revert AzureResourcePreparer changes from TryGetByName

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -243,7 +243,7 @@ internal sealed class AzureResourcePreparer(
 
         if (globalRoleAssignments.Count > 0)
         {
-            EnsureGlobalRoleAssignments(appModel, globalRoleAssignments);
+            CreateGlobalRoleAssignments(appModel, globalRoleAssignments);
         }
     }
 
@@ -384,18 +384,11 @@ internal sealed class AzureResourcePreparer(
         existingRoles.UnionWith(newRoles);
     }
 
-    private void EnsureGlobalRoleAssignments(DistributedApplicationModel appModel, Dictionary<AzureProvisioningResource, HashSet<RoleDefinition>> globalRoleAssignments)
+    private void CreateGlobalRoleAssignments(DistributedApplicationModel appModel, Dictionary<AzureProvisioningResource, HashSet<RoleDefinition>> globalRoleAssignments)
     {
         foreach (var (azureResource, roles) in globalRoleAssignments)
         {
-            var roleAssignmentResourceName = $"{azureResource.Name}-roles";
-
-            if (appModel.Resources.TryGetByName(roleAssignmentResourceName, out _))
-            {
-                continue;
-            }
-
-            var roleAssignmentResource = CreateGlobalRoleAssignmentsResource(roleAssignmentResourceName, azureResource, roles);
+            var roleAssignmentResource = CreateGlobalRoleAssignmentsResource(azureResource, roles);
 
             appModel.Resources.Add(roleAssignmentResource);
 
@@ -406,12 +399,11 @@ internal sealed class AzureResourcePreparer(
     }
 
     private AzureProvisioningResource CreateGlobalRoleAssignmentsResource(
-        string name,
         AzureProvisioningResource targetResource,
         IEnumerable<RoleDefinition> roles)
     {
         var roleAssignmentResource = new AzureProvisioningResource(
-            name,
+            $"{targetResource.Name}-roles",
             infra => AddGlobalRoleAssignmentsInfrastructure(infra, targetResource, roles))
         {
             ProvisioningBuildOptions = options.Value.ProvisioningBuildOptions,

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -174,7 +174,7 @@ public class FoundryExtensionsTests
         var manifest = await AzureManifestUtils.GetManifestWithBicep(model, foundry.Resource);
 
         var roles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "foundry-roles");
-        var rolesManifest = await AzureManifestUtils.GetManifestWithBicep(model, roles);
+        var rolesManifest = await AzureManifestUtils.GetManifestWithBicep(roles, skipPreparer: true);
 
         Assert.Contains("name: 'foundry-caphost'", manifest.BicepText);
 


### PR DESCRIPTION
These changes weren't necessary. The test was calling the preparer twice, which was causing the failure. The fix in the test is to skip the preparer the 2nd time.

Follow up from #16389
