### PR TITLE
Fix TypeScript AppHost package manager detection

### DIFF
--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1385,7 +1385,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             var runtimeSpec = await rpcClient.GetRuntimeSpecAsync(_resolvedLanguage.LanguageId, cancellationToken);
             if (TypeScriptAppHostToolchainResolver.IsTypeScriptLanguage(_resolvedLanguage))
             {
-                var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory);
+                var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory, _logger);
                 runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain);
             }
 

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -71,11 +71,6 @@ internal static class TypeScriptAppHostToolchainResolver
                 return CreateLockFileResolution(TypeScriptAppHostToolchain.Pnpm, PnpmLockFileName, candidateDirectory);
             }
 
-            if (File.Exists(Path.Combine(candidateDirectory.FullName, PackageLockFileName)))
-            {
-                return CreateLockFileResolution(TypeScriptAppHostToolchain.Npm, PackageLockFileName, candidateDirectory);
-            }
-
             if (File.Exists(Path.Combine(candidateDirectory.FullName, YarnLockFileName)))
             {
                 return CreateLockFileResolution(TypeScriptAppHostToolchain.Yarn, YarnLockFileName, candidateDirectory);
@@ -89,6 +84,11 @@ internal static class TypeScriptAppHostToolchainResolver
             if (Directory.Exists(Path.Combine(candidateDirectory.FullName, YarnDirectoryName)))
             {
                 return CreateLockFileResolution(TypeScriptAppHostToolchain.Yarn, YarnDirectoryName, candidateDirectory);
+            }
+
+            if (File.Exists(Path.Combine(candidateDirectory.FullName, PackageLockFileName)))
+            {
+                return CreateLockFileResolution(TypeScriptAppHostToolchain.Npm, PackageLockFileName, candidateDirectory);
             }
         }
 

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -25,7 +25,6 @@ internal static class TypeScriptAppHostToolchainResolver
     private const string BunBinaryLockFileName = "bun.lockb";
     private const string YarnLockFileName = "yarn.lock";
     private const string YarnConfigFileName = ".yarnrc.yml";
-    private const string YarnDirectoryName = ".yarn";
     private const string PackageLockFileName = "package-lock.json";
     private const string PnpmLockFileName = "pnpm-lock.yaml";
 
@@ -79,11 +78,6 @@ internal static class TypeScriptAppHostToolchainResolver
             if (File.Exists(Path.Combine(candidateDirectory.FullName, YarnConfigFileName)))
             {
                 return CreateLockFileResolution(TypeScriptAppHostToolchain.Yarn, YarnConfigFileName, candidateDirectory);
-            }
-
-            if (Directory.Exists(Path.Combine(candidateDirectory.FullName, YarnDirectoryName)))
-            {
-                return CreateLockFileResolution(TypeScriptAppHostToolchain.Yarn, YarnDirectoryName, candidateDirectory);
             }
 
             if (File.Exists(Path.Combine(candidateDirectory.FullName, PackageLockFileName)))

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Utils;
 using Aspire.TypeSystem;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Projects;
 
@@ -19,14 +20,13 @@ internal enum TypeScriptAppHostToolchain
 
 internal static class TypeScriptAppHostToolchainResolver
 {
-    internal const int MaxParentSearchDepth = 8;
-
     private const string PackageJsonFileName = "package.json";
     private const string BunLockFileName = "bun.lock";
     private const string BunBinaryLockFileName = "bun.lockb";
     private const string YarnLockFileName = "yarn.lock";
     private const string YarnConfigFileName = ".yarnrc.yml";
     private const string YarnDirectoryName = ".yarn";
+    private const string PackageLockFileName = "package-lock.json";
     private const string PnpmLockFileName = "pnpm-lock.yaml";
 
     public static bool IsTypeScriptLanguage(LanguageInfo? language)
@@ -36,35 +36,63 @@ internal static class TypeScriptAppHostToolchainResolver
              language.LanguageId.Value.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase));
     }
 
