### PR TITLE
Move Ingress and Gateway extensions to Aspire.Hosting namespace

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes;
 
-namespace Aspire.Hosting.Kubernetes;
+namespace Aspire.Hosting;
 
 /// <summary>
 /// Provides extension methods for configuring Kubernetes Gateway API resources in the Aspire application model.

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes;
 
-namespace Aspire.Hosting.Kubernetes;
+namespace Aspire.Hosting;
 
 /// <summary>
 /// Provides extension methods for configuring Kubernetes Ingress resources in the Aspire application model.


### PR DESCRIPTION
## Description

Move `KubernetesGatewayExtensions` and `KubernetesIngressExtensions` from the `Aspire.Hosting.Kubernetes` namespace to `Aspire.Hosting`.

These extension methods (`AddGateway`, `AddIngress`, `WithRoute`, `WithTls`, `WithHostname`, etc.) were in the wrong namespace, requiring users to add an explicit `using Aspire.Hosting.Kubernetes;` directive. All other Kubernetes extension methods (`AddKubernetesEnvironment`, `WithHelm`, etc.) are already in `Aspire.Hosting`, which is the convention for hosting extension methods across the repo.

This is a source-breaking change for anyone who already has `using Aspire.Hosting.Kubernetes;` — but since these APIs shipped in 13.3 preview and are marked experimental, the break is acceptable. Users who already have the using directive won't be affected (it's still valid, just no longer required).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
