### PR TITLE
Gateway TLS without hostname (FQDN discovery) + TS AppHost endpoint fix

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -14,6 +14,8 @@ using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
 
 namespace Aspire.Hosting.Kubernetes;
 
@@ -977,44 +979,8 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             context.Logger.LogInformation(
                 "Waiting for Gateway '{GatewayName}' to be assigned a hostname address...", gatewayName);
 
-            string? discoveredFqdn = null;
-            var maxAttempts = 60; // 5 minutes with 5s intervals
-            for (var attempt = 0; attempt < maxAttempts; attempt++)
-            {
-                var getArgs = $"get gateway {gatewayName} --namespace {@namespace} -o json";
-                if (environment.KubeConfigPath is not null)
-                {
-                    getArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
-                }
-
-                var stdout = new List<string>();
-                var (getResult, getDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
-                {
-                    Arguments = getArgs,
-                    ThrowOnNonZeroReturnCode = false,
-                    InheritEnv = true,
-                    OnOutputData = stdout.Add,
-                    OnErrorData = _ => { }
-                });
-
-                await using (getDisposable.ConfigureAwait(false))
-                {
-                    var result = await getResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-                    if (result.ExitCode == 0 && stdout.Count > 0)
-                    {
-                        discoveredFqdn = ExtractHostnameFromGatewayJson(string.Join("", stdout));
-                        if (discoveredFqdn is not null)
-                        {
-                            break;
-                        }
-                    }
-                }
-
-                if (attempt < maxAttempts - 1)
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(5), context.CancellationToken).ConfigureAwait(false);
-                }
-            }
+            var discoveredFqdn = await DiscoverGatewayFqdnAsync(
+                gatewayName, @namespace, environment, context).ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(discoveredFqdn))
             {
@@ -1181,6 +1147,64 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 try { tempDir.Delete(recursive: true); } catch { }
             }
         }
+    }
+
+    /// <summary>
+    /// Polls for the Gateway's assigned hostname address using a Polly retry pipeline.
+    /// Retries up to 60 times with 5-second delays (5 minutes total).
+    /// </summary>
+    private static async Task<string?> DiscoverGatewayFqdnAsync(
+        string gatewayName,
+        string @namespace,
+        KubernetesEnvironmentResource environment,
+        PipelineStepContext context)
+    {
+        var pipeline = new ResiliencePipelineBuilder<string?>()
+            .AddRetry(new RetryStrategyOptions<string?>
+            {
+                MaxRetryAttempts = 59,
+                Delay = TimeSpan.FromSeconds(5),
+                BackoffType = DelayBackoffType.Constant,
+                ShouldHandle = new PredicateBuilder<string?>().HandleResult(r => r is null),
+                OnRetry = args =>
+                {
+                    context.Logger.LogDebug(
+                        "Gateway '{GatewayName}' address not yet available (attempt {Attempt}).",
+                        gatewayName, args.AttemptNumber + 1);
+                    return default;
+                }
+            })
+            .Build();
+
+        return await pipeline.ExecuteAsync(async ct =>
+        {
+            var getArgs = $"get gateway {gatewayName} --namespace {@namespace} -o json";
+            if (environment.KubeConfigPath is not null)
+            {
+                getArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+            }
+
+            var stdout = new List<string>();
+            var (getResult, getDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+            {
+                Arguments = getArgs,
+                ThrowOnNonZeroReturnCode = false,
+                InheritEnv = true,
+                OnOutputData = stdout.Add,
+                OnErrorData = _ => { }
+            });
+
+            await using (getDisposable.ConfigureAwait(false))
+            {
+                var result = await getResult.WaitAsync(ct).ConfigureAwait(false);
+                if (result.ExitCode == 0 && stdout.Count > 0)
+                {
+                    return ExtractHostnameFromGatewayJson(string.Join("", stdout));
+                }
+            }
+
+            return null;
+        }, context.CancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -238,6 +238,27 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 steps.Add(tlsBootstrapStep);
             }
 
+            // FQDN discovery step — for Gateway TLS configs with no hostnames, waits for the
+            // Gateway to be assigned an address, patches the listener hostname, and bootstraps TLS.
+            var gatewaysNeedingDiscovery = CollectGatewaysNeedingFqdnDiscovery(model, environment);
+            if (gatewaysNeedingDiscovery.Count > 0)
+            {
+                var fqdnDiscoveryStep = new PipelineStep
+                {
+                    Name = $"tls-fqdn-discovery-{environment.Name}",
+                    Description = "Discovers Gateway FQDN, patches listener hostname, and bootstraps TLS",
+                    Action = ctx => DiscoverFqdnAndBootstrapTlsAsync(ctx, environment, gatewaysNeedingDiscovery)
+                };
+                fqdnDiscoveryStep.DependsOn($"helm-deploy-{environment.Name}");
+                if (tlsSecrets.Count > 0)
+                {
+                    // Run after normal TLS bootstrap (which handles hostnames that are already known)
+                    fqdnDiscoveryStep.DependsOn($"tls-bootstrap-{environment.Name}");
+                }
+                fqdnDiscoveryStep.RequiredBy(WellKnownPipelineSteps.Deploy);
+                steps.Add(fqdnDiscoveryStep);
+            }
+
             // Expand deployment target steps for compute resources (including dashboard if enabled)
             var resources = environment.DashboardEnabled && environment.Dashboard?.Resource is KubernetesAspireDashboardResource dashboard
                 ? [.. model.GetComputeResources(), dashboard]
@@ -718,20 +739,21 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         var tlsListenerIndex = 0;
         foreach (var tls in gatewayResource.TlsConfigs)
         {
-            foreach (var host in tls.Hosts)
+            var resolvedSecretName = await ResolveExpressionAsync(tls.SecretName, cancellationToken).ConfigureAwait(false);
+
+            if (tls.Hosts.Count == 0)
             {
+                // No hostnames specified — create an HTTPS listener without a hostname restriction.
+                // The hostname will be discovered from the Gateway's assigned address after deployment
+                // and patched onto the listener to enable cert-manager certificate issuance.
                 var listenerName = tlsListenerIndex == 0 ? "https" : $"https-{tlsListenerIndex}";
                 tlsListenerIndex++;
-
-                var resolvedHost = await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false);
-                var resolvedSecretName = await ResolveExpressionAsync(tls.SecretName, cancellationToken).ConfigureAwait(false);
 
                 gateway.Spec.Listeners.Add(new GatewayListenerV1
                 {
                     Name = listenerName,
                     Protocol = "HTTPS",
                     Port = 443,
-                    Hostname = resolvedHost,
                     Tls = new GatewayTlsConfigV1
                     {
                         Mode = "Terminate",
@@ -742,6 +764,33 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                         Namespaces = new GatewayRouteNamespacesV1 { From = "Same" }
                     }
                 });
+            }
+            else
+            {
+                foreach (var host in tls.Hosts)
+                {
+                    var listenerName = tlsListenerIndex == 0 ? "https" : $"https-{tlsListenerIndex}";
+                    tlsListenerIndex++;
+
+                    var resolvedHost = await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false);
+
+                    gateway.Spec.Listeners.Add(new GatewayListenerV1
+                    {
+                        Name = listenerName,
+                        Protocol = "HTTPS",
+                        Port = 443,
+                        Hostname = resolvedHost,
+                        Tls = new GatewayTlsConfigV1
+                        {
+                            Mode = "Terminate",
+                            CertificateRefs = { new GatewayCertificateRefV1 { Name = resolvedSecretName } }
+                        },
+                        AllowedRoutes = new GatewayAllowedRoutesV1
+                        {
+                            Namespaces = new GatewayRouteNamespacesV1 { From = "Same" }
+                        }
+                    });
+                }
             }
         }
 
@@ -868,6 +917,296 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         }
 
         return tlsSecrets;
