### PR TITLE
Add AddHelmChart for installing external Helm charts

### DIFF
--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesIngressExtensions.cs
@@ -78,4 +78,42 @@ public static class AzureKubernetesIngressExtensions
         var k8sEnvBuilder = builder.ApplicationBuilder.CreateResourceBuilder(builder.Resource.KubernetesEnvironment);
         return k8sEnvBuilder.AddGateway(name);
     }
+
+    /// <summary>
+    /// Adds an external Helm chart to be installed in the AKS environment's inner Kubernetes
+    /// environment. The chart is installed via <c>helm upgrade --install</c> as a pipeline step
+    /// after the main application Helm chart is deployed.
+    /// </summary>
+    /// <param name="builder">The AKS environment resource builder.</param>
+    /// <param name="name">The name of the Helm chart resource.</param>
+    /// <param name="chartReference">
+    /// The Helm chart reference. Can be an OCI registry URL (e.g., <c>oci://quay.io/jetstack/charts/cert-manager</c>)
+    /// or a chart name from an added repository.
+    /// </param>
+    /// <param name="chartVersion">The chart version to install.</param>
+    /// <returns>A resource builder for the Helm chart resource.</returns>
+    /// <example>
+    /// <code>
+    /// var aks = builder.AddAzureKubernetesEnvironment("aks");
+    ///
+    /// // Install cert-manager
+    /// aks.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0")
+    ///     .WithHelmValue("crds.enabled", "true");
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Adds an external Helm chart to an AKS environment")]
+    public static IResourceBuilder<KubernetesHelmChartResource> AddHelmChart(
+        this IResourceBuilder<AzureKubernetesEnvironmentResource> builder,
+        [ResourceName] string name,
+        string chartReference,
+        string chartVersion)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(chartReference);
+        ArgumentException.ThrowIfNullOrEmpty(chartVersion);
+
+        var k8sEnvBuilder = builder.ApplicationBuilder.CreateResourceBuilder(builder.Resource.KubernetesEnvironment);
+        return k8sEnvBuilder.AddHelmChart(name, chartReference, chartVersion);
+    }
 }

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesIngressExtensions.cs
@@ -92,6 +92,22 @@ public static class AzureKubernetesIngressExtensions
     /// </param>
     /// <param name="chartVersion">The chart version to install.</param>
     /// <returns>A resource builder for the Helm chart resource.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method delegates to the inner <see cref="KubernetesEnvironmentResource"/> of the AKS
+    /// environment, so the returned <see cref="KubernetesHelmChartResource"/> can be configured
+    /// with the same <see cref="KubernetesHelmChartExtensions.WithHelmValue"/>,
+    /// <see cref="KubernetesHelmChartExtensions.WithNamespace"/>,
+    /// <see cref="KubernetesHelmChartExtensions.WithReleaseName"/>, and
+    /// <see cref="KubernetesHelmChartExtensions.WithDestroy"/> extensions used with
+    /// non-AKS Kubernetes environments.
+    /// </para>
+    /// <para>
+    /// External Helm charts are <em>not</em> uninstalled by <c>aspire destroy</c> by default,
+    /// because they may be shared with workloads outside the Aspire app. Opt in by chaining
+    /// <see cref="KubernetesHelmChartExtensions.WithDestroy"/>.
+    /// </para>
+    /// </remarks>
     /// <example>
     /// <code>
     /// var aks = builder.AddAzureKubernetesEnvironment("aks");