-    public static TypeScriptAppHostToolchain Resolve(DirectoryInfo appHostDirectory)
+    public static TypeScriptAppHostToolchain Resolve(DirectoryInfo appHostDirectory, ILogger? logger = null)
+    {
+        var resolution = ResolveWithReason(appHostDirectory);
+        logger?.LogDebug(
+            "Selected TypeScript AppHost package manager '{PackageManager}' because {Reason}.",
+            GetCommandName(resolution.Toolchain),
+            resolution.Reason);
+
+        return resolution.Toolchain;
+    }
+
+    internal static TypeScriptAppHostToolchainResolution ResolveWithReason(DirectoryInfo appHostDirectory)
     {
         foreach (var candidateDirectory in EnumerateCandidateDirectories(appHostDirectory))
         {
-            if (TryGetToolchainFromPackageJson(candidateDirectory, out var configuredToolchain))
+            if (TryGetToolchainFromPackageJson(candidateDirectory, out var configuredToolchain, out var reason))
             {
-                return configuredToolchain;
+                return new(configuredToolchain, reason);
             }
 
-            if (File.Exists(Path.Combine(candidateDirectory.FullName, BunLockFileName)) ||
-                File.Exists(Path.Combine(candidateDirectory.FullName, BunBinaryLockFileName)))
+            if (File.Exists(Path.Combine(candidateDirectory.FullName, BunLockFileName)))
             {
-                return TypeScriptAppHostToolchain.Bun;
+                return CreateLockFileResolution(TypeScriptAppHostToolchain.Bun, BunLockFileName, candidateDirectory);
+            }
+
+            if (File.Exists(Path.Combine(candidateDirectory.FullName, BunBinaryLockFileName)))
+            {
+                return CreateLockFileResolution(TypeScriptAppHostToolchain.Bun, BunBinaryLockFileName, candidateDirectory);
             }
 
             if (File.Exists(Path.Combine(candidateDirectory.FullName, PnpmLockFileName)))
             {
-                return TypeScriptAppHostToolchain.Pnpm;
+                return CreateLockFileResolution(TypeScriptAppHostToolchain.Pnpm, PnpmLockFileName, candidateDirectory);
             }
 
-            if (File.Exists(Path.Combine(candidateDirectory.FullName, YarnLockFileName)) ||
-                File.Exists(Path.Combine(candidateDirectory.FullName, YarnConfigFileName)) ||
-                Directory.Exists(Path.Combine(candidateDirectory.FullName, YarnDirectoryName)))
+            if (File.Exists(Path.Combine(candidateDirectory.FullName, PackageLockFileName)))
             {
-                return TypeScriptAppHostToolchain.Yarn;
+                return CreateLockFileResolution(TypeScriptAppHostToolchain.Npm, PackageLockFileName, candidateDirectory);
+            }
+
+            if (File.Exists(Path.Combine(candidateDirectory.FullName, YarnLockFileName)))
+            {
+                return CreateLockFileResolution(TypeScriptAppHostToolchain.Yarn, YarnLockFileName, candidateDirectory);
+            }
+
+            if (File.Exists(Path.Combine(candidateDirectory.FullName, YarnConfigFileName)))
+            {
+                return CreateLockFileResolution(TypeScriptAppHostToolchain.Yarn, YarnConfigFileName, candidateDirectory);
+            }
+
+            if (Directory.Exists(Path.Combine(candidateDirectory.FullName, YarnDirectoryName)))
+            {
+                return CreateLockFileResolution(TypeScriptAppHostToolchain.Yarn, YarnDirectoryName, candidateDirectory);
             }
         }
 
-        return TypeScriptAppHostToolchain.Npm;
+        return new(TypeScriptAppHostToolchain.Npm, $"no package manager marker found in {appHostDirectory.FullName} or an eligible parent directory");
     }
 
     public static string[] GetRequiredCommands(TypeScriptAppHostToolchain toolchain)
