### PR TITLE
Add BrowserLogs configuration command

### DIFF
--- a/src/Aspire.Hosting/BrowserLogs/BrowserConfiguration.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserConfiguration.cs
@@ -107,16 +107,16 @@ internal readonly record struct BrowserConfiguration(string Browser, string? Pro
         return "chrome";
     }
 
-    private static BrowserUserDataMode? ParseUserDataMode(string? value)
+    private static ConfigurationValue<BrowserUserDataMode> ParseUserDataMode(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
-            return null;
+            return ConfigurationValue<BrowserUserDataMode>.Missing;
         }
 
         if (Enum.TryParse<BrowserUserDataMode>(value, ignoreCase: true, out var parsed))
         {
-            return parsed;
+            return ConfigurationValue<BrowserUserDataMode>.Present(parsed);
         }
 
         throw new InvalidOperationException(
@@ -138,29 +138,16 @@ internal readonly record struct BrowserConfiguration(string Browser, string? Pro
         BrowserConfiguration? globalRuntimeConfiguration,
         IConfigurationSection resourceSection,
         IConfigurationSection browserLogsSection)
-    {
-        if (explicitValues.Profile is not null)
-        {
-            return explicitValues.Profile;
-        }
-
-        if (resourceRuntimeConfiguration is { } resourceRuntime)
-        {
-            return resourceRuntime.Profile;
-        }
-
-        if (resourceSection[BrowserLogsBuilderExtensions.ProfileConfigurationKey] is { } resourceProfile)
-        {
-            return resourceProfile;
-        }
-
-        if (globalRuntimeConfiguration is { } globalRuntime)
-        {
-            return globalRuntime.Profile;
-        }
-
-        return browserLogsSection[BrowserLogsBuilderExtensions.ProfileConfigurationKey];
-    }
+        => ResolveValue(
+            FromOptionalString(explicitValues.Profile),
+            resourceRuntimeConfiguration,
+            globalRuntimeConfiguration,
+            static configuration => configuration.Profile,
+            resourceSection,
+            browserLogsSection,
+            BrowserLogsBuilderExtensions.ProfileConfigurationKey,
+            FromOptionalString,
+            static () => null);
 
     private static BrowserUserDataMode ResolveUserDataMode(
         BrowserConfigurationExplicitValues explicitValues,
@@ -168,30 +155,18 @@ internal readonly record struct BrowserConfiguration(string Browser, string? Pro
         BrowserConfiguration? globalRuntimeConfiguration,
         IConfigurationSection resourceSection,
         IConfigurationSection browserLogsSection)
-    {
-        if (explicitValues.UserDataMode is { } explicitUserDataMode)
-        {
-            return explicitUserDataMode;
-        }
-
-        if (resourceRuntimeConfiguration is { } resourceRuntime)
-        {
-            return resourceRuntime.UserDataMode;
-        }
-
-        if (ParseUserDataMode(resourceSection[BrowserLogsBuilderExtensions.UserDataModeConfigurationKey]) is { } resourceUserDataMode)
-        {
-            return resourceUserDataMode;
-        }
-
-        if (globalRuntimeConfiguration is { } globalRuntime)
-        {
-            return globalRuntime.UserDataMode;
-        }
-
-        return ParseUserDataMode(browserLogsSection[BrowserLogsBuilderExtensions.UserDataModeConfigurationKey])
-            ?? DefaultUserDataMode;
-    }
+        => ResolveValue(
+            explicitValues.UserDataMode is { } explicitUserDataMode
+                ? ConfigurationValue<BrowserUserDataMode>.Present(explicitUserDataMode)
+                : ConfigurationValue<BrowserUserDataMode>.Missing,
+            resourceRuntimeConfiguration,
+            globalRuntimeConfiguration,
+            static configuration => configuration.UserDataMode,
+            resourceSection,
+            browserLogsSection,
+            BrowserLogsBuilderExtensions.UserDataModeConfigurationKey,
+            ParseUserDataMode,
+            static () => DefaultUserDataMode);
 
     private static string ResolveBrowser(
         BrowserConfigurationExplicitValues explicitValues,
@@ -200,29 +175,63 @@ internal readonly record struct BrowserConfiguration(string Browser, string? Pro
         IConfigurationSection resourceSection,
         IConfigurationSection browserLogsSection,
         BrowserUserDataMode resolvedUserDataMode)
+        => ResolveValue<string?>(
+            FromOptionalString(explicitValues.Browser),
+            resourceRuntimeConfiguration,
+            globalRuntimeConfiguration,
+            static configuration => configuration.Browser,
+            resourceSection,
+            browserLogsSection,
+            BrowserLogsBuilderExtensions.BrowserConfigurationKey,
+            FromOptionalString,
+            () => GetDefaultBrowser(resolvedUserDataMode))!;
+
+    private static T ResolveValue<T>(
+        ConfigurationValue<T> explicitValue,
+        BrowserConfiguration? resourceRuntimeConfiguration,
+        BrowserConfiguration? globalRuntimeConfiguration,
+        Func<BrowserConfiguration, T> getRuntimeValue,
+        IConfigurationSection resourceSection,
+        IConfigurationSection browserLogsSection,
+        string configurationKey,
+        Func<string?, ConfigurationValue<T>> parseConfigurationValue,
+        Func<T> getDefault)
     {
-        if (explicitValues.Browser is not null)
+        if (explicitValue.HasValue)
         {
-            return explicitValues.Browser;
+            return explicitValue.Value;
         }
 
         if (resourceRuntimeConfiguration is { } resourceRuntime)
         {
-            return resourceRuntime.Browser;
+            return getRuntimeValue(resourceRuntime);
         }
 
-        if (resourceSection[BrowserLogsBuilderExtensions.BrowserConfigurationKey] is { } resourceBrowser)
+        var resourceConfiguration = parseConfigurationValue(resourceSection[configurationKey]);
+        if (resourceConfiguration.HasValue)
         {
-            return resourceBrowser;
+            return resourceConfiguration.Value;
         }
 
         if (globalRuntimeConfiguration is { } globalRuntime)
         {
-            return globalRuntime.Browser;
+            return getRuntimeValue(globalRuntime);
         }
 
-        return browserLogsSection[BrowserLogsBuilderExtensions.BrowserConfigurationKey]
-            ?? GetDefaultBrowser(resolvedUserDataMode);
+        var globalConfiguration = parseConfigurationValue(browserLogsSection[configurationKey]);
+        return globalConfiguration.HasValue
+            ? globalConfiguration.Value
+            : getDefault();
+    }
+
+    private static ConfigurationValue<string?> FromOptionalString(string? value) =>
+        value is null ? ConfigurationValue<string?>.Missing : ConfigurationValue<string?>.Present(value);
+
+    private readonly record struct ConfigurationValue<T>(bool HasValue, T Value)
+    {
+        public static ConfigurationValue<T> Missing => new(false, default!);
+
+        public static ConfigurationValue<T> Present(T value) => new(true, value);
     }
 }
 

--- a/src/Aspire.Hosting/BrowserLogs/BrowserConfiguration.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserConfiguration.cs
@@ -29,7 +29,9 @@ internal readonly record struct BrowserConfiguration(string Browser, string? Pro
     internal static BrowserConfiguration Resolve(
         IConfiguration configuration,
         string resourceName,
-        BrowserConfigurationOverrides overrides)
+        BrowserConfigurationExplicitValues explicitValues,
+        BrowserConfiguration? resourceRuntimeConfiguration = null,
+        BrowserConfiguration? globalRuntimeConfiguration = null)
     {
         ArgumentNullException.ThrowIfNull(configuration);
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
@@ -40,17 +42,9 @@ internal readonly record struct BrowserConfiguration(string Browser, string? Pro
         // Resolution order is explicit argument -> resource-specific config -> global browser-log config -> default.
         // Resolve user-data mode before browser so the browser default can prefer Edge for shared state and Chrome for
         // disposable isolated state.
-        var resolvedProfile = overrides.Profile
-            ?? resourceSection[BrowserLogsBuilderExtensions.ProfileConfigurationKey]
-            ?? browserLogsSection[BrowserLogsBuilderExtensions.ProfileConfigurationKey];
-        var resolvedUserDataMode = overrides.UserDataMode
-            ?? ParseUserDataMode(resourceSection[BrowserLogsBuilderExtensions.UserDataModeConfigurationKey])
-            ?? ParseUserDataMode(browserLogsSection[BrowserLogsBuilderExtensions.UserDataModeConfigurationKey])
-            ?? DefaultUserDataMode;
-        var resolvedBrowser = overrides.Browser
-            ?? resourceSection[BrowserLogsBuilderExtensions.BrowserConfigurationKey]
-            ?? browserLogsSection[BrowserLogsBuilderExtensions.BrowserConfigurationKey]
-            ?? GetDefaultBrowser(resolvedUserDataMode);
+        var resolvedProfile = ResolveProfile(explicitValues, resourceRuntimeConfiguration, globalRuntimeConfiguration, resourceSection, browserLogsSection);
+        var resolvedUserDataMode = ResolveUserDataMode(explicitValues, resourceRuntimeConfiguration, globalRuntimeConfiguration, resourceSection, browserLogsSection);
+        var resolvedBrowser = ResolveBrowser(explicitValues, resourceRuntimeConfiguration, globalRuntimeConfiguration, resourceSection, browserLogsSection, resolvedUserDataMode);
 
         if (string.IsNullOrWhiteSpace(resolvedBrowser))
         {
@@ -77,8 +71,7 @@ internal readonly record struct BrowserConfiguration(string Browser, string? Pro
 
         // Stable per-AppHost key sourced from DistributedApplicationBuilder. Only Isolated mode actually needs it
         // (its user-data path includes the AppHost segment), but it is always captured here so the registry never
-        // has to re-read configuration. Same SHA value is used by FileDeploymentStateManager for analogous
-        // per-AppHost persistent state.
+        // has to re-read configuration. The same SHA value is used for other per-AppHost persisted state.
         var appHostKey = configuration["AppHost:PathSha256"];
 
         return new BrowserConfiguration(resolvedBrowser, resolvedProfile, resolvedUserDataMode, appHostKey);
@@ -138,9 +131,102 @@ internal readonly record struct BrowserConfiguration(string Browser, string? Pro
 
     private static string GetDefaultBrowser(BrowserUserDataMode userDataMode) =>
         GetDefaultBrowser(userDataMode, ChromiumBrowserResolver.TryResolveExecutable);
+
+    private static string? ResolveProfile(
+        BrowserConfigurationExplicitValues explicitValues,
+        BrowserConfiguration? resourceRuntimeConfiguration,
+        BrowserConfiguration? globalRuntimeConfiguration,
+        IConfigurationSection resourceSection,
+        IConfigurationSection browserLogsSection)
+    {
+        if (explicitValues.Profile is not null)
+        {
+            return explicitValues.Profile;
+        }
+
+        if (resourceRuntimeConfiguration is { } resourceRuntime)
+        {
+            return resourceRuntime.Profile;
+        }
+
+        if (resourceSection[BrowserLogsBuilderExtensions.ProfileConfigurationKey] is { } resourceProfile)
+        {
+            return resourceProfile;
+        }
+
+        if (globalRuntimeConfiguration is { } globalRuntime)
+        {
+            return globalRuntime.Profile;
+        }
+
+        return browserLogsSection[BrowserLogsBuilderExtensions.ProfileConfigurationKey];
+    }
+
+    private static BrowserUserDataMode ResolveUserDataMode(
+        BrowserConfigurationExplicitValues explicitValues,
+        BrowserConfiguration? resourceRuntimeConfiguration,
+        BrowserConfiguration? globalRuntimeConfiguration,
+        IConfigurationSection resourceSection,
+        IConfigurationSection browserLogsSection)
+    {
+        if (explicitValues.UserDataMode is { } explicitUserDataMode)
+        {
+            return explicitUserDataMode;
+        }
+
+        if (resourceRuntimeConfiguration is { } resourceRuntime)
+        {
+            return resourceRuntime.UserDataMode;
+        }
+
+        if (ParseUserDataMode(resourceSection[BrowserLogsBuilderExtensions.UserDataModeConfigurationKey]) is { } resourceUserDataMode)
+        {
+            return resourceUserDataMode;
+        }
+
+        if (globalRuntimeConfiguration is { } globalRuntime)
+        {
+            return globalRuntime.UserDataMode;
+        }
+
+        return ParseUserDataMode(browserLogsSection[BrowserLogsBuilderExtensions.UserDataModeConfigurationKey])
+            ?? DefaultUserDataMode;
+    }
+
+    private static string ResolveBrowser(
+        BrowserConfigurationExplicitValues explicitValues,
+        BrowserConfiguration? resourceRuntimeConfiguration,
+        BrowserConfiguration? globalRuntimeConfiguration,
+        IConfigurationSection resourceSection,
+        IConfigurationSection browserLogsSection,
+        BrowserUserDataMode resolvedUserDataMode)
+    {
+        if (explicitValues.Browser is not null)
+        {
+            return explicitValues.Browser;
+        }
+
+        if (resourceRuntimeConfiguration is { } resourceRuntime)
+        {
+            return resourceRuntime.Browser;
+        }
+
+        if (resourceSection[BrowserLogsBuilderExtensions.BrowserConfigurationKey] is { } resourceBrowser)
+        {
+            return resourceBrowser;
+        }
+
+        if (globalRuntimeConfiguration is { } globalRuntime)
+        {
+            return globalRuntime.Browser;
+        }
+
+        return browserLogsSection[BrowserLogsBuilderExtensions.BrowserConfigurationKey]
+            ?? GetDefaultBrowser(resolvedUserDataMode);
+    }
 }
 
 /// <summary>
-/// Explicit browser configuration values supplied by the resource builder.
+/// Browser configuration values explicitly supplied by the resource builder.
 /// </summary>
-internal readonly record struct BrowserConfigurationOverrides(string? Browser, string? Profile, BrowserUserDataMode? UserDataMode);
+internal readonly record struct BrowserConfigurationExplicitValues(string? Browser, string? Profile, BrowserUserDataMode? UserDataMode);

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsBuilderExtensions.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsBuilderExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only
+
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -37,6 +39,7 @@ public static class BrowserLogsBuilderExtensions
     internal const string LastErrorPropertyName = "Last error";
     internal const string LastSessionPropertyName = "Last session";
     internal const string OpenTrackedBrowserCommandName = "open-tracked-browser";
+    internal const string ConfigureTrackedBrowserCommandName = "configure-tracked-browser";
     internal const string CaptureScreenshotCommandName = "capture-screenshot";
     private static readonly JsonSerializerOptions s_commandResultJsonOptions = new(JsonSerializerDefaults.Web)
     {
@@ -120,15 +123,17 @@ public static class BrowserLogsBuilderExtensions
         ThrowIfBlankWhenSpecified(profile, nameof(profile));
 
         builder.ApplicationBuilder.Services.TryAddSingleton<IBrowserLogsSessionManager, BrowserLogsSessionManager>();
+        builder.ApplicationBuilder.Services.TryAddSingleton<BrowserLogsConfigurationStore>();
+        builder.ApplicationBuilder.Services.TryAddSingleton<BrowserLogsConfigurationManager>();
 
         var parentResource = builder.Resource;
-        var configurationOverrides = new BrowserConfigurationOverrides(browser, profile, userDataMode);
-        var initialConfiguration = BrowserConfiguration.Resolve(builder.ApplicationBuilder.Configuration, parentResource.Name, configurationOverrides);
+        var explicitConfigurationValues = new BrowserConfigurationExplicitValues(browser, profile, userDataMode);
+        var initialConfiguration = BrowserConfiguration.Resolve(builder.ApplicationBuilder.Configuration, parentResource.Name, explicitConfigurationValues);
         var browserLogsResource = new BrowserLogsResource(
             $"{parentResource.Name}-browser-logs",
             parentResource,
             initialConfiguration,
-            configurationOverrides);
+            explicitConfigurationValues);
         browserLogsResource.Annotations.Add(NameValidationPolicyAnnotation.None);
 
         builder.ApplicationBuilder.AddResource(browserLogsResource)
@@ -150,7 +155,8 @@ public static class BrowserLogsBuilderExtensions
                     try
                     {
                         var configuration = context.ServiceProvider.GetRequiredService<IConfiguration>();
-                        var currentConfiguration = browserLogsResource.ResolveCurrentConfiguration(configuration);
+                        var configurationStore = context.ServiceProvider.GetRequiredService<BrowserLogsConfigurationStore>();
+                        var currentConfiguration = browserLogsResource.ResolveCurrentConfiguration(configuration, configurationStore);
                         var url = ResolveBrowserUrl(parentResource);
                         var sessionManager = context.ServiceProvider.GetRequiredService<IBrowserLogsSessionManager>();
                         await sessionManager.StartSessionAsync(browserLogsResource, currentConfiguration, context.ResourceName, url, context.CancellationToken).ConfigureAwait(false);
@@ -189,6 +195,34 @@ public static class BrowserLogsBuilderExtensions
                         }
 
                         return ResourceCommandState.Disabled;
+                    }
+                })
+            .WithCommand(
+                ConfigureTrackedBrowserCommandName,
+                CommandStrings.ConfigureTrackedBrowserName,
+                async context =>
+                {
+                    try
+                    {
+                        var configurationManager = context.ServiceProvider.GetRequiredService<BrowserLogsConfigurationManager>();
+                        return await configurationManager.ConfigureAsync(browserLogsResource, context.CancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        return CommandResults.Failure(ex.Message);
+                    }
+                },
+                new CommandOptions
+                {
+                    Description = CommandStrings.ConfigureTrackedBrowserDescription,
+                    IconName = "Settings",
+                    IconVariant = IconVariant.Regular,
+                    UpdateState = context =>
+                    {
+                        var interactionService = context.ServiceProvider.GetRequiredService<IInteractionService>();
+                        return interactionService.IsAvailable
+                            ? ResourceCommandState.Enabled
+                            : ResourceCommandState.Disabled;
                     }
                 })
             .WithCommand(

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsConfigurationManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsConfigurationManager.cs
@@ -1,0 +1,416 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only
+#pragma warning disable ASPIREUSERSECRETS001 // Type is for evaluation purposes only
+
+using System.Globalization;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Resources;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting;
+
+internal sealed class BrowserLogsConfigurationManager(
+    IConfiguration configuration,
+    IInteractionService interactionService,
+    IUserSecretsManager userSecretsManager,
+    BrowserLogsConfigurationStore configurationStore,
+    ResourceNotificationService resourceNotificationService,
+    ILogger<BrowserLogsConfigurationManager> logger)
+{
+    private const string ScopeInputName = "scope";
+    private const string BrowserInputName = "browser";
+    private const string UserDataModeInputName = "userDataMode";
+    private const string ProfileInputName = "profile";
+    private const string SaveToUserSecretsInputName = "saveToUserSecrets";
+    private const string ResourceScopeValue = "resource";
+    private const string GlobalScopeValue = "global";
+    private const string BrowserDefaultProfileValue = "__aspire_browser_default__";
+
+    public async Task<ExecuteCommandResult> ConfigureAsync(BrowserLogsResource resource, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        if (!interactionService.IsAvailable)
+        {
+            return CommandResults.Failure(CommandStrings.ConfigureTrackedBrowserInteractionUnavailable);
+        }
+
+        var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
+        var inputs = CreateInputs(resource, currentConfiguration);
+        var result = await interactionService.PromptInputsAsync(
+            CommandStrings.ConfigureTrackedBrowserName,
+            CommandStrings.ConfigureTrackedBrowserPromptMessage,
+            inputs,
+            new InputsDialogInteractionOptions
+            {
+                PrimaryButtonText = CommandStrings.ConfigureTrackedBrowserSaveButton,
+                ShowDismiss = true,
+                EnableMessageMarkdown = true,
+                ValidationCallback = ValidateInputsAsync
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (result.Canceled)
+        {
+            return CommandResults.Canceled();
+        }
+
+        var selected = BrowserLogsConfigurationSelection.FromInputs(result.Data);
+        Apply(resource, selected);
+
+        var savedConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
+        await PublishConfigurationSnapshotAsync(resource, savedConfiguration).ConfigureAwait(false);
+
+        var scopeName = selected.Scope == BrowserLogsConfigurationScope.Resource
+            ? resource.ParentResource.Name
+            : CommandStrings.ConfigureTrackedBrowserGlobalScopeResult;
+        var resultMessage = selected.SaveToUserSecrets
+            ? CommandStrings.ConfigureTrackedBrowserSaved
+            : CommandStrings.ConfigureTrackedBrowserApplied;
+
+        return new ExecuteCommandResult
+        {
+            Success = true,
+            Message = string.Format(
+                CultureInfo.CurrentCulture,
+                resultMessage,
+                scopeName)
+        };
+    }
+
+    private List<InteractionInput> CreateInputs(BrowserLogsResource resource, BrowserConfiguration currentConfiguration)
+    {
+        var scopeInput = new InteractionInput
+        {
+            Name = ScopeInputName,
+            Label = CommandStrings.ConfigureTrackedBrowserScopeLabel,
+            InputType = InputType.Choice,
+            Required = true,
+            Value = ResourceScopeValue,
+            Options =
+            [
+                new(ResourceScopeValue, string.Format(CultureInfo.CurrentCulture, CommandStrings.ConfigureTrackedBrowserResourceScopeOption, resource.ParentResource.Name)),
+                new(GlobalScopeValue, CommandStrings.ConfigureTrackedBrowserGlobalScopeOption)
+            ]
+        };
+
+        var browserInput = new InteractionInput
+        {
+            Name = BrowserInputName,
+            Label = CommandStrings.ConfigureTrackedBrowserBrowserLabel,
+            Description = CommandStrings.ConfigureTrackedBrowserBrowserDescription,
+            InputType = InputType.Choice,
+            Required = true,
+            AllowCustomChoice = true,
+            Value = currentConfiguration.Browser,
+            Options = GetBrowserOptions(currentConfiguration.Browser)
+        };
+
+        var userDataModeInput = new InteractionInput
+        {
+            Name = UserDataModeInputName,
+            Label = CommandStrings.ConfigureTrackedBrowserUserDataModeLabel,
+            InputType = InputType.Choice,
+            Required = true,
+            Value = currentConfiguration.UserDataMode.ToString(),
+            Options =
+            [
+                new(nameof(BrowserUserDataMode.Shared), nameof(BrowserUserDataMode.Shared)),
+                new(nameof(BrowserUserDataMode.Isolated), nameof(BrowserUserDataMode.Isolated))
+            ]
+        };
+
+        var profileInput = new InteractionInput
+        {
+            Name = ProfileInputName,
+            Label = CommandStrings.ConfigureTrackedBrowserProfileLabel,
+            Description = CommandStrings.ConfigureTrackedBrowserProfileDescription,
+            InputType = InputType.Choice,
+            Required = false,
+            AllowCustomChoice = true,
+            Value = currentConfiguration.Profile ?? BrowserDefaultProfileValue,
+            DynamicLoading = new InputLoadOptions
+            {
+                AlwaysLoadOnStart = true,
+                DependsOnInputs = [BrowserInputName, UserDataModeInputName],
+                LoadCallback = context =>
+                {
+                    LoadProfileOptions(context);
+                    return Task.CompletedTask;
+                }
+            }
+        };
+
+        var saveInput = CreateSaveToUserSecretsInput();
+
+        return [scopeInput, browserInput, userDataModeInput, profileInput, saveInput];
+    }
+
+    private InteractionInput CreateSaveToUserSecretsInput()
+    {
+        return new InteractionInput
+        {
+            Name = SaveToUserSecretsInputName,
+            Label = CommandStrings.ConfigureTrackedBrowserSaveToUserSecretsLabel,
+            InputType = InputType.Boolean,
+            Value = userSecretsManager.IsAvailable ? "true" : null,
+            Description = userSecretsManager.IsAvailable
+                ? CommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured
+                : CommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured,
+            EnableDescriptionMarkdown = true,
+            Disabled = !userSecretsManager.IsAvailable
+        };
+    }
+
+    private static IReadOnlyList<KeyValuePair<string, string>> GetBrowserOptions(string currentBrowser)
+    {
+        var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        AddKnownBrowser("msedge", CommandStrings.ConfigureTrackedBrowserEdgeOption);
+        AddKnownBrowser("chrome", CommandStrings.ConfigureTrackedBrowserChromeOption);
+        AddKnownBrowser("chromium", CommandStrings.ConfigureTrackedBrowserChromiumOption);
+
+        if (!options.ContainsKey(currentBrowser))
+        {
+            options[currentBrowser] = currentBrowser;
+        }
+
+        return [.. options.Select(static pair => new KeyValuePair<string, string>(pair.Key, pair.Value))];
+
+        void AddKnownBrowser(string browser, string displayName)
+        {
+            if (ChromiumBrowserResolver.TryResolveExecutable(browser) is not null)
+            {
+                options[browser] = displayName;
+            }
+        }
+    }
+
+    private void LoadProfileOptions(LoadInputContext context)
+    {
+        var browser = context.AllInputs[BrowserInputName].Value;
+        var profile = context.Input.Value;
+
+        var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [BrowserDefaultProfileValue] = CommandStrings.ConfigureTrackedBrowserDefaultProfileOption
+        };
+
+        if (Enum.TryParse<BrowserUserDataMode>(context.AllInputs[UserDataModeInputName].Value, ignoreCase: true, out var userDataMode) &&
+            userDataMode == BrowserUserDataMode.Shared &&
+            !string.IsNullOrWhiteSpace(browser))
+        {
+            context.Input.Disabled = false;
+
+            try
+            {
+                // Profile discovery only makes sense for Shared mode. The Shared directory is a persistent
+                // Aspire-managed Chromium user data directory with profile subdirectories such as "Default" and
+                // "Profile 1". Isolated mode is per-AppHost and may not exist until the first browser launch, so
+                // offering profile choices there would be misleading.
+                var browserConfiguration = new BrowserConfiguration(
+                    browser,
+                    Profile: null,
+                    BrowserUserDataMode.Shared,
+                    configuration["AppHost:PathSha256"]);
+                var userDataDirectory = BrowserUserDataPathResolver.Resolve(browserConfiguration, createDirectory: false);
+                foreach (var browserProfile in ChromiumBrowserResolver.GetAvailableProfiles(userDataDirectory))
+                {
+                    options[browserProfile.DirectoryName] = FormatProfileOption(browserProfile);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Text.Json.JsonException)
+            {
+                logger.LogDebug(ex, "Unable to discover tracked browser profiles for '{Browser}'.", browser);
+            }
+        }
+        else
+        {
+            context.Input.Disabled = true;
+            context.Input.Value = BrowserDefaultProfileValue;
+        }
+
+        if (!string.IsNullOrWhiteSpace(profile) && !options.ContainsKey(profile))
+        {
+            options[profile] = profile;
+        }
+
+        context.Input.Options = [.. options.Select(static pair => new KeyValuePair<string, string>(pair.Key, pair.Value))];
+    }
+
+    private static string FormatProfileOption(ChromiumBrowserProfile profile)
+    {
+        if (!string.IsNullOrWhiteSpace(profile.DisplayName) &&
+            !string.Equals(profile.DirectoryName, profile.DisplayName, StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                CommandStrings.ConfigureTrackedBrowserProfileOptionWithDisplayName,
+                profile.DirectoryName,
+                profile.DisplayName);
+        }
+
+        return profile.DirectoryName;
+    }
+
+    private Task ValidateInputsAsync(InputsDialogValidationContext context)
+    {
+        var inputs = context.Inputs;
+        var browser = inputs[BrowserInputName];
+        if (string.IsNullOrWhiteSpace(browser.Value))
+        {
+            context.AddValidationError(browser, CommandStrings.ConfigureTrackedBrowserBrowserRequired);
+        }
+
+        var userDataMode = inputs[UserDataModeInputName];
+        if (!Enum.TryParse<BrowserUserDataMode>(userDataMode.Value, ignoreCase: true, out var parsedUserDataMode))
+        {
+            context.AddValidationError(userDataMode, CommandStrings.ConfigureTrackedBrowserUserDataModeRequired);
+        }
+
+        var profile = inputs[ProfileInputName];
+        if (parsedUserDataMode == BrowserUserDataMode.Isolated &&
+            !string.IsNullOrWhiteSpace(profile.Value) &&
+            !string.Equals(profile.Value, BrowserDefaultProfileValue, StringComparison.Ordinal))
+        {
+            context.AddValidationError(profile, CommandStrings.ConfigureTrackedBrowserProfileRequiresShared);
+        }
+
+        var saveToUserSecrets = inputs[SaveToUserSecretsInputName];
+        if (IsSaveToUserSecretsRequested(inputs) && !userSecretsManager.IsAvailable)
+        {
+            context.AddValidationError(saveToUserSecrets, CommandStrings.ConfigureTrackedBrowserUserSecretsUnavailable);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void Apply(BrowserLogsResource resource, BrowserLogsConfigurationSelection selected)
+    {
+        var configurationPrefix = selected.Scope == BrowserLogsConfigurationScope.Resource
+            ? $"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{resource.ParentResource.Name}"
+            : BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName;
+
+        if (selected.SaveToUserSecrets)
+        {
+            SaveValue($"{configurationPrefix}:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}", selected.Browser);
+            SaveValue($"{configurationPrefix}:{BrowserLogsBuilderExtensions.UserDataModeConfigurationKey}", selected.UserDataMode.ToString());
+
+            var profileKey = $"{configurationPrefix}:{BrowserLogsBuilderExtensions.ProfileConfigurationKey}";
+            if (selected.Profile is { } profile)
+            {
+                SaveValue(profileKey, profile);
+            }
+            else
+            {
+                DeleteValue(profileKey);
+            }
+        }
+
+        configurationStore.Set(
+            selected.Scope,
+            resource.ParentResource.Name,
+            new BrowserConfiguration(
+                selected.Browser,
+                selected.Profile,
+                selected.UserDataMode,
+                configuration["AppHost:PathSha256"]));
+    }
+
+    private void SaveValue(string key, string value)
+    {
+        if (!userSecretsManager.TrySetSecret(key, value))
+        {
+            throw new InvalidOperationException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    CommandStrings.ConfigureTrackedBrowserSaveFailed,
+                    key));
+        }
+    }
+
+    private void DeleteValue(string key)
+    {
+        if (!userSecretsManager.TryDeleteSecret(key))
+        {
+            throw new InvalidOperationException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    CommandStrings.ConfigureTrackedBrowserSaveFailed,
+                    key));
+        }
+    }
+
+    private Task PublishConfigurationSnapshotAsync(BrowserLogsResource resource, BrowserConfiguration browserConfiguration)
+    {
+        return resourceNotificationService.PublishUpdateAsync(resource, snapshot => snapshot with
+        {
+            Properties = SetConfigurationProperties(snapshot.Properties, browserConfiguration)
+        });
+    }
+
+    private static System.Collections.Immutable.ImmutableArray<ResourcePropertySnapshot> SetConfigurationProperties(
+        System.Collections.Immutable.ImmutableArray<ResourcePropertySnapshot> properties,
+        BrowserConfiguration browserConfiguration)
+    {
+        properties = properties
+            .SetResourceProperty(BrowserLogsBuilderExtensions.BrowserPropertyName, browserConfiguration.Browser)
+            .SetResourceProperty(BrowserLogsBuilderExtensions.UserDataModePropertyName, browserConfiguration.UserDataMode.ToString());
+
+        return browserConfiguration.Profile is { } profile
+            ? properties.SetResourceProperty(BrowserLogsBuilderExtensions.ProfilePropertyName, profile)
+            : RemoveProperty(properties, BrowserLogsBuilderExtensions.ProfilePropertyName);
+    }
+
+    private static System.Collections.Immutable.ImmutableArray<ResourcePropertySnapshot> RemoveProperty(
+        System.Collections.Immutable.ImmutableArray<ResourcePropertySnapshot> properties,
+        string name)
+    {
+        for (var i = 0; i < properties.Length; i++)
+        {
+            if (string.Equals(properties[i].Name, name, StringComparisons.ResourcePropertyName))
+            {
+                return properties.RemoveAt(i);
+            }
+        }
+
+        return properties;
+    }
+
+    private readonly record struct BrowserLogsConfigurationSelection(
+        BrowserLogsConfigurationScope Scope,
+        string Browser,
+        BrowserUserDataMode UserDataMode,
+        string? Profile,
+        bool SaveToUserSecrets)
+    {
+        public static BrowserLogsConfigurationSelection FromInputs(InteractionInputCollection inputs)
+        {
+            var scope = string.Equals(inputs[ScopeInputName].Value, GlobalScopeValue, StringComparison.Ordinal)
+                ? BrowserLogsConfigurationScope.Global
+                : BrowserLogsConfigurationScope.Resource;
+            var browser = inputs[BrowserInputName].Value ?? string.Empty;
+            var userDataMode = Enum.Parse<BrowserUserDataMode>(inputs[UserDataModeInputName].Value!, ignoreCase: true);
+            var profileValue = inputs[ProfileInputName].Value;
+            var profile = string.IsNullOrWhiteSpace(profileValue) ||
+                string.Equals(profileValue, BrowserDefaultProfileValue, StringComparison.Ordinal)
+                    ? null
+                    : profileValue;
+            var saveToUserSecrets = IsSaveToUserSecretsRequested(inputs);
+
+            return new BrowserLogsConfigurationSelection(scope, browser, userDataMode, profile, saveToUserSecrets);
+        }
+    }
+
+    private static bool IsSaveToUserSecretsRequested(InteractionInputCollection inputs)
+    {
+        return inputs[SaveToUserSecretsInputName].Value is { Length: > 0 } saveValue &&
+            bool.TryParse(saveValue, out var saveToUserSecrets) &&
+            saveToUserSecrets;
+    }
+}
+
+#pragma warning restore ASPIREUSERSECRETS001
+#pragma warning restore ASPIREINTERACTION001

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsConfigurationManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsConfigurationManager.cs
@@ -202,11 +202,12 @@ internal sealed class BrowserLogsConfigurationManager(
             [BrowserDefaultProfileValue] = CommandStrings.ConfigureTrackedBrowserDefaultProfileOption
         };
 
+        var disableProfileInput = true;
         if (Enum.TryParse<BrowserUserDataMode>(context.AllInputs[UserDataModeInputName].Value, ignoreCase: true, out var userDataMode) &&
             userDataMode == BrowserUserDataMode.Shared &&
             !string.IsNullOrWhiteSpace(browser))
         {
-            context.Input.Disabled = false;
+            disableProfileInput = false;
 
             try
             {
@@ -232,7 +233,6 @@ internal sealed class BrowserLogsConfigurationManager(
         }
         else
         {
-            context.Input.Disabled = true;
             context.Input.Value = BrowserDefaultProfileValue;
         }
 
@@ -242,6 +242,7 @@ internal sealed class BrowserLogsConfigurationManager(
         }
 
         context.Input.Options = [.. options.Select(static pair => new KeyValuePair<string, string>(pair.Key, pair.Value))];
+        context.Input.Disabled = disableProfileInput;
     }
 
     private static string FormatProfileOption(ChromiumBrowserProfile profile)
@@ -297,6 +298,8 @@ internal sealed class BrowserLogsConfigurationManager(
         {
             try
             {
+                // Resolve the final effective configuration so explicit WithBrowserLogs values are validated before
+                // applying runtime settings or mutating user secrets.
                 _ = ResolveEffectiveConfigurations(resource, BrowserLogsConfigurationSelection.FromInputs(inputs));
             }
             catch (InvalidOperationException ex)
@@ -362,6 +365,9 @@ internal sealed class BrowserLogsConfigurationManager(
 
         if (selected.SaveToUserSecrets)
         {
+            // IUserSecretsManager persists one key at a time, so a later failure can leave earlier secret mutations
+            // on disk. Only update the runtime store after every requested mutation succeeds, so the current AppHost
+            // never observes a partial save.
             SaveValue($"{configurationPrefix}:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}", selected.Browser);
             SaveValue($"{configurationPrefix}:{BrowserLogsBuilderExtensions.UserDataModeConfigurationKey}", selected.UserDataMode.ToString());
 

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsConfigurationManager.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsConfigurationManager.cs
@@ -16,6 +16,7 @@ internal sealed class BrowserLogsConfigurationManager(
     IConfiguration configuration,
     IInteractionService interactionService,
     IUserSecretsManager userSecretsManager,
+    DistributedApplicationModel applicationModel,
     BrowserLogsConfigurationStore configurationStore,
     ResourceNotificationService resourceNotificationService,
     ILogger<BrowserLogsConfigurationManager> logger)
@@ -49,7 +50,7 @@ internal sealed class BrowserLogsConfigurationManager(
                 PrimaryButtonText = CommandStrings.ConfigureTrackedBrowserSaveButton,
                 ShowDismiss = true,
                 EnableMessageMarkdown = true,
-                ValidationCallback = ValidateInputsAsync
+                ValidationCallback = context => ValidateInputsAsync(resource, context)
             },
             cancellationToken).ConfigureAwait(false);
 
@@ -59,10 +60,13 @@ internal sealed class BrowserLogsConfigurationManager(
         }
 
         var selected = BrowserLogsConfigurationSelection.FromInputs(result.Data);
+        var resolvedConfigurations = ResolveEffectiveConfigurations(resource, selected);
         Apply(resource, selected);
 
-        var savedConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
-        await PublishConfigurationSnapshotAsync(resource, savedConfiguration).ConfigureAwait(false);
+        foreach (var (browserLogsResource, browserConfiguration) in resolvedConfigurations)
+        {
+            await PublishConfigurationSnapshotAsync(browserLogsResource, browserConfiguration).ConfigureAwait(false);
+        }
 
         var scopeName = selected.Scope == BrowserLogsConfigurationScope.Resource
             ? resource.ParentResource.Name
@@ -255,19 +259,22 @@ internal sealed class BrowserLogsConfigurationManager(
         return profile.DirectoryName;
     }
 
-    private Task ValidateInputsAsync(InputsDialogValidationContext context)
+    private Task ValidateInputsAsync(BrowserLogsResource resource, InputsDialogValidationContext context)
     {
         var inputs = context.Inputs;
         var browser = inputs[BrowserInputName];
+        var hasValidationErrors = false;
         if (string.IsNullOrWhiteSpace(browser.Value))
         {
             context.AddValidationError(browser, CommandStrings.ConfigureTrackedBrowserBrowserRequired);
+            hasValidationErrors = true;
         }
 
         var userDataMode = inputs[UserDataModeInputName];
         if (!Enum.TryParse<BrowserUserDataMode>(userDataMode.Value, ignoreCase: true, out var parsedUserDataMode))
         {
             context.AddValidationError(userDataMode, CommandStrings.ConfigureTrackedBrowserUserDataModeRequired);
+            hasValidationErrors = true;
         }
 
         var profile = inputs[ProfileInputName];
@@ -276,15 +283,75 @@ internal sealed class BrowserLogsConfigurationManager(
             !string.Equals(profile.Value, BrowserDefaultProfileValue, StringComparison.Ordinal))
         {
             context.AddValidationError(profile, CommandStrings.ConfigureTrackedBrowserProfileRequiresShared);
+            hasValidationErrors = true;
         }
 
         var saveToUserSecrets = inputs[SaveToUserSecretsInputName];
         if (IsSaveToUserSecretsRequested(inputs) && !userSecretsManager.IsAvailable)
         {
             context.AddValidationError(saveToUserSecrets, CommandStrings.ConfigureTrackedBrowserUserSecretsUnavailable);
+            hasValidationErrors = true;
+        }
+
+        if (!hasValidationErrors)
+        {
+            try
+            {
+                _ = ResolveEffectiveConfigurations(resource, BrowserLogsConfigurationSelection.FromInputs(inputs));
+            }
+            catch (InvalidOperationException ex)
+            {
+                context.AddValidationError(userDataMode, ex.Message);
+            }
         }
 
         return Task.CompletedTask;
+    }
+
+    private List<(BrowserLogsResource Resource, BrowserConfiguration Configuration)> ResolveEffectiveConfigurations(
+        BrowserLogsResource commandResource,
+        BrowserLogsConfigurationSelection selected)
+    {
+        var selectedConfiguration = ToBrowserConfiguration(selected);
+        IEnumerable<BrowserLogsResource> resources = selected.Scope == BrowserLogsConfigurationScope.Global
+            ? applicationModel.Resources.OfType<BrowserLogsResource>()
+            : [commandResource];
+
+        return [.. resources.Select(resource =>
+            (resource, ResolveEffectiveConfiguration(resource, commandResource, selected, selectedConfiguration)))];
+    }
+
+    private BrowserConfiguration ResolveEffectiveConfiguration(
+        BrowserLogsResource resource,
+        BrowserLogsResource commandResource,
+        BrowserLogsConfigurationSelection selected,
+        BrowserConfiguration selectedConfiguration)
+    {
+        var (resourceConfiguration, globalConfiguration) = configurationStore.GetConfigurations(resource.ParentResource.Name);
+        if (selected.Scope == BrowserLogsConfigurationScope.Global)
+        {
+            globalConfiguration = selectedConfiguration;
+        }
+        else if (ReferenceEquals(resource, commandResource))
+        {
+            resourceConfiguration = selectedConfiguration;
+        }
+
+        return BrowserConfiguration.Resolve(
+            configuration,
+            resource.ParentResource.Name,
+            resource.ExplicitConfigurationValues,
+            resourceConfiguration,
+            globalConfiguration);
+    }
+
+    private BrowserConfiguration ToBrowserConfiguration(BrowserLogsConfigurationSelection selected)
+    {
+        return new BrowserConfiguration(
+            selected.Browser,
+            selected.Profile,
+            selected.UserDataMode,
+            configuration["AppHost:PathSha256"]);
     }
 
     private void Apply(BrowserLogsResource resource, BrowserLogsConfigurationSelection selected)
@@ -309,14 +376,7 @@ internal sealed class BrowserLogsConfigurationManager(
             }
         }
 
-        configurationStore.Set(
-            selected.Scope,
-            resource.ParentResource.Name,
-            new BrowserConfiguration(
-                selected.Browser,
-                selected.Profile,
-                selected.UserDataMode,
-                configuration["AppHost:PathSha256"]));
+        configurationStore.Set(selected.Scope, resource.ParentResource.Name, ToBrowserConfiguration(selected));
     }
 
     private void SaveValue(string key, string value)

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsConfigurationStore.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsConfigurationStore.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+// Stores browser-log configuration chosen from the dashboard for the current AppHost process. User secrets persist the
+// same values for the next run, but the store makes the next command execution use the new values immediately without
+// depending on configuration reload timing.
+internal sealed class BrowserLogsConfigurationStore
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<string, BrowserConfiguration> _resourceConfigurations = new(StringComparers.ResourceName);
+    private BrowserConfiguration? _globalConfiguration;
+
+    public (BrowserConfiguration? Resource, BrowserConfiguration? Global) GetConfigurations(string resourceName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+
+        lock (_lock)
+        {
+            var hasResourceConfiguration = _resourceConfigurations.TryGetValue(resourceName, out var resourceConfiguration);
+            return (hasResourceConfiguration ? resourceConfiguration : null, _globalConfiguration);
+        }
+    }
+
+    public void Set(BrowserLogsConfigurationScope scope, string resourceName, BrowserConfiguration configuration)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+
+        lock (_lock)
+        {
+            if (scope == BrowserLogsConfigurationScope.Global)
+            {
+                _globalConfiguration = configuration;
+            }
+            else
+            {
+                _resourceConfigurations[resourceName] = configuration;
+            }
+        }
+    }
+}
+
+internal enum BrowserLogsConfigurationScope
+{
+    Resource,
+    Global
+}

--- a/src/Aspire.Hosting/BrowserLogs/BrowserLogsResource.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserLogsResource.cs
@@ -10,15 +10,23 @@ internal sealed class BrowserLogsResource(
     string name,
     IResourceWithEndpoints parentResource,
     BrowserConfiguration initialConfiguration,
-    BrowserConfigurationOverrides configurationOverrides)
+    BrowserConfigurationExplicitValues explicitConfigurationValues)
     : Resource(name)
 {
     public IResourceWithEndpoints ParentResource { get; } = parentResource;
 
     public BrowserConfiguration InitialConfiguration { get; } = initialConfiguration;
 
-    public BrowserConfigurationOverrides ConfigurationOverrides { get; } = configurationOverrides;
+    public BrowserConfigurationExplicitValues ExplicitConfigurationValues { get; } = explicitConfigurationValues;
 
-    public BrowserConfiguration ResolveCurrentConfiguration(IConfiguration configuration) =>
-        BrowserConfiguration.Resolve(configuration, ParentResource.Name, ConfigurationOverrides);
+    public BrowserConfiguration ResolveCurrentConfiguration(IConfiguration configuration, BrowserLogsConfigurationStore? configurationStore = null)
+    {
+        var (resourceConfiguration, globalConfiguration) = configurationStore?.GetConfigurations(ParentResource.Name) ?? default;
+        return BrowserConfiguration.Resolve(
+            configuration,
+            ParentResource.Name,
+            ExplicitConfigurationValues,
+            resourceConfiguration,
+            globalConfiguration);
+    }
 }

--- a/src/Aspire.Hosting/BrowserLogs/BrowserUserDataPathResolver.cs
+++ b/src/Aspire.Hosting/BrowserLogs/BrowserUserDataPathResolver.cs
@@ -18,6 +18,22 @@ namespace Aspire.Hosting;
 // Layout (Windows shown; macOS/Linux mirror the same shape under the OS-appropriate data root):
 //   %LocalAppData%\Aspire\BrowserData\shared\<browser>                              (Shared)
 //   %LocalAppData%\Aspire\BrowserData\isolated\<AppHost:PathSha256>\<browser>       (Isolated)
+//     Local State                                                                  Chromium user-data metadata
+//     Default\                                                                     default profile directory
+//       Preferences
+//       Cookies
+//       ...
+//     Profile 1\                                                                   additional profile directory
+//       Preferences
+//       Cookies
+//       ...
+//     Profile 2\
+//       ...
+//
+// Chromium calls the outer <browser> folder a user data directory. Profiles are subdirectories inside that user
+// data directory. The stable command-line value for --profile-directory is the directory name ("Default",
+// "Profile 1", ...), not the display name the user sees in the browser. Display names live in the user-data-root
+// "Local State" file under profile.info_cache, keyed by the profile directory name.
 //
 // Both paths are persistent. AppHost shutdown does not delete them and does not close the browser. The next
 // AppHost run reads the adoption sidecar and connects to the existing browser via CDP.
@@ -29,7 +45,7 @@ internal static class BrowserUserDataPathResolver
     // sub-directories.
     private const int AppHostShaSegmentLength = 16;
 
-    public static string Resolve(BrowserConfiguration configuration)
+    public static string Resolve(BrowserConfiguration configuration, bool createDirectory = true)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(configuration.Browser);
 
@@ -43,7 +59,11 @@ internal static class BrowserUserDataPathResolver
             _ => throw new ArgumentOutOfRangeException(nameof(configuration), configuration.UserDataMode, null)
         };
 
-        Directory.CreateDirectory(path);
+        if (createDirectory)
+        {
+            Directory.CreateDirectory(path);
+        }
+
         return path;
     }
 

--- a/src/Aspire.Hosting/BrowserLogs/ChromiumBrowserResolver.cs
+++ b/src/Aspire.Hosting/BrowserLogs/ChromiumBrowserResolver.cs
@@ -176,9 +176,16 @@ internal static class ChromiumBrowserResolver
             //
             // The directory key is what Chromium accepts in --profile-directory. The display name is friendlier but
             // not unique, so the picker shows both when they differ and we persist the stable directory name.
-            using var localStateStream = File.OpenRead(localStatePath);
-            using var localStateDocument = JsonDocument.Parse(localStateStream);
-            AddProfilesFromLocalState(localStateDocument.RootElement, userDataDirectory, profiles);
+            try
+            {
+                using var localStateStream = File.OpenRead(localStatePath);
+                using var localStateDocument = JsonDocument.Parse(localStateStream);
+                AddProfilesFromLocalState(localStateDocument.RootElement, userDataDirectory, profiles);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+            {
+                // Fall back to profile directory names below. This can happen while Chromium is writing Local State.
+            }
         }
 
         // Local State can be missing (new/empty user data directory), stale, or temporarily unreadable while Chromium

--- a/src/Aspire.Hosting/BrowserLogs/ChromiumBrowserResolver.cs
+++ b/src/Aspire.Hosting/BrowserLogs/ChromiumBrowserResolver.cs
@@ -64,8 +64,9 @@ internal static class ChromiumBrowserResolver
             return directMatch;
         }
 
-        // Chromium stores display names in the user-data-root "Local State" file under profile.info_cache. Directory
-        // names like "Default" or "Profile 1" are stable command-line values, while display names are user-facing.
+        // Chromium stores profile metadata in the user-data-root "Local State" file under profile.info_cache. Directory
+        // names like "Default" or "Profile 1" are stable command-line values, while "name" and "shortcut_name" are
+        // user-facing labels that can be renamed in the browser UI.
         //
         // Relevant Local State shape:
         // {
@@ -152,6 +153,51 @@ internal static class ChromiumBrowserResolver
         return match;
     }
 