+    }
+
+    /// <summary>
+    /// Collects gateway TLS configurations that have no hostnames specified and need
+    /// the assigned FQDN to be discovered from the Gateway's status after deployment.
+    /// </summary>
+    private static List<(KubernetesGatewayResource Gateway, ReferenceExpression SecretName)> CollectGatewaysNeedingFqdnDiscovery(
+        DistributedApplicationModel model,
+        KubernetesEnvironmentResource environment)
+    {
+        var results = new List<(KubernetesGatewayResource Gateway, ReferenceExpression SecretName)>();
+
+        foreach (var gateway in model.Resources.OfType<KubernetesGatewayResource>().Where(g => g.Parent == environment))
+        {
+            foreach (var tls in gateway.TlsConfigs)
+            {
+                if (tls.Hosts.Count == 0)
+                {
+                    results.Add((gateway, tls.SecretName));
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Discovers the assigned FQDN from the Gateway's status, patches the HTTPS listener
+    /// to include the hostname, and creates a bootstrap TLS secret so cert-manager can
+    /// issue a real certificate.
+    /// </summary>
+    private static async Task DiscoverFqdnAndBootstrapTlsAsync(
+        PipelineStepContext context,
+        KubernetesEnvironmentResource environment,
+        List<(KubernetesGatewayResource Gateway, ReferenceExpression SecretName)> gatewaysNeedingDiscovery)
+    {
+        var @namespace = "default";
+        if (environment.TryGetLastAnnotation<KubernetesNamespaceAnnotation>(out var nsAnnotation))
+        {
+            var resolvedNs = await nsAnnotation.Namespace.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(resolvedNs))
+            {
+                @namespace = resolvedNs;
+            }
+        }
+
+        foreach (var (gateway, secretNameExpr) in gatewaysNeedingDiscovery)
+        {
+            var gatewayName = gateway.Name.ToKubernetesResourceName();
+            var secretName = await ResolveExpressionAsync(secretNameExpr, context.CancellationToken).ConfigureAwait(false);
+
+            // Poll for the Gateway's assigned address (load balancer controllers may take time to provision)
+            context.Logger.LogInformation(
+                "Waiting for Gateway '{GatewayName}' to be assigned an address...", gatewayName);
+
+            string? discoveredFqdn = null;
+            var maxAttempts = 60; // 5 minutes with 5s intervals
+            for (var attempt = 0; attempt < maxAttempts; attempt++)
+            {
+                var jsonPathArgs = $"get gateway {gatewayName} --namespace {@namespace} -o jsonpath=\"{{.status.addresses[0].value}}\"";
+                if (environment.KubeConfigPath is not null)
+                {
+                    jsonPathArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                }
+
+                var stdout = new List<string>();
+                var (getResult, getDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+                {
+                    Arguments = jsonPathArgs,
+                    ThrowOnNonZeroReturnCode = false,
+                    InheritEnv = true,
+                    OnOutputData = line =>
+                    {
+                        if (!string.IsNullOrWhiteSpace(line))
+                        {
+                            stdout.Add(line);
+                        }
+                    },
+                    OnErrorData = _ => { }
+                });
+
+                await using (getDisposable.ConfigureAwait(false))
+                {
+                    var result = await getResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                    if (result.ExitCode == 0 && stdout.Count > 0 && !string.IsNullOrWhiteSpace(stdout[0]))
+                    {
+                        discoveredFqdn = stdout[0].Trim();
+                        break;
+                    }
+                }
+
+                if (attempt < maxAttempts - 1)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), context.CancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            if (string.IsNullOrEmpty(discoveredFqdn))
+            {
+                context.Logger.LogWarning(
+                    "Gateway '{GatewayName}' was not assigned an address after waiting. " +
+                    "TLS hostname discovery skipped. You may need to redeploy with an explicit hostname via WithHostname().",
+                    gatewayName);
+                continue;
+            }
+
+            context.Logger.LogInformation(
+                "Gateway '{GatewayName}' assigned address: {Fqdn}. Patching HTTPS listener(s) and bootstrapping TLS.",
+                gatewayName, discoveredFqdn);
+
+            // Find HTTPS listeners without a hostname and patch them with the discovered FQDN.
+            // We query the Gateway spec to find the correct listener indices dynamically.
+            var listenerJsonArgs = $"get gateway {gatewayName} --namespace {@namespace} -o jsonpath=\"{{.spec.listeners}}\"";
+            if (environment.KubeConfigPath is not null)
+            {
+                listenerJsonArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+            }
+
+            var listenerJson = new List<string>();
+            var (listenerResult, listenerDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+            {
+                Arguments = listenerJsonArgs,
+                ThrowOnNonZeroReturnCode = false,
+                InheritEnv = true,
+                OnOutputData = line =>
+                {
+                    if (!string.IsNullOrWhiteSpace(line))
+                    {
+                        listenerJson.Add(line);
+                    }
+                },
+                OnErrorData = _ => { }
+            });
+
+            var httpsListenerIndices = new List<int>();
+            await using (listenerDisposable.ConfigureAwait(false))
+            {
+                var listenerExitResult = await listenerResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                if (listenerExitResult.ExitCode == 0 && listenerJson.Count > 0)
+                {
+                    try
+                    {
+                        using var doc = System.Text.Json.JsonDocument.Parse(string.Join("", listenerJson));
+                        var listeners = doc.RootElement;
+                        for (var i = 0; i < listeners.GetArrayLength(); i++)
+                        {
+                            var listener = listeners[i];
+                            if (listener.TryGetProperty("protocol", out var protocol) &&
+                                string.Equals(protocol.GetString(), "HTTPS", StringComparison.OrdinalIgnoreCase) &&
+                                !listener.TryGetProperty("hostname", out _))
+                            {
+                                httpsListenerIndices.Add(i);
+                            }
+                        }
+                    }
+                    catch (System.Text.Json.JsonException)
+                    {
+                        // Fall back to assuming index 1 (HTTP=0, HTTPS=1)
+                        httpsListenerIndices.Add(1);
+                    }
+                }
+                else
+                {
+                    // Fall back to assuming index 1
+                    httpsListenerIndices.Add(1);
+                }
+            }
+
+            if (httpsListenerIndices.Count == 0)
+            {
+                context.Logger.LogWarning(
+                    "No HTTPS listeners without hostname found on Gateway '{GatewayName}'. Skipping hostname patch.",
+                    gatewayName);
+            }
+            else
+            {
+                // Build a JSON patch that adds the hostname to all HTTPS listeners that don't have one
+                var patchOps = string.Join(",", httpsListenerIndices.Select(
+                    idx => $"{{\"op\":\"add\",\"path\":\"/spec/listeners/{idx}/hostname\",\"value\":\"{discoveredFqdn}\"}}"));
+                var patchJson = $"[{patchOps}]";
+
+                var patchArgs = $"patch gateway {gatewayName} --namespace {@namespace} --type=json -p=\"{patchJson.Replace("\"", "\\\"")}\"";
+                if (environment.KubeConfigPath is not null)
+                {
+                    patchArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                }
+
+                var (patchResult, patchDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+                {
+                    Arguments = patchArgs,
+                    ThrowOnNonZeroReturnCode = false,
+                    InheritEnv = true,
+                    OnOutputData = line => context.Logger.LogDebug("{Line}", line),
+                    OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+                });
+
+                await using (patchDisposable.ConfigureAwait(false))
+                {
+                    var patchExitResult = await patchResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                    if (patchExitResult.ExitCode != 0)
+                    {
+                        context.Logger.LogWarning(
+                            "Failed to patch Gateway '{GatewayName}' with hostname '{Hostname}' (exit code {ExitCode}). " +
+                            "You may need to redeploy with an explicit hostname via WithHostname().",
+                            gatewayName, discoveredFqdn, patchExitResult.ExitCode);
+                        continue;
+                    }
+                }
+            }
+
+            // Check if bootstrap TLS secret already exists
+            var checkArgs = $"get secret {secretName} --namespace {@namespace}";
+            if (environment.KubeConfigPath is not null)
+            {
+                checkArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+            }
+
+            var (checkResult, checkDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+            {
+                Arguments = checkArgs,
+                ThrowOnNonZeroReturnCode = false,
+                InheritEnv = true,
+                OnOutputData = _ => { },
+                OnErrorData = _ => { }
+            });
+
+            await using (checkDisposable.ConfigureAwait(false))
+            {
+                var result = await checkResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                if (result.ExitCode == 0)
+                {
+                    context.Logger.LogInformation("TLS secret '{SecretName}' already exists, skipping bootstrap.", secretName);
+                    continue;
+                }
+            }
+
+            // Create a bootstrap self-signed cert with the discovered FQDN
+            context.Logger.LogInformation("Creating bootstrap TLS secret '{SecretName}' for '{Hostname}'.", secretName, discoveredFqdn);
+
+            using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+            var certRequest = new CertificateRequest($"CN={discoveredFqdn}", ecdsa, HashAlgorithmName.SHA256);
+            using var cert = certRequest.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+
+            var certPem = cert.ExportCertificatePem();
+            var keyPem = ecdsa.ExportECPrivateKeyPem();
+
+            var tempDir = Directory.CreateTempSubdirectory(".aspire-tls-discovery");
+            try
+            {
+                var certPath = Path.Combine(tempDir.FullName, "tls.crt");
+                var keyPath = Path.Combine(tempDir.FullName, "tls.key");
+                await File.WriteAllTextAsync(certPath, certPem, context.CancellationToken).ConfigureAwait(false);
+                await File.WriteAllTextAsync(keyPath, keyPem, context.CancellationToken).ConfigureAwait(false);
+
+                var createArgs = $"create secret tls {secretName} --cert=\"{certPath}\" --key=\"{keyPath}\" --namespace {@namespace}";
+                if (environment.KubeConfigPath is not null)
+                {
+                    createArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                }
+
+                var (createResult, createDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+                {
+                    Arguments = createArgs,
+                    ThrowOnNonZeroReturnCode = false,
+                    InheritEnv = true,
+                    OnOutputData = line => context.Logger.LogDebug("{Line}", line),
+                    OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+                });
+
+                await using (createDisposable.ConfigureAwait(false))
+                {
+                    var createExitResult = await createResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                    if (createExitResult.ExitCode != 0)
+                    {
+                        context.Logger.LogWarning("Failed to create bootstrap TLS secret '{SecretName}' (exit code {ExitCode}).", secretName, createExitResult.ExitCode);
+                    }
+                    else
+                    {
+                        context.Logger.LogInformation(
+                            "Bootstrap TLS secret '{SecretName}' created for '{Hostname}'. " +
+                            "cert-manager will replace this with a real certificate once the hostname is detected on the Gateway listener.",
+                            secretName, discoveredFqdn);
+                    }
+                }
+            }
+            finally
+            {
+                try { tempDir.Delete(recursive: true); } catch { }
+            }
+        }
     }
 
     private static async Task BootstrapTlsSecretsAsync(

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -1093,7 +1093,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             }
             else
             {
-                // Build a JSON patch that adds the hostname to all HTTPS listeners that don't have one
+                // Patch the HTTPS listeners with the discovered hostname using JSON patch,
+                // then transfer field ownership to Helm via server-side apply so that
+                // subsequent Helm deploys don't encounter SSA conflicts.
                 var patchOps = string.Join(",", httpsListenerIndices.Select(
                     idx => $"{{\"op\":\"add\",\"path\":\"/spec/listeners/{idx}/hostname\",\"value\":\"{discoveredFqdn}\"}}"));
                 var patchJson = $"[{patchOps}]";
@@ -1123,6 +1125,68 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                             "You may need to redeploy with an explicit hostname via WithHostname().",
                             gatewayName, discoveredFqdn, patchExitResult.ExitCode);
                         continue;
+                    }
+                }
+
+                // Transfer field ownership to Helm using server-side apply so subsequent
+                // Helm deploys don't encounter SSA conflicts on the patched hostname field.
+                var currentGatewayArgs = $"get gateway {gatewayName} --namespace {@namespace} -o yaml";
+                if (environment.KubeConfigPath is not null)
+                {
+                    currentGatewayArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                }
+
+                var gatewayYamlLines = new List<string>();
+                var (getGwResult, getGwDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+                {
+                    Arguments = currentGatewayArgs,
+                    ThrowOnNonZeroReturnCode = false,
+                    InheritEnv = true,
+                    OnOutputData = gatewayYamlLines.Add,
+                    OnErrorData = _ => { }
+                });
+
+                await using (getGwDisposable.ConfigureAwait(false))
+                {
+                    var getGwExitResult = await getGwResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                    if (getGwExitResult.ExitCode == 0 && gatewayYamlLines.Count > 0)
+                    {
+                        var tempFile = Path.GetTempFileName();
+                        try
+                        {
+                            await File.WriteAllLinesAsync(tempFile, gatewayYamlLines, context.CancellationToken).ConfigureAwait(false);
+
+                            var applyArgs = $"apply --server-side --field-manager=helm --force-conflicts -f \"{tempFile}\"";
+                            if (environment.KubeConfigPath is not null)
+                            {
+                                applyArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                            }
+
+                            var (applyResult, applyDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+                            {
+                                Arguments = applyArgs,
+                                ThrowOnNonZeroReturnCode = false,
+                                InheritEnv = true,
+                                OnOutputData = line => context.Logger.LogDebug("{Line}", line),
+                                OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+                            });
+
+                            await using (applyDisposable.ConfigureAwait(false))
+                            {
+                                var applyExitResult = await applyResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                                if (applyExitResult.ExitCode != 0)
+                                {
+                                    context.Logger.LogDebug(
+                                        "Failed to transfer field ownership to Helm (exit code {ExitCode}). " +
+                                        "Subsequent deploys with an explicit hostname may require --force.",
+                                        applyExitResult.ExitCode);
+                                }
+                            }
+                        }
+                        finally
+                        {
+                            try { File.Delete(tempFile); } catch { }
+                        }
                     }
                 }
             }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -385,8 +385,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             });
         }
 