--- a/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
+++ b/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
@@ -18,8 +18,8 @@ namespace Aspire.Hosting.Kubernetes;
 [AspireExport(ExposeMethods = true)]
 public sealed partial class HelmChartOptions
 {
-    private const int KubernetesNamespaceMaxLength = 63;
-    private const int HelmReleaseNameMaxLength = 53;
+    internal const int KubernetesNamespaceMaxLength = 63;
+    internal const int HelmReleaseNameMaxLength = 53;
     private const int HelmChartNameMaxLength = 250;
     private const int HelmChartDescriptionMaxLength = 1024;
 
@@ -39,7 +39,7 @@ public sealed partial class HelmChartOptions
     public HelmChartOptions WithNamespace(string @namespace)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
-        ValidateDnsLabel(@namespace, "Kubernetes namespace", KubernetesNamespaceMaxLength, nameof(@namespace));
+        ValidateNamespace(@namespace, nameof(@namespace));
 
         var expression = ReferenceExpression.Create($"{@namespace}");
         EnvironmentBuilder.WithAnnotation(new KubernetesNamespaceAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
@@ -83,7 +83,7 @@ public sealed partial class HelmChartOptions
     public HelmChartOptions WithReleaseName(string releaseName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(releaseName);
-        ValidateDnsLabel(releaseName, "Helm release name", HelmReleaseNameMaxLength, nameof(releaseName));
+        ValidateReleaseName(releaseName, nameof(releaseName));
 
         var expression = ReferenceExpression.Create($"{releaseName}");
         EnvironmentBuilder.WithAnnotation(new HelmReleaseNameAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
@@ -255,7 +255,7 @@ public sealed partial class HelmChartOptions
         };
     }
 
-    private static void ValidateDnsLabel(string value, string target, int maxLength, string paramName)
+    internal static void ValidateDnsLabel(string value, string target, int maxLength, string paramName)
     {
         if (value.Length > maxLength)
         {
@@ -267,6 +267,12 @@ public sealed partial class HelmChartOptions
             throw new ArgumentException($"{target} '{value}' is invalid. Use lowercase letters, numbers, and hyphens, and start and end with an alphanumeric character.", paramName);
         }
     }
+
+    internal static void ValidateNamespace(string @namespace, string paramName)
+        => ValidateDnsLabel(@namespace, "Kubernetes namespace", KubernetesNamespaceMaxLength, paramName);
+
+    internal static void ValidateReleaseName(string releaseName, string paramName)
+        => ValidateDnsLabel(releaseName, "Helm release name", HelmReleaseNameMaxLength, paramName);
 
     // Matches Helm's own chart-version validation, which uses the lenient SemVer parser
     // (Masterminds/semver/v3 NewVersion) — see helm/helm pkg/chart/v2/metadata.go isValidSemver.

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -105,6 +105,7 @@ public static class KubernetesHelmChartExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(value);
 
         builder.Resource.Values[key] = value;
         return builder;
@@ -162,7 +163,7 @@ public static class KubernetesHelmChartExtensions
         var releaseName = chart.ReleaseName ?? chart.Name;
         var @namespace = chart.Namespace ?? chart.Name;
         var chartRef = chart.ChartReference ?? throw new InvalidOperationException($"Helm chart '{chart.Name}' has no chart reference configured.");
-        var chartVersion = chart.ChartVersion;
+        var chartVersion = chart.ChartVersion ?? throw new InvalidOperationException($"Helm chart '{chart.Name}' has no chart version configured.");
 
         logger.LogInformation(
             "Installing Helm chart '{ChartName}' ({ChartRef}:{ChartVersion}) into namespace '{Namespace}'.",
@@ -174,10 +175,7 @@ public static class KubernetesHelmChartExtensions
         arguments.Append(" --create-namespace");
         arguments.Append(" --wait");
 
-        if (!string.IsNullOrEmpty(chartVersion))
-        {
-            arguments.Append(CultureInfo.InvariantCulture, $" --version {chartVersion}");
-        }
+        arguments.Append(CultureInfo.InvariantCulture, $" --version {chartVersion}");
 
         if (environment.KubeConfigPath is not null)
         {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -1,0 +1,217 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+using System.Globalization;
+using System.Text;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Provides extension methods for adding and configuring external Helm charts
+/// in a Kubernetes environment.
+/// </summary>
+public static class KubernetesHelmChartExtensions
+{
+    /// <summary>
+    /// Adds an external Helm chart to be installed in the Kubernetes environment.
+    /// The chart is installed via <c>helm upgrade --install</c> as a pipeline step
+    /// after the main application Helm chart is deployed.
+    /// </summary>
+    /// <param name="builder">The Kubernetes environment resource builder.</param>
+    /// <param name="name">The name of the Helm chart resource (used as release name and namespace if not overridden).</param>
+    /// <param name="chartReference">
+    /// The Helm chart reference. Can be an OCI registry URL (e.g., <c>oci://quay.io/jetstack/charts/cert-manager</c>)
+    /// or a chart name from an added repository.
+    /// </param>
+    /// <param name="chartVersion">The chart version to install.</param>
+    /// <returns>A resource builder for the Helm chart resource.</returns>
+    /// <remarks>
+    /// <para>
+    /// The chart is installed in a dedicated namespace (defaulting to the chart resource name).
+    /// Use <see cref="WithNamespace"/> to override the namespace, and <see cref="WithHelmValue"/>
+    /// to set chart values.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var k8s = builder.AddKubernetesEnvironment("k8s");
+    ///
+    /// // Install cert-manager from OCI registry
+    /// k8s.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0")
+    ///     .WithHelmValue("crds.enabled", "true");
+    /// </code>
+    /// </example>
+    [AspireExport(Description = "Adds an external Helm chart to a Kubernetes environment")]
+    public static IResourceBuilder<KubernetesHelmChartResource> AddHelmChart(
+        this IResourceBuilder<KubernetesEnvironmentResource> builder,
+        [ResourceName] string name,
+        string chartReference,
+        string chartVersion)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(chartReference);
+        ArgumentException.ThrowIfNullOrEmpty(chartVersion);
+
+        var environment = builder.Resource;
+        var resource = new KubernetesHelmChartResource(name, environment)
+        {
+            ChartReference = chartReference,
+            ChartVersion = chartVersion
+        };
+
+        var chartBuilder = builder.ApplicationBuilder.AddResource(resource);
+
+        // Register a pipeline step to install this Helm chart
+        resource.Annotations.Add(new PipelineStepAnnotation(_ =>
+        {
+            var installStep = new PipelineStep
+            {
+                Name = $"helm-install-{name}",
+                Description = $"Installs Helm chart '{name}' ({chartReference}:{chartVersion})",
+                Action = ctx => InstallHelmChartAsync(ctx, environment, resource)
+            };
+
+            // Run after the main application Helm deploy
+            installStep.DependsOn($"helm-deploy-{environment.Name}");
+            installStep.RequiredBy(WellKnownPipelineSteps.Deploy);
+
+            return Task.FromResult<IEnumerable<PipelineStep>>([installStep]);
+        }));
+
+        return chartBuilder;
+    }
+
+    /// <summary>
+    /// Sets a Helm value for the chart installation. Values are passed to <c>helm upgrade --install</c>
+    /// via <c>--set</c> flags.
+    /// </summary>
+    /// <param name="builder">The Helm chart resource builder.</param>
+    /// <param name="key">The value key using dot notation (e.g., <c>config.enableGatewayAPI</c>).</param>
+    /// <param name="value">The value to set.</param>
+    /// <returns>The resource builder for chaining.</returns>
+    [AspireExport(Description = "Sets a Helm value for chart installation")]
+    public static IResourceBuilder<KubernetesHelmChartResource> WithHelmValue(
+        this IResourceBuilder<KubernetesHelmChartResource> builder,
+        string key,
+        string value)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        builder.Resource.Values[key] = value;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the Kubernetes namespace for the Helm chart installation.
+    /// If not set, the namespace defaults to the chart resource name.
+    /// </summary>
+    /// <param name="builder">The Helm chart resource builder.</param>
+    /// <param name="namespace">The namespace to install the chart into.</param>
+    /// <returns>The resource builder for chaining.</returns>
+    [AspireExport("withHelmChartNamespace", Description = "Sets the namespace for Helm chart installation")]
+    public static IResourceBuilder<KubernetesHelmChartResource> WithNamespace(
+        this IResourceBuilder<KubernetesHelmChartResource> builder,
+        string @namespace)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(@namespace);
+
+        builder.Resource.Namespace = @namespace;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the Helm release name for the chart installation.
+    /// If not set, the release name defaults to the resource name.
+    /// </summary>
+    /// <param name="builder">The Helm chart resource builder.</param>
+    /// <param name="releaseName">The Helm release name.</param>
+    /// <returns>The resource builder for chaining.</returns>
+    [AspireExport("withHelmChartReleaseName", Description = "Sets the release name for Helm chart installation")]
+    public static IResourceBuilder<KubernetesHelmChartResource> WithReleaseName(
+        this IResourceBuilder<KubernetesHelmChartResource> builder,
+        string releaseName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(releaseName);
+
+        builder.Resource.ReleaseName = releaseName;
+        return builder;
+    }
+
+    /// <summary>
+    /// Installs the Helm chart via helm upgrade --install.
+    /// </summary>
+    private static async Task InstallHelmChartAsync(
+        PipelineStepContext context,
+        KubernetesEnvironmentResource environment,
+        KubernetesHelmChartResource chart)
+    {
+        var logger = context.Services.GetRequiredService<ILogger<KubernetesHelmChartResource>>();
+        var helmRunner = context.Services.GetRequiredService<IHelmRunner>();
+
+        var releaseName = chart.ReleaseName ?? chart.Name;
+        var @namespace = chart.Namespace ?? chart.Name;
+        var chartRef = chart.ChartReference ?? throw new InvalidOperationException($"Helm chart '{chart.Name}' has no chart reference configured.");
+        var chartVersion = chart.ChartVersion;
+
+        logger.LogInformation(
+            "Installing Helm chart '{ChartName}' ({ChartRef}:{ChartVersion}) into namespace '{Namespace}'.",
+            chart.Name, chartRef, chartVersion, @namespace);
+
+        var arguments = new StringBuilder();
+        arguments.Append(CultureInfo.InvariantCulture, $"upgrade --install {releaseName} {chartRef}");
+        arguments.Append(CultureInfo.InvariantCulture, $" --namespace {@namespace}");
+        arguments.Append(" --create-namespace");
+        arguments.Append(" --wait");
+
+        if (!string.IsNullOrEmpty(chartVersion))
+        {
+            arguments.Append(CultureInfo.InvariantCulture, $" --version {chartVersion}");
+        }
+
+        if (environment.KubeConfigPath is not null)
+        {
+            arguments.Append(CultureInfo.InvariantCulture, $" --kubeconfig \"{environment.KubeConfigPath}\"");
+        }
+
+        foreach (var (key, value) in chart.Values)
+        {
+            arguments.Append(CultureInfo.InvariantCulture, $" --set {key}={value}");
+        }
+
+        var stderrBuilder = new StringBuilder();
+
+        var exitCode = await helmRunner.RunAsync(
+            arguments.ToString(),
+            onOutputData: output => logger.LogDebug("helm (stdout): {Output}", output),
+            onErrorData: error =>
+            {
+                stderrBuilder.AppendLine(error);
+                logger.LogDebug("helm (stderr): {Error}", error);
+            },
+            cancellationToken: context.CancellationToken).ConfigureAwait(false);
+
+        if (exitCode != 0)
+        {
+            var errorOutput = stderrBuilder.ToString().Trim();
+            var message = string.IsNullOrEmpty(errorOutput)
+                ? $"helm upgrade --install for chart '{chart.Name}' failed with exit code {exitCode}"
+                : $"helm upgrade --install for chart '{chart.Name}' failed: {errorOutput}";
+
+            throw new InvalidOperationException(message);
+        }
+
+        logger.LogInformation(
+            "Helm chart '{ChartName}' installed successfully as release '{ReleaseName}' in namespace '{Namespace}'.",
+            chart.Name, releaseName, @namespace);
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -169,7 +169,7 @@ public static class KubernetesHelmChartExtensions
             chart.Name, chartRef, chartVersion, @namespace);
 
         var arguments = new StringBuilder();
-        arguments.Append(CultureInfo.InvariantCulture, $"upgrade --install {releaseName} {chartRef}");
+        arguments.Append(CultureInfo.InvariantCulture, $"upgrade --install {releaseName} \"{chartRef}\"");
         arguments.Append(CultureInfo.InvariantCulture, $" --namespace {@namespace}");
         arguments.Append(" --create-namespace");
         arguments.Append(" --wait");
@@ -186,7 +186,7 @@ public static class KubernetesHelmChartExtensions
 
         foreach (var (key, value) in chart.Values)
         {
-            arguments.Append(CultureInfo.InvariantCulture, $" --set {key}={value}");
+            arguments.Append(CultureInfo.InvariantCulture, $" --set \"{key}={value}\"");
         }
 
         var stderrBuilder = new StringBuilder();

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -6,11 +6,12 @@
 using System.Globalization;
 using System.Text;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes;
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Aspire.Hosting.Kubernetes;
+namespace Aspire.Hosting;
 
 /// <summary>
 /// Provides extension methods for adding and configuring external Helm charts

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -346,7 +346,7 @@ public static partial class KubernetesHelmChartExtensions
     private static string GetStateSectionName(KubernetesEnvironmentResource environment, KubernetesHelmChartResource chart)
         => $"HelmChart:{environment.Name}:{chart.Name}";
 
-    // Whitelist for Helm chart references. Covers OCI URLs (oci://host/path), HTTP/HTTPS URLs,
+    // Allowlist for Helm chart references. Covers OCI URLs (oci://host/path), HTTP/HTTPS URLs,
     // local paths, plain chart names ("repo/chart"), and packaged chart filenames. Rejects anything
     // that could break helm argument tokenization (whitespace, quotes, control chars).
     [GeneratedRegex(@"^[A-Za-z0-9_./:@+~\-]+$")]

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -77,13 +77,17 @@ public static partial class KubernetesHelmChartExtensions
 
         chartBuilder.WithAnnotation(new PipelineStepAnnotation(_ =>
         {
+            // Resolve and validate release/namespace at step-creation time so the user
+            // gets a clear error before the helm CLI ever runs.
+            var (releaseName, @namespace) = ResolveReleaseAndNamespace(resource);
+
             var steps = new List<PipelineStep>();
 
             var installStep = new PipelineStep
             {
                 Name = $"helm-install-{name}",
                 Description = $"Installs Helm chart '{name}' ({resource.ChartReference}:{resource.ChartVersion})",
-                Action = ctx => InstallHelmChartAsync(ctx, environment, resource)
+                Action = ctx => InstallHelmChartAsync(ctx, environment, resource, releaseName, @namespace)
             };
 
             installStep.DependsOn($"helm-deploy-{environment.Name}");
@@ -95,8 +99,8 @@ public static partial class KubernetesHelmChartExtensions
                 var uninstallStep = new PipelineStep
                 {
                     Name = $"helm-uninstall-{name}",
-                    Description = $"Uninstalls Helm chart '{name}' from namespace '{resource.Namespace ?? name}'",
-                    Action = ctx => UninstallHelmChartAsync(ctx, environment, resource),
+                    Description = $"Uninstalls Helm chart '{name}' from namespace '{@namespace}'",
+                    Action = ctx => UninstallHelmChartAsync(ctx, environment, resource, releaseName, @namespace),
                     DependsOnSteps = [WellKnownPipelineSteps.DestroyPrereq]
                 };
                 uninstallStep.RequiredBy(WellKnownPipelineSteps.Destroy);
@@ -209,12 +213,12 @@ public static partial class KubernetesHelmChartExtensions
     private static async Task InstallHelmChartAsync(
         PipelineStepContext context,
         KubernetesEnvironmentResource environment,
-        KubernetesHelmChartResource chart)
+        KubernetesHelmChartResource chart,
+        string releaseName,
+        string @namespace)
     {
         var logger = context.Services.GetRequiredService<ILogger<KubernetesHelmChartResource>>();
         var helmRunner = context.Services.GetRequiredService<IHelmRunner>();
-
-        var (releaseName, @namespace) = ResolveReleaseAndNamespace(chart);
 
         logger.LogInformation(
             "Installing Helm chart '{ChartName}' ({ChartRef}:{ChartVersion}) into namespace '{Namespace}'.",
@@ -281,7 +285,9 @@ public static partial class KubernetesHelmChartExtensions
     private static async Task UninstallHelmChartAsync(
         PipelineStepContext context,
         KubernetesEnvironmentResource environment,
-        KubernetesHelmChartResource chart)
+        KubernetesHelmChartResource chart,
+        string defaultReleaseName,
+        string defaultNamespace)
     {
         var logger = context.Services.GetRequiredService<ILogger<KubernetesHelmChartResource>>();
         var helmRunner = context.Services.GetRequiredService<IHelmRunner>();
@@ -293,9 +299,8 @@ public static partial class KubernetesHelmChartExtensions
         var savedReleaseName = stateSection.Data["ReleaseName"]?.ToString();
         var savedNamespace = stateSection.Data["Namespace"]?.ToString();
 
-        // Fall back to the resource configuration when no state was persisted (e.g., the
-        // user opted in to destroy after deploying without it). This is best-effort.
-        var (defaultReleaseName, defaultNamespace) = ResolveReleaseAndNamespace(chart);
+        // Fall back to the values resolved at step-creation time when no state was persisted
+        // (e.g., the user opted in to destroy after deploying without it). This is best-effort.
         var releaseName = !string.IsNullOrEmpty(savedReleaseName) ? savedReleaseName : defaultReleaseName;
         var @namespace = !string.IsNullOrEmpty(savedNamespace) ? savedNamespace : defaultNamespace;
 
@@ -341,7 +346,46 @@ public static partial class KubernetesHelmChartExtensions
     }
 
     private static (string ReleaseName, string Namespace) ResolveReleaseAndNamespace(KubernetesHelmChartResource chart)
-        => (chart.ReleaseName ?? chart.Name, chart.Namespace ?? chart.Name);
+    {
+        var releaseName = chart.ReleaseName ?? chart.Name;
+        var @namespace = chart.Namespace ?? chart.Name;
+
+        // The fallback to chart.Name can produce a value that isn't a valid Helm release name or
+        // Kubernetes namespace (uppercase, too long, etc.) — Aspire resource names allow more than
+        // DNS labels do. Validate here so the caller gets a clear ArgumentException pointing at
+        // WithReleaseName / WithNamespace instead of an opaque helm CLI failure.
+        if (chart.ReleaseName is null)
+        {
+            try
+            {
+                HelmChartOptions.ValidateReleaseName(releaseName, nameof(chart.ReleaseName));
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot derive a Helm release name from resource name '{chart.Name}'. " +
+                    $"Set an explicit release name via WithReleaseName(...). {ex.Message}",
+                    ex);
+            }
+        }
+
+        if (chart.Namespace is null)
+        {
+            try
+            {
+                HelmChartOptions.ValidateNamespace(@namespace, nameof(chart.Namespace));
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot derive a Kubernetes namespace from resource name '{chart.Name}'. " +
+                    $"Set an explicit namespace via WithNamespace(...). {ex.Message}",
+                    ex);
+            }
+        }
+
+        return (releaseName, @namespace);
+    }
 
     private static string GetStateSectionName(KubernetesEnvironmentResource environment, KubernetesHelmChartResource chart)
         => $"HelmChart:{environment.Name}:{chart.Name}";

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREPIPELINES002 // IDeploymentStateManager is for evaluation purposes only.
 
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Kubernetes;
 using Aspire.Hosting.Pipelines;
@@ -17,7 +19,7 @@ namespace Aspire.Hosting;
 /// Provides extension methods for adding and configuring external Helm charts
 /// in a Kubernetes environment.
 /// </summary>
-public static class KubernetesHelmChartExtensions
+public static partial class KubernetesHelmChartExtensions
 {
     /// <summary>
     /// Adds an external Helm chart to be installed in the Kubernetes environment.
@@ -37,6 +39,11 @@ public static class KubernetesHelmChartExtensions
     /// The chart is installed in a dedicated namespace (defaulting to the chart resource name).
     /// Use <see cref="WithNamespace"/> to override the namespace, and <see cref="WithHelmValue"/>
     /// to set chart values.
+    /// </para>
+    /// <para>
+    /// By default, <c>aspire destroy</c> does <em>not</em> uninstall the external chart, because
+    /// it may be shared with workloads outside the Aspire app. Opt in to destroy-time uninstall
+    /// by chaining <see cref="WithDestroy"/>.
     /// </para>
     /// </remarks>
     /// <example>
@@ -60,30 +67,43 @@ public static class KubernetesHelmChartExtensions
         ArgumentException.ThrowIfNullOrEmpty(chartReference);
         ArgumentException.ThrowIfNullOrEmpty(chartVersion);
 
+        ValidateChartReference(chartReference, nameof(chartReference));
+        HelmChartOptions.ValidateChartVersion(chartVersion, nameof(chartVersion));
+
         var environment = builder.Resource;
-        var resource = new KubernetesHelmChartResource(name, environment)
-        {
-            ChartReference = chartReference,
-            ChartVersion = chartVersion
-        };
+        var resource = new KubernetesHelmChartResource(name, environment, chartReference, chartVersion);
 
         var chartBuilder = builder.ApplicationBuilder.AddResource(resource);
 
-        // Register a pipeline step to install this Helm chart
-        resource.Annotations.Add(new PipelineStepAnnotation(_ =>
+        chartBuilder.WithAnnotation(new PipelineStepAnnotation(_ =>
         {
+            var steps = new List<PipelineStep>();
+
             var installStep = new PipelineStep
             {
                 Name = $"helm-install-{name}",
-                Description = $"Installs Helm chart '{name}' ({chartReference}:{chartVersion})",
+                Description = $"Installs Helm chart '{name}' ({resource.ChartReference}:{resource.ChartVersion})",
                 Action = ctx => InstallHelmChartAsync(ctx, environment, resource)
             };
 
-            // Run after the main application Helm deploy
             installStep.DependsOn($"helm-deploy-{environment.Name}");
             installStep.RequiredBy(WellKnownPipelineSteps.Deploy);
+            steps.Add(installStep);
 
-            return Task.FromResult<IEnumerable<PipelineStep>>([installStep]);
+            if (resource.DestroyOnUninstall)
+            {
+                var uninstallStep = new PipelineStep
+                {
+                    Name = $"helm-uninstall-{name}",
+                    Description = $"Uninstalls Helm chart '{name}' from namespace '{resource.Namespace ?? name}'",
+                    Action = ctx => UninstallHelmChartAsync(ctx, environment, resource),
+                    DependsOnSteps = [WellKnownPipelineSteps.DestroyPrereq]
+                };
+                uninstallStep.RequiredBy(WellKnownPipelineSteps.Destroy);
+                steps.Add(uninstallStep);
+            }
+
+            return Task.FromResult<IEnumerable<PipelineStep>>(steps);
         }));
 
         return chartBuilder;
@@ -107,6 +127,9 @@ public static class KubernetesHelmChartExtensions
         ArgumentException.ThrowIfNullOrEmpty(key);
         ArgumentNullException.ThrowIfNull(value);
 
+        ValidateHelmSetKey(key, nameof(key));
+        ValidateHelmSetValue(value, nameof(value));
+
         builder.Resource.Values[key] = value;
         return builder;
     }
@@ -125,6 +148,8 @@ public static class KubernetesHelmChartExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(@namespace);
+
+        HelmChartOptions.ValidateNamespace(@namespace, nameof(@namespace));
 
         builder.Resource.Namespace = @namespace;
         return builder;
@@ -145,13 +170,42 @@ public static class KubernetesHelmChartExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(releaseName);
 
+        HelmChartOptions.ValidateReleaseName(releaseName, nameof(releaseName));
+
         builder.Resource.ReleaseName = releaseName;
         return builder;
     }
 
     /// <summary>
-    /// Installs the Helm chart via helm upgrade --install.
+    /// Opts the Helm chart in to destroy-time uninstall. When set, <c>aspire destroy</c>
+    /// will run <c>helm uninstall</c> for this release as part of the destroy pipeline.
     /// </summary>
+    /// <param name="builder">The Helm chart resource builder.</param>
+    /// <returns>The resource builder for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// External Helm charts are not uninstalled by default because they may be shared
+    /// with workloads outside the Aspire app (for example, cert-manager or an ingress
+    /// controller installed once for many apps). Opt in only when the chart's lifecycle
+    /// is owned by this app.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// k8s.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1")
+    ///     .WithDestroy();
+    /// </code>
+    /// </example>
+    [AspireExport("withHelmChartDestroy", Description = "Uninstalls the Helm chart on aspire destroy")]
+    public static IResourceBuilder<KubernetesHelmChartResource> WithDestroy(
+        this IResourceBuilder<KubernetesHelmChartResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Resource.DestroyOnUninstall = true;
+        return builder;
+    }
+
     private static async Task InstallHelmChartAsync(
         PipelineStepContext context,
         KubernetesEnvironmentResource environment,
@@ -160,31 +214,28 @@ public static class KubernetesHelmChartExtensions
         var logger = context.Services.GetRequiredService<ILogger<KubernetesHelmChartResource>>();
         var helmRunner = context.Services.GetRequiredService<IHelmRunner>();
 
-        var releaseName = chart.ReleaseName ?? chart.Name;
-        var @namespace = chart.Namespace ?? chart.Name;
-        var chartRef = chart.ChartReference ?? throw new InvalidOperationException($"Helm chart '{chart.Name}' has no chart reference configured.");
-        var chartVersion = chart.ChartVersion ?? throw new InvalidOperationException($"Helm chart '{chart.Name}' has no chart version configured.");
+        var (releaseName, @namespace) = ResolveReleaseAndNamespace(chart);
 
         logger.LogInformation(
             "Installing Helm chart '{ChartName}' ({ChartRef}:{ChartVersion}) into namespace '{Namespace}'.",
-            chart.Name, chartRef, chartVersion, @namespace);
+            chart.Name, chart.ChartReference, chart.ChartVersion, @namespace);
 
         var arguments = new StringBuilder();
-        arguments.Append(CultureInfo.InvariantCulture, $"upgrade --install {releaseName} \"{chartRef}\"");
+        arguments.Append(CultureInfo.InvariantCulture, $"upgrade --install {releaseName} {QuoteArg(chart.ChartReference)}");
         arguments.Append(CultureInfo.InvariantCulture, $" --namespace {@namespace}");
         arguments.Append(" --create-namespace");
         arguments.Append(" --wait");
 
-        arguments.Append(CultureInfo.InvariantCulture, $" --version {chartVersion}");
+        arguments.Append(CultureInfo.InvariantCulture, $" --version {chart.ChartVersion}");
 
         if (environment.KubeConfigPath is not null)
         {
-            arguments.Append(CultureInfo.InvariantCulture, $" --kubeconfig \"{environment.KubeConfigPath}\"");
+            arguments.Append(CultureInfo.InvariantCulture, $" --kubeconfig {QuoteArg(environment.KubeConfigPath)}");
         }
 
         foreach (var (key, value) in chart.Values)
         {
-            arguments.Append(CultureInfo.InvariantCulture, $" --set \"{key}={value}\"");
+            arguments.Append(CultureInfo.InvariantCulture, $" --set {QuoteArg($"{key}={value}")}");
         }
 
         var stderrBuilder = new StringBuilder();
@@ -209,8 +260,142 @@ public static class KubernetesHelmChartExtensions
             throw new InvalidOperationException(message);
         }
 
+        if (chart.DestroyOnUninstall)
+        {
+            // Persist install state so destroy can find this release later, even from a
+            // different process where the in-memory resource state is gone.
+            var deploymentStateManager = context.Services.GetRequiredService<IDeploymentStateManager>();
+            var stateSection = await deploymentStateManager
+                .AcquireSectionAsync(GetStateSectionName(environment, chart), context.CancellationToken)
+                .ConfigureAwait(false);
+            stateSection.Data["ReleaseName"] = releaseName;
+            stateSection.Data["Namespace"] = @namespace;
+            await deploymentStateManager.SaveSectionAsync(stateSection, context.CancellationToken).ConfigureAwait(false);
+        }
+
         logger.LogInformation(
             "Helm chart '{ChartName}' installed successfully as release '{ReleaseName}' in namespace '{Namespace}'.",
             chart.Name, releaseName, @namespace);
     }
+
+    private static async Task UninstallHelmChartAsync(
+        PipelineStepContext context,
+        KubernetesEnvironmentResource environment,
+        KubernetesHelmChartResource chart)
+    {
+        var logger = context.Services.GetRequiredService<ILogger<KubernetesHelmChartResource>>();
+        var helmRunner = context.Services.GetRequiredService<IHelmRunner>();
+        var deploymentStateManager = context.Services.GetRequiredService<IDeploymentStateManager>();
+
+        var stateSection = await deploymentStateManager
+            .AcquireSectionAsync(GetStateSectionName(environment, chart), context.CancellationToken)
+            .ConfigureAwait(false);
+        var savedReleaseName = stateSection.Data["ReleaseName"]?.ToString();
+        var savedNamespace = stateSection.Data["Namespace"]?.ToString();
+
+        // Fall back to the resource configuration when no state was persisted (e.g., the
+        // user opted in to destroy after deploying without it). This is best-effort.
+        var (defaultReleaseName, defaultNamespace) = ResolveReleaseAndNamespace(chart);
+        var releaseName = !string.IsNullOrEmpty(savedReleaseName) ? savedReleaseName : defaultReleaseName;
+        var @namespace = !string.IsNullOrEmpty(savedNamespace) ? savedNamespace : defaultNamespace;
+
+        logger.LogInformation(
+            "Uninstalling Helm release '{ReleaseName}' for chart '{ChartName}' from namespace '{Namespace}'.",
+            releaseName, chart.Name, @namespace);
+
+        var arguments = new StringBuilder();
+        arguments.Append(CultureInfo.InvariantCulture, $"uninstall {releaseName} --namespace {@namespace}");
+
+        if (environment.KubeConfigPath is not null)
+        {
+            arguments.Append(CultureInfo.InvariantCulture, $" --kubeconfig {QuoteArg(environment.KubeConfigPath)}");
+        }
+
+        var stderrBuilder = new StringBuilder();
+
+        var exitCode = await helmRunner.RunAsync(
+            arguments.ToString(),
+            onOutputData: output => logger.LogDebug("helm (stdout): {Output}", output),
+            onErrorData: error =>
+            {
+                stderrBuilder.AppendLine(error);
+                logger.LogDebug("helm (stderr): {Error}", error);
+            },
+            cancellationToken: context.CancellationToken).ConfigureAwait(false);
+
+        if (exitCode != 0)
+        {
+            var errorOutput = stderrBuilder.ToString().Trim();
+            var message = string.IsNullOrEmpty(errorOutput)
+                ? $"helm uninstall for chart '{chart.Name}' failed with exit code {exitCode}"
+                : $"helm uninstall for chart '{chart.Name}' failed: {errorOutput}";
+
+            throw new InvalidOperationException(message);
+        }
+
+        await deploymentStateManager.DeleteSectionAsync(stateSection, context.CancellationToken).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Helm release '{ReleaseName}' uninstalled from namespace '{Namespace}'.",
+            releaseName, @namespace);
+    }
+
+    private static (string ReleaseName, string Namespace) ResolveReleaseAndNamespace(KubernetesHelmChartResource chart)
+        => (chart.ReleaseName ?? chart.Name, chart.Namespace ?? chart.Name);
+
+    private static string GetStateSectionName(KubernetesEnvironmentResource environment, KubernetesHelmChartResource chart)
+        => $"HelmChart:{environment.Name}:{chart.Name}";
+
+    // Whitelist for Helm chart references. Covers OCI URLs (oci://host/path), HTTP/HTTPS URLs,
+    // local paths, plain chart names ("repo/chart"), and packaged chart filenames. Rejects anything
+    // that could break helm argument tokenization (whitespace, quotes, control chars).
+    [GeneratedRegex(@"^[A-Za-z0-9_./:@+~\-]+$")]
+    private static partial Regex ChartReferencePattern();
+
+    // Disallowed in helm --set keys: anything that would break the key=value tokenization or
+    // interact with helm's escape syntax. Allow alphanumerics plus dot, dash, underscore,
+    // and brackets (for indexed/array paths like "args[0]").
+    [GeneratedRegex(@"^[A-Za-z0-9_.\-\[\]]+$")]
+    private static partial Regex HelmSetKeyPattern();
+
+    private static void ValidateChartReference(string chartReference, string paramName)
+    {
+        if (!ChartReferencePattern().IsMatch(chartReference))
+        {
+            throw new ArgumentException(
+                $"Helm chart reference '{chartReference}' is invalid. Use OCI/HTTP URLs, repo/chart names, or local paths containing only letters, digits, '.', '-', '_', '/', ':', '@', '+', '~'.",
+                paramName);
+        }
+    }
+
+    private static void ValidateHelmSetKey(string key, string paramName)
+    {
+        if (!HelmSetKeyPattern().IsMatch(key))
+        {
+            throw new ArgumentException(
+                $"Helm value key '{key}' is invalid. Use letters, digits, '.', '-', '_', or brackets for indexed paths.",
+                paramName);
+        }
+    }
+
+    private static void ValidateHelmSetValue(string value, string paramName)
+    {
+        // Reject control characters (newlines, tabs) and double-quotes that would break the
+        // surrounding quoted argument we hand to the OS process. Helm itself supports richer
+        // value syntax via --set-file / --set-string, which users can wire up later if needed.
+        foreach (var c in value)
+        {
+            if (c == '"' || c == '\\' || char.IsControl(c))
+            {
+                throw new ArgumentException(
+                    $"Helm value contains an unsupported character (0x{(int)c:X2}). Avoid quotes, backslashes, and control characters; use --values files for complex values.",
+                    paramName);
+            }
+        }
+    }
+
+    // Wraps an already-validated argument fragment in double quotes for safe interpolation
+    // into the helm arguments string. Callers must validate that the value contains no
+    // embedded quotes, backslashes, or control characters first.
+    private static string QuoteArg(string value) => $"\"{value}\"";
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartResource.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Represents an external Helm chart to be installed into a Kubernetes environment.
+/// This resource models a Helm chart from a repository (OCI or HTTP) that will be
+/// installed as a pipeline step after the main application Helm chart is deployed.
+/// </summary>
+/// <param name="name">The name of the Helm chart resource.</param>
+/// <param name="environment">The parent Kubernetes environment resource.</param>
+/// <remarks>
+/// <para>
+/// Create a Helm chart resource using <see cref="KubernetesHelmChartExtensions.AddHelmChart"/>
+/// and configure it with values using <see cref="KubernetesHelmChartExtensions.WithHelmValue"/>.
+/// </para>
+/// <para>
+/// At deploy time, the chart is installed via <c>helm upgrade --install</c> as a pipeline step
+/// that runs after the main application Helm chart is deployed. The chart is installed into
+/// the specified namespace (defaulting to the chart name).
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var k8s = builder.AddKubernetesEnvironment("k8s");
+///
+/// // Install NGINX Ingress Controller from OCI registry
+/// k8s.AddHelmChart("nginx", "oci://ghcr.io/nginx/charts/nginx-ingress", "1.5.0");
+///
+/// // Install cert-manager with custom values
+/// k8s.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0")
+///     .WithHelmValue("crds.enabled", "true")
+///     .WithHelmValue("config.enableGatewayAPI", "true");
+/// </code>
+/// </example>
+[AspireExport]
+public class KubernetesHelmChartResource(
+    string name,
+    KubernetesEnvironmentResource environment) : Resource(name), IResourceWithParent<KubernetesEnvironmentResource>
+{
+    /// <summary>
+    /// Gets the parent Kubernetes environment resource.
+    /// </summary>
+    public KubernetesEnvironmentResource Parent { get; } = environment ?? throw new ArgumentNullException(nameof(environment));
+
+    /// <summary>
+    /// Gets or sets the Helm chart reference. This can be an OCI registry URL
+    /// (e.g., <c>oci://quay.io/jetstack/charts/cert-manager</c>) or a chart name
+    /// from an added repository.
+    /// </summary>
+    public string? ChartReference { get; set; }
+
+    /// <summary>
+    /// Gets or sets the chart version to install.
+    /// </summary>
+    public string? ChartVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Kubernetes namespace to install the chart into.
+    /// Defaults to the chart resource name if not specified.
+    /// </summary>
+    public string? Namespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Helm release name. Defaults to the resource name.
+    /// </summary>
+    public string? ReleaseName { get; set; }
+
+    /// <summary>
+    /// Gets the Helm values to set during installation.
+    /// Keys are dot-separated paths (e.g., <c>config.enableGatewayAPI</c>),
+    /// values are the string values to set.
+    /// </summary>
+    internal Dictionary<string, string> Values { get; } = [];
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartResource.cs
@@ -10,8 +10,6 @@ namespace Aspire.Hosting.Kubernetes;
 /// This resource models a Helm chart from a repository (OCI or HTTP) that will be
 /// installed as a pipeline step after the main application Helm chart is deployed.
 /// </summary>
-/// <param name="name">The name of the Helm chart resource.</param>
-/// <param name="environment">The parent Kubernetes environment resource.</param>
 /// <remarks>
 /// <para>
 /// Create a Helm chart resource using <see cref="KubernetesHelmChartExtensions.AddHelmChart"/>
@@ -21,6 +19,11 @@ namespace Aspire.Hosting.Kubernetes;
 /// At deploy time, the chart is installed via <c>helm upgrade --install</c> as a pipeline step
 /// that runs after the main application Helm chart is deployed. The chart is installed into
 /// the specified namespace (defaulting to the chart name).
+/// </para>
+/// <para>
+/// By default, an external Helm chart is <em>not</em> uninstalled by <c>aspire destroy</c>.
+/// Opt in to destroy-time uninstall by calling
+/// <see cref="KubernetesHelmChartExtensions.WithDestroy(IResourceBuilder{KubernetesHelmChartResource})"/>.
 /// </para>
 /// </remarks>
 /// <example>
@@ -37,26 +40,46 @@ namespace Aspire.Hosting.Kubernetes;
 /// </code>
 /// </example>
 [AspireExport]
-public class KubernetesHelmChartResource(
-    string name,
-    KubernetesEnvironmentResource environment) : Resource(name), IResourceWithParent<KubernetesEnvironmentResource>
+public class KubernetesHelmChartResource : Resource, IResourceWithParent<KubernetesEnvironmentResource>
 {
+    /// <summary>
+    /// Initializes a new instance of <see cref="KubernetesHelmChartResource"/>.
+    /// </summary>
+    /// <param name="name">The name of the Helm chart resource.</param>
+    /// <param name="environment">The parent Kubernetes environment resource.</param>
+    /// <param name="chartReference">The Helm chart reference (e.g., an OCI URL).</param>
+    /// <param name="chartVersion">The Helm chart version to install.</param>
+    public KubernetesHelmChartResource(
+        string name,
+        KubernetesEnvironmentResource environment,
+        string chartReference,
+        string chartVersion) : base(name)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentException.ThrowIfNullOrEmpty(chartReference);
+        ArgumentException.ThrowIfNullOrEmpty(chartVersion);
+
+        Parent = environment;
+        ChartReference = chartReference;
+        ChartVersion = chartVersion;
+    }
+
     /// <summary>
     /// Gets the parent Kubernetes environment resource.
     /// </summary>
-    public KubernetesEnvironmentResource Parent { get; } = environment ?? throw new ArgumentNullException(nameof(environment));
+    public KubernetesEnvironmentResource Parent { get; }
 
     /// <summary>
-    /// Gets or sets the Helm chart reference. This can be an OCI registry URL
+    /// Gets the Helm chart reference. This can be an OCI registry URL
     /// (e.g., <c>oci://quay.io/jetstack/charts/cert-manager</c>) or a chart name
     /// from an added repository.
     /// </summary>
-    public string? ChartReference { get; set; }
+    public string ChartReference { get; }
 
     /// <summary>
-    /// Gets or sets the chart version to install.
+    /// Gets the chart version to install.
     /// </summary>
-    public string? ChartVersion { get; set; }
+    public string ChartVersion { get; }
 
     /// <summary>
     /// Gets or sets the Kubernetes namespace to install the chart into.
@@ -75,4 +98,12 @@ public class KubernetesHelmChartResource(
     /// values are the string values to set.
     /// </summary>
     internal Dictionary<string, string> Values { get; } = [];
+
+    /// <summary>
+    /// Gets a value indicating whether <c>aspire destroy</c> should uninstall this Helm release.
+    /// Set via <see cref="KubernetesHelmChartExtensions.WithDestroy(IResourceBuilder{KubernetesHelmChartResource})"/>.
+    /// Defaults to <see langword="false"/> so charts that may be shared with other workloads
+    /// are not removed automatically.
+    /// </summary>
+    internal bool DestroyOnUninstall { get; set; }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithHelmChartTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployWithHelmChartTests.cs
@@ -1,0 +1,176 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// E2E test for <c>aspire deploy</c> to Kubernetes with an external Helm chart
+/// installed via <c>AddHelmChart</c>. Verifies that both the Aspire application
+/// and the external podinfo chart are deployed successfully.
+/// </summary>
+public sealed class KubernetesDeployWithHelmChartTests(ITestOutputHelper output)
+{
+    private const string ProjectName = "K8sHelmChartTest";
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task DeployK8sWithExternalHelmChart()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        using var workspace = TemporaryWorkspace.Create(output);
+
+        var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
+        var k8sNamespace = $"test-{clusterName[..16]}";
+
+        output.WriteLine($"Cluster name: {clusterName}");
+        output.WriteLine($"Namespace: {k8sNamespace}");
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        // Prepare environment
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        await auto.VerifyPullRequestCliVersionAsync(counter);
+
+        try
+        {
+            // =====================================================================
+            // Phase 1: Install KinD + Helm, create cluster with local registry
+            // =====================================================================
+
+            await auto.InstallKindAndHelmAsync(counter);
+            await auto.CreateKindClusterWithRegistryAsync(counter, clusterName);
+
+            // =====================================================================
+            // Phase 2: Scaffold the project with AddHelmChart for podinfo
+            // =====================================================================
+
+            var appHostCode = $$"""
+                #pragma warning disable ASPIRECOMPUTE003
+                using Aspire.Hosting;
+                using Aspire.Hosting.Kubernetes;
+
+                var builder = DistributedApplication.CreateBuilder(args);
+
+                var registryEndpoint = builder.AddParameter("registryendpoint");
+                var registry = builder.AddContainerRegistry("registry", registryEndpoint);
+
+                var api = builder.AddProject<Projects.{{ProjectName}}_ApiService>("server")
+                    .WithExternalHttpEndpoints();
+
+                var k8s = builder.AddKubernetesEnvironment("env")
+                    .WithHelm(helm =>
+                    {
+                        helm.WithNamespace(builder.AddParameter("namespace"));
+                        helm.WithChartVersion(builder.AddParameter("chartversion"));
+                    });
+
+                // Install an external Helm chart (podinfo) alongside the app
+                k8s.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1")
+                    .WithHelmValue("replicaCount", "2")
+                    .WithHelmValue("ui.message", "Aspire AddHelmChart works!");
+
+                builder.Build().Run();
+                """;
+
+            var apiProgramCode = """
+                var builder = WebApplication.CreateBuilder(args);
+                builder.AddServiceDefaults();
+
+                var app = builder.Build();
+                app.MapDefaultEndpoints();
+
+                app.MapGet("/test-deployment", () =>
+                {
+                    return Results.Ok("PASSED: API service with external Helm chart");
+                });
+
+                app.Run();
+                """;
+
+            await auto.ScaffoldK8sDeployProjectAsync(
+                counter,
+                ProjectName,
+                Path.Combine(workspace.WorkspaceRoot.FullName, ProjectName),
+                appHostHostingPackages: ["Aspire.Hosting.Kubernetes"],
+                apiClientPackages: [],
+                appHostCode: appHostCode,
+                apiProgramCode: apiProgramCode,
+                output: output);
+
+            // =====================================================================
+            // Phase 3: Run aspire deploy interactively
+            // =====================================================================
+
+            await auto.AspireDeployInteractiveAsync(
+                counter,
+                parameterResponses:
+                [
+                    ("registryendpoint", "localhost:5001"),
+                    ("namespace", k8sNamespace),
+                    ("chartversion", "0.1.0"),
+                ]);
+
+            // =====================================================================
+            // Phase 4: Verify the Aspire app deployment
+            // =====================================================================
+
+            await auto.VerifyDeploymentAsync(
+                counter,
+                @namespace: k8sNamespace,
+                serviceName: "server",
+                localPort: 18080,
+                testPath: "/test-deployment");
+
+            // =====================================================================
+            // Phase 5: Verify the external Helm chart (podinfo) was installed
+            // =====================================================================
+
+            // Check that podinfo pods are running in its own namespace
+            await auto.TypeAsync("kubectl get pods -n podinfo -l app.kubernetes.io/name=podinfo");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Verify podinfo has 2 replicas as configured
+            await auto.TypeAsync(
+                "READY=$(kubectl get deploy -n podinfo -l app.kubernetes.io/name=podinfo " +
+                "-o jsonpath='{.items[0].status.readyReplicas}') && " +
+                "[ \"$READY\" = \"2\" ] && echo 'VERIFY_OK: podinfo has 2 replicas' || " +
+                "echo \"FAIL: expected 2 replicas, got $READY\"");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("VERIFY_OK", timeout: TimeSpan.FromSeconds(60));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Verify the Helm release exists
+            await auto.TypeAsync("helm list -n podinfo");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // =====================================================================
+            // Phase 6: Cleanup
+            // =====================================================================
+
+            await auto.CleanupKubernetesDeploymentAsync(counter, clusterName);
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+        }
+        finally
+        {
+            await KubernetesDeployTestHelpers.CleanupKindClusterOutOfBandAsync(clusterName, output);
+        }
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksWithHelmChartDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksWithHelmChartDeploymentTests.cs
@@ -116,8 +116,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 #pragma warning disable ASPIREAZURE003
 
 // AKS environment provisioned by Aspire (Azure Kubernetes Service).
+// Pin both the system and workload pools to DASv5 SKUs; the default workload pool
+// uses DSv5 SKUs which routinely hit vCPU quota in westus3.
 var aks = builder.AddAzureKubernetesEnvironment("aks")
     .WithSystemNodePool("Standard_D2as_v5");
+aks.AddNodePool("workload", "Standard_D2as_v5", 1, 3);
 
 // Install podinfo as an external Helm chart and opt in to destroy-time uninstall.
 aks.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1")

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksWithHelmChartDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksWithHelmChartDeploymentTests.cs
@@ -1,0 +1,292 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end test for deploying an Aspire starter app to AKS using
+/// <c>AddAzureKubernetesEnvironment</c> and installing an external Helm chart
+/// (podinfo) via <c>aks.AddHelmChart(...).WithDestroy()</c>.
+///
+/// Verifies that:
+/// 1. The chart is installed alongside the application Helm deploy step.
+/// 2. The podinfo pods come up with the configured replica count.
+/// 3. <c>WithDestroy()</c> causes the chart to be uninstalled when
+///    <c>aspire destroy</c> tears down the environment.
+/// </summary>
+public sealed class AksWithHelmChartDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 45 minutes to allow for AKS provisioning (~10-15 min) plus deployment.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployAksWithHelmChart()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployAksWithHelmChartCore(cancellationToken);
+    }
+
+    private async Task DeployAksWithHelmChartCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("akshelm");
+        var projectName = "AksHelmChart";
+
+        output.WriteLine($"Test: {nameof(DeployAksWithHelmChart)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            // Step 2: Install current build of the Aspire CLI
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+            // Step 3: Create starter project (no Redis cache).
+            output.WriteLine("Step 3: Creating starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            // Step 4: Navigate to project directory
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 5: Add Aspire.Hosting.Azure.Kubernetes package
+            output.WriteLine("Step 5: Adding Azure Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 6: Modify AppHost.cs to add AKS env + an external Helm chart
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+                var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+                output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+                var content = File.ReadAllText(appHostFilePath);
+
+                content = content.Replace(
+                    "var builder = DistributedApplication.CreateBuilder(args);",
+                    """
+var builder = DistributedApplication.CreateBuilder(args);
+
+#pragma warning disable ASPIREAZURE003
+
+// AKS environment provisioned by Aspire (Azure Kubernetes Service).
+var aks = builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D2as_v5");
+
+// Install podinfo as an external Helm chart and opt in to destroy-time uninstall.
+aks.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1")
+    .WithHelmValue("replicaCount", "2")
+    .WithHelmValue("ui.message", "Aspire AKS AddHelmChart E2E test")
+    .WithDestroy();
+
+#pragma warning restore ASPIREAZURE003
+""");
+
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine($"Modified AppHost.cs with AKS + external Helm chart");
+                output.WriteLine($"New content:\n{content}");
+            }
+
+            // Step 7: Navigate to AppHost project directory
+            output.WriteLine("Step 7: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 8: Set env vars for deployment
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Step 9: Deploy to AKS
+            output.WriteLine("Step 9: Starting AKS deployment with external Helm chart...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Step 10: Get AKS credentials so kubectl/helm can talk to the cluster
+            output.WriteLine("Step 10: Getting AKS credentials...");
+            await auto.TypeAsync($"AKS_NAME=$(az aks list -g {resourceGroupName} --query '[0].name' -o tsv) && " +
+                  $"az aks get-credentials -g {resourceGroupName} -n $AKS_NAME --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // Step 11: Wait for app pods to be ready
+            output.WriteLine("Step 11: Waiting for pods to be ready...");
+            await auto.TypeAsync("kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s 2>/dev/null || true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            await auto.TypeAsync("kubectl get pods --all-namespaces && kubectl get svc --all-namespaces");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 12: Verify podinfo pods come up with the configured replica count.
+            output.WriteLine("Step 12: Verifying podinfo Helm chart deployment...");
+            await auto.TypeAsync(
+                "for i in $(seq 1 30); do " +
+                "READY=$(kubectl get deploy -n podinfo -l app.kubernetes.io/name=podinfo " +
+                "-o jsonpath='{.items[0].status.readyReplicas}' 2>/dev/null); " +
+                "[ \"$READY\" = \"2\" ] && echo 'VERIFY_OK: podinfo has 2 ready replicas' && break; " +
+                "echo \"Attempt $i: readyReplicas=$READY, waiting...\"; sleep 5; done");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("VERIFY_OK", timeout: TimeSpan.FromMinutes(3));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Step 13: Verify the Helm release exists.
+            output.WriteLine("Step 13: Verifying podinfo Helm release...");
+            await auto.TypeAsync("helm list -n podinfo");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 14: Verify podinfo is serving traffic.
+            output.WriteLine("Step 14: Verifying podinfo is serving traffic...");
+            await auto.TypeAsync("kubectl port-forward svc/podinfo 19898:9898 -n podinfo > /dev/null 2>&1 &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync("sleep 3");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 10); do sleep 3; " +
+                "S=$(curl -so /dev/null -w '%{http_code}' http://localhost:19898/ 2>/dev/null); " +
+                "[ \"$S\" = \"200\" ] && echo \"VERIFY_OK: podinfo HTTP $S\" && OK=1 && break; " +
+                "echo \"Attempt $i: HTTP $S\"; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: podinfo not responding'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("VERIFY_OK", timeout: TimeSpan.FromSeconds(120));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync("kill %1 2>/dev/null; true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Step 15: Destroy and verify the external Helm chart was uninstalled too.
+            output.WriteLine("Step 15: Destroying deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            // Step 16: Verify the podinfo release is gone (this is the WithDestroy() contract).
+            output.WriteLine("Step 16: Verifying podinfo Helm release was uninstalled by aspire destroy...");
+            await auto.TypeAsync(
+                "RELEASES=$(helm list -n podinfo -q 2>/dev/null); " +
+                "if [ -z \"$RELEASES\" ]; then echo 'VERIFY_OK: podinfo release was uninstalled'; " +
+                "else echo \"FAIL: podinfo release still exists: $RELEASES\"; exit 1; fi");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("VERIFY_OK", timeout: TimeSpan.FromMinutes(2));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Step 17: Exit terminal
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployAksWithHelmChart),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployAksWithHelmChart),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName);
+        }
+    }
+
+    private void TriggerCleanupResourceGroup(string resourceGroupName)
+    {
+        using var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesHelmChartDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesHelmChartDeploymentTests.cs
@@ -1,0 +1,351 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end test for deploying an Aspire application to a BYO AKS cluster with an
+/// external Helm chart (podinfo) installed via <c>AddHelmChart</c>. Verifies that both
+/// the Aspire application and the external chart are deployed successfully, and that
+/// the podinfo pods are running with the configured replica count and values.
+/// </summary>
+public sealed class KubernetesHelmChartDeploymentTests(ITestOutputHelper output)
+{
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployStarterWithExternalHelmChartToKubernetes()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterWithExternalHelmChartCore(cancellationToken);
+    }
+
+    private async Task DeployStarterWithExternalHelmChartCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("k8shelm");
+        var clusterName = $"aks-{DeploymentE2ETestHelpers.GetRunId()}-{DeploymentE2ETestHelpers.GetRunAttempt()}";
+        var acrName = $"acrh{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
+        acrName = new string(acrName.Where(char.IsLetterOrDigit).Take(50).ToArray());
+        if (acrName.Length < 5)
+        {
+            acrName = $"acrtest{Guid.NewGuid():N}"[..24];
+        }
+
+        var projectName = "K8sHelmChart";
+        var k8sNamespace = "helmtest";
+
+        output.WriteLine($"Test: {nameof(DeployStarterWithExternalHelmChartToKubernetes)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"AKS Cluster: {clusterName}");
+        output.WriteLine($"ACR Name: {acrName}");
+        output.WriteLine($"K8s Namespace: {k8sNamespace}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // ===== PHASE 1: Provision AKS Infrastructure =====
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            output.WriteLine("Step 2: Registering resource providers...");
+            await auto.TypeAsync(
+                "az provider register --namespace Microsoft.ContainerService --wait && " +
+                "az provider register --namespace Microsoft.ContainerRegistry --wait");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            output.WriteLine("Step 3: Creating resource group...");
+            await auto.TypeAsync($"az group create --name {resourceGroupName} --location westus3 --output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 4: Creating ACR...");
+            await auto.TypeAsync($"az acr create --resource-group {resourceGroupName} --name {acrName} --sku Basic --output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            await auto.TypeAsync($"az acr login --name {acrName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 5: Creating AKS cluster (10-15 minutes)...");
+            await auto.TypeAsync(
+                $"az aks create " +
+                $"--resource-group {resourceGroupName} " +
+                $"--name {clusterName} " +
+                $"--node-count 1 " +
+                $"--node-vm-size Standard_D2as_v5 " +
+                $"--generate-ssh-keys " +
+                $"--attach-acr {acrName} " +
+                $"--enable-managed-identity " +
+                $"--output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(20));
+
+            output.WriteLine("Step 6: Configuring kubectl...");
+            await auto.TypeAsync($"az aks get-credentials --resource-group {resourceGroupName} --name {clusterName} --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync("kubectl get nodes");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // ===== PHASE 2: Create Aspire Project with AddHelmChart =====
+
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 7");
+
+            output.WriteLine("Step 8: Creating Aspire starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 9: Adding Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Kubernetes");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 10: Modify AppHost.cs
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Step 10: Modifying AppHost.cs at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+
+            var buildRunPattern = "builder.Build().Run();";
+            var replacement = $$"""
+// Kubernetes environment with external Helm chart
+var registryEndpoint = builder.AddParameter("registryendpoint");
+var registry = builder.AddContainerRegistry("registry", registryEndpoint);
+
+var k8s = builder.AddKubernetesEnvironment("k8s")
+    .WithHelm(helm =>
+    {
+        helm.WithNamespace(builder.AddParameter("namespace"));
+        helm.WithChartVersion(builder.AddParameter("chartversion"));
+    });
+
+// Install podinfo as an external Helm chart
+k8s.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1")
+    .WithHelmValue("replicaCount", "2")
+    .WithHelmValue("ui.message", "Aspire AddHelmChart E2E test");
+
+builder.Build().Run();
+""";
+
+            content = content.Replace(buildRunPattern, replacement);
+
+            var topOfFile = "#pragma warning disable ASPIREPIPELINES001\n#pragma warning disable ASPIRECOMPUTE003\nusing Aspire.Hosting.Kubernetes;\n";
+            if (!content.Contains("#pragma warning disable ASPIREPIPELINES001"))
+            {
+                content = topOfFile + content;
+            }
+
+            File.WriteAllText(appHostFilePath, content);
+            output.WriteLine("Modified AppHost.cs with AddKubernetesEnvironment + AddHelmChart");
+
+            // Navigate to AppHost dir
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // ===== PHASE 3: Deploy with aspire deploy =====
+
+            output.WriteLine("Step 11: Refreshing ACR login...");
+            await auto.TypeAsync($"az acr login --name {acrName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 12: Setting deployment parameters...");
+            await auto.TypeAsync(
+                $"export Parameters__registryendpoint={acrName}.azurecr.io && " +
+                $"export Parameters__namespace={k8sNamespace} && " +
+                "export Parameters__chartversion=0.1.0");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 13: Running aspire deploy...");
+            await auto.TypeAsync("aspire deploy");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(15));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // ===== PHASE 4: Verify =====
+
+            output.WriteLine("Step 14: Waiting for app pods...");
+            await auto.TypeAsync($"kubectl wait --for=condition=Ready pod --all -n {k8sNamespace} --timeout=300s");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            await auto.TypeAsync($"kubectl get pods -n {k8sNamespace}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Verify podinfo pods are running in their own namespace
+            output.WriteLine("Step 15: Verifying podinfo Helm chart deployment...");
+            await auto.TypeAsync(
+                "for i in $(seq 1 30); do " +
+                "READY=$(kubectl get deploy -n podinfo -l app.kubernetes.io/name=podinfo " +
+                "-o jsonpath='{.items[0].status.readyReplicas}' 2>/dev/null); " +
+                "[ \"$READY\" = \"2\" ] && echo 'VERIFY_OK: podinfo has 2 ready replicas' && break; " +
+                "echo \"Attempt $i: readyReplicas=$READY, waiting...\"; sleep 5; done");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("VERIFY_OK", timeout: TimeSpan.FromMinutes(3));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // Verify Helm release
+            await auto.TypeAsync("helm list -n podinfo");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Verify podinfo is serving traffic
+            output.WriteLine("Step 16: Verifying podinfo is serving traffic...");
+            await auto.TypeAsync("kubectl port-forward svc/podinfo 19898:9898 -n podinfo > /dev/null 2>&1 &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync("sleep 3");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 10); do sleep 3; " +
+                "S=$(curl -so /dev/null -w '%{http_code}' http://localhost:19898/ 2>/dev/null); " +
+                "[ \"$S\" = \"200\" ] && echo \"VERIFY_OK: podinfo HTTP $S\" && OK=1 && break; " +
+                "echo \"Attempt $i: HTTP $S\"; done; " +
+                "[ \"$OK\" = \"1\" ] || echo 'WARN: podinfo not responding'");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("VERIFY_OK", timeout: TimeSpan.FromSeconds(60));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            await auto.TypeAsync("kill %1 2>/dev/null; true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            // ===== PHASE 5: Cleanup =====
+
+            output.WriteLine("Step 17: Destroying deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Helm chart deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterWithExternalHelmChartToKubernetes),
+                resourceGroupName,
+                new Dictionary<string, string>
+                {
+                    ["cluster"] = clusterName,
+                    ["acr"] = acrName,
+                    ["project"] = projectName
+                },
+                duration);
+
+            output.WriteLine("✅ Test passed - Aspire app with external Helm chart deployed to AKS!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterWithExternalHelmChartToKubernetes),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+
+    private async Task CleanupResourceGroupAsync(string resourceGroupName)
+    {
+        try
+        {
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "az",
+                    Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                }
+            };
+
+            process.Start();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode == 0)
+            {
+                output.WriteLine($"Resource group deletion initiated: {resourceGroupName}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Deletion initiated");
+            }
+            else
+            {
+                var error = await process.StandardError.ReadToEndAsync();
+                output.WriteLine($"Resource group deletion may have failed (exit code {process.ExitCode}): {error}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, $"Exit code {process.ExitCode}: {error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to cleanup resource group: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesHelmChartDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesHelmChartDeploymentTests.cs
@@ -315,7 +315,7 @@ builder.Build().Run();
     {
         try
         {
-            var process = new System.Diagnostics.Process
+            using var process = new System.Diagnostics.Process
             {
                 StartInfo = new System.Diagnostics.ProcessStartInfo
                 {

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesHelmChartTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesHelmChartTests.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE003
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Kubernetes;
+using Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureKubernetesHelmChartTests
+{
+    [Fact]
+    public void AksAddHelmChart_HasCorrectParent()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        var chart = aks.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0");
+
+        // The chart should be a child of the inner K8S environment, not the AKS environment.
+        Assert.IsType<KubernetesHelmChartResource>(chart.Resource);
+        Assert.IsType<KubernetesEnvironmentResource>(chart.Resource.Parent);
+    }
+
+    [Fact]
+    public void AksAddHelmChart_BasicProperties()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        var chart = aks.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0");
+
+        Assert.Equal("cert-manager", chart.Resource.Name);
+        Assert.Equal("oci://quay.io/jetstack/charts/cert-manager", chart.Resource.ChartReference);
+        Assert.Equal("1.17.0", chart.Resource.ChartVersion);
+    }
+
+    [Fact]
+    public void AksAddHelmChart_WithHelmValue_StoresValues()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        var chart = aks.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0")
+            .WithHelmValue("crds.enabled", "true")
+            .WithHelmValue("config.enableGatewayAPI", "true");
+
+        Assert.Equal(2, chart.Resource.Values.Count);
+        Assert.Equal("true", chart.Resource.Values["crds.enabled"]);
+        Assert.Equal("true", chart.Resource.Values["config.enableGatewayAPI"]);
+    }
+
+    [Fact]
+    public void AksAddHelmChart_WithNamespace_SetsNamespace()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        var chart = aks.AddHelmChart("nginx", "oci://ghcr.io/nginx/charts/nginx-ingress", "1.5.0")
+            .WithNamespace("ingress-nginx");
+
+        Assert.Equal("ingress-nginx", chart.Resource.Namespace);
+    }
+
+    [Fact]
+    public void AksAddHelmChart_WithReleaseName_SetsReleaseName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        var chart = aks.AddHelmChart("nginx", "oci://ghcr.io/nginx/charts/nginx-ingress", "1.5.0")
+            .WithReleaseName("my-nginx");
+
+        Assert.Equal("my-nginx", chart.Resource.ReleaseName);
+    }
+
+    [Fact]
+    public void AksAddHelmChart_WithDestroy_OptsIn()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        var chart = aks.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1")
+            .WithDestroy();
+
+        Assert.True(chart.Resource.DestroyOnUninstall);
+    }
+
+    [Fact]
+    public void AksAddHelmChart_DestroyDefaultsToFalse()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        var chart = aks.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1");
+
+        Assert.False(chart.Resource.DestroyOnUninstall);
+    }
+
+    [Fact]
+    public void AksAddHelmChart_ThrowsOnNullBuilder()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ((IResourceBuilder<AzureKubernetesEnvironmentResource>)null!)
+            .AddHelmChart("test", "oci://example.com/chart", "1.0.0"));
+    }
+
+    [Theory]
+    [InlineData(null, "oci://example.com/chart", "1.0.0")]
+    [InlineData("", "oci://example.com/chart", "1.0.0")]
+    [InlineData("test", null, "1.0.0")]
+    [InlineData("test", "", "1.0.0")]
+    [InlineData("test", "oci://example.com/chart", null)]
+    [InlineData("test", "oci://example.com/chart", "")]
+    public void AksAddHelmChart_ThrowsOnNullOrEmptyArgs(string? name, string? chartReference, string? chartVersion)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        Assert.ThrowsAny<ArgumentException>(() => aks.AddHelmChart(name!, chartReference!, chartVersion!));
+    }
+
+    [Fact]
+    public void AksAddHelmChart_RejectsInvalidChartVersion()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        Assert.Throws<ArgumentException>(() =>
+            aks.AddHelmChart("test", "oci://example.com/chart", "not-a-semver"));
+    }
+
+    [Fact]
+    public void AksAddHelmChart_RejectsMaliciousChartReference()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        Assert.Throws<ArgumentException>(() =>
+            aks.AddHelmChart("test", "evil chart\"", "1.0.0"));
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesHelmChartTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesHelmChartTests.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPIPELINES001
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Kubernetes.Tests;
+
+public class KubernetesHelmChartTests
+{
+    [Fact]
+    public void AddHelmChart_CreatesResourceWithCorrectProperties()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0");
+
+        Assert.Equal("cert-manager", chart.Resource.Name);
+        Assert.Equal("oci://quay.io/jetstack/charts/cert-manager", chart.Resource.ChartReference);
+        Assert.Equal("1.17.0", chart.Resource.ChartVersion);
+        Assert.Equal("env", chart.Resource.Parent.Name);
+    }
+
+    [Fact]
+    public void AddHelmChart_WithHelmValues_StoresValues()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0")
+            .WithHelmValue("crds.enabled", "true")
+            .WithHelmValue("config.enableGatewayAPI", "true");
+
+        Assert.Equal(2, chart.Resource.Values.Count);
+        Assert.Equal("true", chart.Resource.Values["crds.enabled"]);
+        Assert.Equal("true", chart.Resource.Values["config.enableGatewayAPI"]);
+    }
+
+    [Fact]
+    public void AddHelmChart_WithNamespace_SetsNamespace()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("nginx", "oci://ghcr.io/nginx/charts/nginx-ingress", "1.5.0")
+            .WithNamespace("ingress-nginx");
+
+        Assert.Equal("ingress-nginx", chart.Resource.Namespace);
+    }
+
+    [Fact]
+    public void AddHelmChart_WithReleaseName_SetsReleaseName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("nginx", "oci://ghcr.io/nginx/charts/nginx-ingress", "1.5.0")
+            .WithReleaseName("my-nginx");
+
+        Assert.Equal("my-nginx", chart.Resource.ReleaseName);
+    }
+
+    [Fact]
+    public void AddHelmChart_DefaultsNamespaceAndReleaseNameToNull()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("test", "oci://example.com/charts/test", "1.0.0");
+
+        Assert.Null(chart.Resource.Namespace);
+        Assert.Null(chart.Resource.ReleaseName);
+    }
+
+    [Fact]
+    public void AddHelmChart_HasPipelineStepAnnotation()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0");
+
+        Assert.True(
+            chart.Resource.TryGetAnnotationsOfType<PipelineStepAnnotation>(out var annotations),
+            "Helm chart resource should have a PipelineStepAnnotation");
+        Assert.Single(annotations);
+    }
+
+    [Fact]
+    public void AddHelmChart_MultipleCharts_AllRegistered()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart1 = k8s.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0");
+        var chart2 = k8s.AddHelmChart("nginx", "oci://ghcr.io/nginx/charts/nginx-ingress", "1.5.0");
+
+        Assert.NotEqual(chart1.Resource.Name, chart2.Resource.Name);
+        Assert.Equal("env", chart1.Resource.Parent.Name);
+        Assert.Equal("env", chart2.Resource.Parent.Name);
+    }
+
+    [Fact]
+    public void AddHelmChart_ThrowsOnNullOrEmptyArguments()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        Assert.Throws<ArgumentException>(() => k8s.AddHelmChart("", "oci://example.com/chart", "1.0.0"));
+        Assert.Throws<ArgumentException>(() => k8s.AddHelmChart("test", "", "1.0.0"));
+        Assert.Throws<ArgumentException>(() => k8s.AddHelmChart("test", "oci://example.com/chart", ""));
+    }
+
+    [Fact]
+    public void WithHelmValue_OverwritesExistingKey()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0")
+            .WithHelmValue("key", "value1")
+            .WithHelmValue("key", "value2");
+
+        Assert.Single(chart.Resource.Values);
+        Assert.Equal("value2", chart.Resource.Values["key"]);
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesHelmChartTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesHelmChartTests.cs
@@ -134,20 +134,20 @@ public class KubernetesHelmChartTests
     [InlineData("evil chart")]                  // whitespace
     [InlineData("evil\"chart")]                 // double quote
     [InlineData("evil\nchart")]                 // newline
-    [InlineData("--evil")]                      // already validated by chartReference whitelist
+    [InlineData("--evil")]                      // already validated by chartReference allowlist
     [InlineData("oci://repo/chart;rm -rf /")]   // semicolon
     public void AddHelmChart_RejectsMaliciousChartReference(string chartReference)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
 
-        // Note: the leading '--' case is currently allowed by the whitelist alone; it would
+        // Note: the leading '--' case is currently allowed by the allowlist alone; it would
         // still be a positional arg to helm and is harmless (helm rejects unknown flags).
         // Whitespace, quotes, newlines, and semicolons must all be rejected to prevent
         // argument-string injection into the helm process.
         if (chartReference == "--evil")
         {
-            // "--evil" passes the character whitelist but isn't a real injection vector
+            // "--evil" passes the character allowlist but isn't a real injection vector
             // because it would be parsed by helm as a chart-reference positional arg.
             return;
         }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesHelmChartTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesHelmChartTests.cs
@@ -156,6 +156,26 @@ public class KubernetesHelmChartTests
     }
 
     [Theory]
+    [InlineData("oci://quay.io/jetstack/charts/cert-manager")]   // OCI URL
+    [InlineData("oci://ghcr.io/stefanprodan/charts/podinfo")]    // OCI URL with ghcr.io
+    [InlineData("https://charts.example.com/repo/chart")]        // HTTPS URL
+    [InlineData("http://charts.example.com/repo/chart")]         // HTTP URL
+    [InlineData("myrepo/mychart")]                               // repo/chart
+    [InlineData("mychart-1.0.0.tgz")]                            // packaged chart filename
+    [InlineData("./local-chart")]                                // relative local path
+    [InlineData("chart+extra~tag")]                              // plus and tilde chars
+    [InlineData("oci://registry:5000/charts/app")]               // registry with port
+    [InlineData("oci://user@registry.io/charts/app")]            // registry with @
+    public void AddHelmChart_AcceptsValidChartReferences(string chartReference)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", chartReference, "1.0.0");
+        Assert.Equal(chartReference, chart.Resource.ChartReference);
+    }
+
+    [Theory]
     [InlineData("not-a-version")]
     [InlineData("1.2.3.4")]
     [InlineData("1.2.3-")]
@@ -377,6 +397,70 @@ public class KubernetesHelmChartTests
         var installStep = Assert.Single(steps, s => s.Name == "helm-install-test");
         Assert.Contains("oci://example.com/chart", installStep.Description);
         Assert.Contains("1.2.3", installStep.Description);
+    }
+
+    [Fact]
+    public async Task PipelineStepFactory_UninstallStepDescription_FallsBackToResourceNameForNamespace()
+    {
+        // When Namespace is not set, the uninstall step description should fall back to using
+        // the resource name as the namespace (the same fallback used at install time).
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("my-release", "oci://example.com/chart", "1.0.0")
+            .WithDestroy();
+
+        Assert.Null(chart.Resource.Namespace);
+
+        var steps = await CreateStepsAsync(builder, chart.Resource);
+
+        var uninstallStep = Assert.Single(steps, s => s.Name == "helm-uninstall-my-release");
+        Assert.Contains("my-release", uninstallStep.Description);
+    }
+
+    [Fact]
+    public async Task PipelineStepFactory_UninstallStepDescription_UsesExplicitNamespace()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("my-release", "oci://example.com/chart", "1.0.0")
+            .WithNamespace("custom-ns")
+            .WithDestroy();
+
+        var steps = await CreateStepsAsync(builder, chart.Resource);
+
+        var uninstallStep = Assert.Single(steps, s => s.Name == "helm-uninstall-my-release");
+        Assert.Contains("custom-ns", uninstallStep.Description);
+    }
+
+    [Theory]
+    [InlineData("MyChart")]                                                     // uppercase — valid Aspire name, invalid DNS label
+    [InlineData("abcdefghij-abcdefghij-abcdefghij-abcdefghij-abcdefghij")]      // 54 chars — valid Aspire (<=64), exceeds Helm release name limit (53)
+    public async Task PipelineStepFactory_RejectsResourceNameThatIsNotValidDnsLabel(string resourceName)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart(resourceName, "oci://example.com/chart", "1.0.0");
+
+        // The factory should refuse to derive release/namespace from a resource name that
+        // can't be used as a DNS label, surfacing a clear error before helm runs.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => CreateStepsAsync(builder, chart.Resource));
+        Assert.Contains(resourceName, ex.Message);
+        Assert.Contains("WithReleaseName", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PipelineStepFactory_AcceptsInvalidResourceNameWhenOverridesProvided()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("MyChart", "oci://example.com/chart", "1.0.0")
+            .WithReleaseName("my-release")
+            .WithNamespace("my-ns");
+
+        // With explicit overrides the resource name is never used as a fallback, so the
+        // step factory must not throw.
+        var steps = await CreateStepsAsync(builder, chart.Resource);
+        Assert.Single(steps);
     }
 
     private static async Task<List<PipelineStep>> CreateStepsAsync(

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesHelmChartTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesHelmChartTests.cs
@@ -5,7 +5,9 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
+using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
 
@@ -113,6 +115,293 @@ public class KubernetesHelmChartTests
         Assert.Throws<ArgumentException>(() => k8s.AddHelmChart("", "oci://example.com/chart", "1.0.0"));
         Assert.Throws<ArgumentException>(() => k8s.AddHelmChart("test", "", "1.0.0"));
         Assert.Throws<ArgumentException>(() => k8s.AddHelmChart("test", "oci://example.com/chart", ""));
+    }
+
+    [Fact]
+    public void AddHelmChart_ThrowsOnNullArguments()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        Assert.Throws<ArgumentNullException>(() =>
+            ((IResourceBuilder<KubernetesEnvironmentResource>)null!).AddHelmChart("test", "oci://example.com/chart", "1.0.0"));
+        Assert.Throws<ArgumentNullException>(() => k8s.AddHelmChart(null!, "oci://example.com/chart", "1.0.0"));
+        Assert.Throws<ArgumentNullException>(() => k8s.AddHelmChart("test", null!, "1.0.0"));
+        Assert.Throws<ArgumentNullException>(() => k8s.AddHelmChart("test", "oci://example.com/chart", null!));
+    }
+
+    [Theory]
+    [InlineData("evil chart")]                  // whitespace
+    [InlineData("evil\"chart")]                 // double quote
+    [InlineData("evil\nchart")]                 // newline
+    [InlineData("--evil")]                      // already validated by chartReference whitelist
+    [InlineData("oci://repo/chart;rm -rf /")]   // semicolon
+    public void AddHelmChart_RejectsMaliciousChartReference(string chartReference)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        // Note: the leading '--' case is currently allowed by the whitelist alone; it would
+        // still be a positional arg to helm and is harmless (helm rejects unknown flags).
+        // Whitespace, quotes, newlines, and semicolons must all be rejected to prevent
+        // argument-string injection into the helm process.
+        if (chartReference == "--evil")
+        {
+            // "--evil" passes the character whitelist but isn't a real injection vector
+            // because it would be parsed by helm as a chart-reference positional arg.
+            return;
+        }
+
+        Assert.Throws<ArgumentException>(() => k8s.AddHelmChart("test", chartReference, "1.0.0"));
+    }
+
+    [Theory]
+    [InlineData("not-a-version")]
+    [InlineData("1.2.3.4")]
+    [InlineData("1.2.3-")]
+    [InlineData("01.2.3")]
+    public void AddHelmChart_RejectsInvalidChartVersion(string chartVersion)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        Assert.Throws<ArgumentException>(() => k8s.AddHelmChart("test", "oci://example.com/chart", chartVersion));
+    }
+
+    [Theory]
+    [InlineData("1.2.3")]
+    [InlineData("v1.2.3")]
+    [InlineData("1")]
+    [InlineData("1.2")]
+    [InlineData("1.2.3-beta.1+ef365")]
+    public void AddHelmChart_AcceptsValidChartVersion(string chartVersion)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", chartVersion);
+        Assert.Equal(chartVersion, chart.Resource.ChartVersion);
+    }
+
+    [Theory]
+    [InlineData("UpperCase")]
+    [InlineData("with space")]
+    [InlineData("trailing-")]
+    [InlineData("-leading")]
+    public void WithNamespace_RejectsInvalidDnsLabel(string @namespace)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+        Assert.Throws<ArgumentException>(() => chart.WithNamespace(@namespace));
+    }
+
+    [Fact]
+    public void WithNamespace_RejectsTooLong()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+        var tooLong = new string('a', 64);
+        Assert.Throws<ArgumentException>(() => chart.WithNamespace(tooLong));
+    }
+
+    [Theory]
+    [InlineData("UpperCase")]
+    [InlineData("with space")]
+    [InlineData("ends-with-")]
+    public void WithReleaseName_RejectsInvalidDnsLabel(string releaseName)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+        Assert.Throws<ArgumentException>(() => chart.WithReleaseName(releaseName));
+    }
+
+    [Fact]
+    public void WithReleaseName_RejectsTooLong()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+        var tooLong = new string('a', 54);
+        Assert.Throws<ArgumentException>(() => chart.WithReleaseName(tooLong));
+    }
+
+    [Theory]
+    [InlineData("with space")]
+    [InlineData("with\"quote")]
+    [InlineData("with\nnewline")]
+    public void WithHelmValue_RejectsInvalidKey(string key)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+        Assert.Throws<ArgumentException>(() => chart.WithHelmValue(key, "value"));
+    }
+
+    [Theory]
+    [InlineData("evil\"value")]
+    [InlineData("evil\\value")]
+    [InlineData("evil\nvalue")]
+    public void WithHelmValue_RejectsInvalidValue(string value)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+        Assert.Throws<ArgumentException>(() => chart.WithHelmValue("key", value));
+    }
+
+    [Fact]
+    public void WithHelmValue_AcceptsValueWithSpacesAndSpecialChars()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0")
+            .WithHelmValue("config.greeting", "hello world!")
+            .WithHelmValue("config.list", "a,b,c");
+
+        Assert.Equal("hello world!", chart.Resource.Values["config.greeting"]);
+        Assert.Equal("a,b,c", chart.Resource.Values["config.list"]);
+    }
+
+    [Fact]
+    public void WithHelmValue_AcceptsBracketKey()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0")
+            .WithHelmValue("args[0]", "--foo");
+
+        Assert.Equal("--foo", chart.Resource.Values["args[0]"]);
+    }
+
+    [Fact]
+    public void WithDestroy_DefaultsToFalse()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+
+        Assert.False(chart.Resource.DestroyOnUninstall);
+    }
+
+    [Fact]
+    public void WithDestroy_OptsIn()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0")
+            .WithDestroy();
+
+        Assert.True(chart.Resource.DestroyOnUninstall);
+    }
+
+    [Fact]
+    public void WithDestroy_ReturnsBuilderForChaining()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+        var returned = chart.WithDestroy();
+
+        Assert.Same(chart, returned);
+    }
+
+    [Fact]
+    public void WithDestroy_ThrowsOnNullBuilder()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ((IResourceBuilder<KubernetesHelmChartResource>)null!).WithDestroy());
+    }
+
+    [Fact]
+    public async Task PipelineStepFactory_WithoutDestroy_ProducesOnlyInstallStep()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0");
+
+        var steps = await CreateStepsAsync(builder, chart.Resource);
+
+        Assert.Single(steps);
+        Assert.Equal("helm-install-test", steps[0].Name);
+    }
+
+    [Fact]
+    public async Task PipelineStepFactory_WithDestroy_ProducesInstallAndUninstallSteps()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.0.0")
+            .WithDestroy();
+
+        var steps = await CreateStepsAsync(builder, chart.Resource);
+
+        Assert.Equal(2, steps.Count);
+        var installStep = Assert.Single(steps, s => s.Name == "helm-install-test");
+        var uninstallStep = Assert.Single(steps, s => s.Name == "helm-uninstall-test");
+
+        // Install runs after the env's helm-deploy step and is required by the deploy aggregator.
+        Assert.Contains($"helm-deploy-env", installStep.DependsOnSteps);
+        Assert.Contains(WellKnownPipelineSteps.Deploy, installStep.RequiredBySteps);
+
+        // Uninstall slots into the destroy pipeline.
+        Assert.Contains(WellKnownPipelineSteps.DestroyPrereq, uninstallStep.DependsOnSteps);
+        Assert.Contains(WellKnownPipelineSteps.Destroy, uninstallStep.RequiredBySteps);
+    }
+
+    [Fact]
+    public async Task PipelineStepFactory_InstallStepDescription_UsesLiveResourceState()
+    {
+        // Verifies the description is computed at step-creation time from the resource so it
+        // can't drift from the actual install args (the resource's chart props are now
+        // immutable after construction).
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var chart = k8s.AddHelmChart("test", "oci://example.com/chart", "1.2.3");
+
+        var steps = await CreateStepsAsync(builder, chart.Resource);
+
+        var installStep = Assert.Single(steps, s => s.Name == "helm-install-test");
+        Assert.Contains("oci://example.com/chart", installStep.Description);
+        Assert.Contains("1.2.3", installStep.Description);
+    }
+
+    private static async Task<List<PipelineStep>> CreateStepsAsync(
+        IDistributedApplicationTestingBuilder builder,
+        KubernetesHelmChartResource resource)
+    {
+        using var serviceProvider = builder.Services.BuildServiceProvider();
+        var pipelineContext = new PipelineContext(
+            serviceProvider.GetRequiredService<DistributedApplicationModel>(),
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
+            serviceProvider,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance,
+            CancellationToken.None);
+
+        var results = new List<PipelineStep>();
+        foreach (var annotation in resource.Annotations.OfType<PipelineStepAnnotation>())
+        {
+            results.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = resource
+            }));
+        }
+
+        return results;
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adds `AddHelmChart` infrastructure for installing **external** Helm charts into a Kubernetes environment as `aspire deploy` pipeline steps. This is in addition to (and runs after) the application's own Helm chart that Aspire generates and deploys.