+    internal static IReadOnlyList<ChromiumBrowserProfile> GetAvailableProfiles(string userDataDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userDataDirectory);
+
+        if (!Directory.Exists(userDataDirectory))
+        {
+            return [];
+        }
+
+        var profiles = new Dictionary<string, ChromiumBrowserProfile>(StringComparer.OrdinalIgnoreCase);
+        var localStatePath = Path.Combine(userDataDirectory, "Local State");
+        if (File.Exists(localStatePath))
+        {
+            // Prefer Local State because it is the only place we can get the profile display names shown in the
+            // configure dialog. The profile.info_cache object is keyed by profile directory name:
+            //
+            // <user-data-dir>\
+            //   Local State
+            //   Default\       <-- key "Default"; often displayed as "Profile 1" or a user-chosen name
+            //   Profile 1\     <-- key "Profile 1"; display name might be "Work"
+            //
+            // The directory key is what Chromium accepts in --profile-directory. The display name is friendlier but
+            // not unique, so the picker shows both when they differ and we persist the stable directory name.
+            using var localStateStream = File.OpenRead(localStatePath);
+            using var localStateDocument = JsonDocument.Parse(localStateStream);
+            AddProfilesFromLocalState(localStateDocument.RootElement, userDataDirectory, profiles);
+        }
+
+        // Local State can be missing (new/empty user data directory), stale, or temporarily unreadable while Chromium
+        // is writing it. Fall back to the profile directory names Chromium conventionally creates so the picker still
+        // offers useful values when metadata is incomplete.
+        foreach (var directoryPath in Directory.EnumerateDirectories(userDataDirectory))
+        {
+            var directoryName = Path.GetFileName(directoryPath);
+            if (IsLikelyProfileDirectory(directoryName) && !profiles.ContainsKey(directoryName))
+            {
+                profiles[directoryName] = new ChromiumBrowserProfile(directoryName, DisplayName: null, ShortcutName: null);
+            }
+        }
+
+        return [.. profiles.Values
+            .OrderBy(static profile => string.Equals(profile.DirectoryName, "Default", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+            .ThenBy(static profile => profile.DirectoryName, StringComparer.OrdinalIgnoreCase)];
+    }
+
     /// <summary>
     /// Gets platform-specific candidate executables for logical browser names.
     /// </summary>
@@ -223,6 +269,40 @@ internal static class ChromiumBrowserResolver
         return null;
     }
 