-        // Build deployment target lookup for endpoint resolution
-        var deploymentTargets = new Dictionary<IResource, KubernetesResource>();
+        // Build deployment target lookup for endpoint resolution.
+        // Use name-based equality so that endpoint references created through the
+        // TypeScript AppHost RPC bridge (which may use a different resource instance)
+        // resolve correctly.
+        var deploymentTargets = new Dictionary<IResource, KubernetesResource>(new ResourceNameComparer());
 
         foreach (var r in appModel.GetComputeResources())
         {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -971,43 +971,42 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             var gatewayName = gateway.Name.ToKubernetesResourceName();
             var secretName = await ResolveExpressionAsync(secretNameExpr, context.CancellationToken).ConfigureAwait(false);
 
-            // Poll for the Gateway's assigned address (load balancer controllers may take time to provision)
+            // Poll for the Gateway's assigned hostname address.
+            // We use -o json and parse the full status to select Hostname-type addresses,
+            // since some controllers return IP addresses which are not valid for TLS hostnames.
             context.Logger.LogInformation(
-                "Waiting for Gateway '{GatewayName}' to be assigned an address...", gatewayName);
+                "Waiting for Gateway '{GatewayName}' to be assigned a hostname address...", gatewayName);
 
             string? discoveredFqdn = null;
             var maxAttempts = 60; // 5 minutes with 5s intervals
             for (var attempt = 0; attempt < maxAttempts; attempt++)
             {
-                var jsonPathArgs = $"get gateway {gatewayName} --namespace {@namespace} -o jsonpath=\"{{.status.addresses[0].value}}\"";
+                var getArgs = $"get gateway {gatewayName} --namespace {@namespace} -o json";
                 if (environment.KubeConfigPath is not null)
                 {
-                    jsonPathArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                    getArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
                 }
 
                 var stdout = new List<string>();
                 var (getResult, getDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
                 {
-                    Arguments = jsonPathArgs,
+                    Arguments = getArgs,
                     ThrowOnNonZeroReturnCode = false,
                     InheritEnv = true,
-                    OnOutputData = line =>
-                    {
-                        if (!string.IsNullOrWhiteSpace(line))
-                        {
-                            stdout.Add(line);
-                        }
-                    },
+                    OnOutputData = stdout.Add,
                     OnErrorData = _ => { }
                 });
 
                 await using (getDisposable.ConfigureAwait(false))
                 {
                     var result = await getResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-                    if (result.ExitCode == 0 && stdout.Count > 0 && !string.IsNullOrWhiteSpace(stdout[0]))
+                    if (result.ExitCode == 0 && stdout.Count > 0)
                     {
-                        discoveredFqdn = stdout[0].Trim();
-                        break;
+                        discoveredFqdn = ExtractHostnameFromGatewayJson(string.Join("", stdout));
+                        if (discoveredFqdn is not null)
+                        {
+                            break;
+                        }
                     }
                 }
 
@@ -1020,7 +1019,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             if (string.IsNullOrEmpty(discoveredFqdn))
             {
                 context.Logger.LogWarning(
-                    "Gateway '{GatewayName}' was not assigned an address after waiting. " +
+                    "Gateway '{GatewayName}' was not assigned a hostname address after waiting. " +
                     "TLS hostname discovery skipped. You may need to redeploy with an explicit hostname via WithHostname().",
                     gatewayName);
                 continue;
@@ -1030,63 +1029,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 "Gateway '{GatewayName}' assigned address: {Fqdn}. Patching HTTPS listener(s) and bootstrapping TLS.",
                 gatewayName, discoveredFqdn);
 
-            // Find HTTPS listeners without a hostname and patch them with the discovered FQDN.
-            // We query the Gateway spec to find the correct listener indices dynamically.
-            var listenerJsonArgs = $"get gateway {gatewayName} --namespace {@namespace} -o jsonpath=\"{{.spec.listeners}}\"";
-            if (environment.KubeConfigPath is not null)
-            {
-                listenerJsonArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
-            }
-
-            var listenerJson = new List<string>();
-            var (listenerResult, listenerDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
-            {
-                Arguments = listenerJsonArgs,
-                ThrowOnNonZeroReturnCode = false,
-                InheritEnv = true,
-                OnOutputData = line =>
-                {
-                    if (!string.IsNullOrWhiteSpace(line))
-                    {
-                        listenerJson.Add(line);
-                    }
-                },
-                OnErrorData = _ => { }
-            });
-
-            var httpsListenerIndices = new List<int>();
-            await using (listenerDisposable.ConfigureAwait(false))
-            {
-                var listenerExitResult = await listenerResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-                if (listenerExitResult.ExitCode == 0 && listenerJson.Count > 0)
-                {
-                    try
-                    {
-                        using var doc = System.Text.Json.JsonDocument.Parse(string.Join("", listenerJson));
-                        var listeners = doc.RootElement;
-                        for (var i = 0; i < listeners.GetArrayLength(); i++)
-                        {
-                            var listener = listeners[i];
-                            if (listener.TryGetProperty("protocol", out var protocol) &&
-                                string.Equals(protocol.GetString(), "HTTPS", StringComparison.OrdinalIgnoreCase) &&
-                                !listener.TryGetProperty("hostname", out _))
-                            {
-                                httpsListenerIndices.Add(i);
-                            }
-                        }
-                    }
-                    catch (System.Text.Json.JsonException)
-                    {
-                        // Fall back to assuming index 1 (HTTP=0, HTTPS=1)
-                        httpsListenerIndices.Add(1);
-                    }
-                }
-                else
-                {
-                    // Fall back to assuming index 1
-                    httpsListenerIndices.Add(1);
-                }
-            }
+            // Find HTTPS listeners without a hostname by parsing the full Gateway JSON.
+            var httpsListenerIndices = await FindHostnamelessHttpsListeners(
+                gatewayName, @namespace, environment, context).ConfigureAwait(false);
 
             if (httpsListenerIndices.Count == 0)
             {
@@ -1096,102 +1041,61 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             }
             else
             {
-                // Patch the HTTPS listeners with the discovered hostname using JSON patch,
-                // then transfer field ownership to Helm via server-side apply so that
-                // subsequent Helm deploys don't encounter SSA conflicts.
-                var patchOps = string.Join(",", httpsListenerIndices.Select(
-                    idx => $"{{\"op\":\"add\",\"path\":\"/spec/listeners/{idx}/hostname\",\"value\":\"{discoveredFqdn}\"}}"));
-                var patchJson = $"[{patchOps}]";
-
-                var patchArgs = $"patch gateway {gatewayName} --namespace {@namespace} --type=json -p=\"{patchJson.Replace("\"", "\\\"")}\"";
-                if (environment.KubeConfigPath is not null)
+                // Build the JSON patch using proper serialization to avoid injection issues.
+                var patchOperations = httpsListenerIndices.Select(idx => new
                 {
-                    patchArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
-                }
-
-                var (patchResult, patchDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
-                {
-                    Arguments = patchArgs,
-                    ThrowOnNonZeroReturnCode = false,
-                    InheritEnv = true,
-                    OnOutputData = line => context.Logger.LogDebug("{Line}", line),
-                    OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+                    op = "add",
+                    path = $"/spec/listeners/{idx}/hostname",
+                    value = discoveredFqdn
                 });
+                var patchJson = System.Text.Json.JsonSerializer.Serialize(patchOperations);
 
-                await using (patchDisposable.ConfigureAwait(false))
+                // Write patch to a temp file to avoid shell escaping issues with kubectl -p
+                var patchTempDir = Directory.CreateTempSubdirectory(".aspire-gateway-patch");
+                try
                 {
-                    var patchExitResult = await patchResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-                    if (patchExitResult.ExitCode != 0)
+                    var patchFilePath = Path.Combine(patchTempDir.FullName, "patch.json");
+                    await File.WriteAllTextAsync(patchFilePath, patchJson, context.CancellationToken).ConfigureAwait(false);
+
+                    var patchArgs = $"patch gateway {gatewayName} --namespace {@namespace} --type=json --patch-file \"{patchFilePath}\"";
+                    if (environment.KubeConfigPath is not null)
                     {
-                        context.Logger.LogWarning(
-                            "Failed to patch Gateway '{GatewayName}' with hostname '{Hostname}' (exit code {ExitCode}). " +
-                            "You may need to redeploy with an explicit hostname via WithHostname().",
-                            gatewayName, discoveredFqdn, patchExitResult.ExitCode);
-                        continue;
+                        patchArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
                     }
-                }
 
-                // Transfer field ownership to Helm using server-side apply so subsequent
-                // Helm deploys don't encounter SSA conflicts on the patched hostname field.
-                var currentGatewayArgs = $"get gateway {gatewayName} --namespace {@namespace} -o yaml";
-                if (environment.KubeConfigPath is not null)
-                {
-                    currentGatewayArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
-                }
-
-                var gatewayYamlLines = new List<string>();
-                var (getGwResult, getGwDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
-                {
-                    Arguments = currentGatewayArgs,
-                    ThrowOnNonZeroReturnCode = false,
-                    InheritEnv = true,
-                    OnOutputData = gatewayYamlLines.Add,
-                    OnErrorData = _ => { }
-                });
-
-                await using (getGwDisposable.ConfigureAwait(false))
-                {
-                    var getGwExitResult = await getGwResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-                    if (getGwExitResult.ExitCode == 0 && gatewayYamlLines.Count > 0)
+                    var (patchResult, patchDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
                     {
-                        var tempFile = Path.GetTempFileName();
-                        try
+                        Arguments = patchArgs,
+                        ThrowOnNonZeroReturnCode = false,
+                        InheritEnv = true,
+                        OnOutputData = line => context.Logger.LogDebug("{Line}", line),
+                        OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+                    });
+
+                    await using (patchDisposable.ConfigureAwait(false))
+                    {
+                        var patchExitResult = await patchResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                        if (patchExitResult.ExitCode != 0)
                         {
-                            await File.WriteAllLinesAsync(tempFile, gatewayYamlLines, context.CancellationToken).ConfigureAwait(false);
-
-                            var applyArgs = $"apply --server-side --field-manager=helm --force-conflicts -f \"{tempFile}\"";
-                            if (environment.KubeConfigPath is not null)
-                            {
-                                applyArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
-                            }
-
-                            var (applyResult, applyDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
-                            {
-                                Arguments = applyArgs,
-                                ThrowOnNonZeroReturnCode = false,
-                                InheritEnv = true,
-                                OnOutputData = line => context.Logger.LogDebug("{Line}", line),
-                                OnErrorData = line => context.Logger.LogDebug("{Line}", line)
-                            });
-
-                            await using (applyDisposable.ConfigureAwait(false))
-                            {
-                                var applyExitResult = await applyResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-                                if (applyExitResult.ExitCode != 0)
-                                {
-                                    context.Logger.LogDebug(
-                                        "Failed to transfer field ownership to Helm (exit code {ExitCode}). " +
-                                        "Subsequent deploys with an explicit hostname may require --force.",
-                                        applyExitResult.ExitCode);
-                                }
-                            }
-                        }
-                        finally
-                        {
-                            try { File.Delete(tempFile); } catch { }
+                            context.Logger.LogWarning(
+                                "Failed to patch Gateway '{GatewayName}' with hostname '{Hostname}' (exit code {ExitCode}). " +
+                                "You may need to redeploy with an explicit hostname via WithHostname().",
+                                gatewayName, discoveredFqdn, patchExitResult.ExitCode);
+                            continue;
                         }
                     }
                 }
+                finally
+                {
+                    try { patchTempDir.Delete(recursive: true); } catch { }
+                }
+
+                // Transfer field ownership to Helm using server-side apply with a minimal
+                // Gateway manifest so subsequent Helm deploys don't encounter SSA conflicts.
+                // We construct a minimal spec rather than re-applying kubectl get output,
+                // which would include server-populated fields (status, resourceVersion, etc.).
+                await TransferGatewayFieldOwnership(
+                    gatewayName, @namespace, environment, context).ConfigureAwait(false);
             }
 
             // Check if bootstrap TLS secret already exists
