### PR TITLE
Expose endpoint property expressions to ATS

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -114,7 +114,7 @@ public sealed class EndpointReference : IExpressionValue, IManifestExpressionPro
     public NetworkIdentifier? ContextNetworkID => _contextNetworkID;
 
     /// <summary>
-    /// Gets the specified property expression of the endpoint. Defaults to the URL if no property is specified.
+    /// Gets the specified property expression of the endpoint.
     /// </summary>
     internal string GetExpression(EndpointProperty property = EndpointProperty.Url)
     {
@@ -134,7 +134,7 @@ public sealed class EndpointReference : IExpressionValue, IManifestExpressionPro
     }
 
     /// <summary>
-    /// Gets the specified property expression of the endpoint. Defaults to the URL if no property is specified.
+    /// Gets the specified property expression of the endpoint.
     /// </summary>
     /// <param name="property">The <see cref="EndpointProperty"/> enum value to use in the reference.</param>
     /// <returns>An <see cref="EndpointReferenceExpression"/> representing the specified <see cref="EndpointProperty"/>.</returns>

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -138,7 +138,7 @@ public sealed class EndpointReference : IExpressionValue, IManifestExpressionPro
     /// </summary>
     /// <param name="property">The <see cref="EndpointProperty"/> enum value to use in the reference.</param>
     /// <returns>An <see cref="EndpointReferenceExpression"/> representing the specified <see cref="EndpointProperty"/>.</returns>
-    [AspireExportIgnore]
+    [AspireExport(Description = "Gets the specified property expression of the endpoint")]
     public EndpointReferenceExpression Property(EndpointProperty property)
     {
         return new(this, property);

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -1,4 +1,4 @@
-// aspire.go - Capability-based Aspire SDK
+﻿// aspire.go - Capability-based Aspire SDK
 // GENERATED CODE - DO NOT EDIT
 
 package aspire
@@ -19959,3 +19959,4 @@ func CreateBuilder(options *CreateBuilderOptions) (*IDistributedApplicationBuild
 	}
 	return result.(*IDistributedApplicationBuilder), nil
 }
+

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -6871,6 +6871,19 @@ func (s *EndpointReference) GetValueAsync(cancellationToken *CancellationToken) 
 	return result.(*string), nil
 }
 
+// Property gets the specified property expression of the endpoint
+func (s *EndpointReference) Property(property EndpointProperty) (*EndpointReferenceExpression, error) {
+	reqArgs := map[string]any{
+		"context": SerializeValue(s.Handle()),
+	}
+	reqArgs["property"] = SerializeValue(property)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/EndpointReference.property", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EndpointReferenceExpression), nil
+}
+
 // GetTlsValue gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise.
 func (s *EndpointReference) GetTlsValue(enabledValue *ReferenceExpression, disabledValue *ReferenceExpression) (*ReferenceExpression, error) {
 	reqArgs := map[string]any{
@@ -19946,4 +19959,3 @@ func CreateBuilder(options *CreateBuilderOptions) (*IDistributedApplicationBuild
 	}
 	return result.(*IDistributedApplicationBuilder), nil
 }
-

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -8363,6 +8363,14 @@ public class EndpointReference extends HandleWrapperBase {
         return (String) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/EndpointReference.getValueAsync", reqArgs);
     }
 
+    /** Gets the specified property expression of the endpoint */
+    public EndpointReferenceExpression property(EndpointProperty property) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("property", AspireClient.serializeValue(property));
+        return (EndpointReferenceExpression) getClient().invokeCapability("Aspire.Hosting.ApplicationModel/EndpointReference.property", reqArgs);
+    }
+
     /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
     public ReferenceExpression getTlsValue(ReferenceExpression enabledValue, ReferenceExpression disabledValue) {
         Map<String, Object> reqArgs = new HashMap<>();

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1,4 +1,4 @@
-#   -------------------------------------------------------------
+﻿#   -------------------------------------------------------------
 #   Copyright (c) Microsoft Corporation. All rights reserved.
 #   Licensed under the MIT License. See LICENSE in project root for information.
 #
@@ -3854,6 +3854,16 @@ class EndpointReference:
             rpc_args,
         )
         return result
+
+    def property(self, property: EndpointProperty) -> EndpointReferenceExpression:
+        """Gets the specified property expression of the endpoint"""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['property'] = property
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/EndpointReference.property',
+            rpc_args,
+        )
+        return typing.cast(EndpointReferenceExpression, result)
 
     def get_tls_value(self, enabled_value: ReferenceExpression, disabled_value: ReferenceExpression) -> ReferenceExpression:
         """Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise."""

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1,4 +1,4 @@
-﻿#   -------------------------------------------------------------
+#   -------------------------------------------------------------
 #   Copyright (c) Microsoft Corporation. All rights reserved.
 #   Licensed under the MIT License. See LICENSE in project root for information.
 #

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -6382,6 +6382,16 @@ impl EndpointReference {
         Ok(serde_json::from_value(result)?)
     }
 