@@ -219,12 +247,12 @@ internal static class TypeScriptAppHostToolchainResolver
         return "tsconfig.apphost.json";
     }
 
-    private static bool TryGetToolchainFromPackageJson(DirectoryInfo appHostDirectory, out TypeScriptAppHostToolchain toolchain)
+    private static bool TryGetToolchainFromPackageJson(DirectoryInfo appHostDirectory, out TypeScriptAppHostToolchain toolchain, out string reason)
     {
         var packageJsonPath = Path.Combine(appHostDirectory.FullName, PackageJsonFileName);
         if (!File.Exists(packageJsonPath))
         {
-            return SetUnknownToolchain(out toolchain);
+            return SetUnknownToolchain(out toolchain, out reason);
         }
 
         try
@@ -234,17 +262,23 @@ internal static class TypeScriptAppHostToolchainResolver
                 !packageManagerValue.TryGetValue<string>(out var packageManager) ||
                 string.IsNullOrWhiteSpace(packageManager))
             {
-                return SetUnknownToolchain(out toolchain);
+                return SetUnknownToolchain(out toolchain, out reason);
             }
 
             var packageManagerName = packageManager.Split('@', 2)[0];
-            return TryParseToolchain(packageManagerName, out toolchain);
+            if (TryParseToolchain(packageManagerName, out toolchain))
+            {
+                reason = $"packageManager '{packageManager}' found in {packageJsonPath}";
+                return true;
+            }
+
+            return SetUnknownToolchain(out toolchain, out reason);
         }
         catch (Exception ex) when (ex is JsonException or IOException
             or UnauthorizedAccessException or SecurityException
             or NotSupportedException)
         {
-            return SetUnknownToolchain(out toolchain);
+            return SetUnknownToolchain(out toolchain, out reason);
         }
     }
 
@@ -265,19 +299,39 @@ internal static class TypeScriptAppHostToolchainResolver
 
     private static IEnumerable<DirectoryInfo> EnumerateCandidateDirectories(DirectoryInfo appHostDirectory)
     {
-        // Allow nested AppHosts to pick up workspace-level lockfiles/packageManager settings
-        // without accidentally walking all the way to an unrelated parent directory.
-        var currentDirectory = appHostDirectory;
-        for (var depth = 0; currentDirectory is not null && depth <= MaxParentSearchDepth; depth++)
+        yield return appHostDirectory;
+
+        var parentDirectory = appHostDirectory.Parent;
+        if (parentDirectory is not null && ShouldSearchParentDirectory(parentDirectory))
         {
-            yield return currentDirectory;
-            currentDirectory = currentDirectory.Parent;
+            yield return parentDirectory;
         }
     }
 
-    private static bool SetUnknownToolchain(out TypeScriptAppHostToolchain toolchain)
+    internal static bool ShouldSearchParentDirectory(DirectoryInfo parentDirectory, string? homeDirectory = null)
+    {
+        var parentPath = Path.TrimEndingDirectorySeparator(parentDirectory.FullName);
+        if (string.Equals(parentPath, Path.TrimEndingDirectorySeparator(parentDirectory.Root.FullName), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        homeDirectory ??= Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return string.IsNullOrWhiteSpace(homeDirectory) ||
+            !string.Equals(parentPath, Path.TrimEndingDirectorySeparator(Path.GetFullPath(homeDirectory)), StringComparison.Ordinal);
+    }
+
+    private static TypeScriptAppHostToolchainResolution CreateLockFileResolution(TypeScriptAppHostToolchain toolchain, string markerName, DirectoryInfo directory)
+    {
+        return new(toolchain, $"{markerName} found in {directory.FullName}");
+    }
+
+    private static bool SetUnknownToolchain(out TypeScriptAppHostToolchain toolchain, out string reason)
     {
         toolchain = default;
+        reason = string.Empty;
         return false;
     }
 }
+
+internal readonly record struct TypeScriptAppHostToolchainResolution(TypeScriptAppHostToolchain Toolchain, string Reason);

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -35,7 +35,7 @@ internal static class TypeScriptAppHostToolchainResolver
              language.LanguageId.Value.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase));
     }
 
