### PR TITLE
Mark DashboardCommand and DashboardRunCommand as preview commands

### DIFF
--- a/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Manage the Aspire dashboard</value>
+    <value>Manage the Aspire dashboard (Preview)</value>
   </data>
   <data name="RunDescription" xml:space="preserve">
-    <value>Start the Aspire dashboard</value>
+    <value>Start the Aspire dashboard (Preview)</value>
   </data>
   <data name="BundleNotAvailable" xml:space="preserve">
     <value>The Aspire dashboard requires the CLI bundle. The bundle was not found.</value>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage the Aspire dashboard</source>
-        <target state="new">Manage the Aspire dashboard</target>
+        <source>Manage the Aspire dashboard (Preview)</source>
+        <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">
-        <source>Start the Aspire dashboard</source>
-        <target state="new">Start the Aspire dashboard</target>
+        <source>Start the Aspire dashboard (Preview)</source>
+        <target state="new">Start the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
       <trans-unit id="StartingDashboard">


### PR DESCRIPTION
## Description

Mark `DashboardCommand` and `DashboardRunCommand` as preview commands by appending `(Preview)` to their description strings in `DashboardCommandStrings.resx`. Updated xlf localization files accordingly.

- `dashboard` → "Manage the Aspire dashboard (Preview)"
- `dashboard run` → "Start the Aspire dashboard (Preview)"

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