+    private static void AddProfilesFromLocalState(JsonElement localStateRoot, string userDataDirectory, Dictionary<string, ChromiumBrowserProfile> profiles)
+    {
+        if (!localStateRoot.TryGetProperty("profile", out var profileElement) ||
+            !profileElement.TryGetProperty("info_cache", out var infoCacheElement) ||
+            infoCacheElement.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        foreach (var profileEntry in infoCacheElement.EnumerateObject())
+        {
+            // Chromium can leave profile.info_cache entries behind after a profile is deleted. Ignore entries whose
+            // directories are missing so the dashboard doesn't offer stale profile choices.
+            if (!Directory.Exists(Path.Combine(userDataDirectory, profileEntry.Name)))
+            {
+                continue;
+            }
+
+            profiles[profileEntry.Name] = new ChromiumBrowserProfile(
+                profileEntry.Name,
+                TryGetProfileProperty(profileEntry.Value, "name"),
+                TryGetProfileProperty(profileEntry.Value, "shortcut_name"));
+        }
+    }
+
+    private static bool IsLikelyProfileDirectory(string directoryName)
+    {
+        // Chromium's profile folders are convention-based. "Default" is the first profile, then additional profiles
+        // are usually "Profile 1", "Profile 2", etc. Other folders in the user data directory (ShaderCache, Crashpad,
+        // BrowserMetrics, component data, ...) are not launchable profiles and should not be shown as choices.
+        return string.Equals(directoryName, "Default", StringComparison.OrdinalIgnoreCase) ||
+            directoryName.StartsWith("Profile ", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool MatchesBrowserProfile(JsonProperty profileEntry, string profile)
     {
         return string.Equals(profileEntry.Name, profile, StringComparison.OrdinalIgnoreCase) ||
@@ -236,4 +316,14 @@ internal static class ChromiumBrowserResolver
             propertyElement.ValueKind == JsonValueKind.String &&
             string.Equals(propertyElement.GetString(), profile, StringComparison.OrdinalIgnoreCase);
     }
+
+    private static string? TryGetProfileProperty(JsonElement profileElement, string propertyName)
+    {
+        return profileElement.TryGetProperty(propertyName, out var propertyElement) &&
+            propertyElement.ValueKind == JsonValueKind.String
+                ? propertyElement.GetString()
+                : null;
+    }
 }
+
+internal sealed record ChromiumBrowserProfile(string DirectoryName, string? DisplayName, string? ShortcutName);

--- a/src/Aspire.Hosting/Resources/CommandStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/CommandStrings.Designer.cs
@@ -124,6 +124,267 @@ namespace Aspire.Hosting.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Choose the browser, profile, and scope used by tracked browser sessions..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserDescription {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Configure tracked browser.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserName {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserPromptMessage {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserPromptMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Apply.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserSaveButton {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserSaveButton", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Scope.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserScopeLabel {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserScopeLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This resource only ({0}).
+        /// </summary>
+        internal static string ConfigureTrackedBrowserResourceScopeOption {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserResourceScopeOption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to All BrowserLogs resources.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserGlobalScopeOption {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserGlobalScopeOption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to all BrowserLogs resources.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserGlobalScopeResult {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserGlobalScopeResult", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Browser.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserBrowserLabel {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserBrowserLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Choose an installed Chromium-based browser or enter an executable path..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserBrowserDescription {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserBrowserDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Microsoft Edge (msedge).
+        /// </summary>
+        internal static string ConfigureTrackedBrowserEdgeOption {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserEdgeOption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Google Chrome (chrome).
+        /// </summary>
+        internal static string ConfigureTrackedBrowserChromeOption {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserChromeOption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Chromium (chromium).
+        /// </summary>
+        internal static string ConfigureTrackedBrowserChromiumOption {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserChromiumOption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to User data mode.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserUserDataModeLabel {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserUserDataModeLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Profile.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserProfileLabel {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserProfileLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserProfileDescription {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserProfileDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Browser default profile.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserDefaultProfileOption {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserDefaultProfileOption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} ({1}).
+        /// </summary>
+        internal static string ConfigureTrackedBrowserProfileOptionWithDisplayName {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserProfileOptionWithDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Browser is required..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserBrowserRequired {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserBrowserRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to User data mode must be Shared or Isolated..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserUserDataModeRequired {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserUserDataModeRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Profiles can only be selected when user data mode is Shared..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserProfileRequiresShared {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserProfileRequiresShared", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Save to AppHost user secrets.
+        /// </summary>
+        internal static string ConfigureTrackedBrowserSaveToUserSecretsLabel {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserSaveToUserSecretsLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to User secrets are not configured for this AppHost, so settings can only apply to this running AppHost..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tracked browser settings cannot be configured because dashboard interactions are not available..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserInteractionUnavailable {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserInteractionUnavailable", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tracked browser settings cannot be saved because the AppHost does not have user secrets configured..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserUserSecretsUnavailable {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserUserSecretsUnavailable", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Applied tracked browser settings for {0}..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserApplied {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserApplied", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Saved tracked browser settings for {0}..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserSaved {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserSaved", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tracked browser settings could not be saved to user secrets for key '{0}'..
+        /// </summary>
+        internal static string ConfigureTrackedBrowserSaveFailed {
+            get {
+                return ResourceManager.GetString("ConfigureTrackedBrowserSaveFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Capture a screenshot from the active tracked browser session and save it as a PNG artifact..
         /// </summary>
         internal static string CaptureScreenshotDescription {

--- a/src/Aspire.Hosting/Resources/CommandStrings.resx
+++ b/src/Aspire.Hosting/Resources/CommandStrings.resx
@@ -156,6 +156,98 @@
   <data name="OpenTrackedBrowserName" xml:space="preserve">
     <value>Open tracked browser</value>
   </data>
+  <data name="ConfigureTrackedBrowserDescription" xml:space="preserve">
+    <value>Choose the browser, profile, and scope used by tracked browser sessions.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserName" xml:space="preserve">
+    <value>Configure tracked browser</value>
+  </data>
+  <data name="ConfigureTrackedBrowserPromptMessage" xml:space="preserve">
+    <value>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserSaveButton" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="ConfigureTrackedBrowserScopeLabel" xml:space="preserve">
+    <value>Scope</value>
+  </data>
+  <data name="ConfigureTrackedBrowserResourceScopeOption" xml:space="preserve">
+    <value>This resource only ({0})</value>
+    <comment>{0} is the parent resource name.</comment>
+  </data>
+  <data name="ConfigureTrackedBrowserGlobalScopeOption" xml:space="preserve">
+    <value>All BrowserLogs resources</value>
+  </data>
+  <data name="ConfigureTrackedBrowserGlobalScopeResult" xml:space="preserve">
+    <value>all BrowserLogs resources</value>
+  </data>
+  <data name="ConfigureTrackedBrowserBrowserLabel" xml:space="preserve">
+    <value>Browser</value>
+  </data>
+  <data name="ConfigureTrackedBrowserBrowserDescription" xml:space="preserve">
+    <value>Choose an installed Chromium-based browser or enter an executable path.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserEdgeOption" xml:space="preserve">
+    <value>Microsoft Edge (msedge)</value>
+  </data>
+  <data name="ConfigureTrackedBrowserChromeOption" xml:space="preserve">
+    <value>Google Chrome (chrome)</value>
+  </data>
+  <data name="ConfigureTrackedBrowserChromiumOption" xml:space="preserve">
+    <value>Chromium (chromium)</value>
+  </data>
+  <data name="ConfigureTrackedBrowserUserDataModeLabel" xml:space="preserve">
+    <value>User data mode</value>
+  </data>
+  <data name="ConfigureTrackedBrowserProfileLabel" xml:space="preserve">
+    <value>Profile</value>
+  </data>
+  <data name="ConfigureTrackedBrowserProfileDescription" xml:space="preserve">
+    <value>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserDefaultProfileOption" xml:space="preserve">
+    <value>Browser default profile</value>
+  </data>
+  <data name="ConfigureTrackedBrowserProfileOptionWithDisplayName" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>{0} is the Chromium profile directory name, {1} is the profile display name.</comment>
+  </data>
+  <data name="ConfigureTrackedBrowserBrowserRequired" xml:space="preserve">
+    <value>Browser is required.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserUserDataModeRequired" xml:space="preserve">
+    <value>User data mode must be Shared or Isolated.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserProfileRequiresShared" xml:space="preserve">
+    <value>Profiles can only be selected when user data mode is Shared.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserSaveToUserSecretsLabel" xml:space="preserve">
+    <value>Save to AppHost user secrets</value>
+  </data>
+  <data name="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured" xml:space="preserve">
+    <value>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured" xml:space="preserve">
+    <value>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserInteractionUnavailable" xml:space="preserve">
+    <value>Tracked browser settings cannot be configured because dashboard interactions are not available.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserUserSecretsUnavailable" xml:space="preserve">
+    <value>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</value>
+  </data>
+  <data name="ConfigureTrackedBrowserApplied" xml:space="preserve">
+    <value>Applied tracked browser settings for {0}.</value>
+    <comment>{0} is the selected configuration scope.</comment>
+  </data>
+  <data name="ConfigureTrackedBrowserSaved" xml:space="preserve">
+    <value>Saved tracked browser settings for {0}.</value>
+    <comment>{0} is the selected configuration scope.</comment>
+  </data>
+  <data name="ConfigureTrackedBrowserSaveFailed" xml:space="preserve">
+    <value>Tracked browser settings could not be saved to user secrets for key '{0}'.</value>
+    <comment>{0} is the user secrets key.</comment>
+  </data>
   <data name="CaptureScreenshotDescription" xml:space="preserve">
     <value>Capture a screenshot from the active tracked browser session and save it as a PNG artifact.</value>
   </data>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.cs.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Odstranit hodnotu parametru</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.de.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Parameterwert löschen</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.es.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Eliminar valor de parámetro</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.fr.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Supprimer la valeur du paramètre</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.it.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Elimina valore parametro</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ja.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">パラメーター値の削除</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ko.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">매개 변수 값 삭제</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.pl.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Usuń wartość parametru</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.pt-BR.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Excluir valor do parâmetro</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ru.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Удалить значение параметра</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.tr.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">Parametre değerini sil</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hans.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">删除参数值</target>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hant.xlf
@@ -12,6 +12,151 @@
         <target state="new">Capture screenshot</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserApplied">
+        <source>Applied tracked browser settings for {0}.</source>
+        <target state="new">Applied tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserDescription">
+        <source>Choose an installed Chromium-based browser or enter an executable path.</source>
+        <target state="new">Choose an installed Chromium-based browser or enter an executable path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserLabel">
+        <source>Browser</source>
+        <target state="new">Browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserBrowserRequired">
+        <source>Browser is required.</source>
+        <target state="new">Browser is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromeOption">
+        <source>Google Chrome (chrome)</source>
+        <target state="new">Google Chrome (chrome)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserChromiumOption">
+        <source>Chromium (chromium)</source>
+        <target state="new">Chromium (chromium)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDefaultProfileOption">
+        <source>Browser default profile</source>
+        <target state="new">Browser default profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserDescription">
+        <source>Choose the browser, profile, and scope used by tracked browser sessions.</source>
+        <target state="new">Choose the browser, profile, and scope used by tracked browser sessions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserEdgeOption">
+        <source>Microsoft Edge (msedge)</source>
+        <target state="new">Microsoft Edge (msedge)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeOption">
+        <source>All BrowserLogs resources</source>
+        <target state="new">All BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserGlobalScopeResult">
+        <source>all BrowserLogs resources</source>
+        <target state="new">all BrowserLogs resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserInteractionUnavailable">
+        <source>Tracked browser settings cannot be configured because dashboard interactions are not available.</source>
+        <target state="new">Tracked browser settings cannot be configured because dashboard interactions are not available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserName">
+        <source>Configure tracked browser</source>
+        <target state="new">Configure tracked browser</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileDescription">
+        <source>Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</source>
+        <target state="new">Choose a Chromium profile from the Aspire-managed browser hive, or enter a profile directory/name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileLabel">
+        <source>Profile</source>
+        <target state="new">Profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileOptionWithDisplayName">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>{0} is the Chromium profile directory name, {1} is the profile display name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserProfileRequiresShared">
+        <source>Profiles can only be selected when user data mode is Shared.</source>
+        <target state="new">Profiles can only be selected when user data mode is Shared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserPromptMessage">
+        <source>Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</source>
+        <target state="new">Choose tracked browser settings. Resource-specific settings override global BrowserLogs settings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserResourceScopeOption">
+        <source>This resource only ({0})</source>
+        <target state="new">This resource only ({0})</target>
+        <note>{0} is the parent resource name.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveButton">
+        <source>Apply</source>
+        <target state="new">Apply</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveFailed">
+        <source>Tracked browser settings could not be saved to user secrets for key '{0}'.</source>
+        <target state="new">Tracked browser settings could not be saved to user secrets for key '{0}'.</target>
+        <note>{0} is the user secrets key.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured">
+        <source>Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</source>
+        <target state="new">Save these settings to [user secrets](https://aka.ms/aspire/user-secrets) so future AppHost runs use them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured">
+        <source>User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</source>
+        <target state="new">User secrets are not configured for this AppHost, so settings can only apply to this running AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaveToUserSecretsLabel">
+        <source>Save to AppHost user secrets</source>
+        <target state="new">Save to AppHost user secrets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserSaved">
+        <source>Saved tracked browser settings for {0}.</source>
+        <target state="new">Saved tracked browser settings for {0}.</target>
+        <note>{0} is the selected configuration scope.</note>
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserScopeLabel">
+        <source>Scope</source>
+        <target state="new">Scope</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeLabel">
+        <source>User data mode</source>
+        <target state="new">User data mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserDataModeRequired">
+        <source>User data mode must be Shared or Isolated.</source>
+        <target state="new">User data mode must be Shared or Isolated.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigureTrackedBrowserUserSecretsUnavailable">
+        <source>Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</source>
+        <target state="new">Tracked browser settings cannot be saved because the AppHost does not have user secrets configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DeleteParameterDescription">
         <source>Delete parameter value</source>
         <target state="translated">刪除參數值</target>

--- a/src/Aspire.Hosting/UserSecrets/IUserSecretsManager.cs
+++ b/src/Aspire.Hosting/UserSecrets/IUserSecretsManager.cs
@@ -37,6 +37,14 @@ public interface IUserSecretsManager
     bool TrySetSecret(string name, string value);
 
     /// <summary>
+    /// Attempts to delete a user secret value synchronously.
+    /// </summary>
+    /// <param name="name">The name of the secret.</param>
+    /// <returns>True if the secret was deleted successfully; otherwise, false.</returns>
+    [AspireExport(Description = "Attempts to delete a user secret value")]
+    bool TryDeleteSecret(string name);
+
+    /// <summary>
     /// Gets a secret value if it exists in configuration, or sets it using the value generator if it doesn't.
     /// </summary>
     /// <param name="configuration">The configuration manager to check and update.</param>

--- a/src/Aspire.Hosting/UserSecrets/IUserSecretsManager.cs
+++ b/src/Aspire.Hosting/UserSecrets/IUserSecretsManager.cs
@@ -41,8 +41,14 @@ public interface IUserSecretsManager
     /// </summary>
     /// <param name="name">The name of the secret.</param>
     /// <returns>True if the secret was deleted successfully; otherwise, false.</returns>
+    /// <remarks>
+    /// The default implementation returns <see langword="false"/> so existing implementations remain compatible.
+    /// </remarks>
     [AspireExport(Description = "Attempts to delete a user secret value")]
-    bool TryDeleteSecret(string name);
+    bool TryDeleteSecret(string name)
+    {
+        return false;
+    }
 
     /// <summary>
     /// Gets a secret value if it exists in configuration, or sets it using the value generator if it doesn't.

--- a/src/Aspire.Hosting/UserSecrets/NoopUserSecretsManager.cs
+++ b/src/Aspire.Hosting/UserSecrets/NoopUserSecretsManager.cs
@@ -30,6 +30,12 @@ internal sealed class NoopUserSecretsManager : IUserSecretsManager
         return false;
     }
 
+    public bool TryDeleteSecret(string name)
+    {
+        Debug.WriteLine($"User secrets are not enabled. Cannot delete secret '{name}'.");
+        return false;
+    }
+
     public void GetOrSetSecret(IConfigurationManager configuration, string name, Func<string> valueGenerator)
     {
         Debug.WriteLine($"User secrets are not enabled. Generating and adding secret '{name}' to configuration in-memory.");

--- a/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
+++ b/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
@@ -115,6 +115,27 @@ internal sealed class UserSecretsManagerFactory
             }
         }
 
+        public bool TryDeleteSecret(string name)
+        {
+            try
+            {
+                _semaphore.Wait();
+                try
+                {
+                    DeleteSecretCore(name);
+                    return true;
+                }
+                finally
+                {
+                    _semaphore.Release();
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
         public void GetOrSetSecret(IConfigurationManager configuration, string name, Func<string> valueGenerator)
         {
             var existingValue = configuration[name];
@@ -163,6 +184,16 @@ internal sealed class UserSecretsManagerFactory
             var secrets = Load();
             secrets[name] = value;
             Save(secrets);
+        }
+
+        private void DeleteSecretCore(string name)
+        {
+            var secrets = Load();
+            if (secrets.Remove(name))
+            {
+                EnsureUserSecretsDirectory();
+                Save(secrets);
+            }
         }
 
         private Dictionary<string, string?> Load()

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -1,4 +1,4 @@
-// aspire.go - Capability-based Aspire SDK
+﻿// aspire.go - Capability-based Aspire SDK
 // GENERATED CODE - DO NOT EDIT
 
 package aspire
@@ -10904,6 +10904,19 @@ func (s *IUserSecretsManager) TrySetSecret(name string, value string) (*bool, er
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/IUserSecretsManager.trySetSecret", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*bool), nil
+}
+
+// TryDeleteSecret attempts to delete a user secret value
+func (s *IUserSecretsManager) TryDeleteSecret(name string) (*bool, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["name"] = SerializeValue(name)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/IUserSecretsManager.tryDeleteSecret", reqArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -12790,6 +12790,14 @@ public class IUserSecretsManager extends HandleWrapperBase {
         return (boolean) getClient().invokeCapability("Aspire.Hosting/IUserSecretsManager.trySetSecret", reqArgs);
     }
 
+    /** Attempts to delete a user secret value */
+    public boolean tryDeleteSecret(String name) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        return (boolean) getClient().invokeCapability("Aspire.Hosting/IUserSecretsManager.tryDeleteSecret", reqArgs);
+    }
+
     public void saveStateJson(String json) {
         saveStateJson(json, null);
     }

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1,4 +1,4 @@
-#   -------------------------------------------------------------
+﻿#   -------------------------------------------------------------
 #   Copyright (c) Microsoft Corporation. All rights reserved.
 #   Licensed under the MIT License. See LICENSE in project root for information.
 #
@@ -2920,6 +2920,16 @@ class AbstractUserSecretsManager:
         rpc_args['value'] = value
         result = self._client.invoke_capability(
             'Aspire.Hosting/IUserSecretsManager.trySetSecret',
+            rpc_args,
+        )
+        return result
+
+    def try_delete_secret(self, name: str) -> bool:
+        """Attempts to delete a user secret value"""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['name'] = name
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/IUserSecretsManager.tryDeleteSecret',
             rpc_args,
         )
         return result

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -1,4 +1,4 @@
-//! aspire.rs - Capability-based Aspire SDK
+﻿//! aspire.rs - Capability-based Aspire SDK
 //! GENERATED CODE - DO NOT EDIT
 
 use std::collections::HashMap;
@@ -10162,6 +10162,15 @@ impl IUserSecretsManager {
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
         let result = self.client.invoke_capability("Aspire.Hosting/IUserSecretsManager.trySetSecret", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Attempts to delete a user secret value
+    pub fn try_delete_secret(&self, name: &str) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/IUserSecretsManager.tryDeleteSecret", args)?;
         Ok(serde_json::from_value(result)?)
     }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -7473,6 +7473,8 @@ export interface UserSecretsManager {
     filePath(): Promise<string>;
     /** Attempts to set a user secret value */
     trySetSecret(name: string, value: string): Promise<boolean>;
+    /** Attempts to delete a user secret value */
+    tryDeleteSecret(name: string): Promise<boolean>;
     /** Saves state to user secrets from a JSON string */
     saveStateJson(json: string, options?: SaveStateJsonOptions): UserSecretsManagerPromise;
     /** Gets a secret value if it exists, or sets it to the provided value if it does not */
@@ -7486,6 +7488,8 @@ export interface UserSecretsManagerPromise extends PromiseLike<UserSecretsManage
     filePath(): Promise<string>;
     /** Attempts to set a user secret value */
     trySetSecret(name: string, value: string): Promise<boolean>;
+    /** Attempts to delete a user secret value */
+    tryDeleteSecret(name: string): Promise<boolean>;
     /** Saves state to user secrets from a JSON string */
     saveStateJson(json: string, options?: SaveStateJsonOptions): UserSecretsManagerPromise;
     /** Gets a secret value if it exists, or sets it to the provided value if it does not */
@@ -7527,6 +7531,16 @@ class UserSecretsManagerImpl implements UserSecretsManager {
         );
     }
 
+    /** Attempts to delete a user secret value */
+    async tryDeleteSecret(name: string): Promise<boolean> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle, name };
+        return await this._client.invokeCapability<boolean>(
+            'Aspire.Hosting/IUserSecretsManager.tryDeleteSecret',
+            rpcArgs
+        );
+    }
+
+    /** Saves state to user secrets from a JSON string */
     /** @internal */
     async _saveStateJsonInternal(json: string, cancellationToken?: AbortSignal | CancellationToken): Promise<UserSecretsManager> {
         const rpcArgs: Record<string, unknown> = { userSecretsManager: this._handle, json };
@@ -7587,6 +7601,12 @@ class UserSecretsManagerPromiseImpl implements UserSecretsManagerPromise {
         return this._promise.then(obj => obj.trySetSecret(name, value));
     }
 
+    /** Attempts to delete a user secret value */
+    tryDeleteSecret(name: string): Promise<boolean> {
+        return this._promise.then(obj => obj.tryDeleteSecret(name));
+    }
+
+    /** Saves state to user secrets from a JSON string */
     saveStateJson(json: string, options?: SaveStateJsonOptions): UserSecretsManagerPromise {
         return new UserSecretsManagerPromiseImpl(this._promise.then(obj => obj.saveStateJson(json, options)), this._client);
     }
@@ -33415,4 +33435,3 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints', (handle, client) => new ResourceWithEndpointsImpl(handle as IResourceWithEndpointsHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment', (handle, client) => new ResourceWithEnvironmentImpl(handle as IResourceWithEnvironmentHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport', (handle, client) => new ResourceWithWaitSupportImpl(handle as IResourceWithWaitSupportHandle, client));
-

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -7531,7 +7531,6 @@ class UserSecretsManagerImpl implements UserSecretsManager {
         );
     }
 
-    /** Attempts to delete a user secret value */
     async tryDeleteSecret(name: string): Promise<boolean> {
         const rpcArgs: Record<string, unknown> = { context: this._handle, name };
         return await this._client.invokeCapability<boolean>(
@@ -7540,7 +7539,6 @@ class UserSecretsManagerImpl implements UserSecretsManager {
         );
     }
 
-    /** Saves state to user secrets from a JSON string */
     /** @internal */
     async _saveStateJsonInternal(json: string, cancellationToken?: AbortSignal | CancellationToken): Promise<UserSecretsManager> {
         const rpcArgs: Record<string, unknown> = { userSecretsManager: this._handle, json };
@@ -7601,12 +7599,10 @@ class UserSecretsManagerPromiseImpl implements UserSecretsManagerPromise {
         return this._promise.then(obj => obj.trySetSecret(name, value));
     }
 
-    /** Attempts to delete a user secret value */
     tryDeleteSecret(name: string): Promise<boolean> {
         return this._promise.then(obj => obj.tryDeleteSecret(name));
     }
 
-    /** Saves state to user secrets from a JSON string */
     saveStateJson(json: string, options?: SaveStateJsonOptions): UserSecretsManagerPromise {
         return new UserSecretsManagerPromiseImpl(this._promise.then(obj => obj.saveStateJson(json, options)), this._client);
     }
@@ -33435,3 +33431,4 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints', (handle, client) => new ResourceWithEndpointsImpl(handle as IResourceWithEndpointsHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment', (handle, client) => new ResourceWithEnvironmentImpl(handle as IResourceWithEnvironmentHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport', (handle, client) => new ResourceWithWaitSupportImpl(handle as IResourceWithWaitSupportHandle, client));
+

--- a/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -561,6 +561,61 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandDoesNotApplyRuntimeSettingsWhenUserSecretSaveFails()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var interactionService = new TestInteractionService();
+        var userSecretsManager = new RecordingUserSecretsManager();
+        builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
+        builder.Configuration[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"] = "chrome";
+        builder.Configuration[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.UserDataModeConfigurationKey}"] = nameof(BrowserUserDataMode.Shared);
+        builder.Services.AddSingleton<IInteractionService>(interactionService);
+        builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
+
+        var userDataModeKey = $"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.UserDataModeConfigurationKey}";
+        userSecretsManager.FailingSetSecretNames.Add(userDataModeKey);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs();
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        interaction.Inputs["scope"].Value = "resource";
+        interaction.Inputs["browser"].Value = "msedge";
+        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Isolated);
+        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
+        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
+
+        var result = await commandTask.DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Contains(userDataModeKey, result.Message, StringComparison.Ordinal);
+        Assert.Equal("msedge", userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"]);
+        Assert.DoesNotContain(userDataModeKey, userSecretsManager.Secrets.Keys);
+
+        var effectiveConfiguration = browserLogsResource.ResolveCurrentConfiguration(
+            app.Services.GetRequiredService<IConfiguration>(),
+            app.Services.GetRequiredService<BrowserLogsConfigurationStore>());
+        Assert.Equal("chrome", effectiveConfiguration.Browser);
+        Assert.Equal(BrowserUserDataMode.Shared, effectiveConfiguration.UserDataMode);
+        Assert.Null(effectiveConfiguration.Profile);
+    }
+
+    [Fact]
     public async Task WithBrowserLogs_ConfigureCommandRefreshesAllBrowserLogsResourcesForGlobalSettings()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
@@ -1844,12 +1899,21 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
 
         public HashSet<string> DeletedSecrets { get; } = new(StringComparer.Ordinal);
 
+        public HashSet<string> FailingSetSecretNames { get; } = new(StringComparer.Ordinal);
+
+        public HashSet<string> FailingDeleteSecretNames { get; } = new(StringComparer.Ordinal);
+
         public bool IsAvailable { get; init; } = true;
 
         public string FilePath => Path.Combine(AppContext.BaseDirectory, "test-secrets.json");
 
         public bool TrySetSecret(string name, string value)
         {
+            if (FailingSetSecretNames.Contains(name))
+            {
+                return false;
+            }
+
             Secrets[name] = value;
             DeletedSecrets.Remove(name);
             return true;
@@ -1857,6 +1921,11 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
 
         public bool TryDeleteSecret(string name)
         {
+            if (FailingDeleteSecretNames.Contains(name))
+            {
+                return false;
+            }
+
             Secrets.Remove(name);
             DeletedSecrets.Add(name);
             return true;

--- a/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -561,6 +561,115 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandRefreshesAllBrowserLogsResourcesForGlobalSettings()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var interactionService = new TestInteractionService();
+        var userSecretsManager = new RecordingUserSecretsManager();
+        builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
+        builder.Services.AddSingleton<IInteractionService>(interactionService);
+        builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        var admin = builder.AddResource(new TestHttpResource("admin"))
+            .WithHttpEndpoint(targetPort: 8081)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8081))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs();
+        admin.WithBrowserLogs();
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResources = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().ToArray();
+        var webBrowserLogsResource = browserLogsResources.Single(resource => resource.ParentResource.Name == "web");
+        var adminBrowserLogsResource = browserLogsResources.Single(resource => resource.ParentResource.Name == "admin");
+        var commandTask = app.ResourceCommands.ExecuteCommandAsync(webBrowserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        interaction.Inputs["scope"].Value = "global";
+        interaction.Inputs["browser"].Value = "chrome";
+        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Isolated);
+        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
+        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
+
+        var result = await commandTask.DefaultTimeout();
+
+        Assert.True(result.Success);
+
+        await app.ResourceNotifications.WaitForResourceAsync(
+            adminBrowserLogsResource.Name,
+            resourceEvent =>
+                HasProperty(resourceEvent.Snapshot, BrowserLogsBuilderExtensions.BrowserPropertyName, "chrome") &&
+                HasProperty(resourceEvent.Snapshot, BrowserLogsBuilderExtensions.UserDataModePropertyName, nameof(BrowserUserDataMode.Isolated)) &&
+                DoesNotHaveProperty(resourceEvent.Snapshot, BrowserLogsBuilderExtensions.ProfilePropertyName)).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandValidatesEffectiveConfigurationBeforeSaving()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var interactionService = new TestInteractionService();
+        var userSecretsManager = new RecordingUserSecretsManager();
+        builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
+        builder.Services.AddSingleton<IInteractionService>(interactionService);
+        builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs(profile: "Default");
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        interaction.Inputs["scope"].Value = "resource";
+        interaction.Inputs["browser"].Value = "chrome";
+        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Isolated);
+        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
+        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
+
+        var result = await commandTask.DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Contains("Profiles can only be selected", result.Message, StringComparison.Ordinal);
+        Assert.Empty(userSecretsManager.Secrets);
+        Assert.Empty(userSecretsManager.DeletedSecrets);
+
+        var effectiveConfiguration = browserLogsResource.ResolveCurrentConfiguration(
+            app.Services.GetRequiredService<IConfiguration>(),
+            app.Services.GetRequiredService<BrowserLogsConfigurationStore>());
+        Assert.Equal(BrowserUserDataMode.Shared, effectiveConfiguration.UserDataMode);
+        Assert.Equal("Default", effectiveConfiguration.Profile);
+    }
+
+    [Fact]
     public async Task WithBrowserLogs_CaptureScreenshotCommandReturnsArtifactResult()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);

--- a/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -2,14 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREBROWSERLOGS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREUSERSECRETS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Aspire.Hosting.Eventing;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using HealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
@@ -53,6 +58,9 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         var command = Assert.Single(browserLogsResource.Annotations.OfType<ResourceCommandAnnotation>(), annotation => annotation.Name == BrowserLogsBuilderExtensions.OpenTrackedBrowserCommandName);
         Assert.Equal(CommandStrings.OpenTrackedBrowserName, command.DisplayName);
         Assert.Equal(CommandStrings.OpenTrackedBrowserDescription, command.DisplayDescription);
+        var configureCommand = Assert.Single(browserLogsResource.Annotations.OfType<ResourceCommandAnnotation>(), annotation => annotation.Name == BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        Assert.Equal(CommandStrings.ConfigureTrackedBrowserName, configureCommand.DisplayName);
+        Assert.Equal(CommandStrings.ConfigureTrackedBrowserDescription, configureCommand.DisplayDescription);
         var screenshotCommand = Assert.Single(browserLogsResource.Annotations.OfType<ResourceCommandAnnotation>(), annotation => annotation.Name == BrowserLogsBuilderExtensions.CaptureScreenshotCommandName);
         Assert.Equal(CommandStrings.CaptureScreenshotName, screenshotCommand.DisplayName);
         Assert.Equal(CommandStrings.CaptureScreenshotDescription, screenshotCommand.DisplayDescription);
@@ -90,7 +98,7 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
                 Properties = []
             });
 
-        web.WithBrowserLogs();
+        web.WithBrowserLogs(browser: "chrome");
 
         using var app = builder.Build();
         var browserLogsResource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>());
@@ -327,6 +335,229 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         Assert.Equal("chrome", call.Configuration.Browser);
         Assert.Null(call.Configuration.Profile);
         Assert.Equal(new Uri("http://localhost:8080", UriKind.Absolute), call.Url);
+    }
+
+    [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandSavesResourceScopedBrowserSettingsAndAppliesImmediately()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var interactionService = new TestInteractionService();
+        var userSecretsManager = new RecordingUserSecretsManager();
+        builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
+        builder.Services.AddSingleton<IInteractionService>(interactionService);
+        builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs();
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        Assert.Equal(CommandStrings.ConfigureTrackedBrowserName, interaction.Title);
+        Assert.Equal(CommandStrings.ConfigureTrackedBrowserPromptMessage, interaction.Message);
+        Assert.Equal(CommandStrings.ConfigureTrackedBrowserSaveButton, ((InputsDialogInteractionOptions)interaction.Options!).PrimaryButtonText);
+        Assert.Collection(interaction.Inputs,
+            input => Assert.Equal("scope", input.Name),
+            input => Assert.Equal("browser", input.Name),
+            input => Assert.Equal("userDataMode", input.Name),
+            input => Assert.Equal("profile", input.Name),
+            input =>
+            {
+                Assert.Equal("saveToUserSecrets", input.Name);
+                Assert.Equal("true", input.Value);
+                Assert.False(input.Disabled);
+                Assert.Equal(CommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured, input.Description);
+            });
+
+        interaction.Inputs["scope"].Value = "resource";
+        interaction.Inputs["browser"].Value = "msedge";
+        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Shared);
+        interaction.Inputs["profile"].Value = "Default";
+        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
+
+        var result = await commandTask.DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal("msedge", userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"]);
+        Assert.Equal(nameof(BrowserUserDataMode.Shared), userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.UserDataModeConfigurationKey}"]);
+        Assert.Equal("Default", userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.ProfileConfigurationKey}"]);
+
+        var effectiveConfiguration = browserLogsResource.ResolveCurrentConfiguration(
+            app.Services.GetRequiredService<IConfiguration>(),
+            app.Services.GetRequiredService<BrowserLogsConfigurationStore>());
+        Assert.Equal("msedge", effectiveConfiguration.Browser);
+        Assert.Equal(BrowserUserDataMode.Shared, effectiveConfiguration.UserDataMode);
+        Assert.Equal("Default", effectiveConfiguration.Profile);
+    }
+
+    [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandAppliesRuntimeSettingsWhenUserSecretsAreUnavailable()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var interactionService = new TestInteractionService();
+        var userSecretsManager = new RecordingUserSecretsManager
+        {
+            IsAvailable = false
+        };
+        builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
+        builder.Services.AddSingleton<IInteractionService>(interactionService);
+        builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs();
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        var saveToUserSecrets = interaction.Inputs["saveToUserSecrets"];
+        Assert.True(saveToUserSecrets.Disabled);
+        Assert.Null(saveToUserSecrets.Value);
+        Assert.Equal(CommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured, saveToUserSecrets.Description);
+
+        interaction.Inputs["scope"].Value = "resource";
+        interaction.Inputs["browser"].Value = "msedge";
+        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Shared);
+        interaction.Inputs["profile"].Value = "Default";
+        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
+
+        var result = await commandTask.DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, CommandStrings.ConfigureTrackedBrowserApplied, "web"), result.Message);
+        Assert.Empty(userSecretsManager.Secrets);
+        Assert.Empty(userSecretsManager.DeletedSecrets);
+
+        var effectiveConfiguration = browserLogsResource.ResolveCurrentConfiguration(
+            app.Services.GetRequiredService<IConfiguration>(),
+            app.Services.GetRequiredService<BrowserLogsConfigurationStore>());
+        Assert.Equal("msedge", effectiveConfiguration.Browser);
+        Assert.Equal(BrowserUserDataMode.Shared, effectiveConfiguration.UserDataMode);
+        Assert.Equal("Default", effectiveConfiguration.Profile);
+    }
+
+    [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandDoesNotOverrideExplicitBuilderSettings()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var interactionService = new TestInteractionService();
+        var userSecretsManager = new RecordingUserSecretsManager();
+        builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
+        builder.Services.AddSingleton<IInteractionService>(interactionService);
+        builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs(browser: "chrome");
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        interaction.Inputs["scope"].Value = "resource";
+        interaction.Inputs["browser"].Value = "msedge";
+        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Shared);
+        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
+        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
+
+        var result = await commandTask.DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal("msedge", userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"]);
+
+        var effectiveConfiguration = browserLogsResource.ResolveCurrentConfiguration(
+            app.Services.GetRequiredService<IConfiguration>(),
+            app.Services.GetRequiredService<BrowserLogsConfigurationStore>());
+        Assert.Equal("chrome", effectiveConfiguration.Browser);
+        Assert.Equal(BrowserUserDataMode.Shared, effectiveConfiguration.UserDataMode);
+        Assert.Null(effectiveConfiguration.Profile);
+    }
+
+    [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandSavesGlobalSettingsAndClearsProfile()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var interactionService = new TestInteractionService();
+        var userSecretsManager = new RecordingUserSecretsManager();
+        builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
+        builder.Services.AddSingleton<IInteractionService>(interactionService);
+        builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
+        builder.Configuration[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.ProfileConfigurationKey}"] = "Profile 1";
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs();
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
+        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        interaction.Inputs["scope"].Value = "global";
+        interaction.Inputs["browser"].Value = "chrome";
+        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Isolated);
+        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
+        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
+
+        var result = await commandTask.DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal("chrome", userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"]);
+        Assert.Equal(nameof(BrowserUserDataMode.Isolated), userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.UserDataModeConfigurationKey}"]);
+        Assert.Contains($"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.ProfileConfigurationKey}", userSecretsManager.DeletedSecrets);
+
+        var effectiveConfiguration = browserLogsResource.ResolveCurrentConfiguration(
+            app.Services.GetRequiredService<IConfiguration>(),
+            app.Services.GetRequiredService<BrowserLogsConfigurationStore>());
+        Assert.Equal("chrome", effectiveConfiguration.Browser);
+        Assert.Equal(BrowserUserDataMode.Isolated, effectiveConfiguration.UserDataMode);
+        Assert.Null(effectiveConfiguration.Profile);
     }
 
     [Fact]
@@ -1498,6 +1729,38 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         }
     }
 
+    private sealed class RecordingUserSecretsManager : IUserSecretsManager
+    {
+        public Dictionary<string, string> Secrets { get; } = new(StringComparer.Ordinal);
+
+        public HashSet<string> DeletedSecrets { get; } = new(StringComparer.Ordinal);
+
+        public bool IsAvailable { get; init; } = true;
+
+        public string FilePath => Path.Combine(AppContext.BaseDirectory, "test-secrets.json");
+
+        public bool TrySetSecret(string name, string value)
+        {
+            Secrets[name] = value;
+            DeletedSecrets.Remove(name);
+            return true;
+        }
+
+        public bool TryDeleteSecret(string name)
+        {
+            Secrets.Remove(name);
+            DeletedSecrets.Add(name);
+            return true;
+        }
+
+        public void GetOrSetSecret(IConfigurationManager configuration, string name, Func<string> valueGenerator)
+        {
+            configuration[name] ??= valueGenerator();
+        }
+
+        public Task SaveStateAsync(JsonObject state, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
     private static JsonSerializerOptions BrowserSessionPropertyJsonOptions { get; } = new(JsonSerializerDefaults.Web);
 
     private sealed record BrowserSessionPropertyValue(
@@ -1514,4 +1777,6 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         string TargetId);
 }
 
+#pragma warning restore ASPIREUSERSECRETS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning restore ASPIREBROWSERLOGS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/tests/Aspire.Hosting.Tests/BrowserLogsSessionManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsSessionManagerTests.cs
@@ -470,6 +470,34 @@ public class BrowserLogsSessionManagerTests
     }
 
     [Fact]
+    public void GetAvailableProfiles_FallsBackToDirectoriesWhenLocalStateIsInvalid()
+    {
+        WithTempUserDataDirectory(userDataDirectory =>
+        {
+            Directory.CreateDirectory(Path.Combine(userDataDirectory, "Default"));
+            Directory.CreateDirectory(Path.Combine(userDataDirectory, "Profile 1"));
+            File.WriteAllText(Path.Combine(userDataDirectory, "Local State"), "{");
+
+            var profiles = ChromiumBrowserResolver.GetAvailableProfiles(userDataDirectory);
+
+            Assert.Collection(
+                profiles,
+                profile =>
+                {
+                    Assert.Equal("Default", profile.DirectoryName);
+                    Assert.Null(profile.DisplayName);
+                    Assert.Null(profile.ShortcutName);
+                },
+                profile =>
+                {
+                    Assert.Equal("Profile 1", profile.DirectoryName);
+                    Assert.Null(profile.DisplayName);
+                    Assert.Null(profile.ShortcutName);
+                });
+        });
+    }
+
+    [Fact]
     public void ResolveProfileDirectory_ThrowsWhenDisplayNameIsAmbiguous()
     {
         WithTempUserDataDirectory(userDataDirectory =>

--- a/tests/Aspire.Hosting.Tests/BrowserLogsSessionManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/BrowserLogsSessionManagerTests.cs
@@ -415,6 +415,61 @@ public class BrowserLogsSessionManagerTests
     }
 
     [Fact]
+    public void GetAvailableProfiles_UsesLocalStateAndLikelyProfileDirectories()
+    {
+        WithTempUserDataDirectory(userDataDirectory =>
+        {
+            Directory.CreateDirectory(Path.Combine(userDataDirectory, "Default"));
+            Directory.CreateDirectory(Path.Combine(userDataDirectory, "Profile 1"));
+            Directory.CreateDirectory(Path.Combine(userDataDirectory, "Profile 2"));
+            Directory.CreateDirectory(Path.Combine(userDataDirectory, "System Profile"));
+            File.WriteAllText(
+                Path.Combine(userDataDirectory, "Local State"),
+                """
+                {
+                  "profile": {
+                    "info_cache": {
+                      "Default": {
+                        "name": "Personal",
+                        "shortcut_name": "Personal shortcut"
+                      },
+                      "Profile 1": {
+                        "name": "Work"
+                      },
+                      "Missing": {
+                        "name": "Stale"
+                      }
+                    }
+                  }
+                }
+                """);
+
+            var profiles = ChromiumBrowserResolver.GetAvailableProfiles(userDataDirectory);
+
+            Assert.Collection(
+                profiles,
+                profile =>
+                {
+                    Assert.Equal("Default", profile.DirectoryName);
+                    Assert.Equal("Personal", profile.DisplayName);
+                    Assert.Equal("Personal shortcut", profile.ShortcutName);
+                },
+                profile =>
+                {
+                    Assert.Equal("Profile 1", profile.DirectoryName);
+                    Assert.Equal("Work", profile.DisplayName);
+                    Assert.Null(profile.ShortcutName);
+                },
+                profile =>
+                {
+                    Assert.Equal("Profile 2", profile.DirectoryName);
+                    Assert.Null(profile.DisplayName);
+                    Assert.Null(profile.ShortcutName);
+                });
+        });
+    }
+
+    [Fact]
     public void ResolveProfileDirectory_ThrowsWhenDisplayNameIsAmbiguous()
     {
         WithTempUserDataDirectory(userDataDirectory =>
@@ -459,7 +514,7 @@ public class BrowserLogsSessionManagerTests
             "web-browser-logs",
             new TestResourceWithEndpoints("web"),
             new BrowserConfiguration("chrome", null, BrowserUserDataMode.Isolated, AppHostKey: "test-apphost"),
-            new BrowserConfigurationOverrides());
+            new BrowserConfigurationExplicitValues());
 
         await manager.DisposeAsync();
 

--- a/tests/Aspire.Hosting.Tests/UserSecretsParameterDefaultTests.cs
+++ b/tests/Aspire.Hosting.Tests/UserSecretsParameterDefaultTests.cs
@@ -179,6 +179,28 @@ public class UserSecretsParameterDefaultTests
     }
 
     [Fact]
+    public void TryDeleteUserSecret_RemovesOnlyRequestedSecret()
+    {
+        var userSecretsId = Guid.NewGuid().ToString("N");
+        ClearUsersSecrets(userSecretsId);
+
+        var testAssembly = AssemblyBuilder.DefineDynamicAssembly(
+            new("TestAssembly"), AssemblyBuilderAccess.RunAndCollect, [new CustomAttributeBuilder(s_userSecretsIdAttrCtor, [userSecretsId])]);
+        var factory = CreateFactory();
+        var manager = factory.GetOrCreate(testAssembly);
+
+        Assert.True(manager.TrySetSecret("Parameters:sql-password", "SqlPassword123!"));
+        Assert.True(manager.TrySetSecret("Parameters:rabbit-password", "RabbitPassword456!"));
+        Assert.True(manager.TryDeleteSecret("Parameters:sql-password"));
+
+        var userSecrets = GetUserSecrets(userSecretsId);
+        Assert.False(userSecrets.ContainsKey("Parameters:sql-password"));
+        Assert.Equal("RabbitPassword456!", userSecrets["Parameters:rabbit-password"]);
+
+        DeleteUserSecretsFile(userSecretsId);
+    }
+
+    [Fact]
     public async Task TrySetUserSecret_ConcurrentWritesSameKey_LastWriteWins()
     {
         var userSecretsId = Guid.NewGuid().ToString("N");

--- a/tests/Aspire.Hosting.Tests/Utils/MockUserSecretsManager.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/MockUserSecretsManager.cs
@@ -16,6 +16,8 @@ internal sealed class MockUserSecretsManager : IUserSecretsManager
 
     public bool TrySetSecret(string name, string value) => true;
 
+    public bool TryDeleteSecret(string name) => true;
+
     public void GetOrSetSecret(IConfigurationManager configuration, string name, Func<string> valueGenerator)
     {
     }


### PR DESCRIPTION
## Description

Adds a BrowserLogs dashboard command for configuring tracked browser sessions. The command lets developers choose resource/global scope, Chromium browser, user data mode, and profile, applies the selection immediately at runtime, and optionally persists the settings to AppHost user secrets when available.

The change also adds Chromium profile discovery for the Aspire-managed browser hive, expands BrowserLogs resource state with the effective configuration, and adds `IUserSecretsManager.TryDeleteSecret` so cleared profile settings can be removed without using deployment state.

<img width="754" height="650" alt="image" src="https://github.com/user-attachments/assets/8f062203-09d3-46dc-98cb-86e589badbad" />


Validation:
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj -- --filter-class "*.BrowserLogsBuilderExtensionsTests" --filter-class "*.BrowserLogsSessionManagerTests" --filter-class "*.UserSecretsParameterDefaultTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build /t:UpdateXlf src/Aspire.Hosting/Aspire.Hosting.csproj`
- `git diff --check`
- BrowserTelemetry playground E2E: opened/configured `web-browser-logs` and verified browser logs flowed to the resource.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