-    public static TypeScriptAppHostToolchain Resolve(DirectoryInfo appHostDirectory, ILogger? logger = null)
+    public static TypeScriptAppHostToolchain Resolve(DirectoryInfo appHostDirectory, ILogger? logger)
     {
         var resolution = ResolveWithReason(appHostDirectory);
         logger?.LogDebug(
@@ -243,10 +243,13 @@ internal static class TypeScriptAppHostToolchainResolver
 
     private static bool TryGetToolchainFromPackageJson(DirectoryInfo appHostDirectory, out TypeScriptAppHostToolchain toolchain, out string reason)
     {
+        toolchain = default;
+        reason = string.Empty;
+
         var packageJsonPath = Path.Combine(appHostDirectory.FullName, PackageJsonFileName);
         if (!File.Exists(packageJsonPath))
         {
-            return SetUnknownToolchain(out toolchain, out reason);
+            return false;
         }
 
         try
@@ -256,7 +259,7 @@ internal static class TypeScriptAppHostToolchainResolver
                 !packageManagerValue.TryGetValue<string>(out var packageManager) ||
                 string.IsNullOrWhiteSpace(packageManager))
             {
-                return SetUnknownToolchain(out toolchain, out reason);
+                return false;
             }
 
             var packageManagerName = packageManager.Split('@', 2)[0];
@@ -266,13 +269,13 @@ internal static class TypeScriptAppHostToolchainResolver
                 return true;
             }
 
-            return SetUnknownToolchain(out toolchain, out reason);
+            return false;
         }
         catch (Exception ex) when (ex is JsonException or IOException
             or UnauthorizedAccessException or SecurityException
             or NotSupportedException)
         {
-            return SetUnknownToolchain(out toolchain, out reason);
+            return false;
         }
     }
 
@@ -295,6 +298,8 @@ internal static class TypeScriptAppHostToolchainResolver
     {
         yield return appHostDirectory;
 
+        // Only use the immediate parent as a fallback so a project folder can provide
+        // workspace-level hints without inheriting unrelated markers from higher directories.
         var parentDirectory = appHostDirectory.Parent;
         if (parentDirectory is not null && ShouldSearchParentDirectory(parentDirectory))
         {
@@ -307,8 +312,11 @@ internal static class TypeScriptAppHostToolchainResolver
         var pathComparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
-        var parentPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(parentDirectory.FullName));
-        if (string.Equals(parentPath, Path.TrimEndingDirectorySeparator(Path.GetFullPath(parentDirectory.Root.FullName)), pathComparison))
+
+        // Root and home directories are not project folders. They can contain unrelated user-level
+        // files, so package manager markers there should not influence TypeScript AppHost projects.
+        var parentPath = Path.TrimEndingDirectorySeparator(parentDirectory.FullName);
+        if (string.Equals(parentPath, Path.TrimEndingDirectorySeparator(parentDirectory.Root.FullName), pathComparison))
         {
             return false;
         }
@@ -321,13 +329,6 @@ internal static class TypeScriptAppHostToolchainResolver
     private static TypeScriptAppHostToolchainResolution CreateLockFileResolution(TypeScriptAppHostToolchain toolchain, string markerName, DirectoryInfo directory)
     {
         return new(toolchain, $"{markerName} found in {directory.FullName}");
-    }
-
-    private static bool SetUnknownToolchain(out TypeScriptAppHostToolchain toolchain, out string reason)
-    {
-        toolchain = default;
-        reason = string.Empty;
-        return false;
     }
 }
 

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -310,15 +310,18 @@ internal static class TypeScriptAppHostToolchainResolver
 
     internal static bool ShouldSearchParentDirectory(DirectoryInfo parentDirectory, string? homeDirectory = null)
     {
-        var parentPath = Path.TrimEndingDirectorySeparator(parentDirectory.FullName);
-        if (string.Equals(parentPath, Path.TrimEndingDirectorySeparator(parentDirectory.Root.FullName), StringComparison.Ordinal))
+        var pathComparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var parentPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(parentDirectory.FullName));
+        if (string.Equals(parentPath, Path.TrimEndingDirectorySeparator(Path.GetFullPath(parentDirectory.Root.FullName)), pathComparison))
         {
             return false;
         }
 
         homeDirectory ??= Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         return string.IsNullOrWhiteSpace(homeDirectory) ||