+    /// Gets the specified property expression of the endpoint
+    pub fn property(&self, property: EndpointProperty) -> Result<EndpointReferenceExpression, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("property".to_string(), serde_json::to_value(&property).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/EndpointReference.property", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointReferenceExpression::new(handle, self.client.clone()))
+    }
+
     /// Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise.
     pub fn get_tls_value(&self, enabled_value: ReferenceExpression, disabled_value: ReferenceExpression) -> Result<ReferenceExpression, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -17542,4 +17552,3 @@ pub fn create_builder(options: Option<CreateBuilderOptions>) -> Result<IDistribu
     let handle: Handle = serde_json::from_value(result)?;
     Ok(IDistributedApplicationBuilder::new(handle, client))
 }
-

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -1,4 +1,4 @@
-//! aspire.rs - Capability-based Aspire SDK
+﻿//! aspire.rs - Capability-based Aspire SDK
 //! GENERATED CODE - DO NOT EDIT
 
 use std::collections::HashMap;
@@ -17552,3 +17552,4 @@ pub fn create_builder(options: Option<CreateBuilderOptions>) -> Result<IDistribu
     let handle: Handle = serde_json::from_value(result)?;
     Ok(IDistributedApplicationBuilder::new(handle, client))
 }
+

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -2280,6 +2280,8 @@ export interface EndpointReference {
     url(): Promise<string>;
     /** Gets the URL of the endpoint asynchronously */
     getValueAsync(options?: GetValueAsyncOptions): Promise<string>;
+    /** Gets the specified property expression of the endpoint */
+    property(property: EndpointProperty): Promise<EndpointReferenceExpression>;
     /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
     getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression>;
 }
@@ -2315,6 +2317,8 @@ export interface EndpointReferencePromise extends PromiseLike<EndpointReference>
     url(): Promise<string>;
     /** Gets the URL of the endpoint asynchronously */
     getValueAsync(options?: GetValueAsyncOptions): Promise<string>;
+    /** Gets the specified property expression of the endpoint */
+    property(property: EndpointProperty): Promise<EndpointReferenceExpression>;
     /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
     getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression>;
 }
@@ -2456,6 +2460,16 @@ class EndpointReferenceImpl implements EndpointReference {
         );
     }
 
+    /** Gets the specified property expression of the endpoint */
+    async property(property: EndpointProperty): Promise<EndpointReferenceExpression> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle, property };
+        return await this._client.invokeCapability<EndpointReferenceExpression>(
+            'Aspire.Hosting.ApplicationModel/EndpointReference.property',
+            rpcArgs
+        );
+    }
+
+    /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
     async getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
         const rpcArgs: Record<string, unknown> = { context: this._handle, enabledValue, disabledValue };
         return await this._client.invokeCapability<ReferenceExpression>(
@@ -2541,6 +2555,12 @@ class EndpointReferencePromiseImpl implements EndpointReferencePromise {
         return this._promise.then(obj => obj.getValueAsync(options));
     }
 
+    /** Gets the specified property expression of the endpoint */
+    property(property: EndpointProperty): Promise<EndpointReferenceExpression> {
+        return this._promise.then(obj => obj.property(property));
+    }
+
+    /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
     getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
         return this._promise.then(obj => obj.getTlsValue(enabledValue, disabledValue));
     }
@@ -33415,4 +33435,3 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints', (handle, client) => new ResourceWithEndpointsImpl(handle as IResourceWithEndpointsHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment', (handle, client) => new ResourceWithEnvironmentImpl(handle as IResourceWithEnvironmentHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport', (handle, client) => new ResourceWithWaitSupportImpl(handle as IResourceWithWaitSupportHandle, client));
-

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -2460,7 +2460,6 @@ class EndpointReferenceImpl implements EndpointReference {
         );
     }
 
