### PR TITLE
Detect duplicate polyglot capability IDs

### DIFF
--- a/src/Aspire.Hosting.Integration.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Aspire.Hosting.Integration.Analyzers/AnalyzerReleases.Unshipped.md
@@ -17,3 +17,4 @@ ASPIREEXPORT009 | Design | Warning | AspireExportAnalyzer, [Documentation](https
 ASPIREEXPORT010 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT010)
 ASPIREEXPORT011 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT011)
 ASPIREEXPORT012 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT012)
+ASPIREEXPORT013 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT013)

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
@@ -131,6 +131,17 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{CallbackContextTypeMissingExportId}");
 
+        private const string DuplicatePolyglotCapabilityIdId = "ASPIREEXPORT013";
+        internal static readonly DiagnosticDescriptor s_duplicatePolyglotCapabilityId = new(
+            id: DuplicatePolyglotCapabilityIdId,
+            title: "Duplicate polyglot capability ID",
+            messageFormat: "Polyglot capability ID '{0}' is defined by multiple exports in this assembly: {1}. Use unique AspireExport IDs for overloaded or colliding members.",
+            category: "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: $"https://aka.ms/aspire/diagnostics/{DuplicatePolyglotCapabilityIdId}",
+            customTags: [WellKnownDiagnosticTags.CompilationEnd]);
+
         public static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics = ImmutableArray.Create(
             s_exportMethodMustBeStatic,
             s_invalidExportIdFormat,
@@ -143,7 +154,8 @@ public partial class AspireExportAnalyzer
             s_exportNameShouldBeUnique,
             s_exportedSyncDelegateInvokedInline,
             s_redundantExportId,
-            s_callbackContextTypeMissingExport
+            s_callbackContextTypeMissingExport,
+            s_duplicatePolyglotCapabilityId
         );
     }
 }

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -16,12 +16,43 @@ namespace Aspire.Hosting.Analyzers;
 public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 {
     private const string RunSyncOnBackgroundThreadPropertyName = "RunSyncOnBackgroundThread";
+    private const string ExposeMethodsPropertyName = "ExposeMethods";
+    private const string ExposePropertiesPropertyName = "ExposeProperties";
+    private const string MethodNamePropertyName = "MethodName";
 
     // Matches: valid method name (camelCase identifier, may contain dots for namespacing)
     // Examples: addRedis, addContainer, Dictionary.set
     private static readonly Regex s_exportIdPattern = new(
         @"^[a-zA-Z][a-zA-Z0-9.]*$",
         RegexOptions.Compiled);
+
+    private readonly struct CapabilityExport : IEquatable<CapabilityExport>
+    {
+        public CapabilityExport(string source, Location location)
+        {
+            Source = source;
+            Location = location;
+        }
+
+        public string Source { get; }
+
+        public Location Location { get; }
+
+        public bool Equals(CapabilityExport other)
+        {
+            return Source == other.Source && Location.Equals(other.Location);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is CapabilityExport other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return StringComparer.Ordinal.GetHashCode(Source) ^ Location.GetHashCode();
+        }
+    }
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => Diagnostics.SupportedDiagnostics;
 
@@ -76,12 +107,20 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // Key: (exportId, targetTypeFullName), Value: list of (method, location)
         var exportsByKey = new ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>>();
 
+        // Collection for ASPIREEXPORT013: track generated capability IDs across the assembly.
+        var capabilityIds = new ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>>();
+
         context.RegisterSymbolAction(
-            c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, currentAssemblyExportedTypes, exportsByKey),
+            c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, currentAssemblyExportedTypes, exportsByKey, capabilityIds),
             SymbolKind.Method);
+
+        context.RegisterSymbolAction(
+            c => AnalyzeNamedType(c, aspireExportAttribute, aspireExportIgnoreAttribute, capabilityIds),
+            SymbolKind.NamedType);
 
         // At the end of compilation, report duplicate export IDs
         context.RegisterCompilationEndAction(c => ReportDuplicateExports(c, exportsByKey));