-            !string.Equals(parentPath, Path.TrimEndingDirectorySeparator(Path.GetFullPath(homeDirectory)), StringComparison.Ordinal);
+            !string.Equals(parentPath, Path.TrimEndingDirectorySeparator(Path.GetFullPath(homeDirectory)), pathComparison);
     }
 
     private static TypeScriptAppHostToolchainResolution CreateLockFileResolution(TypeScriptAppHostToolchain toolchain, string markerName, DirectoryInfo directory)

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -181,7 +181,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
         var runtimeSpec = await rpcClient.GetRuntimeSpecAsync(language.LanguageId.Value, cancellationToken);
         if (TypeScriptAppHostToolchainResolver.IsTypeScriptLanguage(language))
         {
-            var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory);
+            var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory, _logger);
             runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain);
         }
 
@@ -280,14 +280,14 @@ internal sealed class ScaffoldingService : IScaffoldingService
             language.LanguageId.Value.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string GetPackageManagerCommand(DirectoryInfo directory, LanguageInfo language)
+    private string GetPackageManagerCommand(DirectoryInfo directory, LanguageInfo language)
     {
         if (!TypeScriptAppHostToolchainResolver.IsTypeScriptLanguage(language))
         {
             return "npm";
         }
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory, _logger);
         return TypeScriptAppHostToolchainResolver.GetCommandName(toolchain);
     }
 }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/TypeScriptAppHostToolingCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/TypeScriptAppHostToolingCheck.cs
@@ -48,7 +48,7 @@ internal sealed class TypeScriptAppHostToolingCheck : IEnvironmentCheck
             return [];
         }
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory, _logger);
         var missingResults = new List<EnvironmentCheckResult>();
 
         foreach (var command in TypeScriptAppHostToolchainResolver.GetRequiredCommands(toolchain))

--- a/src/Aspire.Cli/Utils/MissingJavaScriptToolWarning.cs
+++ b/src/Aspire.Cli/Utils/MissingJavaScriptToolWarning.cs
@@ -41,7 +41,7 @@ internal static class MissingJavaScriptToolWarning
     {
         if (TypeScriptAppHostToolchainResolver.IsTypeScriptLanguage(language))
         {
-            var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory);
+            var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory, logger: null);
             return (TypeScriptAppHostToolchainResolver.GetInstallCommand(toolchain), TypeScriptAppHostToolchainResolver.GetDisplayName(toolchain));
         }
 

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -66,7 +66,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
-    public void Resolve_WhenYarnDirectoryExists_ReturnsYarn()
+    public void Resolve_WhenYarnDirectoryExists_ReturnsNpm()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"name\": \"apphost\" }");
@@ -74,7 +74,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
 
         var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot);
 
-        Assert.Equal(TypeScriptAppHostToolchain.Yarn, toolchain);
+        Assert.Equal(TypeScriptAppHostToolchain.Npm, toolchain);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -52,6 +52,20 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
+    public void Resolve_WhenPackageLockAndYarnLockExistInSameDirectory_ReturnsYarn()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"name\": \"apphost\" }");
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package-lock.json"), "{}");
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "yarn.lock"), string.Empty);
+
+        var resolution = TypeScriptAppHostToolchainResolver.ResolveWithReason(workspace.WorkspaceRoot);
+
+        Assert.Equal(TypeScriptAppHostToolchain.Yarn, resolution.Toolchain);
+        Assert.Equal($"yarn.lock found in {workspace.WorkspaceRoot.FullName}", resolution.Reason);
+    }
+
+    [Fact]
     public void Resolve_WhenYarnDirectoryExists_ReturnsYarn()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -4,6 +4,8 @@
 using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.Utils;
 using Aspire.TypeSystem;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Cli.Tests.Projects;
 
