### PR TITLE
[release/13.3] Remove MarkupString from SpanDetails and StructuredLogDetails resource strings

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -8,11 +8,11 @@
     {
         <FluentToolbar Orientation="Orientation.Horizontal">
             <div>
-                @((MarkupString)string.Format(ControlsStrings.SpanDetailsResource, ViewModel.Span.Source.Resource.ResourceName))
+                @Loc[nameof(ControlsStrings.SpanDetailsResourceLabel)] <strong>@ViewModel.Span.Source.Resource.ResourceName</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
-                @((MarkupString)string.Format(ControlsStrings.SpanDetailsDuration, DurationFormatter.FormatDuration(ViewModel.Span.Duration, CultureInfo.CurrentCulture)))
+                @Loc[nameof(ControlsStrings.SpanDetailsDurationLabel)] <strong>@DurationFormatter.FormatDuration(ViewModel.Span.Duration, CultureInfo.CurrentCulture)</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
@@ -21,7 +21,7 @@
                     var startTime = ViewModel.Span.StartTime - ViewModel.Span.Trace.FirstSpan.StartTime;
                     var formattedStartTime = startTime > TimeSpan.Zero ? DurationFormatter.FormatDuration(startTime, CultureInfo.CurrentCulture) : $"0{DurationFormatter.GetUnit(ViewModel.Span.Duration)}";
                 }
-                @((MarkupString)string.Format(ControlsStrings.SpanDetailsStartTime, formattedStartTime))
+                @Loc[nameof(ControlsStrings.SpanDetailsStartTimeLabel)] <strong>@formattedStartTime</strong>
             </div>
             <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                           Immediate="true"

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
@@ -7,11 +7,11 @@
 <div class="structured-log-details-layout">
     <FluentToolbar Orientation="Orientation.Horizontal">
         <div>
-            @((MarkupString)string.Format(ControlsStrings.StructuredLogsDetailsResource, ViewModel.LogEntry.ResourceView.Resource.ResourceName))
+            @Loc[nameof(ControlsStrings.StructuredLogsDetailsResourceLabel)] <strong>@ViewModel.LogEntry.ResourceView.Resource.ResourceName</strong>
         </div>
         <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <div title="@FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, ViewModel.LogEntry.TimeStamp, MillisecondsDisplay.Full)">
-            @((MarkupString)string.Format(ControlsStrings.StructuredLogsDetailsTimestamp, FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, ViewModel.LogEntry.TimeStamp, MillisecondsDisplay.Truncated)))
+            @Loc[nameof(ControlsStrings.StructuredLogsDetailsTimestampLabel)] <strong>@FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, ViewModel.LogEntry.TimeStamp, MillisecondsDisplay.Truncated)</strong>
         </div>
         <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -979,11 +979,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Duration &lt;strong&gt;{0}&lt;/strong&gt;.
+        ///   Looks up a localized string similar to Duration.
         /// </summary>