-    /** Gets the specified property expression of the endpoint */
     async property(property: EndpointProperty): Promise<EndpointReferenceExpression> {
         const rpcArgs: Record<string, unknown> = { context: this._handle, property };
         return await this._client.invokeCapability<EndpointReferenceExpression>(
@@ -2469,7 +2468,6 @@ class EndpointReferenceImpl implements EndpointReference {
         );
     }
 
-    /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
     async getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
         const rpcArgs: Record<string, unknown> = { context: this._handle, enabledValue, disabledValue };
         return await this._client.invokeCapability<ReferenceExpression>(
@@ -2555,12 +2553,10 @@ class EndpointReferencePromiseImpl implements EndpointReferencePromise {
         return this._promise.then(obj => obj.getValueAsync(options));
     }
 
-    /** Gets the specified property expression of the endpoint */
     property(property: EndpointProperty): Promise<EndpointReferenceExpression> {
         return this._promise.then(obj => obj.property(property));
     }
 
-    /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
     getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
         return this._promise.then(obj => obj.getTlsValue(enabledValue, disabledValue));
     }
@@ -33435,3 +33431,4 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints', (handle, client) => new ResourceWithEndpointsImpl(handle as IResourceWithEndpointsHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment', (handle, client) => new ResourceWithEnvironmentImpl(handle as IResourceWithEnvironmentHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport', (handle, client) => new ResourceWithWaitSupportImpl(handle as IResourceWithWaitSupportHandle, client));
+

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -45,6 +45,9 @@ void main() throws Exception {
         dockerContainer.withHttpEndpointCallback((updateContext) -> { updateContext.setPort(8080.0); updateContext.setIsProxied(false); }, new WithHttpEndpointCallbackOptions().name("http").createIfNotExists(false));
         var endpoint = dockerContainer.getEndpoint("http");
         var expr = ReferenceExpression.refExpr("Host=%s", endpoint);
+        var endpointHost = endpoint.property(EndpointProperty.HOST);
+        var endpointPort = endpoint.property(EndpointProperty.PORT);
+        var endpointUrl = ReferenceExpression.refExpr("http://%s:%s", endpointHost, endpointPort);
         var builtConnectionString = builder.addConnectionString("customcs", expr);
         var envConnectionString = builder.addConnectionString("envcs");
         var expressionConnectionString = builder.addConnectionString("exprcs", expr);
@@ -62,6 +65,7 @@ void main() throws Exception {
         pipeline.addStep("custom-builder-step", (stepContext) -> { var builderSummary = stepContext.summary(); builderSummary.add("BuilderPipelineStep", "Validated"); }, new AddStepOptions().dependsOn(new String[] { WellKnownPipelineSteps.Build }).requiredBy(new String[] { WellKnownPipelineSteps.Publish }));
         pipeline.configure((configContext) -> { var builderPipeline = configContext.pipeline(); var _allSteps = builderPipeline.steps(); var _builderTaggedSteps = configContext.getSteps("custom-build"); });
         container.withEnvironment("MY_ENDPOINT", endpoint);
+        container.withEnvironment("MY_ENDPOINT_URL", endpointUrl);
         container.withEnvironment("MY_PARAM", configParam);
         container.withEnvironment("MY_BUILT_CONN", builtConnectionString);
         container.withEnvironment("MY_CONN", envConnectionString);

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -119,6 +119,9 @@ with create_builder() as builder:
     docker_container.with_http_endpoint_callback(update_existing_http_endpoint, name="http", create_if_not_exists=False)
     endpoint = docker_container.get_endpoint("http")
     expr = ReferenceExpression.format_string("Host=%s", endpoint)
+    endpoint_host = endpoint.property("Host")
+    endpoint_port = endpoint.property("Port")
+    endpoint_url = ReferenceExpression.format_string("http://%s:%s", endpoint_host, endpoint_port)
     built_connection_string = builder.add_connection_string("connection-string", env_var_name_or_expression=expr)
     env_connection_string = builder.add_connection_string("env-connection-string")
     expression_connection_string = builder.add_connection_string("expression-connection-string", env_var_name_or_expression=expr)
@@ -175,6 +178,8 @@ with create_builder() as builder:
     container.with_environment("MY_ENDPOINT", endpoint)
     # withEnvironment - ParameterResource
     container.with_environment("MY_PARAM", builder.add_parameter("param"))
+    # withEnvironment - endpoint property expression
+    container.with_environment("MY_ENDPOINT_URL", endpoint_url)
     # withEnvironment - connection string resource
     container.with_environment("MY_CONN", env_connection_string)
     container.with_environment("MY_EXPR_CONN", expression_connection_string)

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
@@ -5,6 +5,7 @@ import {
     WellKnownPipelineTags,
     createBuilder,
     CertificateTrustScope,
+    EndpointProperty,
     IconVariant,
     ProbeType,
     refExpr,
@@ -126,6 +127,9 @@ await dockerContainer.withHttpEndpointCallback(async (updateContext) => {
 }, { name: "http", createIfNotExists: false });
 const endpoint = await dockerContainer.getEndpoint("http");
 const expr = refExpr`Host=${endpoint}`;
+const endpointHost = await endpoint.property(EndpointProperty.Host);
+const endpointPort = await endpoint.property(EndpointProperty.Port);
+const endpointUrl = refExpr`http://${endpointHost}:${endpointPort}`;
 
 const builtConnectionString = await builder.addConnectionString("customcs", { environmentVariableNameOrExpression: expr });
 
@@ -178,6 +182,7 @@ await container.withEnvironment("MY_ENDPOINT", endpoint);
 
 // withEnvironment — with ReferenceExpression
 await container.withEnvironment("MY_EXPR", expr);
+await container.withEnvironment("MY_ENDPOINT_URL", endpointUrl);
 
 // withEnvironment — with ParameterResource
 await container.withEnvironment("MY_PARAM", configParam);


### PR DESCRIPTION
## Description

Fixes #15868

TypeScript AppHosts could already reference endpoint properties conceptually through the C# `EndpointProperty` enum, but `EndpointReference.Property(...)` was explicitly ignored by ATS, so generated SDKs could not construct expressions such as `http://${Host}:${Port}` from endpoint properties.

This exposes `EndpointReference.Property(EndpointProperty)` through ATS, refreshes the generated TypeScript, Python, and Java SDK snapshots, and updates the polyglot validation AppHosts to build an endpoint URL from `Host` and `Port` endpoint properties.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