@@ -33,6 +35,23 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
+    public void Resolve_WhenPackageLockExists_ReturnsNpm()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"name\": \"workspace\" }");
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "yarn.lock"), string.Empty);
+
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("apps").CreateSubdirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package.json"), "{ \"name\": \"apphost\" }");
+        File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package-lock.json"), "{}");
+
+        var resolution = TypeScriptAppHostToolchainResolver.ResolveWithReason(appHostDirectory);
+
+        Assert.Equal(TypeScriptAppHostToolchain.Npm, resolution.Toolchain);
+        Assert.Equal($"package-lock.json found in {appHostDirectory.FullName}", resolution.Reason);
+    }
+
+    [Fact]
     public void Resolve_WhenYarnDirectoryExists_ReturnsYarn()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -56,12 +75,30 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
-    public void Resolve_WhenWorkspaceRootDefinesToolchain_ReturnsParentToolchain()
+    public void Resolve_WhenMarkerExists_LogsReason()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"packageManager\": \"pnpm@10.12.1\" }");
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"name\": \"apphost\" }");
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "yarn.lock"), string.Empty);
+
+        var sink = new TestSink();
+        var logger = new TestLogger(nameof(TypeScriptAppHostToolchainResolverTests), sink, logLevel => logLevel == LogLevel.Debug);
+
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot, logger);
+
+        Assert.Equal(TypeScriptAppHostToolchain.Yarn, toolchain);
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Debug, write.LogLevel);
+        Assert.Equal($"Selected TypeScript AppHost package manager 'yarn' because yarn.lock found in {workspace.WorkspaceRoot.FullName}.", write.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenParentDirectoryDefinesToolchain_ReturnsParentToolchain()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("apps").CreateSubdirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDirectory.Parent!.FullName, "package.json"), "{ \"packageManager\": \"pnpm@10.12.1\" }");
         File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package.json"), "{ \"name\": \"apphost\" }");
 
         var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory);
@@ -70,20 +107,38 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
-    public void Resolve_WhenToolchainConfigurationIsBeyondMaxDepth_ReturnsNpm()
+    public void Resolve_WhenGrandparentDirectoryDefinesToolchain_ReturnsNpm()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"packageManager\": \"bun@1.2.0\" }");
 
-        var currentDirectory = workspace.WorkspaceRoot;
-        for (var i = 0; i < TypeScriptAppHostToolchainResolver.MaxParentSearchDepth + 1; i++)
-        {
-            currentDirectory = currentDirectory.CreateSubdirectory($"level{i}");
-        }
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("apps").CreateSubdirectory("apphost");
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(currentDirectory);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory);
 
         Assert.Equal(TypeScriptAppHostToolchain.Npm, toolchain);
+    }
+
+    [Fact]
+    public void ShouldSearchParentDirectory_WhenDirectoryIsRoot_ReturnsFalse()
+    {
+        var directory = new DirectoryInfo(Path.GetPathRoot(Path.GetTempPath())!);
+
+        var shouldSearch = TypeScriptAppHostToolchainResolver.ShouldSearchParentDirectory(directory);
+
+        Assert.False(shouldSearch);
+    }
+
+    [Fact]
+    public void ShouldSearchParentDirectory_WhenDirectoryIsHome_ReturnsFalse()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var shouldSearch = TypeScriptAppHostToolchainResolver.ShouldSearchParentDirectory(
+            workspace.WorkspaceRoot,
+            workspace.WorkspaceRoot.FullName);
+
+        Assert.False(shouldSearch);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -142,6 +142,19 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
+    public void ShouldSearchParentDirectory_WhenDirectoryIsHomeWithDifferentCasingOnCaseInsensitiveOS_ReturnsFalse()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS(), "Case-insensitive path comparison only applies to Windows and macOS.");
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var shouldSearch = TypeScriptAppHostToolchainResolver.ShouldSearchParentDirectory(
+            workspace.WorkspaceRoot,
+            InvertCasing(workspace.WorkspaceRoot.FullName));
+
+        Assert.False(shouldSearch);
+    }
+
+    [Fact]
     public void ApplyToRuntimeSpec_WhenBunSelected_UsesBunCommandsAndPreservesExtensionLaunch()
     {
         var baseRuntimeSpec = CreateBaseRuntimeSpec();
@@ -198,5 +211,10 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
             },
             ExtensionLaunchCapability = "node"
         };
