### PR TITLE
Improve confirm prompt UX in ConsoleInteractionService

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -542,7 +542,7 @@ internal class ConsoleInteractionService : IInteractionService
 
             if (key.Key == ConsoleKey.Enter || key.KeyChar is '\r' or '\n')
             {
-                MessageConsole.WriteLine(yesChoice.ToString()); // Echo the default choice
+                MessageConsole.WriteLine((defaultValue ? yesChoice : noChoice).ToString()); // Echo the default choice
                 return defaultValue;
             }
 

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -529,34 +529,32 @@ internal class ConsoleInteractionService : IInteractionService
     private async Task<bool> PromptConfirmWithSingleKeyAsync(string promptText, char yesChoice, char noChoice, bool defaultValue, CancellationToken cancellationToken)
     {
         MessageConsole.Markup(promptText);
-        MessageConsole.Write($" [{yesChoice}/{noChoice}] ");
+        MessageConsole.Markup($" [blue][[{yesChoice}/{noChoice}]][/]: ");
 
         while (true)
         {
-            var key = await MessageConsole.Input.ReadKeyAsync(intercept: true, cancellationToken);
-            if (key is null)
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (await MessageConsole.Input.ReadKeyAsync(intercept: true, cancellationToken) is not { } key)
             {
-                MessageConsole.WriteLine();
+                continue;
+            }
+
+            if (key.Key == ConsoleKey.Enter || key.KeyChar is '\r' or '\n')
+            {
+                MessageConsole.WriteLine(yesChoice.ToString()); // Echo the default choice
                 return defaultValue;
             }
 
-            if (key.Value.Key == ConsoleKey.Enter || key.Value.KeyChar is '\r' or '\n')
+            if (char.ToLowerInvariant(key.KeyChar) == char.ToLowerInvariant(yesChoice))
             {
-                MessageConsole.WriteLine();
-                return defaultValue;
-            }
-
-            if (key.Value.Key == ConsoleKey.Y || key.Value.KeyChar is 'y' or 'Y')
-            {
-                var echoedChoice = key.Value.KeyChar is 'y' or 'Y' ? key.Value.KeyChar : yesChoice;
-                MessageConsole.WriteLine(echoedChoice.ToString());
+                MessageConsole.WriteLine(key.KeyChar.ToString());
                 return true;
             }
 
-            if (key.Value.Key == ConsoleKey.N || key.Value.KeyChar is 'n' or 'N')
+            if (char.ToLowerInvariant(key.KeyChar) == char.ToLowerInvariant(noChoice))
             {
-                var echoedChoice = key.Value.KeyChar is 'n' or 'N' ? key.Value.KeyChar : noChoice;
-                MessageConsole.WriteLine(echoedChoice.ToString());
+                MessageConsole.WriteLine(key.KeyChar.ToString());
                 return false;
             }
         }


### PR DESCRIPTION
## Description

Improves the confirm prompt UX in `ConsoleInteractionService.PromptConfirmWithSingleKeyAsync`:

- Style `[Y/n]` choices in blue with a trailing colon for visual clarity
- Match key input against `yesChoice`/`noChoice` parameters (case-insensitive) instead of hardcoded `Y`/`N` characters, making the method properly generic
- Use `is not { } key` pattern matching to unwrap the nullable `ReadKeyAsync` result, eliminating `.Value` accesses
- Continue looping on null key (stdin EOF) instead of silently returning default
- Echo the default choice character when Enter is pressed

Before: 
<img width="919" height="44" alt="image" src="https://github.com/user-attachments/assets/a3a2f793-283b-40df-b466-db4f10b52f29" />

After:
<img width="930" height="45" alt="image" src="https://github.com/user-attachments/assets/ac7840db-0fa4-48ec-a930-b07997824b2a" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