@@ -1225,6 +1129,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
             using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
             var certRequest = new CertificateRequest($"CN={discoveredFqdn}", ecdsa, HashAlgorithmName.SHA256);
+            var sanBuilder = new SubjectAlternativeNameBuilder();
+            sanBuilder.AddDnsName(discoveredFqdn);
+            certRequest.CertificateExtensions.Add(sanBuilder.Build());
             using var cert = certRequest.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
 
             var certPem = cert.ExportCertificatePem();
@@ -1273,6 +1180,227 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             {
                 try { tempDir.Delete(recursive: true); } catch { }
             }
+        }
+    }
+
+    /// <summary>
+    /// Extracts the first Hostname-type address from Gateway JSON status.
+    /// Returns null if no hostname address is found (e.g., only IP addresses).
+    /// </summary>
+    private static string? ExtractHostnameFromGatewayJson(string gatewayJson)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(gatewayJson);
+            if (doc.RootElement.TryGetProperty("status", out var status) &&
+                status.TryGetProperty("addresses", out var addresses))
+            {
+                // Prefer Hostname-type addresses over IPAddress
+                foreach (var addr in addresses.EnumerateArray())
+                {
+                    if (addr.TryGetProperty("type", out var type) &&
+                        string.Equals(type.GetString(), "Hostname", StringComparison.OrdinalIgnoreCase) &&
+                        addr.TryGetProperty("value", out var value))
+                    {
+                        var hostname = value.GetString()?.Trim();
+                        if (!string.IsNullOrEmpty(hostname))
+                        {
+                            return hostname;
+                        }
+                    }
+                }
+
+                // Fall back to any address that looks like a DNS name (contains a dot, no colons)
+                foreach (var addr in addresses.EnumerateArray())
+                {
+                    if (addr.TryGetProperty("value", out var value))
+                    {
+                        var addrValue = value.GetString()?.Trim();
+                        if (!string.IsNullOrEmpty(addrValue) && addrValue.Contains('.') && !addrValue.Contains(':'))
+                        {
+                            return addrValue;
+                        }
+                    }
+                }
+            }
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            // Gateway JSON was malformed
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds HTTPS listener indices that don't have a hostname set, by parsing the
+    /// full Gateway JSON from kubectl.
+    /// </summary>
+    private static async Task<List<int>> FindHostnamelessHttpsListeners(
+        string gatewayName,
+        string @namespace,
+        KubernetesEnvironmentResource environment,
+        PipelineStepContext context)
+    {
+        var getArgs = $"get gateway {gatewayName} --namespace {@namespace} -o json";
+        if (environment.KubeConfigPath is not null)
+        {
+            getArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+        }
+
+        var stdout = new List<string>();
+        var (getResult, getDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+        {
+            Arguments = getArgs,
+            ThrowOnNonZeroReturnCode = false,
+            InheritEnv = true,
+            OnOutputData = stdout.Add,
+            OnErrorData = _ => { }
+        });
+
+        var indices = new List<int>();
+        await using (getDisposable.ConfigureAwait(false))
+        {
+            var result = await getResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+            if (result.ExitCode == 0 && stdout.Count > 0)
+            {
+                try
+                {
+                    using var doc = System.Text.Json.JsonDocument.Parse(string.Join("", stdout));
+                    if (doc.RootElement.TryGetProperty("spec", out var spec) &&
+                        spec.TryGetProperty("listeners", out var listeners))
+                    {
+                        for (var i = 0; i < listeners.GetArrayLength(); i++)
+                        {
+                            var listener = listeners[i];
+                            if (listener.TryGetProperty("protocol", out var protocol) &&
+                                string.Equals(protocol.GetString(), "HTTPS", StringComparison.OrdinalIgnoreCase) &&
+                                !listener.TryGetProperty("hostname", out _))
+                            {
+                                indices.Add(i);
+                            }
+                        }
+                    }
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    // Fall back to assuming index 1 (HTTP=0, HTTPS=1)
+                    indices.Add(1);
+                }
+            }
+            else
+            {
+                // Fall back to assuming index 1
+                indices.Add(1);
+            }
+        }
+
+        return indices;
+    }
+
+    /// <summary>
+    /// Transfers field ownership of the Gateway's patched hostname to Helm using server-side apply
+    /// with a minimal Gateway manifest, avoiding server-populated fields like status and resourceVersion.
+    /// </summary>
+    private static async Task TransferGatewayFieldOwnership(
+        string gatewayName,
+        string @namespace,
+        KubernetesEnvironmentResource environment,
+        PipelineStepContext context)
+    {
+        // Build a minimal Gateway JSON with only the fields needed for ownership transfer.
+        // We read the current Gateway, strip server-populated fields, update the hostname,
+        // and re-apply with Helm's field manager.
+        var getArgs = $"get gateway {gatewayName} --namespace {@namespace} -o json";
+        if (environment.KubeConfigPath is not null)
+        {
+            getArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+        }
+
+        var stdout = new List<string>();
+        var (getResult, getDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+        {
+            Arguments = getArgs,
+            ThrowOnNonZeroReturnCode = false,
+            InheritEnv = true,
+            OnOutputData = stdout.Add,
+            OnErrorData = _ => { }
+        });
+
+        await using (getDisposable.ConfigureAwait(false))
+        {
+            var exitResult = await getResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+            if (exitResult.ExitCode != 0 || stdout.Count == 0)
+            {
+                context.Logger.LogDebug("Could not read Gateway for field ownership transfer.");
+                return;
+            }
+        }
+
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(string.Join("", stdout));
+            var root = doc.RootElement;
+
+            // Build a minimal manifest: apiVersion, kind, metadata (name + namespace only), spec
+            var minimal = new System.Text.Json.Nodes.JsonObject
+            {
+                ["apiVersion"] = root.GetProperty("apiVersion").GetString(),
+                ["kind"] = root.GetProperty("kind").GetString(),
+                ["metadata"] = new System.Text.Json.Nodes.JsonObject
+                {
+                    ["name"] = gatewayName,
+                    ["namespace"] = @namespace
+                }
+            };
+
+            // Copy the spec as-is (it already has the patched hostname from the previous step)
+            if (root.TryGetProperty("spec", out var spec))
+            {
+                minimal["spec"] = System.Text.Json.Nodes.JsonNode.Parse(spec.GetRawText());
+            }
+
+            var tempDir = Directory.CreateTempSubdirectory(".aspire-gateway-ownership");
+            try
+            {
+                var manifestPath = Path.Combine(tempDir.FullName, "gateway.json");
+                await File.WriteAllTextAsync(manifestPath, minimal.ToJsonString(), context.CancellationToken).ConfigureAwait(false);
+
+                var applyArgs = $"apply --server-side --field-manager=helm --force-conflicts -f \"{manifestPath}\"";
+                if (environment.KubeConfigPath is not null)
+                {
+                    applyArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                }
+
+                var (applyResult, applyDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+                {
+                    Arguments = applyArgs,
+                    ThrowOnNonZeroReturnCode = false,
+                    InheritEnv = true,
+                    OnOutputData = line => context.Logger.LogDebug("{Line}", line),
+                    OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+                });
+
+                await using (applyDisposable.ConfigureAwait(false))
+                {
+                    var applyExitResult = await applyResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                    if (applyExitResult.ExitCode != 0)
+                    {
+                        context.Logger.LogDebug(
+                            "Failed to transfer field ownership to Helm (exit code {ExitCode}). " +
+                            "Subsequent deploys with an explicit hostname may require --force.",
+                            applyExitResult.ExitCode);
+                    }
+                }
+            }
+            finally
+            {
+                try { tempDir.Delete(recursive: true); } catch { }
+            }
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            context.Logger.LogDebug(ex, "Failed to parse Gateway JSON for field ownership transfer.");
         }
     }
 
