### PR TITLE
Set Dashboard AI disabled default to true

### DIFF
--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -85,7 +85,16 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
             options.Api.PrimaryApiKey = apiKey;
         }
 
-        options.AI.Disabled = _configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey) ?? true;
+        // ASPIRE_DASHBOARD_AI_DISABLED takes precendence over ASPIRE__DASHBOARD__AI__DISABLED.
+        if (_configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey) is { } aiDisabled)
+        {
+            options.AI.Disabled = aiDisabled;
+        }
+        else
+        {
+            // If there is no explicit setting then default to disabled.
+            options.AI.Disabled = true;
+        }
 
         // DashboardAspireApiDisabledName takes precedence over DashboardAspireApiEnabledName.
         if (_configuration.GetBool(DashboardConfigNames.DashboardAspireApiDisabledName.ConfigKey) is { } apiDisabled)

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -85,7 +85,7 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
             options.Api.PrimaryApiKey = apiKey;
         }
 
-        options.AI.Disabled = _configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey);
+        options.AI.Disabled = _configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey) ?? true;
 
         // DashboardAspireApiDisabledName takes precedence over DashboardAspireApiEnabledName.
         if (_configuration.GetBool(DashboardConfigNames.DashboardAspireApiDisabledName.ConfigKey) is { } apiDisabled)

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -985,10 +985,10 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    [InlineData(null)]
-    public async Task Configuration_DisableAI_EnsureValueSetOnOptions(bool? value)
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    [InlineData(null, true)]
+    public async Task Configuration_DisableAI_EnsureValueSetOnOptions(bool? value, bool expectedAIDisabled)
     {
         // Arrange & Act
         var testCert = TelemetryTestHelpers.GenerateDummyCertificate();
@@ -1008,8 +1008,8 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         var aiContextProvider = app.Services.GetRequiredService<IAIContextProvider>();
 
         // Assert
-        Assert.Equal(value, app.DashboardOptionsMonitor.CurrentValue.AI.Disabled);
-        Assert.Equal(!(value ?? false), aiContextProvider.Enabled);
+        Assert.Equal(expectedAIDisabled, app.DashboardOptionsMonitor.CurrentValue.AI.Disabled);
+        Assert.Equal(!expectedAIDisabled, aiContextProvider.Enabled);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -282,8 +282,11 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("TestKey123!", app.DashboardOptionsMonitor.CurrentValue.Otlp.PrimaryApiKey);
     }
 
-    [Fact]
-    public async Task Configuration_OptionsMonitor_DebugSession()
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public async Task Configuration_OptionsMonitor_DebugSession(bool? aiDisabled, bool expectedAIDisabled)
     {
         // Arrange
         var testCert = TelemetryTestHelpers.GenerateDummyCertificate();
@@ -291,6 +294,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
             additionalConfiguration: initialData =>
             {
+                initialData[DashboardConfigNames.DashboardAIDisabledName.ConfigKey] = aiDisabled?.ToString().ToLower();
                 initialData[DashboardConfigNames.DebugSessionPortName.ConfigKey] = "8080";
                 initialData[DashboardConfigNames.DebugSessionServerCertificateName.ConfigKey] = Convert.ToBase64String(testCert.Export(X509ContentType.Cert));
                 initialData[DashboardConfigNames.DebugSessionTokenName.ConfigKey] = "token!";
@@ -312,7 +316,8 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("token!", app.DashboardOptionsMonitor.CurrentValue.DebugSession.Token);
         Assert.Equal(true, app.DashboardOptionsMonitor.CurrentValue.DebugSession.TelemetryOptOut);
 
-        Assert.True(aiContextProvider.Enabled, "AI enabled because debug session is present.");
+        Assert.Equal(expectedAIDisabled, app.DashboardOptionsMonitor.CurrentValue.AI.Disabled);
+        Assert.Equal(!expectedAIDisabled, aiContextProvider.Enabled);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- default Dashboard:AI:Disabled to 	rue when the value is not configured
- keep explicit config values unchanged when set to 	rue or alse
- update Configuration_DisableAI_EnsureValueSetOnOptions to pass expected values directly in theory data

## Validation
- dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-method "*.Configuration_DisableAI_EnsureValueSetOnOptions" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

fixes #13695