+        context.RegisterCompilationEndAction(c => ReportDuplicateCapabilityIds(c, capabilityIds));
 
         // Warn when exported builder methods invoke synchronous callback delegates inline. Deferred callbacks
         // that are stored for later execution are fine, and exports that opt into background-thread dispatch
@@ -123,7 +162,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol? aspireExportIgnoreAttribute,
         INamedTypeSymbol? aspireUnionAttribute,
         HashSet<ITypeSymbol> currentAssemblyExportedTypes,
-        ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>> exportsByKey)
+        ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>> exportsByKey,
+        ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>> capabilityIds)
     {
         var method = (IMethodSymbol)context.Symbol;
 
@@ -202,6 +242,17 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         var normalizedExportId = isExportIdFormatValid ? exportId : null;
         var effectiveExportId = normalizedExportId ?? derivedExportId;
 
+        // Track the runtime capability ID for static exports. Instance exports are tracked from
+        // their containing type so ExposeMethods/ExposeProperties semantics match the scanner.
+        if (method.IsStatic && effectiveExportId is not null)
+        {
+            AddCapabilityExport(
+                capabilityIds,
+                $"{context.Compilation.Assembly.Identity.Name}/{effectiveExportId}",
+                GetMethodDisplayString(method),
+                location);
+        }
+
         // Rule 2b (ASPIREEXPORT011): Warn when explicit id matches the convention-derived name.
         // Suppressed when Rule 7 (ASPIREEXPORT009) also fires — the two give contradictory advice
         // (ASPIREEXPORT011 says "remove the id"; ASPIREEXPORT009 says "make the id more specific"),
@@ -265,6 +316,116 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         // Rule 8 (ASPIREEXPORT012): Check that callback parameter types (Action<T>/Func<T>) have [AspireExport]
         AnalyzeCallbackContextTypes(context, method, aspireExportAttribute, location);
+    }
+
+    private static void AnalyzeNamedType(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol aspireExportAttribute,
+        INamedTypeSymbol? aspireExportIgnoreAttribute,
+        ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>> capabilityIds)
+    {
+        var type = (INamedTypeSymbol)context.Symbol;
+        var typeExportAttribute = GetContainingTypeAspireExportAttribute(type, aspireExportAttribute);
+
+        if (typeExportAttribute is null)
+        {
+            return;
+        }
+
+        var exposeProperties = IsBooleanNamedArgumentEnabled(typeExportAttribute, ExposePropertiesPropertyName);
+        var exposeMethods = IsBooleanNamedArgumentEnabled(typeExportAttribute, ExposeMethodsPropertyName);
+
+        if (!exposeProperties && !exposeMethods)
+        {
+            var hasExportedMember = type.GetMembers()
+                .Any(member => member is IMethodSymbol or IPropertySymbol &&
+                    GetAspireExportAttribute(member, aspireExportAttribute) is not null);
+
+            if (!hasExportedMember)
+            {
+                return;
+            }
+        }
+
+        var package = GetCapabilityPackage(type, context.Compilation.Assembly.Identity.Name);
+        var typeName = type.Name;
+        var typeId = $"{package}/{typeName}";
+
+        foreach (var property in type.GetMembers().OfType<IPropertySymbol>())
+        {
+            if (property.IsStatic ||
+                HasAspireExportIgnoreAttribute(property, aspireExportIgnoreAttribute))
+            {
+                continue;
+            }
+
+            var memberExportAttribute = GetAspireExportAttribute(property, aspireExportAttribute);
+            var isPublicGetter = property.GetMethod?.DeclaredAccessibility == Accessibility.Public;
+            if (!ShouldExportMember(isPublicGetter, exposeProperties, memberExportAttribute))
+            {
+                continue;
+            }
+
+            var location = GetAttributeLocation(memberExportAttribute, context.CancellationToken) ??
+                property.Locations.FirstOrDefault() ??
+                Location.None;
+            var customMethodName = memberExportAttribute is null ? null : GetExportId(memberExportAttribute);
+            var methodNameOverride = GetNamedStringArgument(memberExportAttribute, MethodNamePropertyName);
+            var getterMethodName = methodNameOverride ?? ToCamelCase(property.Name);
+
+            if (property.GetMethod is not null)
+            {
+                var getMethodName = customMethodName ?? $"{typeName}.{getterMethodName}";
+                AddCapabilityExport(
+                    capabilityIds,
+                    $"{package}/{getMethodName}",
+                    property.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                    location);
+            }
+
+            if (property.SetMethod is not null)
+            {
+                var setterMethodNameSuffix = methodNameOverride is { Length: > 0 }
+                    ? char.ToUpperInvariant(methodNameOverride[0]) + methodNameOverride.Substring(1)
+                    : property.Name;
+                AddCapabilityExport(
+                    capabilityIds,
+                    $"{typeId}.set{setterMethodNameSuffix}",
+                    property.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                    location);
+            }
+        }
+
+        foreach (var method in type.GetMembers().OfType<IMethodSymbol>())
+        {
+            if (method.IsStatic ||
+                method.MethodKind != MethodKind.Ordinary ||
+                method.IsGenericMethod ||
+                HasAspireExportIgnoreAttribute(method, aspireExportIgnoreAttribute))
+            {
+                continue;
+            }
+
+            var memberExportAttribute = GetAspireExportAttribute(method, aspireExportAttribute);
+            if (!ShouldExportMember(method.DeclaredAccessibility == Accessibility.Public, exposeMethods, memberExportAttribute))
+            {
+                continue;
+            }
+
+            var customMethodName = memberExportAttribute is null ? null : GetExportId(memberExportAttribute);
+            var methodCapabilityName = customMethodName ?? (exposeMethods
+                ? $"{typeName}.{ToCamelCase(method.Name)}"
+                : ToCamelCase(method.Name));
+            var location = GetAttributeLocation(memberExportAttribute, context.CancellationToken) ??
+                method.Locations.FirstOrDefault() ??
+                Location.None;
+
+            AddCapabilityExport(
+                capabilityIds,
+                $"{package}/{methodCapabilityName}",
+                GetMethodDisplayString(method),
+                location);
+        }
     }
 
     private static void AnalyzeMissingExportAttribute(
@@ -952,6 +1113,45 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    private static void ReportDuplicateCapabilityIds(
+        CompilationAnalysisContext context,
+        ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>> capabilityIds)
+    {
+        foreach (var kvp in capabilityIds.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+        {
+            var exports = kvp.Value
+                .Distinct()
+                .OrderBy(static e => e.Location.SourceSpan.Start)
+                .ThenBy(static e => e.Source, StringComparer.Ordinal)
+                .ToArray();
+
+            if (exports.Length <= 1)
+            {
+                continue;
+            }
+
+            var sources = string.Join(", ", exports.Select(static e => e.Source).Distinct(StringComparer.Ordinal));
+            foreach (var export in exports)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.s_duplicatePolyglotCapabilityId,
+                    export.Location,
+                    kvp.Key,
+                    sources));
+            }
+        }
+    }
+
+    private static void AddCapabilityExport(
+        ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>> capabilityIds,
+        string capabilityId,
+        string source,
+        Location location)
+    {
+        var bag = capabilityIds.GetOrAdd(capabilityId, _ => []);
+        bag.Add(new CapabilityExport(source, location));
+    }
+
     private static string? GetExportId(AttributeData attribute)
     {
         if (attribute.ConstructorArguments.Length > 0 &&
@@ -980,7 +1180,19 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         return camelCaseName;
     }
 
+    private static string ToCamelCase(string name)
+    {
+        return string.IsNullOrEmpty(name)
+            ? name
+            : char.ToLowerInvariant(name[0]) + name.Substring(1);
+    }
+
     private static bool IsExposeMethodsEnabled(AttributeData? exportAttribute)
+    {
+        return IsBooleanNamedArgumentEnabled(exportAttribute, ExposeMethodsPropertyName);
+    }
+
+    private static bool IsBooleanNamedArgumentEnabled(AttributeData? exportAttribute, string argumentName)
     {
         if (exportAttribute is null)
         {
@@ -989,7 +1201,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         foreach (var namedArgument in exportAttribute.NamedArguments)
         {
-            if (namedArgument.Key == "ExposeMethods" &&
+            if (namedArgument.Key == argumentName &&
                 namedArgument.Value.Value is bool enabled)
             {
                 return enabled;
@@ -997,6 +1209,78 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static string? GetNamedStringArgument(AttributeData? exportAttribute, string argumentName)
+    {
+        if (exportAttribute is null)
+        {
+            return null;
+        }
+
+        foreach (var namedArgument in exportAttribute.NamedArguments)
+        {
+            if (namedArgument.Key == argumentName &&
+                namedArgument.Value.Value is string value)
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private static AttributeData? GetAspireExportAttribute(ISymbol symbol, INamedTypeSymbol aspireExportAttribute)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, aspireExportAttribute))
+            {
+                return attr;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasAspireExportIgnoreAttribute(ISymbol symbol, INamedTypeSymbol? aspireExportIgnoreAttribute)
+    {
+        if (aspireExportIgnoreAttribute is null)
+        {
+            return false;
+        }
+
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, aspireExportIgnoreAttribute))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ShouldExportMember(bool isPublic, bool exposeAll, AttributeData? exportAttribute)
+    {
+        return exportAttribute is not null || (exposeAll && isPublic);
+    }
+
+    private static string GetCapabilityPackage(INamedTypeSymbol type, string assemblyName)
+    {
+        return type.ContainingNamespace.IsGlobalNamespace
+            ? assemblyName
+            : type.ContainingNamespace.ToDisplayString();
+    }
+
+    private static string GetMethodDisplayString(IMethodSymbol method)
+    {
+        return method.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+    }
+
+    private static Location? GetAttributeLocation(AttributeData? attribute, CancellationToken cancellationToken)
+    {
+        return attribute?.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation();
     }
 
     private static bool TryGetEffectiveAspireExportAttribute(IMethodSymbol method, INamedTypeSymbol aspireExportAttribute, out AttributeData? exportAttribute, out AttributeData? containingTypeExportAttribute)

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -109,6 +109,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         // Collection for ASPIREEXPORT013: track generated capability IDs across the assembly.
         var capabilityIds = new ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>>();
+        AnalyzeAssemblyExportedTypes(context.Compilation, aspireExportAttribute, aspireExportIgnoreAttribute, capabilityIds, context.CancellationToken);
 
         context.RegisterSymbolAction(
             c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, currentAssemblyExportedTypes, exportsByKey, capabilityIds),
@@ -326,8 +327,46 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
     {
         var type = (INamedTypeSymbol)context.Symbol;
         var typeExportAttribute = GetContainingTypeAspireExportAttribute(type, aspireExportAttribute);
+        AnalyzeContextType(type, typeExportAttribute, context.Compilation.Assembly.Identity.Name, aspireExportAttribute, aspireExportIgnoreAttribute, capabilityIds, context.CancellationToken);
+    }
 
+    private static void AnalyzeAssemblyExportedTypes(
+        Compilation compilation,
+        INamedTypeSymbol aspireExportAttribute,
+        INamedTypeSymbol? aspireExportIgnoreAttribute,
+        ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>> capabilityIds,
+        CancellationToken cancellationToken)
+    {
+        foreach (var attribute in compilation.Assembly.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, aspireExportAttribute) ||
+                !TryGetAssemblyExportedType(attribute, out var exportedType) ||
+                exportedType is not INamedTypeSymbol namedType ||
+                (!IsBooleanNamedArgumentEnabled(attribute, ExposePropertiesPropertyName) &&
+                 !IsBooleanNamedArgumentEnabled(attribute, ExposeMethodsPropertyName)))
+            {
+                continue;
+            }
+
+            AnalyzeContextType(namedType, attribute, compilation.Assembly.Identity.Name, aspireExportAttribute, aspireExportIgnoreAttribute, capabilityIds, cancellationToken);
+        }
+    }
+
+    private static void AnalyzeContextType(
+        INamedTypeSymbol type,
+        AttributeData? typeExportAttribute,
+        string assemblyName,
+        INamedTypeSymbol aspireExportAttribute,
+        INamedTypeSymbol? aspireExportIgnoreAttribute,
+        ConcurrentDictionary<string, ConcurrentBag<CapabilityExport>> capabilityIds,
+        CancellationToken cancellationToken)
+    {
         if (typeExportAttribute is null)
+        {
+            return;
+        }
+
+        if (HasAspireExportIgnoreAttribute(type, aspireExportIgnoreAttribute))
         {
             return;
         }
@@ -347,8 +386,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        var package = GetCapabilityPackage(type, context.Compilation.Assembly.Identity.Name);
-        var typeName = type.Name;
+        var package = GetCapabilityPackage(type, assemblyName);
+        var typeName = GetRuntimeTypeName(type);
         var typeId = $"{package}/{typeName}";
 
         foreach (var property in type.GetMembers().OfType<IPropertySymbol>())
@@ -366,7 +405,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var location = GetAttributeLocation(memberExportAttribute, context.CancellationToken) ??
+            var location = GetAttributeLocation(memberExportAttribute, cancellationToken) ??
                 property.Locations.FirstOrDefault() ??
                 Location.None;
             var customMethodName = memberExportAttribute is null ? null : GetExportId(memberExportAttribute);
@@ -400,6 +439,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         {
             if (method.IsStatic ||
                 method.MethodKind != MethodKind.Ordinary ||
+                IsSpecialRuntimeMethod(method) ||
                 method.IsGenericMethod ||
                 HasAspireExportIgnoreAttribute(method, aspireExportIgnoreAttribute))
             {
@@ -416,7 +456,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             var methodCapabilityName = customMethodName ?? (exposeMethods
                 ? $"{typeName}.{ToCamelCase(method.Name)}"
                 : ToCamelCase(method.Name));
-            var location = GetAttributeLocation(memberExportAttribute, context.CancellationToken) ??
+            var location = GetAttributeLocation(memberExportAttribute, cancellationToken) ??
                 method.Locations.FirstOrDefault() ??
                 Location.None;
 
@@ -1174,10 +1214,21 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // Non-static methods auto-exposed via ExposeMethods=true use TypeName.methodName to avoid collisions
         if (!method.IsStatic && IsExposeMethodsEnabled(containingTypeExportAttribute))
         {
-            return $"{method.ContainingType.Name}.{camelCaseName}";
+            return $"{GetRuntimeTypeName(method.ContainingType)}.{camelCaseName}";
         }
 
         return camelCaseName;
+    }
+
+    private static string GetRuntimeTypeName(INamedTypeSymbol type)
+    {
+        return type.MetadataName;
+    }
+
+    private static bool IsSpecialRuntimeMethod(IMethodSymbol method)
+    {
+        return method.MethodKind != MethodKind.Ordinary ||
+            method.Name is "GetType" or "ToString" or "Equals" or "GetHashCode";
     }
 
     private static string ToCamelCase(string name)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -164,7 +164,7 @@ public static class KubernetesGatewayExtensions
     /// <param name="builder">The gateway resource builder.</param>
     /// <param name="hostname">The hostname to match (e.g., <c>"api.example.com"</c>).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
-    [AspireExport(Description = "Adds a hostname to a Kubernetes Gateway")]
+    [AspireExport("withGatewayHostname", MethodName = "withHostname", Description = "Adds a hostname to a Kubernetes Gateway")]
     public static IResourceBuilder<KubernetesGatewayResource> WithHostname(
         this IResourceBuilder<KubernetesGatewayResource> builder,
         string hostname)
@@ -203,7 +203,7 @@ public static class KubernetesGatewayExtensions
     /// <param name="builder">The gateway resource builder.</param>
     /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
-    [AspireExport(Description = "Configures TLS on a Kubernetes Gateway listener")]
+    [AspireExport("withGatewayTls", MethodName = "withTls", Description = "Configures TLS on a Kubernetes Gateway listener")]
     public static IResourceBuilder<KubernetesGatewayResource> WithTls(
         this IResourceBuilder<KubernetesGatewayResource> builder,
         string secretName)
@@ -312,4 +312,3 @@ public static class KubernetesGatewayExtensions
         return builder;
     }
 }
-

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -188,7 +188,7 @@ public static class KubernetesIngressExtensions
     ///        .WithHostname("www.example.com");
     /// </code>
     /// </example>
-    [AspireExport(Description = "Adds a hostname to a Kubernetes Ingress")]
+    [AspireExport("withIngressHostname", MethodName = "withHostname", Description = "Adds a hostname to a Kubernetes Ingress")]
     public static IResourceBuilder<KubernetesIngressResource> WithHostname(
         this IResourceBuilder<KubernetesIngressResource> builder,
         string hostname)
@@ -225,7 +225,7 @@ public static class KubernetesIngressExtensions
     /// <param name="builder">The ingress resource builder.</param>
     /// <param name="secretName">The name of the Kubernetes <c>kubernetes.io/tls</c> Secret.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
-    [AspireExport(Description = "Configures TLS for a Kubernetes Ingress using a K8S secret")]
+    [AspireExport("withIngressTls", MethodName = "withTls", Description = "Configures TLS for a Kubernetes Ingress using a K8S secret")]
     public static IResourceBuilder<KubernetesIngressResource> WithTls(
         this IResourceBuilder<KubernetesIngressResource> builder,
         string secretName)

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -1153,6 +1153,96 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
+    [Fact]
+    public async Task ExposeMethodsSpecialRuntimeMethods_NoASPIREEXPORT013()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            public static class Program
+            {
+                public static void Main() { }
+            }
+
+            namespace TestPackage
+            {
+                [AspireExport(ExposeMethods = true)]
+                public class Context
+                {
+                    public override string ToString() => "";
+
+                    public string ToString(string format) => format;
+
+                    public override int GetHashCode() => 0;
+
+                    public override bool Equals(object? obj) => false;
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExposeMethodsGenericAndNonGenericTypesWithSameName_NoASPIREEXPORT013()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            public static class Program
+            {
+                public static void Main() { }
+            }
+
+            namespace TestPackage
+            {
+                [AspireExport(ExposeMethods = true)]
+                public class Context
+                {
+                    public void Configure() { }
+                }
+
+                [AspireExport(ExposeMethods = true)]
+                public class Context<T>
+                {
+                    public void Configure() { }
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task AssemblyExportExposeMethodsOverloads_ReportASPIREEXPORT013()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicatePolyglotCapabilityId;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            [assembly: AspireExport(typeof(AssemblyContext), ExposeMethods = true)]
+
+            public static class Program
+            {
+                public static void Main() { }
+            }
+
+            public class AssemblyContext
+            {
+                public void Configure(string name) { }
+
+                public void Configure(int port) { }
+            }
+            """,
+            [
+                CompilerWarning(diagnostic.Id).WithLocation(12, 17),
+                CompilerWarning(diagnostic.Id).WithLocation(14, 17)
+            ]);
+
+        await test.RunAsync();
+    }
+
     // Additional ASPIREEXPORT006 tests - valid ATS types in unions
 
     [Fact]

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -1011,6 +1011,7 @@ public class AspireExportAnalyzerTests
     public async Task DuplicateExportIdSameTargetType_ReportsASPIREEXPORT007()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateExportId;
+        var capabilityDiagnostic = AspireExportAnalyzer.Diagnostics.s_duplicatePolyglotCapabilityId;
 
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
             using Aspire.Hosting;
@@ -1028,7 +1029,9 @@ public class AspireExportAnalyzerTests
             """,
             [
                 new DiagnosticResult(diagnostic).WithLocation(7, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder"),
-                new DiagnosticResult(diagnostic).WithLocation(10, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder")
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(7, 6),
+                new DiagnosticResult(diagnostic).WithLocation(10, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder"),
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(10, 6)
             ]);
 
         await test.RunAsync();
@@ -1056,8 +1059,10 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task SameExportIdDifferentTargetTypes_NoDiagnostics()
+    public async Task SameExportIdDifferentTargetTypes_ReportsASPIREEXPORT013()
     {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicatePolyglotCapabilityId;
+
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
             using Aspire.Hosting;
             using Aspire.Hosting.ApplicationModel;
@@ -1080,16 +1085,20 @@ public class AspireExportAnalyzerTests
                 public static IResourceBuilder<MyResource> ConfigureResource(this IResourceBuilder<MyResource> builder, string value)
                     => builder;
             }
-            """, []);
+            """,
+            [
+                CompilerWarning(diagnostic.Id).WithLocation(15, 6),
+                CompilerWarning(diagnostic.Id).WithLocation(18, 6)
+            ]);
 
         await test.RunAsync();
     }
 
     [Fact]
-    public async Task NonExtensionMethod_NoDuplicateCheck()
+    public async Task NonExtensionMethod_ReportsASPIREEXPORT013()
     {
-        // Non-extension methods with same export ID should not trigger ASPIREEXPORT007
-        // since they don't have a target type in the same way
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicatePolyglotCapabilityId;
+
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
             using Aspire.Hosting;
 
@@ -1103,7 +1112,43 @@ public class AspireExportAnalyzerTests
                 [AspireExport("getValue")]
                 public static string GetValueWithDefault(string defaultValue) => defaultValue;
             }
-            """, []);
+            """,
+            [
+                CompilerWarning(diagnostic.Id).WithLocation(7, 6),
+                CompilerWarning(diagnostic.Id).WithLocation(10, 6)
+            ]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExposeMethodsOverloadsLikeKubernetesHelmOptions_ReportASPIREEXPORT013()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicatePolyglotCapabilityId;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            public static class Program
+            {
+                public static void Main() { }
+            }
+
+            namespace Aspire.Hosting.Kubernetes
+            {
+                [AspireExport(ExposeMethods = true)]
+                public class HelmChartOptions
+                {
+                    public void WithNamespace(string namespaceName) { }
+
+                    public void WithNamespace(int namespaceNumber) { }
+                }
+            }
+            """,
+            [
+                CompilerWarning(diagnostic.Id).WithLocation(13, 21),
+                CompilerWarning(diagnostic.Id).WithLocation(15, 21)
+            ]);
 
         await test.RunAsync();
     }
@@ -1203,6 +1248,7 @@ public class AspireExportAnalyzerTests
     public async Task DuplicateExportIdAcrossClasses_ReportsASPIREEXPORT007()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateExportId;
+        var capabilityDiagnostic = AspireExportAnalyzer.Diagnostics.s_duplicatePolyglotCapabilityId;
 
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
             using Aspire.Hosting;
@@ -1223,7 +1269,9 @@ public class AspireExportAnalyzerTests
             """,
             [
                 new DiagnosticResult(diagnostic).WithLocation(7, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder"),
-                new DiagnosticResult(diagnostic).WithLocation(13, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder")
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(7, 6),
+                new DiagnosticResult(diagnostic).WithLocation(13, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder"),
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(13, 6)
             ]);
 
         await test.RunAsync();
@@ -1233,6 +1281,7 @@ public class AspireExportAnalyzerTests
     public async Task ThreeOrMoreDuplicates_ReportsAllASPIREEXPORT007()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateExportId;
+        var capabilityDiagnostic = AspireExportAnalyzer.Diagnostics.s_duplicatePolyglotCapabilityId;
 
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
             using Aspire.Hosting;
@@ -1253,8 +1302,11 @@ public class AspireExportAnalyzerTests
             """,
             [
                 new DiagnosticResult(diagnostic).WithLocation(7, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder"),
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(7, 6),
                 new DiagnosticResult(diagnostic).WithLocation(10, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder"),
-                new DiagnosticResult(diagnostic).WithLocation(13, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder")
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(10, 6),
+                new DiagnosticResult(diagnostic).WithLocation(13, 6).WithArguments("addThing", "Aspire.Hosting.IDistributedApplicationBuilder"),
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(13, 6)
             ]);
 
         await test.RunAsync();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
@@ -37,6 +37,12 @@ void main() throws Exception {
         var _resolvedHelmChartName = kubernetes.helmChartName();
         var _resolvedDefaultStorageClassName = kubernetes.defaultStorageClassName();
         var _resolvedDefaultServiceType = kubernetes.defaultServiceType();
+        var gateway = kubernetes.addGateway("public-gateway");
+        gateway.withHostname("gateway.example.com");
+        gateway.withTls("gateway-tls");
+        var ingress = kubernetes.addIngress("public-ingress");
+        ingress.withHostname("ingress.example.com");
+        ingress.withTls("ingress-tls");
         var serviceContainer = builder.addContainer("kube-service", "redis:alpine");
         serviceContainer.publishAsKubernetesService((service) -> {
             var _serviceName = service.name();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
@@ -23,6 +23,12 @@ with create_builder() as builder:
     _resolved_helm_chart_name = kubernetes.helm_chart_name
     _resolved_default_storage_class_name = kubernetes.default_storage_class_name
     _resolved_default_service_type = kubernetes.default_service_type
+    gateway = kubernetes.add_gateway("public-gateway")
+    gateway.with_hostname("gateway.example.com")
+    gateway.with_tls("gateway-tls")
+    ingress = kubernetes.add_ingress("public-ingress")
+    ingress.with_hostname("ingress.example.com")
+    ingress.with_tls("ingress-tls")
     service_container = builder.add_container("resource", "image")
     service_container.publish_as_kubernetes_service()
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -52,6 +52,14 @@ const _resolvedHelmChartName: string = await kubernetes.helmChartName.get();
 const _resolvedDefaultStorageClassName: string | undefined = await kubernetes.defaultStorageClassName.get();
 const _resolvedDefaultServiceType: string = await kubernetes.defaultServiceType.get();
 
+const gateway = await kubernetes.addGateway('public-gateway');
+await gateway.withHostname('gateway.example.com');
+await gateway.withTls('gateway-tls');
+
+const ingress = await kubernetes.addIngress('public-ingress');
+await ingress.withHostname('ingress.example.com');
+await ingress.withTls('ingress-tls');
+
 const serviceContainer = await builder.addContainer('kube-service', 'redis:alpine');
 await serviceContainer.publishAsKubernetesService(async (service) => {
     const _serviceName: string = await service.name();


### PR DESCRIPTION
## Description

Polyglot capability IDs must be unique within an assembly, but the existing analyzer only caught duplicate export IDs for the same target type. This adds ASPIREEXPORT013 to detect assembly-wide generated capability ID collisions, including static exports and members exposed from `[AspireExport(ExposeMethods/ExposeProperties)]` context types.

The analyzer now mirrors the capability ID shapes used by the ATS scanner closely enough to catch collisions like differently targeted static exports with the same generated ID and overloaded context-type methods that produce the same capability ID. This PR intentionally does not change the Kubernetes exports themselves; that fix is handled separately.

Fixes # (issue)
N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