@@ -1325,6 +1453,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
             using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
             var request = new CertificateRequest($"CN={hostname}", ecdsa, HashAlgorithmName.SHA256);
+            var sanBuilder = new SubjectAlternativeNameBuilder();
+            sanBuilder.AddDnsName(hostname);
+            request.CertificateExtensions.Add(sanBuilder.Build());
             using var cert = request.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
 
             var certPem = cert.ExportCertificatePem();

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -1342,16 +1342,32 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             using var doc = System.Text.Json.JsonDocument.Parse(string.Join("", stdout));
             var root = doc.RootElement;
 
-            // Build a minimal manifest: apiVersion, kind, metadata (name + namespace only), spec
+            // Build a minimal manifest: apiVersion, kind, metadata (name, namespace, annotations, labels), spec
+            var metadataNode = new System.Text.Json.Nodes.JsonObject
+            {
+                ["name"] = gatewayName,
+                ["namespace"] = @namespace
+            };
+
+            // Preserve annotations and labels from the current Gateway
+            if (root.TryGetProperty("metadata", out var metadata))
+            {
+                if (metadata.TryGetProperty("annotations", out var annotations))
+                {
+                    metadataNode["annotations"] = System.Text.Json.Nodes.JsonNode.Parse(annotations.GetRawText());
+                }
+
+                if (metadata.TryGetProperty("labels", out var labels))
+                {
+                    metadataNode["labels"] = System.Text.Json.Nodes.JsonNode.Parse(labels.GetRawText());
+                }
+            }
+
             var minimal = new System.Text.Json.Nodes.JsonObject
             {
                 ["apiVersion"] = root.GetProperty("apiVersion").GetString(),
                 ["kind"] = root.GetProperty("kind").GetString(),
-                ["metadata"] = new System.Text.Json.Nodes.JsonObject
-                {
-                    ["name"] = gatewayName,
-                    ["namespace"] = @namespace
-                }
+                ["metadata"] = metadataNode
             };
 
             // Copy the spec as-is (it already has the patched hostname from the previous step)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -293,9 +293,11 @@ builder.Build().Run();
 
             content = content.Replace(buildRunPattern, replacement);
 
+            // Add required pragmas and using directive at the top of the file
+            var topOfFile = "#pragma warning disable ASPIREPIPELINES001\n#pragma warning disable ASPIRECOMPUTE003\nusing Aspire.Hosting.Kubernetes;\n";
             if (!content.Contains("#pragma warning disable ASPIREPIPELINES001"))
             {
-                content = "#pragma warning disable ASPIREPIPELINES001\n" + content;
+                content = topOfFile + content;
             }
 
             File.WriteAllText(appHostFilePath, content);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -130,20 +130,23 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
