### PR TITLE
Update scheduled workflows for the 13.3 release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -102,7 +102,7 @@ The workflow uses concurrency groups based on the issue/PR number to prevent rac
 
 ## Backmerge Release Workflow
 
-The `backmerge-release.yml` workflow automatically creates PRs to merge changes from `release/13.2` back into `main`.
+The `backmerge-release.yml` workflow automatically creates PRs to merge changes from `release/13.3` back into `main`.
 
 ### Schedule
 
@@ -110,8 +110,8 @@ Runs daily at 00:00 UTC (4pm PT during standard time, 5pm PT during daylight sav
 
 ### Behavior
 
-1. **Change Detection**: Checks if `release/13.2` has commits not in `main`
-2. **PR Creation**: If changes exist, creates a PR to merge `release/13.2` → `main`
+1. **Change Detection**: Checks if `release/13.3` has commits not in `main`
+2. **PR Creation**: If changes exist, creates a PR to merge `release/13.3` → `main`
 3. **Auto-merge**: Enables GitHub's auto-merge feature, so the PR merges automatically once approved
 4. **Conflict Handling**: If merge conflicts occur, creates an issue instead of a PR
 

--- a/.github/workflows/backmerge-release.yml
+++ b/.github/workflows/backmerge-release.yml
@@ -33,15 +33,15 @@ jobs:
       - name: Check for changes to backmerge
         id: check
         run: |
-          git fetch origin main release/13.2
-          BEHIND_COUNT=$(git rev-list --count origin/main..origin/release/13.2)
+          git fetch origin main release/13.3
+          BEHIND_COUNT=$(git rev-list --count origin/main..origin/release/13.3)
           echo "behind_count=$BEHIND_COUNT" >> $GITHUB_OUTPUT
           if [ "$BEHIND_COUNT" -gt 0 ]; then
             echo "changes=true" >> $GITHUB_OUTPUT
-            echo "Found $BEHIND_COUNT commits in release/13.2 not in main"
+            echo "Found $BEHIND_COUNT commits in release/13.3 not in main"
           else
             echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No changes to backmerge - release/13.2 is up-to-date with main"
+            echo "No changes to backmerge - release/13.3 is up-to-date with main"
           fi
 
       - name: Attempt merge and create branch
@@ -52,12 +52,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git checkout origin/main
-          git checkout -b backmerge/release-13.2-to-main
+          git checkout -b backmerge/release-13.3-to-main
 
           # Attempt the merge
-          if git merge origin/release/13.2 --no-edit; then
+          if git merge origin/release/13.3 --no-edit; then
             echo "merge_success=true" >> $GITHUB_OUTPUT
-            git push origin backmerge/release-13.2-to-main --force
+            git push origin backmerge/release-13.3-to-main --force
             echo "Merge successful, branch pushed"
           else
             echo "merge_success=false" >> $GITHUB_OUTPUT
@@ -72,7 +72,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Check if a PR already exists for this branch
-          EXISTING_PR=$(gh pr list --head backmerge/release-13.2-to-main --base main --json number --jq '.[0].number // empty')
+          EXISTING_PR=$(gh pr list --head backmerge/release-13.3-to-main --base main --json number --jq '.[0].number // empty')
 
           if [ -n "$EXISTING_PR" ]; then
             echo "PR #$EXISTING_PR already exists, updating it"
@@ -80,7 +80,7 @@ jobs:
           else
             PR_BODY="## Automated Backmerge
           
-          This PR merges changes from \`release/13.2\` back into \`main\`.
+          This PR merges changes from \`release/13.3\` back into \`main\`.
           
           **Commits to merge:** ${{ steps.check.outputs.behind_count }}
           
@@ -94,9 +94,9 @@ jobs:
             PR_BODY=$(echo "$PR_BODY" | sed 's/^          //')
 
             PR_URL=$(gh pr create \
-              --head backmerge/release-13.2-to-main \
+              --head backmerge/release-13.3-to-main \
               --base main \
-              --title "[Automated] Backmerge release/13.2 to main" \
+              --title "[Automated] Backmerge release/13.3 to main" \
               --body "$PR_BODY" \
               --assignee joperezr,radical \
               --label area-engineering-systems)
@@ -142,7 +142,7 @@ jobs:
             const issueBody = [
               '## Backmerge Conflict',
               '',
-              'The automated backmerge from `release/13.2` to `main` failed due to merge conflicts.',
+              'The automated backmerge from `release/13.3` to `main` failed due to merge conflicts.',
               '',
               '### What to do',
               '',
@@ -150,7 +150,7 @@ jobs:
               '   ```bash',
               '   git checkout main',
               '   git pull origin main',
-              '   git merge origin/release/13.2',
+              '   git merge origin/release/13.3',
               '   ```',
               '2. Resolve the conflicts',
               '3. Push the merge commit or create a PR manually',
@@ -167,7 +167,7 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: '[Backmerge] Merge conflicts between release/13.2 and main',
+              title: '[Backmerge] Merge conflicts between release/13.3 and main',
               body: issueBody,
               assignees: ['joperezr', 'radical'],
               labels: ['area-engineering-systems', 'backmerge-conflict']

--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -22,9 +22,9 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Daily burndown report for the Aspire 13.2 milestone. Tracks progress
+# Daily burndown report for the Aspire 13.3 milestone. Tracks progress
 # on issues closed, new bugs found, notable changes merged into the
-# release/13.2 branch, pending PR reviews, and discussions. Generates
+# release/13.3 branch, pending PR reviews, and discussions. Generates
 # a 7-day burndown chart using cached daily snapshots.
 #
 # Secrets used:
@@ -50,7 +50,7 @@
 #   - ghcr.io/github/github-mcp-server:v1.0.0
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
-name: "13.2 Release Burndown Report"
+name: "13.3 Release Burndown Report"
 "on":
   schedule:
   - cron: "13 8 * * *"
@@ -68,7 +68,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "13.2 Release Burndown Report"
+run-name: "13.3 Release Burndown Report"
 
 jobs:
   activation:
@@ -100,7 +100,7 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.21"
           GH_AW_INFO_AGENT_VERSION: "1.0.21"
           GH_AW_INFO_CLI_VERSION: "v0.69.0"
-          GH_AW_INFO_WORKFLOW_NAME: "13.2 Release Burndown Report"
+          GH_AW_INFO_WORKFLOW_NAME: "13.3 Release Burndown Report"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -419,14 +419,14 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_deefd5e90ca1753a_EOF'
-          {"create_issue":{"close_older_issues":true,"labels":["report","burndown"],"max":1,"title_prefix":"[13.2-burndown] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          {"create_issue":{"close_older_issues":true,"labels":["report","burndown"],"max":1,"title_prefix":"[13.3-burndown] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
           GH_AW_SAFE_OUTPUTS_CONFIG_deefd5e90ca1753a_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[13.2-burndown] \". Labels [\"report\" \"burndown\"] will be automatically added."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[13.3-burndown] \". Labels [\"report\" \"burndown\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -918,7 +918,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "13.2 Release Burndown Report"
+          GH_AW_WORKFLOW_NAME: "13.3 Release Burndown Report"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "true"
@@ -934,7 +934,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "13.2 Release Burndown Report"
+          GH_AW_WORKFLOW_NAME: "13.3 Release Burndown Report"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
           GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
@@ -951,7 +951,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "13.2 Release Burndown Report"
+          GH_AW_WORKFLOW_NAME: "13.3 Release Burndown Report"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -965,7 +965,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "13.2 Release Burndown Report"
+          GH_AW_WORKFLOW_NAME: "13.3 Release Burndown Report"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -979,7 +979,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "13.2 Release Burndown Report"
+          GH_AW_WORKFLOW_NAME: "13.3 Release Burndown Report"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "daily-repo-status"
@@ -1089,8 +1089,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
-          WORKFLOW_NAME: "13.2 Release Burndown Report"
-          WORKFLOW_DESCRIPTION: "Daily burndown report for the Aspire 13.2 milestone. Tracks progress\non issues closed, new bugs found, notable changes merged into the\nrelease/13.2 branch, pending PR reviews, and discussions. Generates\na 7-day burndown chart using cached daily snapshots."
+          WORKFLOW_NAME: "13.3 Release Burndown Report"
+          WORKFLOW_DESCRIPTION: "Daily burndown report for the Aspire 13.3 milestone. Tracks progress\non issues closed, new bugs found, notable changes merged into the\nrelease/13.3 branch, pending PR reviews, and discussions. Generates\na 7-day burndown chart using cached daily snapshots."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1183,7 +1183,7 @@ jobs:
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
       GH_AW_WORKFLOW_ID: "daily-repo-status"
-      GH_AW_WORKFLOW_NAME: "13.2 Release Burndown Report"
+      GH_AW_WORKFLOW_NAME: "13.3 Release Burndown Report"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
@@ -1232,7 +1232,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":true,\"labels\":[\"report\",\"burndown\"],\"max\":1,\"title_prefix\":\"[13.2-burndown] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":true,\"labels\":[\"report\",\"burndown\"],\"max\":1,\"title_prefix\":\"[13.3-burndown] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/daily-repo-status.md
+++ b/.github/workflows/daily-repo-status.md
@@ -1,8 +1,8 @@
 ---
 description: |
-  Daily burndown report for the Aspire 13.2 milestone. Tracks progress
+  Daily burndown report for the Aspire 13.3 milestone. Tracks progress
   on issues closed, new bugs found, notable changes merged into the
-  release/13.2 branch, pending PR reviews, and discussions. Generates
+  release/13.3 branch, pending PR reviews, and discussions. Generates
   a 7-day burndown chart using cached daily snapshots.
 
 on:
@@ -25,15 +25,15 @@ tools:
 
 safe-outputs:
   create-issue:
-    title-prefix: "[13.2-burndown] "
+    title-prefix: "[13.3-burndown] "
     labels: [report, burndown]
     close-older-issues: true
 ---
 
-# 13.2 Release Burndown Report
+# 13.3 Release Burndown Report
 
-Create a daily burndown report for the **Aspire 13.2 milestone** as a GitHub issue.
-The primary goal of this report is to help the team track progress towards the 13.2 release.
+Create a daily burndown report for the **Aspire 13.3 milestone** as a GitHub issue.
+The primary goal of this report is to help the team track progress towards the 13.3 release.
 
 ## Data gathering
 
@@ -41,9 +41,9 @@ Collect the following data using the GitHub tools. All time-based queries should
 
 ### 1. Milestone snapshot
 
-- Find the milestone named **13.2** in this repository.
-- Count the **total open issues** and **total closed issues** in the milestone, **excluding pull requests**. Use an issues-only filter (for example, a search query like `is:issue milestone:"13.2" state:open` / `state:closed`) so the counts are consistent across tools.
-- Store today's snapshot (date, open count, closed count) using the **cache-memory** tool with the key `burndown-13.2-snapshot`.
+- Find the milestone named **13.3** in this repository.
+- Count the **total open issues** and **total closed issues** in the milestone, **excluding pull requests**. Use an issues-only filter (for example, a search query like `is:issue milestone:"13.3" state:open` / `state:closed`) so the counts are consistent across tools.
+- Store today's snapshot (date, open count, closed count) using the **cache-memory** tool with the key `burndown-13.3-snapshot`.
   - The value for this key **must** be a JSON array of objects with the exact shape:
     `[{ "date": "YYYY-MM-DD", "open": <number>, "closed": <number> }, ...]`
   - When writing today's data:
@@ -57,7 +57,7 @@ Collect the following data using the GitHub tools. All time-based queries should
 
 If the cache from step 1 contains **fewer than 7 data points** after adding today's entry, fill in the missing days by reading previous burndown report issues:
 
-- Search for issues (open or closed) with `[13.2-burndown]` in the title, sorted by creation date descending, limit to the most recent 7.
+- Search for issues (open or closed) with `[13.3-burndown]` in the title, sorted by creation date descending, limit to the most recent 7.
 - For each previous report issue, find the **Milestone Progress** section and extract the **Open Issues** count from the table row labeled "Open Issues".
 - Extract the date from the issue title (e.g., "Daily Burndown Report - February 19, 2026" → "2026-02-19").
 - Merge these data points into the cache array, keeping only dates that are not already present (cache entries take priority).
@@ -65,46 +65,46 @@ If the cache from step 1 contains **fewer than 7 data points** after adding toda
 
 Skip this step entirely if the cache already has 7 data points.
 
-### 2. Issues closed in the last 24 hours (13.2 milestone)
+### 2. Issues closed in the last 24 hours (13.3 milestone)
 
-- Search for issues in this repository that were **closed in the last 24 hours** and belong to the **13.2 milestone**.
+- Search for issues in this repository that were **closed in the last 24 hours** and belong to the **13.3 milestone**.
 - For each issue, note the issue number, title, and who closed it.
 
-### 3. New issues added to 13.2 milestone in the last 24 hours
+### 3. New issues added to 13.3 milestone in the last 24 hours
 
-- Search for issues in this repository that were **opened in the last 24 hours** and are assigned to the **13.2 milestone**.
+- Search for issues in this repository that were **opened in the last 24 hours** and are assigned to the **13.3 milestone**.
 - Highlight any that are labeled as `bug` — these are newly discovered bugs for the release.
 
-### 4. Notable changes merged into release/13.2
+### 4. Notable changes merged into release/13.3
 
-- Look at pull requests **merged in the last 24 hours** whose **base branch is `release/13.2`**.
+- Look at pull requests **merged in the last 24 hours** whose **base branch is `release/13.3`**.
 - Summarize the most impactful or interesting changes (group by area if possible).
 
-### 5. PRs pending review targeting release/13.2
+### 5. PRs pending review targeting release/13.3
 
-- Find **open pull requests** with base branch `release/13.2` that are **awaiting reviews** (have no approving reviews yet, or have review requests pending).
+- Find **open pull requests** with base branch `release/13.3` that are **awaiting reviews** (have no approving reviews yet, or have review requests pending).
 - List them with PR number, title, author, and how long they've been open.
 
-### 6. Discussions related to 13.2
+### 6. Discussions related to 13.3
 
-- Search discussions in this repository that mention "13.2" or the milestone, especially any **recent activity in the last 24 hours**.
+- Search discussions in this repository that mention "13.3" or the milestone, especially any **recent activity in the last 24 hours**.
 - Briefly summarize any relevant discussion threads.
 
 ### 7. General triage needs (secondary)
 
 - Briefly note any **new issues opened in the last 24 hours that have no milestone assigned** and may need triage.
-- Keep this section short — the focus is on 13.2.
+- Keep this section short — the focus is on 13.3.
 
 ## Burndown chart
 
-Using the data from **cache-memory** (enriched with previous issue data if needed from step 1b), generate a **Mermaid xychart** showing the number of **open issues** in the 13.2 milestone over the last 7 days (or however many data points are available).
+Using the data from **cache-memory** (enriched with previous issue data if needed from step 1b), generate a **Mermaid xychart** showing the number of **open issues** in the 13.3 milestone over the last 7 days (or however many data points are available).
 
 Use this format so it renders natively in the GitHub issue:
 
 ~~~
 ```mermaid
 xychart-beta
-    title "13.2 Milestone Burndown (Open Issues)"
+    title "13.3 Milestone Burndown (Open Issues)"
     x-axis [Feb 13, Feb 14, Feb 15, ...]
     y-axis "Open Issues" 0 --> MAX
     line [N1, N2, N3, ...]

--- a/.github/workflows/generate-api-diffs.yml
+++ b/.github/workflows/generate-api-diffs.yml
@@ -15,6 +15,8 @@ jobs:
     if: ${{ github.repository_owner == 'microsoft' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: release/13.3
 
       - name: Restore and build
         run: |
@@ -38,7 +40,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-api-diffs
-          base: main
+          base: release/13.3
           labels: |
             NO-MERGE
           title: "[Automated] Update API Surface Area"


### PR DESCRIPTION
Branched for 13.3, so adjust scheduled workflows accordingly. All changes target `main` so the scheduled runs pick them up.

## Changes

- **`generate-api-diffs.yml`**: Check out `release/13.3` and target the auto-generated PR at `release/13.3` (was `main`). Now main is 13.4, this ensures the API diff PR only reflects new API changes shipping in 13.3.
- **`daily-repo-status.md` + `.lock.yml`** (burndown agentic workflow): Retarget from the 13.2 milestone / `release/13.2` branch to 13.3 / `release/13.3`. Issue title prefix updated to `[13.3-burndown]`.
- **`backmerge-release.yml`**: Backmerge `release/13.3` → `main` (was `release/13.2`). Updated branch names, PR title/body, and conflict-issue title.
- **`README.md`**: Doc references updated to match.

## Description

None.

## Checklist

- [x] Is this feature complete?
  - [x] Test coverage
  - [x] Documentation
- [x] Breaking changes guidance?
- [x] Engineering style guide compliance
  - [x] Code style
  - [x] Code comments style
  - [x] Use of new language syntax
- [x] Telemetry implications?