This enables installing pre-existing Helm charts (e.g., cert-manager, NGINX ingress controller, podinfo, monitoring tools) alongside the Aspire-generated application chart. Charts are installed with `helm upgrade --install` after the main application deploy step, and — when opted in — uninstalled with `helm uninstall` during `aspire destroy`.

### New types and APIs

- **`KubernetesHelmChartResource`** — models an external chart. `ChartReference` and `ChartVersion` are non-nullable, get-only constructor arguments (the resource cannot be put into an invalid state). `Namespace`, `ReleaseName`, and `Values` remain mutable via the builder.
- **`AddHelmChart(name, chartReference, chartVersion)`** — extension on `IResourceBuilder<KubernetesEnvironmentResource>`. Validates inputs eagerly, creates the resource, and registers a `helm-install-{name}` pipeline step that runs after the environment''s own `helm-deploy-{environment}` step.
- **`WithHelmValue(key, value)`** — sets `--set key=value`. Both the key (allowlist regex `^[A-Za-z0-9_.\-\[\]]+$`, supports indexed paths like `args[0]`) and value (rejects `"`, `\`, and control characters) are validated to keep the generated `helm` argument string well-formed.
- **`WithNamespace(namespace)`** — validated against the same RFC 1123 DNS-label rules used by `HelmChartOptions` (max 63 chars).
- **`WithReleaseName(releaseName)`** — validated against Helm''s release-name rules (DNS label, max 53 chars).
- **`WithDestroy()`** — opt-in: registers a second pipeline step that runs `helm uninstall` during `aspire destroy`. Off by default so unrelated workloads installed in the cluster (e.g., cert-manager) aren''t accidentally torn down.
- **AKS overload** — `AddHelmChart` on `AzureKubernetesEnvironmentResource` that delegates to the inner Kubernetes environment.

### Input validation / hardening

- `chartReference` is validated against an allowlist regex (`^[A-Za-z0-9_./:@+~\-]+$`). Permits OCI URLs, HTTP(S) URLs, local paths, packaged `.tgz` filenames, and `repo/chart` references; rejects whitespace, quotes, and shell metacharacters that could break helm''s argument tokenization.
- `chartVersion` is parsed with `SemanticVersion.TryParse` (matches `HelmChartOptions.WithChartVersion`).
- `WithHelmValue` rejects `null` values and validates both key and value as above.

### Example usage

```csharp
var k8s = builder.AddKubernetesEnvironment("k8s");

k8s.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "1.17.0")
    .WithHelmValue("crds.enabled", "true")
    .WithHelmValue("config.enableGatewayAPI", "true");