-        public static string SpanDetailsDuration {
+        public static string SpanDetailsDurationLabel {
             get {
-                return ResourceManager.GetString("SpanDetailsDuration", resourceCulture);
+                return ResourceManager.GetString("SpanDetailsDurationLabel", resourceCulture);
             }
         }
         
@@ -1006,11 +1006,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Resource &lt;strong&gt;{0}&lt;/strong&gt;.
+        ///   Looks up a localized string similar to Resource.
         /// </summary>
-        public static string SpanDetailsResource {
+        public static string SpanDetailsResourceLabel {
             get {
-                return ResourceManager.GetString("SpanDetailsResource", resourceCulture);
+                return ResourceManager.GetString("SpanDetailsResourceLabel", resourceCulture);
             }
         }
         
@@ -1051,11 +1051,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start time &lt;strong&gt;{0}&lt;/strong&gt;.
+        ///   Looks up a localized string similar to Start time.
         /// </summary>
-        public static string SpanDetailsStartTime {
+        public static string SpanDetailsStartTimeLabel {
             get {
-                return ResourceManager.GetString("SpanDetailsStartTime", resourceCulture);
+                return ResourceManager.GetString("SpanDetailsStartTimeLabel", resourceCulture);
             }
         }
         
@@ -1150,11 +1150,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Resource &lt;strong&gt;{0}&lt;/strong&gt;.
+        ///   Looks up a localized string similar to Resource.
         /// </summary>
-        public static string StructuredLogsDetailsResource {
+        public static string StructuredLogsDetailsResourceLabel {
             get {
-                return ResourceManager.GetString("StructuredLogsDetailsResource", resourceCulture);
+                return ResourceManager.GetString("StructuredLogsDetailsResourceLabel", resourceCulture);
             }
         }
         
@@ -1168,11 +1168,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Timestamp &lt;strong&gt;{0}&lt;/strong&gt;.
+        ///   Looks up a localized string similar to Timestamp.
         /// </summary>
-        public static string StructuredLogsDetailsTimestamp {
+        public static string StructuredLogsDetailsTimestampLabel {
             get {
-                return ResourceManager.GetString("StructuredLogsDetailsTimestamp", resourceCulture);
+                return ResourceManager.GetString("StructuredLogsDetailsTimestampLabel", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -192,17 +192,14 @@
   <data name="StateColumnHeader" xml:space="preserve">
     <value>State</value>
   </data>
-  <data name="SpanDetailsResource" xml:space="preserve">
-    <value>Resource &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <comment>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
+  <data name="SpanDetailsResourceLabel" xml:space="preserve">
+    <value>Resource</value>
   </data>
-  <data name="SpanDetailsDuration" xml:space="preserve">
-    <value>Duration &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <comment>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
+  <data name="SpanDetailsDurationLabel" xml:space="preserve">
+    <value>Duration</value>
   </data>
-  <data name="SpanDetailsStartTime" xml:space="preserve">
-    <value>Start time &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <comment>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
+  <data name="SpanDetailsStartTimeLabel" xml:space="preserve">
+    <value>Start time</value>
   </data>
   <data name="ViewLogsLink" xml:space="preserve">
     <value>View logs</value>
@@ -286,13 +283,11 @@
   <data name="Loading" xml:space="preserve">
     <value>Loading...</value>
   </data>
-  <data name="StructuredLogsDetailsResource" xml:space="preserve">
-    <value>Resource &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <comment>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
+  <data name="StructuredLogsDetailsResourceLabel" xml:space="preserve">
+    <value>Resource</value>
   </data>
-  <data name="StructuredLogsDetailsTimestamp" xml:space="preserve">
-    <value>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <comment>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
+  <data name="StructuredLogsDetailsTimestampLabel" xml:space="preserve">
+    <value>Timestamp</value>
   </data>
   <data name="ResourceDetailsUrlsHeader" xml:space="preserve">
     <value>URLs</value>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Podrobnosti</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Doba trvání: &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Odkazy</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Prostředek &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Prostředek</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Rozpětí</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Čas spuštění: &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Položka protokolu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Prostředek &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Prostředek</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Časové razítko &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Details</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Dauer &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Links</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Ressource &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Ressource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Span</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Startzeit &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Protokolleintrag</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Ressource &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Ressource</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Zeitstempel &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Detalles</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Duración &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Vínculos</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Recurso &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Recurso</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Span</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Hora de inicio &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Entrada del registro</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Recurso &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Recurso</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Marca de tiempo &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Détails</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Durée &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Liens</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Ressource &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Ressource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Étendue</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">&lt;strong&gt;Heure de début : &lt;/strong&gt; {0}</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Entrée de journal</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Ressource &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Ressource</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Dettagli</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Durata &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Collegamenti</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Risorsa &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Risorsa</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Span</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Ora di inizio &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Voce di log</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Risorsa &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Risorsa</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -512,10 +512,10 @@
         <target state="translated">詳細</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">期間 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">リンク</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">リソース &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">リソース</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">スパン</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">開始時刻 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">ログ エントリ</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">リソース &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">リソース</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">タイムスタンプ &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -512,10 +512,10 @@
         <target state="translated">세부 정보</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">기간 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">링크</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">리소스 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">리소스</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">범위</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">시작 시간 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">로그 항목</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">리소스 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">리소스</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">타임스탬프 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Szczegóły</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Czas trwania: &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Linki</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Zasób &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Zasób</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Zakres</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Czas rozpoczęcia: &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Wpis dziennika</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Zasób &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Zasób</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Sygnatura czasowa &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Detalhes</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Duração &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Links</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Recurso &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Recurso</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Intervalo</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Horário de início &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Entrada de log</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Recurso &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Recurso</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Carimbo de data &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Сведения</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Длительность: &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Ссылки</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Ресурс &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Ресурс</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Диапазон</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">&lt;strong&gt;Время начала: &lt;/strong&gt; {0}</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Запись журнала</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Ресурс &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Ресурс</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Метка времени &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -512,10 +512,10 @@
         <target state="translated">Ayrıntılar</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Süre &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">Bağlantılar</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Kaynak &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Kaynak</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">Yayılma</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Başlangıç zamanı &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">Günlük girişi</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Kaynak &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">Kaynak</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">Zaman damgası &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -512,10 +512,10 @@
         <target state="translated">详细信息</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">持续时间 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">链接</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">资源 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">资源</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">范围</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">开始时间 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">日志条目</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">资源 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">资源</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">时间戳 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -512,10 +512,10 @@
         <target state="translated">詳細資料</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsDuration">
-        <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">期間 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsDurationLabel">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanDetailsEventsHeader">
         <source>Events</source>
@@ -527,14 +527,14 @@
         <target state="translated">連結</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">資源 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="SpanDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">資源</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsSpanColumnHeader">
@@ -552,10 +552,10 @@
         <target state="translated">跨度</target>
         <note />
       </trans-unit>
-      <trans-unit id="SpanDetailsStartTime">
-        <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">開始時間 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="SpanDetailsStartTimeLabel">
+        <source>Start time</source>
+        <target state="new">Start time</target>
+        <note />
       </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
@@ -607,20 +607,20 @@
         <target state="translated">記錄項目</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsResource">
-        <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">資源 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
-      </trans-unit>
       <trans-unit id="StructuredLogsDetailsResourceHeader">
         <source>Resource</source>
         <target state="translated">資源</target>
         <note />
       </trans-unit>
-      <trans-unit id="StructuredLogsDetailsTimestamp">
-        <source>Timestamp &lt;strong&gt;{0}&lt;/strong&gt;</source>
-        <target state="translated">時間戳記 &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note>{0} is a date. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+      <trans-unit id="StructuredLogsDetailsResourceLabel">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StructuredLogsDetailsTimestampLabel">
+        <source>Timestamp</source>
+        <target state="new">Timestamp</target>
+        <note />
       </trans-unit>
       <trans-unit id="TimeOffsetColumnHeader">
         <source>Time offset</source>


### PR DESCRIPTION
## Summary

Remove HTML-embedded resource strings and replace them with plain label strings, eliminating `MarkupString` casts in the dashboard Razor components.

Manual testing that it works correctly:
<img width="617" height="175" alt="image" src="https://github.com/user-attachments/assets/151c7dbc-2272-4ac1-8762-23e9d4f5a626" />

## Changes

- **SpanDetails.razor**: Replace `MarkupString` + `string.Format` for Resource/Duration/Start time toolbar items with `@Loc[...]` + inline `<strong>` tags
- **StructuredLogDetails.razor**: Same pattern for Resource/Timestamp toolbar items
- **ControlsStrings.resx**: Replace `SpanDetailsResource`, `SpanDetailsDuration`, `SpanDetailsStartTime`, `StructuredLogsDetailsResource`, `StructuredLogsDetailsTimestamp` (all containing `<strong>{0}</strong>`) with plain label strings (`*Label` suffix)
- **ControlsStrings.Designer.cs**: Updated to match new resource names
- **xlf files**: Regenerated via `dotnet build /t:UpdateXlf`

## Motivation

Resource strings should not contain HTML markup. Moving the `<strong>` formatting into Razor markup directly is safer (no XSS risk from `MarkupString`) and allows the resource strings to be simple translatable text.