-            // Create AKS with OIDC + workload identity + ALB controller in a single command
-            output.WriteLine("Step 5: Creating AKS cluster with ALB controller (10-15 minutes)...");
+            // Create AKS with Azure CNI, OIDC, workload identity, Gateway API, and ALB controller
+            // Per https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon
+            output.WriteLine("Step 5: Creating AKS cluster with Gateway API + ALB (10-15 minutes)...");
             await auto.TypeAsync(
                 $"az aks create " +
                 $"--resource-group {resourceGroupName} " +
                 $"--name {clusterName} " +
+                $"--location westus3 " +
                 $"--node-count 1 " +
                 $"--node-vm-size Standard_D2as_v5 " +
+                $"--network-plugin azure " +
                 $"--generate-ssh-keys " +
                 $"--attach-acr {acrName} " +
-                $"--enable-managed-identity " +
                 $"--enable-oidc-issuer " +
                 $"--enable-workload-identity " +
-                $"--enable-alb " +
+                $"--enable-gateway-api " +
+                $"--enable-application-load-balancer " +
                 $"--output table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(20));
@@ -153,17 +156,22 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Create ALB subnet + ApplicationLoadBalancer CRD
-            output.WriteLine("Step 6: Creating ALB subnet and ApplicationLoadBalancer...");
+            // Verify ALB controller is running and GatewayClass exists
+            output.WriteLine("Step 6: Verifying ALB controller and GatewayClass...");
+            await auto.TypeAsync("kubectl get pods -n kube-system | grep alb-controller && kubectl get gatewayclass azure-alb-external");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Create ApplicationLoadBalancer CRD using the add-on's auto-created subnet
+            output.WriteLine("Step 7: Creating ApplicationLoadBalancer...");
             await auto.TypeAsync(
                 $"MC_RG=$(az aks show -g {resourceGroupName} -n {clusterName} --query nodeResourceGroup -o tsv) && " +
-                "VNET_NAME=$(az network vnet list -g $MC_RG --query '[0].name' -o tsv) && " +
-                "az network vnet subnet create -g $MC_RG --vnet-name $VNET_NAME --name subnet-alb " +
-                "--address-prefix 10.237.0.0/24 --delegations Microsoft.ServiceNetworking/trafficControllers && " +
-                "SUBNET_ID=$(az network vnet subnet show -g $MC_RG --vnet-name $VNET_NAME --name subnet-alb --query id -o tsv) && " +
+                "SUBNET_ID=$(az network vnet subnet show -g $MC_RG " +
+                "--vnet-name $(az network vnet list -g $MC_RG --query '[0].name' -o tsv) " +
+                "--name aks-appgateway --query id -o tsv) && " +
                 "echo \"Subnet: $SUBNET_ID\"");
             await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
             await auto.TypeAsync(
                 "cat <<EOF | kubectl apply -f -\n" +
@@ -188,7 +196,7 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
 
             // Install cert-manager with Gateway API support
-            output.WriteLine("Step 7: Installing cert-manager...");
+            output.WriteLine("Step 8: Installing cert-manager...");
             await auto.TypeAsync(
                 "helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager " +
                 "--namespace cert-manager --create-namespace " +
@@ -197,7 +205,7 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
 
             // Create HTTP-01 ClusterIssuer
-            output.WriteLine("Step 8: Creating HTTP-01 ClusterIssuer...");
+            output.WriteLine("Step 9: Creating HTTP-01 ClusterIssuer...");
             await auto.TypeAsync(
                 "cat <<EOF | kubectl apply -f -\n" +
                 "apiVersion: cert-manager.io/v1\n" +
@@ -225,7 +233,7 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
 
             // ===== PHASE 2: Create Aspire Project with Gateway + TLS =====
 
-            await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 9");
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 10");
 
             output.WriteLine("Step 9: Creating Aspire starter project...");
             await auto.AspireNewAsync(projectName, counter, useRedisCache: false);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -130,28 +130,23 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
-            // Create AKS with OIDC + workload identity (required for ALB controller)
-            output.WriteLine("Step 5: Creating AKS cluster (10-15 minutes)...");
+            // Create AKS with OIDC + workload identity + ALB controller in a single command
+            output.WriteLine("Step 5: Creating AKS cluster with ALB controller (10-15 minutes)...");
             await auto.TypeAsync(
                 $"az aks create " +
                 $"--resource-group {resourceGroupName} " +
                 $"--name {clusterName} " +
                 $"--node-count 1 " +
-                $"--node-vm-size Standard_D2s_v3 " +
+                $"--node-vm-size Standard_D2as_v5 " +
                 $"--generate-ssh-keys " +
                 $"--attach-acr {acrName} " +
                 $"--enable-managed-identity " +
                 $"--enable-oidc-issuer " +
                 $"--enable-workload-identity " +
+                $"--enable-alb " +
                 $"--output table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(20));
-
-            // Enable ALB controller addon
-            output.WriteLine("Step 6: Enabling ALB controller...");
-            await auto.TypeAsync($"az aks update --resource-group {resourceGroupName} --name {clusterName} --enable-alb");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(10));
 
             // Get credentials
             await auto.TypeAsync($"az aks get-credentials --resource-group {resourceGroupName} --name {clusterName} --overwrite-existing");
@@ -159,7 +154,7 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
             // Create ALB subnet + ApplicationLoadBalancer CRD
-            output.WriteLine("Step 7: Creating ALB subnet and ApplicationLoadBalancer...");
+            output.WriteLine("Step 6: Creating ALB subnet and ApplicationLoadBalancer...");
             await auto.TypeAsync(
                 $"MC_RG=$(az aks show -g {resourceGroupName} -n {clusterName} --query nodeResourceGroup -o tsv) && " +
                 "VNET_NAME=$(az network vnet list -g $MC_RG --query '[0].name' -o tsv) && " +
@@ -193,7 +188,7 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
 
             // Install cert-manager with Gateway API support
-            output.WriteLine("Step 8: Installing cert-manager...");
+            output.WriteLine("Step 7: Installing cert-manager...");
             await auto.TypeAsync(
                 "helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager " +
                 "--namespace cert-manager --create-namespace " +
@@ -202,7 +197,7 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
 
             // Create HTTP-01 ClusterIssuer
-            output.WriteLine("Step 9: Creating HTTP-01 ClusterIssuer...");
+            output.WriteLine("Step 8: Creating HTTP-01 ClusterIssuer...");
             await auto.TypeAsync(
                 "cat <<EOF | kubectl apply -f -\n" +
                 "apiVersion: cert-manager.io/v1\n" +
@@ -230,16 +225,16 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
 
             // ===== PHASE 2: Create Aspire Project with Gateway + TLS =====
 
-            await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 10");
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 9");
 
-            output.WriteLine("Step 11: Creating Aspire starter project...");
+            output.WriteLine("Step 9: Creating Aspire starter project...");
             await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
 
             await auto.TypeAsync($"cd {projectName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 
-            output.WriteLine("Step 12: Adding Kubernetes hosting package...");
+            output.WriteLine("Step 9: Adding Kubernetes hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Kubernetes");
             await auto.EnterAsync();
             await auto.WaitForAspireAddCompletionAsync(counter);
@@ -249,7 +244,7 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
             var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
 
-            output.WriteLine($"Step 13: Modifying AppHost.cs at: {appHostFilePath}");
+            output.WriteLine($"Step 9: Modifying AppHost.cs at: {appHostFilePath}");
 
             var content = File.ReadAllText(appHostFilePath);
 
@@ -295,13 +290,13 @@ builder.Build().Run();
             // ===== PHASE 3: Deploy with aspire deploy =====
 
             // Refresh ACR login
-            output.WriteLine("Step 14: Refreshing ACR login...");
+            output.WriteLine("Step 9: Refreshing ACR login...");
             await auto.TypeAsync($"az acr login --name {acrName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
             // Set parameters as environment variables so aspire deploy doesn't prompt
-            output.WriteLine("Step 15: Setting deployment parameters...");
+            output.WriteLine("Step 9: Setting deployment parameters...");
             await auto.TypeAsync(
                 $"export Parameters__registryendpoint={acrName}.azurecr.io && " +
                 $"export Parameters__namespace={k8sNamespace} && " +
@@ -310,7 +305,7 @@ builder.Build().Run();
             await auto.WaitForSuccessPromptAsync(counter);
 
             // Deploy using aspire deploy
-            output.WriteLine("Step 16: Running aspire deploy...");
+            output.WriteLine("Step 9: Running aspire deploy...");
             await auto.TypeAsync("aspire deploy");
             await auto.EnterAsync();
             await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(15));
@@ -319,7 +314,7 @@ builder.Build().Run();
             // ===== PHASE 4: Verify Gateway TLS =====
 
             // Wait for pods
-            output.WriteLine("Step 17: Waiting for pods...");
+            output.WriteLine("Step 9: Waiting for pods...");
             await auto.TypeAsync($"kubectl wait --for=condition=Ready pod --all -n {k8sNamespace} --timeout=300s");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
@@ -329,7 +324,7 @@ builder.Build().Run();
             await auto.WaitForSuccessPromptAsync(counter);
 
             // Check Gateway has address
-            output.WriteLine("Step 18: Checking Gateway address...");
+            output.WriteLine("Step 9: Checking Gateway address...");
             await auto.TypeAsync(
                 $"for i in $(seq 1 30); do " +
                 $"FQDN=$(kubectl get gateway ingress -n {k8sNamespace} -o jsonpath='{{.status.addresses[0].value}}' 2>/dev/null); " +
@@ -338,7 +333,7 @@ builder.Build().Run();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
 
             // Check HTTPS listener has hostname (patched by FQDN discovery step)
-            output.WriteLine("Step 19: Checking HTTPS listener hostname...");
+            output.WriteLine("Step 9: Checking HTTPS listener hostname...");
             await auto.TypeAsync(
                 $"kubectl get gateway ingress -n {k8sNamespace} " +
                 "-o jsonpath='{range .spec.listeners[*]}{.name} {.protocol} {.hostname}{\"\\n\"}{end}'");
@@ -346,7 +341,7 @@ builder.Build().Run();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
             // Wait for certificate
-            output.WriteLine("Step 20: Waiting for TLS certificate (up to 10 minutes)...");
+            output.WriteLine("Step 9: Waiting for TLS certificate (up to 10 minutes)...");
             await auto.TypeAsync(
                 $"for i in $(seq 1 60); do " +
                 $"READY=$(kubectl get certificate -n {k8sNamespace} -o jsonpath='{{.items[0].status.conditions[?(@.type==\"Ready\")].status}}' 2>/dev/null); " +
@@ -357,7 +352,7 @@ builder.Build().Run();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(12));
 
             // Test HTTPS access
-            output.WriteLine("Step 21: Testing HTTPS access...");
+            output.WriteLine("Step 9: Testing HTTPS access...");
             await auto.TypeAsync(
                 $"FQDN=$(kubectl get gateway ingress -n {k8sNamespace} -o jsonpath='{{.status.addresses[0].value}}') && " +
                 "echo \"Testing: https://$FQDN\" && " +
@@ -370,7 +365,7 @@ builder.Build().Run();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
             // Verify via port-forward (confirms app is running regardless of external TLS)
-            output.WriteLine("Step 22: Verifying app via port-forward...");
+            output.WriteLine("Step 9: Verifying app via port-forward...");
             await auto.TypeAsync($"kubectl port-forward svc/webfrontend-service 18081:8080 -n {k8sNamespace} &");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
@@ -393,7 +388,7 @@ builder.Build().Run();
 
             // ===== PHASE 5: Cleanup =====
 
-            output.WriteLine("Step 23: Destroying deployment...");
+            output.WriteLine("Step 9: Destroying deployment...");
             await auto.AspireDestroyAsync(counter);
 
             await auto.TypeAsync("exit");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -267,6 +267,17 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
 
             var content = File.ReadAllText(appHostFilePath);
 
+            // The starter template doesn't assign webfrontend to a variable.
+            // Insert "var webfrontend = " before the AddProject("webfrontend") call.
+            content = content.Replace(
+                "builder.AddProject<Projects.",
+                "var __proj__ = builder.AddProject<Projects.");
+            // The apiService line already has "var apiService = " so it became
+            // "var apiService = var __proj__ = ..." — fix it back:
+            content = content.Replace("var apiService = var __proj__ = ", "var apiService = ");
+            // Rename the webfrontend capture to the actual name:
+            content = content.Replace("var __proj__ = ", "var webfrontend = ");
+
             var buildRunPattern = "builder.Build().Run();";
             var replacement = $$"""
 // Kubernetes environment with Gateway API + TLS (no hostname — FQDN auto-discovered)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -1,0 +1,477 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end test for deploying an Aspire application to a pre-created AKS cluster
+/// with Kubernetes Gateway API + TLS using <c>AddKubernetesEnvironment</c> and <c>AddGateway</c>.
+/// The test creates the AKS cluster with ALB controller and Gateway API support, installs
+/// cert-manager with a Let's Encrypt HTTP-01 ClusterIssuer (gatewayHTTPRoute solver), then
+/// uses <c>aspire deploy</c> with <c>WithTls()</c> (no hostname). It verifies that:
+/// 1. The Gateway gets an FQDN assigned by AGC
+/// 2. The FQDN discovery pipeline step patches the hostname onto the HTTPS listener
+/// 3. cert-manager issues a real TLS certificate via HTTP-01
+/// 4. The app is accessible via port-forward and over HTTPS
+/// </summary>
+public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output)
+{
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(60);
+
+    [Fact]
+    public async Task DeployStarterWithGatewayTlsToKubernetes()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterWithGatewayTlsToKubernetesCore(cancellationToken);
+    }
+
+    private async Task DeployStarterWithGatewayTlsToKubernetesCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("k8sgwtls");
+        var clusterName = $"aks-{DeploymentE2ETestHelpers.GetRunId()}-{DeploymentE2ETestHelpers.GetRunAttempt()}";
+        var acrName = $"acrgw{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
+        acrName = new string(acrName.Where(char.IsLetterOrDigit).Take(50).ToArray());
+        if (acrName.Length < 5)
+        {
+            acrName = $"acrtest{Guid.NewGuid():N}"[..24];
+        }
+
+        var projectName = "K8sGatewayTls";
+        var k8sNamespace = "gwtls";
+
+        output.WriteLine($"Test: {nameof(DeployStarterWithGatewayTlsToKubernetes)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"AKS Cluster: {clusterName}");
+        output.WriteLine($"ACR Name: {acrName}");
+        output.WriteLine($"K8s Namespace: {k8sNamespace}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // ===== PHASE 1: Provision AKS with ALB + cert-manager =====
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            // Register resource providers for AGC + Gateway API
+            output.WriteLine("Step 2: Registering resource providers...");
+            await auto.TypeAsync(
+                "az provider register --namespace Microsoft.ContainerService --wait && " +
+                "az provider register --namespace Microsoft.ContainerRegistry --wait && " +
+                "az provider register --namespace Microsoft.Network --wait && " +
+                "az provider register --namespace Microsoft.NetworkFunction --wait && " +
+                "az provider register --namespace Microsoft.ServiceNetworking --wait");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            await auto.TypeAsync(
+                "az feature register --namespace Microsoft.ContainerService --name ManagedGatewayAPIPreview 2>/dev/null || true && " +
+                "az feature register --namespace Microsoft.ContainerService --name ApplicationLoadBalancerPreview 2>/dev/null || true && " +
+                "az provider register --namespace Microsoft.ContainerService");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            await auto.TypeAsync("az extension add --name alb --yes 2>/dev/null || true && az extension add --name aks-preview --yes 2>/dev/null || true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Create resource group
+            output.WriteLine("Step 3: Creating resource group...");
+            await auto.TypeAsync($"az group create --name {resourceGroupName} --location westus3 --output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Create ACR
+            output.WriteLine("Step 4: Creating ACR...");
+            await auto.TypeAsync($"az acr create --resource-group {resourceGroupName} --name {acrName} --sku Basic --output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            // Login to ACR early (OIDC token expires during AKS creation)
+            await auto.TypeAsync($"az acr login --name {acrName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Create AKS with OIDC + workload identity (required for ALB controller)
+            output.WriteLine("Step 5: Creating AKS cluster (10-15 minutes)...");
+            await auto.TypeAsync(
+                $"az aks create " +
+                $"--resource-group {resourceGroupName} " +
+                $"--name {clusterName} " +
+                $"--node-count 1 " +
+                $"--node-vm-size Standard_D2s_v3 " +
+                $"--generate-ssh-keys " +
+                $"--attach-acr {acrName} " +
+                $"--enable-managed-identity " +
+                $"--enable-oidc-issuer " +
+                $"--enable-workload-identity " +
+                $"--output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(20));
+
+            // Enable ALB controller addon
+            output.WriteLine("Step 6: Enabling ALB controller...");
+            await auto.TypeAsync($"az aks update --resource-group {resourceGroupName} --name {clusterName} --enable-alb");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(10));
+
+            // Get credentials
+            await auto.TypeAsync($"az aks get-credentials --resource-group {resourceGroupName} --name {clusterName} --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Create ALB subnet + ApplicationLoadBalancer CRD
+            output.WriteLine("Step 7: Creating ALB subnet and ApplicationLoadBalancer...");
+            await auto.TypeAsync(
+                $"MC_RG=$(az aks show -g {resourceGroupName} -n {clusterName} --query nodeResourceGroup -o tsv) && " +
+                "VNET_NAME=$(az network vnet list -g $MC_RG --query '[0].name' -o tsv) && " +
+                "az network vnet subnet create -g $MC_RG --vnet-name $VNET_NAME --name subnet-alb " +
+                "--address-prefix 10.237.0.0/24 --delegations Microsoft.ServiceNetworking/trafficControllers && " +
+                "SUBNET_ID=$(az network vnet subnet show -g $MC_RG --vnet-name $VNET_NAME --name subnet-alb --query id -o tsv) && " +
+                "echo \"Subnet: $SUBNET_ID\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            await auto.TypeAsync(
+                "cat <<EOF | kubectl apply -f -\n" +
+                "apiVersion: alb.networking.azure.io/v1\n" +
+                "kind: ApplicationLoadBalancer\n" +
+                "metadata:\n" +
+                "  name: alb-aspire\n" +
+                "  namespace: default\n" +
+                "spec:\n" +
+                "  associations:\n" +
+                "  - $SUBNET_ID\n" +
+                "EOF");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Wait for ALB ready
+            await auto.TypeAsync(
+                "for i in $(seq 1 60); do " +
+                "STATUS=$(kubectl get applicationloadbalancer alb-aspire -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' 2>/dev/null); " +
+                "[ \"$STATUS\" = \"True\" ] && echo 'ALB Ready' && break; sleep 5; done");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            // Install cert-manager with Gateway API support
+            output.WriteLine("Step 8: Installing cert-manager...");
+            await auto.TypeAsync(
+                "helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager " +
+                "--namespace cert-manager --create-namespace " +
+                "--set crds.enabled=true --set config.enableGatewayAPI=true --wait");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            // Create HTTP-01 ClusterIssuer
+            output.WriteLine("Step 9: Creating HTTP-01 ClusterIssuer...");
+            await auto.TypeAsync(
+                "cat <<EOF | kubectl apply -f -\n" +
+                "apiVersion: cert-manager.io/v1\n" +
+                "kind: ClusterIssuer\n" +
+                "metadata:\n" +
+                "  name: letsencrypt-http01\n" +
+                "spec:\n" +
+                "  acme:\n" +
+                "    server: https://acme-v02.api.letsencrypt.org/directory\n" +
+                "    email: aspire-e2e-test@microsoft.com\n" +
+                "    privateKeySecretRef:\n" +
+                "      name: letsencrypt-http01-account-key\n" +
+                "    solvers:\n" +
+                "    - http01:\n" +
+                "        gatewayHTTPRoute:\n" +
+                "          parentRefs:\n" +
+                "          - kind: Gateway\n" +
+                "EOF");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync("kubectl get clusterissuer letsencrypt-http01");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(15));
+
+            // ===== PHASE 2: Create Aspire Project with Gateway + TLS =====
+
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 10");
+
+            output.WriteLine("Step 11: Creating Aspire starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 12: Adding Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Kubernetes");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Modify AppHost.cs: AddKubernetesEnvironment + AddGateway + WithTls (no hostname)
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Step 13: Modifying AppHost.cs at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+
+            var buildRunPattern = "builder.Build().Run();";
+            var replacement = $$"""
+// Kubernetes environment with Gateway API + TLS (no hostname — FQDN auto-discovered)
+var registryEndpoint = builder.AddParameter("registryendpoint");
+var registry = builder.AddContainerRegistry("registry", registryEndpoint);
+
+var k8s = builder.AddKubernetesEnvironment("k8s")
+    .WithHelm(helm =>
+    {
+        helm.WithNamespace(builder.AddParameter("namespace"));
+        helm.WithChartVersion(builder.AddParameter("chartversion"));
+    });
+
+var gateway = k8s.AddGateway("ingress")
+    .WithGatewayClass("azure-alb-external")
+    .WithGatewayAnnotation("alb.networking.azure.io/alb-name", "alb-aspire")
+    .WithGatewayAnnotation("alb.networking.azure.io/alb-namespace", "default")
+    .WithGatewayAnnotation("cert-manager.io/cluster-issuer", "letsencrypt-http01")
+    .WithRoute("/", webfrontend.GetEndpoint("http"))
+    .WithTls();
+
+builder.Build().Run();
+""";
+
+            content = content.Replace(buildRunPattern, replacement);
+
+            if (!content.Contains("#pragma warning disable ASPIREPIPELINES001"))
+            {
+                content = "#pragma warning disable ASPIREPIPELINES001\n" + content;
+            }
+
+            File.WriteAllText(appHostFilePath, content);
+            output.WriteLine("Modified AppHost.cs with AddKubernetesEnvironment + AddGateway + WithTls");
+
+            // Navigate to AppHost dir
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // ===== PHASE 3: Deploy with aspire deploy =====
+
+            // Refresh ACR login
+            output.WriteLine("Step 14: Refreshing ACR login...");
+            await auto.TypeAsync($"az acr login --name {acrName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Set parameters as environment variables so aspire deploy doesn't prompt
+            output.WriteLine("Step 15: Setting deployment parameters...");
+            await auto.TypeAsync(
+                $"export Parameters__registryendpoint={acrName}.azurecr.io && " +
+                $"export Parameters__namespace={k8sNamespace} && " +
+                "export Parameters__chartversion=0.1.0");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Deploy using aspire deploy
+            output.WriteLine("Step 16: Running aspire deploy...");
+            await auto.TypeAsync("aspire deploy");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(15));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // ===== PHASE 4: Verify Gateway TLS =====
+
+            // Wait for pods
+            output.WriteLine("Step 17: Waiting for pods...");
+            await auto.TypeAsync($"kubectl wait --for=condition=Ready pod --all -n {k8sNamespace} --timeout=300s");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            await auto.TypeAsync($"kubectl get pods -n {k8sNamespace}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Check Gateway has address
+            output.WriteLine("Step 18: Checking Gateway address...");
+            await auto.TypeAsync(
+                $"for i in $(seq 1 30); do " +
+                $"FQDN=$(kubectl get gateway ingress -n {k8sNamespace} -o jsonpath='{{.status.addresses[0].value}}' 2>/dev/null); " +
+                "[ -n \"$FQDN\" ] && echo \"Gateway FQDN: $FQDN\" && break; sleep 5; done");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            // Check HTTPS listener has hostname (patched by FQDN discovery step)
+            output.WriteLine("Step 19: Checking HTTPS listener hostname...");
+            await auto.TypeAsync(
+                $"kubectl get gateway ingress -n {k8sNamespace} " +
+                "-o jsonpath='{range .spec.listeners[*]}{.name} {.protocol} {.hostname}{\"\\n\"}{end}'");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Wait for certificate
+            output.WriteLine("Step 20: Waiting for TLS certificate (up to 10 minutes)...");
+            await auto.TypeAsync(
+                $"for i in $(seq 1 60); do " +
+                $"READY=$(kubectl get certificate -n {k8sNamespace} -o jsonpath='{{.items[0].status.conditions[?(@.type==\"Ready\")].status}}' 2>/dev/null); " +
+                "[ \"$READY\" = \"True\" ] && echo 'Certificate Ready!' && break; " +
+                "echo \"Attempt $i: waiting...\"; sleep 10; done && " +
+                $"kubectl get certificate -n {k8sNamespace}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(12));
+
+            // Test HTTPS access
+            output.WriteLine("Step 21: Testing HTTPS access...");
+            await auto.TypeAsync(
+                $"FQDN=$(kubectl get gateway ingress -n {k8sNamespace} -o jsonpath='{{.status.addresses[0].value}}') && " +
+                "echo \"Testing: https://$FQDN\" && " +
+                "OK=0; for i in $(seq 1 10); do sleep 5; " +
+                "S=$(curl -so /dev/null -w '%{http_code}' -m 10 https://$FQDN/ 2>/dev/null); " +
+                "[ \"$S\" = \"200\" ] && echo \"HTTPS $S OK\" && OK=1 && break; " +
+                "echo \"Attempt $i: $S\"; done; " +
+                "[ \"$OK\" = \"1\" ] || echo 'WARN: HTTPS not 200 yet (cert may still be provisioning)'");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Verify via port-forward (confirms app is running regardless of external TLS)
+            output.WriteLine("Step 22: Verifying app via port-forward...");
+            await auto.TypeAsync($"kubectl port-forward svc/webfrontend-service 18081:8080 -n {k8sNamespace} &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync("sleep 3");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 10); do sleep 3 && " +
+                "curl -sf http://localhost:18081/ -o /dev/null -w '%{http_code}' && " +
+                "echo ' OK' && OK=1 && break; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: webfrontend unreachable'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            await auto.TypeAsync("kill %1 2>/dev/null; true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // ===== PHASE 5: Cleanup =====
+
+            output.WriteLine("Step 23: Destroying deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Gateway TLS deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterWithGatewayTlsToKubernetes),
+                resourceGroupName,
+                new Dictionary<string, string>
+                {
+                    ["cluster"] = clusterName,
+                    ["acr"] = acrName,
+                    ["project"] = projectName
+                },
+                duration);
+
+            output.WriteLine("✅ Test passed - Aspire app deployed with Gateway API TLS via HTTP-01!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterWithGatewayTlsToKubernetes),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+
+    private async Task CleanupResourceGroupAsync(string resourceGroupName)
+    {
+        try
+        {
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "az",
+                    Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                }
+            };
+
+            process.Start();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode == 0)
+            {
+                output.WriteLine($"Resource group deletion initiated: {resourceGroupName}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Deletion initiated");
+            }
+            else
+            {
+                var error = await process.StandardError.ReadToEndAsync();
+                output.WriteLine($"Resource group deletion may have failed (exit code {process.ExitCode}): {error}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, $"Exit code {process.ExitCode}: {error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to cleanup resource group: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -157,10 +157,19 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
             // Verify ALB controller is running and GatewayClass exists
-            output.WriteLine("Step 6: Verifying ALB controller and GatewayClass...");
-            await auto.TypeAsync("kubectl get pods -n kube-system | grep alb-controller && kubectl get gatewayclass azure-alb-external");
+            // The ALB controller pods may still be initializing after cluster creation,
+            // so poll until they are running and the GatewayClass is available.
+            output.WriteLine("Step 6: Waiting for ALB controller and GatewayClass...");
+            await auto.TypeAsync(
+                "for i in $(seq 1 60); do " +
+                "READY=$(kubectl get pods -n kube-system -l app=alb-controller -o jsonpath='{.items[0].status.phase}' 2>/dev/null); " +
+                "[ \"$READY\" = \"Running\" ] && kubectl get gatewayclass azure-alb-external >/dev/null 2>&1 && " +
+                "echo 'ALB controller running and GatewayClass available' && break; " +
+                "echo \"Attempt $i: ALB controller status=$READY, waiting...\"; sleep 10; done && " +
+                "kubectl get pods -n kube-system | grep alb-controller && " +
+                "kubectl get gatewayclass azure-alb-external");
             await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(10));
 
             // Create ApplicationLoadBalancer CRD using the add-on's auto-created subnet
             output.WriteLine("Step 7: Creating ApplicationLoadBalancer...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -232,6 +232,8 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
                 "        gatewayHTTPRoute:\n" +
                 "          parentRefs:\n" +
                 "          - kind: Gateway\n" +
+                $"            name: ingress\n" +
+                $"            namespace: {k8sNamespace}\n" +
                 "EOF");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -261,12 +261,12 @@ public class KubernetesGatewayTests
         // The HTTPS listener should NOT have a hostname field (since no WithHostname was called)
         // Verify it has the listener but the hostname line should not appear after HTTPS
         var lines = content.Split('\n').Select(l => l.Trim()).ToList();
-        var httpsIndex = lines.FindIndex(l => l.Contains("protocol: HTTPS"));
-        Assert.True(httpsIndex >= 0, "HTTPS listener not found");
+        var httpsIndex = lines.FindIndex(l => l.Contains("protocol:") && l.Contains("HTTPS"));
+        Assert.True(httpsIndex >= 0, "HTTPS listener not found in:\n" + content);
 
         // Find the next listener or end of listeners to check there's no hostname
         var nextListenerOrEnd = lines.FindIndex(httpsIndex + 1, l => l.StartsWith("- name:") || l == "");
         var httpsSection = lines.Skip(httpsIndex).Take((nextListenerOrEnd > httpsIndex ? nextListenerOrEnd : lines.Count) - httpsIndex);
-        Assert.DoesNotContain(httpsSection, l => l.StartsWith("hostname:"));
+        Assert.DoesNotContain(httpsSection, l => l.StartsWith("hostname:") || l.StartsWith("hostname "));
     }
 }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -227,4 +227,46 @@ public class KubernetesGatewayTests
         Assert.DoesNotContain(files, f => f.Contains("gateway", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(files, f => f.Contains("route", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public async Task AddGateway_WithTls_NoHostname_GeneratesHttpsListenerWithoutHostname()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("azure-alb-external");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        // WithTls() without WithHostname() — should still generate an HTTPS listener
+        gateway
+            .WithRoute("/", api.GetEndpoint("http"))
+            .WithTls("my-tls-secret");
+
+        var app = builder.Build();
+        app.Run();
+
+        // Check Gateway has HTTPS listener without a hostname
+        var gatewayFile = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(gatewayFile);
+
+        Assert.Contains("HTTPS", content);
+        Assert.Contains("Terminate", content);
+        Assert.Contains("my-tls-secret", content);
+        // Should also have HTTP listener
+        Assert.Contains("HTTP", content);
+
+        // The HTTPS listener should NOT have a hostname field (since no WithHostname was called)
+        // Verify it has the listener but the hostname line should not appear after HTTPS
+        var lines = content.Split('\n').Select(l => l.Trim()).ToList();
+        var httpsIndex = lines.FindIndex(l => l.Contains("protocol: HTTPS"));
+        Assert.True(httpsIndex >= 0, "HTTPS listener not found");
+
+        // Find the next listener or end of listeners to check there's no hostname
+        var nextListenerOrEnd = lines.FindIndex(httpsIndex + 1, l => l.StartsWith("- name:") || l == "");
+        var httpsSection = lines.Skip(httpsIndex).Take((nextListenerOrEnd > httpsIndex ? nextListenerOrEnd : lines.Count) - httpsIndex);
+        Assert.DoesNotContain(httpsSection, l => l.StartsWith("hostname:"));
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds support for Gateway TLS without a pre-known hostname and fixes endpoint resource lookup for TypeScript AppHosts.

### 1. Gateway TLS without pre-known hostname (FQDN auto-discovery)

When `WithTls()` is called without `WithHostname()`, the Gateway now:
1. Generates an HTTPS listener **without** a hostname restriction
2. After Helm deploy, a new `tls-fqdn-discovery` pipeline step polls `kubectl get gateway` for the assigned address (up to 5 min)
3. Discovers Hostname-type addresses, dynamically finds HTTPS listeners without hostnames, and patches them with the discovered FQDN
4. Creates a bootstrap self-signed TLS secret (with SAN) with the discovered FQDN
5. cert-manager then detects the hostname on the listener and issues a real certificate

This enables single-deploy TLS for controllers like AGC that assign FQDNs automatically (e.g., `*.alb.azure.com`).

### 2. Helm field manager conflict fix

After patching the Gateway hostname, re-applies a minimal Gateway manifest (apiVersion, kind, metadata with annotations/labels, spec — no server fields) with `--server-side --field-manager=helm --force-conflicts` to transfer field ownership back to Helm. This prevents SSA conflicts when the user later redeploys with an explicit hostname via `WithHostname()`.

### 3. TypeScript AppHost endpoint resource lookup fix

Uses `ResourceNameComparer` on the `deploymentTargets` dictionary so that endpoint references created through the TypeScript AppHost RPC bridge (which may use a different resource instance) resolve correctly by resource name. This matches the pattern already used in `KubernetesEnvironmentContext._kubernetesComponents`.

## Testing

- All 116 K8S tests pass
- New test: `AddGateway_WithTls_NoHostname_GeneratesHttpsListenerWithoutHostname`
- Tested on AKS cluster with AGC: Gateway TLS with hostname + HTTP-01 cert-manager
- Tested TS AppHost with Gateway route — HTTPRoute now correctly generated