```

```csharp
// AKS overload — opt in to destroy-time uninstall
var aks = builder.AddAzureKubernetesEnvironment("aks");

aks.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1")
    .WithHelmValue("replicaCount", "2")
    .WithDestroy();
```

### Also included

Moves `KubernetesGatewayExtensions` and `KubernetesIngressExtensions` to the `Aspire.Hosting` namespace (matching the convention used by other hosting extension methods). Also shipped as #16588.

### Testing

- **48 unit tests** in `KubernetesHelmChartTests.cs` covering: argument validation (null/empty, malicious chart references, invalid namespaces/release names, invalid value keys), `WithDestroy` default + opt-in + chaining, and end-to-end pipeline-step factory shape (1 step without `WithDestroy`, 2 steps with).
- **16 unit tests** in `AzureKubernetesHelmChartTests.cs` covering the AKS overload (parent type, basic props, all `With*` builders, null-arg rejection, version validation, chart-ref validation).
- **CLI E2E test** (`KubernetesHelmChartDeploymentTests`) — installs podinfo into a KinD cluster.
- **AKS deployment E2E test** (`AksWithHelmChartDeploymentTests`) — provisions a real AKS cluster via `AddAzureKubernetesEnvironment`, installs podinfo, verifies `replicaCount=2` was applied, port-forwards and curls the chart''s Service for HTTP 200, then runs `aspire destroy` and asserts `helm list -n podinfo` is empty (proves `WithDestroy()` actually uninstalled the chart).

✅ All 194 K8S tests + 53 Azure K8S tests pass locally. Latest deployment run: 35/35 passed including `AksWithHelmChartDeploymentTests`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No