+    }
+
+    private static string InvertCasing(string value)
+    {
+        return new string(value.Select(c => char.IsUpper(c) ? char.ToLowerInvariant(c) : char.ToUpperInvariant(c)).ToArray());
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -17,7 +17,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"packageManager\": \"bun@1.2.0\" }");
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot, logger: null);
 
         Assert.Equal(TypeScriptAppHostToolchain.Bun, toolchain);
     }
@@ -29,7 +29,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"name\": \"apphost\" }");
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "pnpm-lock.yaml"), "lockfileVersion: '9.0'");
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot, logger: null);
 
         Assert.Equal(TypeScriptAppHostToolchain.Pnpm, toolchain);
     }
@@ -38,10 +38,10 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     public void Resolve_WhenPackageLockExists_ReturnsNpm()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"name\": \"workspace\" }");
-        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "yarn.lock"), string.Empty);
-
         var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("apps").CreateSubdirectory("apphost");
+        var parentDirectory = appHostDirectory.Parent!;
+        File.WriteAllText(Path.Combine(parentDirectory.FullName, "package.json"), "{ \"name\": \"workspace\" }");
+        File.WriteAllText(Path.Combine(parentDirectory.FullName, "yarn.lock"), string.Empty);
         File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package.json"), "{ \"name\": \"apphost\" }");
         File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package-lock.json"), "{}");
 
@@ -72,7 +72,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"name\": \"apphost\" }");
         Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, ".yarn"));
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot, logger: null);
 
         Assert.Equal(TypeScriptAppHostToolchain.Npm, toolchain);
     }
@@ -83,7 +83,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{ \"name\": \"apphost\" }");
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(workspace.WorkspaceRoot, logger: null);
 
         Assert.Equal(TypeScriptAppHostToolchain.Npm, toolchain);
     }
@@ -115,7 +115,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
         File.WriteAllText(Path.Combine(appHostDirectory.Parent!.FullName, "package.json"), "{ \"packageManager\": \"pnpm@10.12.1\" }");
         File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package.json"), "{ \"name\": \"apphost\" }");
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory, logger: null);
 
         Assert.Equal(TypeScriptAppHostToolchain.Pnpm, toolchain);
     }
@@ -128,7 +128,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
 
         var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("apps").CreateSubdirectory("apphost");
 
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory);
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory, logger: null);
 
         Assert.Equal(TypeScriptAppHostToolchain.Npm, toolchain);
     }


### PR DESCRIPTION
TypeScript AppHost package-manager detection could accidentally inherit a distant parent `yarn.lock`, causing npm-based generated projects to run through Yarn. This is especially visible for `aspire new` TypeScript starter projects created under a repository that already has a top-level Yarn marker.

This change treats `package-lock.json` as an npm marker, limits package-manager probing to the AppHost directory plus one eligible parent, and skips parent probing when that parent is the filesystem root or user home directory. The resolver now logs the exact marker used for the package-manager decision, which should make future diagnosis easier.

Tests added/updated cover npm lockfile detection, parent-only probing, root/home parent skipping, and the debug reason log.

Validation:

```text
./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.TypeScriptAppHostToolchainResolverTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```