### PR TITLE
[release/13.3] Fix unbounded collection growth in TelemetryRepository

### DIFF
--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -303,6 +303,7 @@ public sealed class TelemetryLimitOptions
     public int MaxAttributeCount { get; set; } = 128;
     public int MaxAttributeLength { get; set; } = int.MaxValue;
     public int MaxSpanEventCount { get; set; } = int.MaxValue;
+    public int MaxResourceCount { get; set; } = 10_000;
 }
 
 public sealed class UIOptions

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -467,18 +466,23 @@ public static partial class OtlpHelpers
             // Semantically when InstrumentationScope isn't set, it is equivalent with
             // an empty instrumentation scope name (unknown).
             var name = scope?.Name ?? string.Empty;
-            ref var scopeRef = ref CollectionsMarshal.GetValueRefOrAddDefault(scopes, name, out _);
-            // Adds to dictionary if not present.
-            if (scopeRef == null)
+            if (scopes.TryGetValue(name, out s))
             {
-                scopeRef = (scope != null)
-                    ? new OtlpScope(scope.Name, scope.Version, scope.Attributes.ToKeyValuePairs(context))
-                    : OtlpScope.Empty;
-
-                context.Logger.LogTrace("Added scope '{ScopeName}' to {TelemetryType}.", scopeRef.Name, telemetryType);
+                return true;
             }
 
-            s = scopeRef;
+            if (scopes.Count >= TelemetryRepository.MaxScopeCount)
+            {
+                throw new InvalidOperationException($"Scope limit of {TelemetryRepository.MaxScopeCount} reached for {telemetryType}. Scope '{name}' will not be added.");
+            }
+
+            s = (scope != null)
+                ? new OtlpScope(scope.Name, scope.Version, scope.Attributes.ToKeyValuePairs(context))
+                : OtlpScope.Empty;
+
+            scopes.Add(name, s);
+
+            context.Logger.LogTrace("Added scope '{ScopeName}' to {TelemetryType}.", s.Name, telemetryType);
             return true;
         }
         catch (Exception ex)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
 
@@ -63,6 +64,11 @@ public class OtlpInstrument
         // Need to add dimensions using durable attributes instance after scope is created.
         if (!Dimensions.TryGetValue(comparableAttributes, out var dimension))
         {
+            if (Dimensions.Count >= TelemetryRepository.MaxDimensionCount)
+            {
+                throw new InvalidOperationException($"Dimension limit of {TelemetryRepository.MaxDimensionCount} reached for instrument '{Summary.Name}'.");
+            }
+
             dimension = CreateDimensionScope(comparableAttributes);
             Dimensions.Add(dimension.Attributes, dimension);
         }
@@ -78,28 +84,35 @@ public class OtlpInstrument
         var keys = KnownAttributeValues.Keys.Union(durableAttributes.Select(a => a.Key)).Distinct();
         foreach (var key in keys)
         {
-            ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(KnownAttributeValues, key, out _);
+            ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(KnownAttributeValues, key, out var existed);
             // Adds to dictionary if not present.
             if (values == null)
             {
+                if (!existed && KnownAttributeValues.Count > TelemetryRepository.MaxKnownAttributeValueCount)
+                {
+                    // Over limit. Remove the default entry that GetValueRefOrAddDefault added.
+                    KnownAttributeValues.Remove(key);
+                    continue;
+                }
+
                 values = new List<string?>();
 
                 // If the key is new and there are already dimensions, add an empty value because there are dimensions without this key.
                 if (!isFirst)
                 {
-                    TryAddValue(values, null);
+                    TryAddValue(values, null, TelemetryRepository.MaxKnownAttributeValuesPerKey);
                 }
             }
 
             var currentDimensionValue = OtlpHelpers.GetValue(durableAttributes, key);
-            TryAddValue(values, currentDimensionValue);
+            TryAddValue(values, currentDimensionValue, TelemetryRepository.MaxKnownAttributeValuesPerKey);
         }
 
         return dimension;
 
-        static void TryAddValue(List<string?> values, string? value)
+        static void TryAddValue(List<string?> values, string? value, int maxValues)
         {
-            if (!values.Contains(value))
+            if (values.Count < maxValues && !values.Contains(value))
             {
                 values.Add(value);
             }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -45,8 +45,9 @@ public class OtlpResource : IOtlpResource
     public ResourceKey ResourceKey => new ResourceKey(ResourceName, InstanceId);
 
     private readonly ReaderWriterLockSlim _metricsLock = new();
-    // Bounded by the number of unique instrumentation scope names. Constrained by TelemetryRepository.MaxInstrumentCount
-    // because each instrument requires a meter/scope.
+    // Stores metrics scopes by unique instrumentation scope name for this resource.
+    // Not strictly bounded by TelemetryRepository.MaxInstrumentCount — new scopes can be added even when
+    // the instrument limit is reached, but growth is naturally limited by the number of distinct scope names.
     private readonly Dictionary<string, OtlpScope> _meters = new();
     private readonly Dictionary<OtlpInstrumentKey, OtlpInstrument> _instruments = new();
     private readonly ConcurrentDictionary<KeyValuePair<string, string>[], OtlpResourceView> _resourceViews = new(ResourceViewKeyComparer.Instance);

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -45,6 +45,8 @@ public class OtlpResource : IOtlpResource
     public ResourceKey ResourceKey => new ResourceKey(ResourceName, InstanceId);
 
     private readonly ReaderWriterLockSlim _metricsLock = new();
+    // Bounded by the number of unique instrumentation scope names. Constrained by TelemetryRepository.MaxInstrumentCount
+    // because each instrument requires a meter/scope.
     private readonly Dictionary<string, OtlpScope> _meters = new();
     private readonly Dictionary<OtlpInstrumentKey, OtlpInstrument> _instruments = new();
     private readonly ConcurrentDictionary<KeyValuePair<string, string>[], OtlpResourceView> _resourceViews = new(ResourceViewKeyComparer.Instance);
@@ -86,25 +88,34 @@ public class OtlpResource : IOtlpResource
                         }
 
                         var instrumentKey = new OtlpInstrumentKey(scope.Name, metric.Name);
-                        ref var instrumentRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_instruments, instrumentKey, out _);
+                        ref var instrumentRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_instruments, instrumentKey, out var instrumentExists);
                         if (instrumentRef == null)
                         {
-                            // Adds to dictionary if not present.
-                            instrumentRef = new OtlpInstrument
+                            if (instrumentExists || _instruments.Count <= TelemetryRepository.MaxInstrumentCount)
                             {
-                                Summary = new OtlpInstrumentSummary
+                                // Adds to dictionary if not present.
+                                instrumentRef = new OtlpInstrument
                                 {
-                                    Name = metric.Name,
-                                    Description = metric.Description,
-                                    Unit = metric.Unit,
-                                    Type = MapMetricType(metric.DataCase),
-                                    AggregationTemporality = MapAggregationTemporality(metric),
-                                    Parent = scope
-                                },
-                                Context = Context
-                            };
+                                    Summary = new OtlpInstrumentSummary
+                                    {
+                                        Name = metric.Name,
+                                        Description = metric.Description,
+                                        Unit = metric.Unit,
+                                        Type = MapMetricType(metric.DataCase),
+                                        AggregationTemporality = MapAggregationTemporality(metric),
+                                        Parent = scope
+                                    },
+                                    Context = Context
+                                };
 
-                            Context.Logger.LogTrace("Added metric instrument '{InstrumentName}' for scope '{ScopeName}'.", instrumentRef.Summary.Name, scope.Name);
+                                Context.Logger.LogTrace("Added metric instrument '{InstrumentName}' for scope '{ScopeName}'.", instrumentRef.Summary.Name, scope.Name);
+                            }
+                            else
+                            {
+                                // Over limit. Remove the default entry that GetValueRefOrAddDefault added.
+                                _instruments.Remove(instrumentKey);
+                                throw new InvalidOperationException($"Instrument limit of {TelemetryRepository.MaxInstrumentCount} reached. Instrument '{metric.Name}' will not be added.");
+                            }
                         }
 
                         instrument = instrumentRef;
@@ -207,6 +218,7 @@ public class OtlpResource : IOtlpResource
         try
         {
             _instruments.Clear();
+            _meters.Clear();
         }
         finally
         {
@@ -294,6 +306,11 @@ public class OtlpResource : IOtlpResource
         if (_resourceViews.TryGetValue(view.Properties, out var resourceView))
         {
             return resourceView;
+        }
+
+        if (_resourceViews.Count >= TelemetryRepository.MaxResourceViewCount)
+        {
+            throw new InvalidOperationException($"Resource view limit of {TelemetryRepository.MaxResourceViewCount} reached.");
         }
 
         return _resourceViews.GetOrAdd(view.Properties, view);

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
@@ -45,9 +44,7 @@ public class OtlpResource : IOtlpResource
     public ResourceKey ResourceKey => new ResourceKey(ResourceName, InstanceId);
 
     private readonly ReaderWriterLockSlim _metricsLock = new();
-    // Stores metrics scopes by unique instrumentation scope name for this resource.
-    // Not strictly bounded by TelemetryRepository.MaxInstrumentCount — new scopes can be added even when
-    // the instrument limit is reached, but growth is naturally limited by the number of distinct scope names.
+    // Bounded by TelemetryRepository.MaxScopeCount. Cleared when metrics are cleared.
     private readonly Dictionary<string, OtlpScope> _meters = new();
     private readonly Dictionary<OtlpInstrumentKey, OtlpInstrument> _instruments = new();
     private readonly ConcurrentDictionary<KeyValuePair<string, string>[], OtlpResourceView> _resourceViews = new(ResourceViewKeyComparer.Instance);
@@ -73,7 +70,7 @@ public class OtlpResource : IOtlpResource
             {
                 if (!OtlpHelpers.TryGetOrAddScope(_meters, sm.Scope, Context, TelemetryType.Metrics, out var scope))
                 {
-                    context.FailureCount += sm.Metrics.Count;
+                    context.FailureCount += sm.Metrics.Sum(m => GetMetricDataPointCount(m));
                     continue;
                 }
 
@@ -89,37 +86,35 @@ public class OtlpResource : IOtlpResource
                         }
 
                         var instrumentKey = new OtlpInstrumentKey(scope.Name, metric.Name);
-                        ref var instrumentRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_instruments, instrumentKey, out var instrumentExists);
-                        if (instrumentRef == null)
+                        if (_instruments.TryGetValue(instrumentKey, out var existingInstrument))
                         {
-                            if (instrumentExists || _instruments.Count <= TelemetryRepository.MaxInstrumentCount)
-                            {
-                                // Adds to dictionary if not present.
-                                instrumentRef = new OtlpInstrument
-                                {
-                                    Summary = new OtlpInstrumentSummary
-                                    {
-                                        Name = metric.Name,
-                                        Description = metric.Description,
-                                        Unit = metric.Unit,
-                                        Type = MapMetricType(metric.DataCase),
-                                        AggregationTemporality = MapAggregationTemporality(metric),
-                                        Parent = scope
-                                    },
-                                    Context = Context
-                                };
-
-                                Context.Logger.LogTrace("Added metric instrument '{InstrumentName}' for scope '{ScopeName}'.", instrumentRef.Summary.Name, scope.Name);
-                            }
-                            else
-                            {
-                                // Over limit. Remove the default entry that GetValueRefOrAddDefault added.
-                                _instruments.Remove(instrumentKey);
-                                throw new InvalidOperationException($"Instrument limit of {TelemetryRepository.MaxInstrumentCount} reached. Instrument '{metric.Name}' will not be added.");
-                            }
+                            instrument = existingInstrument;
                         }
+                        else if (_instruments.Count < TelemetryRepository.MaxInstrumentCount)
+                        {
+                            var newInstrument = new OtlpInstrument
+                            {
+                                Summary = new OtlpInstrumentSummary
+                                {
+                                    Name = metric.Name,
+                                    Description = metric.Description,
+                                    Unit = metric.Unit,
+                                    Type = MapMetricType(metric.DataCase),
+                                    AggregationTemporality = MapAggregationTemporality(metric),
+                                    Parent = scope
+                                },
+                                Context = Context
+                            };
 
-                        instrument = instrumentRef;
+                            _instruments.Add(instrumentKey, newInstrument);
+                            instrument = newInstrument;
+
+                            Context.Logger.LogTrace("Added metric instrument '{InstrumentName}' for scope '{ScopeName}'.", instrument.Summary.Name, scope.Name);
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"Instrument limit of {TelemetryRepository.MaxInstrumentCount} reached. Instrument '{metric.Name}' will not be added.");
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -139,7 +134,7 @@ public class OtlpResource : IOtlpResource
         }
     }
 
-    private static int GetMetricDataPointCount(Metric metric)
+    internal static int GetMetricDataPointCount(Metric metric)
     {
         return metric.DataCase switch
         {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -28,6 +28,7 @@ public sealed partial class TelemetryRepository : IDisposable
 {
     internal const int MaxResourceViewCount = 10_000;
     internal const int MaxInstrumentCount = 10_000;
+    internal const int MaxScopeCount = 10_000;
     internal const int MaxDimensionCount = 10_000;
     internal const int MaxKnownAttributeValueCount = 10_000;
     internal const int MaxKnownAttributeValuesPerKey = 10_000;
@@ -52,7 +53,7 @@ public sealed partial class TelemetryRepository : IDisposable
     private readonly ConcurrentDictionary<ResourceKey, OtlpResource> _resources = new();
 
     private readonly ReaderWriterLockSlim _logsLock = new();
-    // Bounded by the number of unique instrumentation scope names across log producers. Cleared when all logs are cleared.
+    // Bounded by MaxScopeCount. Cleared when all logs are cleared.
     private readonly Dictionary<string, OtlpScope> _logScopes = new();
     private readonly CircularBuffer<OtlpLogEntry> _logs;
     // Bounded by _resources count * MaxAttributeCount. Cleared per-resource or when all logs are cleared.
@@ -62,10 +63,11 @@ public sealed partial class TelemetryRepository : IDisposable
     private readonly Dictionary<ResourceKey, int> _resourceUnviewedErrorLogs = new();
 
     private readonly ReaderWriterLockSlim _tracesLock = new();
-    // Bounded by the number of unique instrumentation scope names across trace producers. Cleared when all traces are cleared.
+    // Bounded by MaxScopeCount. Cleared when all traces are cleared.
     private readonly Dictionary<string, OtlpScope> _traceScopes = new();
     private readonly CircularBuffer<OtlpTrace> _traces;
-    // Bounded by total span link count across traces in _traces. Cleaned up on trace eviction and clear.
+    // Not explicitly capped per add — bounded only by the sum of span links across in-buffer traces.
+    // Cleaned up on trace eviction and clear, so growth is limited by the circular buffer capacity.
     private readonly List<OtlpSpanLink> _spanLinks = new();
     private readonly List<IDisposable> _peerResolverSubscriptions = new();
     internal readonly OtlpContext _otlpContext;
@@ -342,7 +344,7 @@ public sealed partial class TelemetryRepository : IDisposable
             }
             catch (Exception ex)
             {
-                context.FailureCount += rl.ScopeLogs.Count;
+                context.FailureCount += rl.ScopeLogs.Sum(s => s.LogRecords.Count);
                 _otlpContext.Logger.LogInformation(ex, "Error adding resource.");
                 continue;
             }
@@ -1114,7 +1116,7 @@ public sealed partial class TelemetryRepository : IDisposable
             }
             catch (Exception ex)
             {
-                context.FailureCount += rm.ScopeMetrics.Sum(s => s.Metrics.Count);
+                context.FailureCount += rm.ScopeMetrics.Sum(sm => sm.Metrics.Sum(OtlpResource.GetMetricDataPointCount));
                 _otlpContext.Logger.LogInformation(ex, "Error adding resource.");
                 continue;
             }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -814,6 +814,11 @@ public sealed partial class TelemetryRepository : IDisposable
                 _traceScopes.Clear();
                 _tracePropertyKeys.Clear();
                 _spanLinks.Clear();
+
+                foreach (var resource in _resources.Values)
+                {
+                    SetResourceHasTraces(resource, false);
+                }
             }
             else
             {
@@ -871,6 +876,13 @@ public sealed partial class TelemetryRepository : IDisposable
                 _logs.Clear();
                 _logScopes.Clear();
                 _logPropertyKeys.Clear();
+
+                foreach (var resource in _resources.Values)
+                {
+                    SetResourceHasLogs(resource, false);
+                }
+
+                _resourceUnviewedErrorLogs.Clear();
             }
             else
             {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -26,6 +26,12 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed partial class TelemetryRepository : IDisposable
 {
+    internal const int MaxResourceViewCount = 10_000;
+    internal const int MaxInstrumentCount = 10_000;
+    internal const int MaxDimensionCount = 10_000;
+    internal const int MaxKnownAttributeValueCount = 10_000;
+    internal const int MaxKnownAttributeValuesPerKey = 10_000;
+
     private readonly PauseManager _pauseManager;
     private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers;
     private readonly ILogger _logger;
@@ -46,15 +52,20 @@ public sealed partial class TelemetryRepository : IDisposable
     private readonly ConcurrentDictionary<ResourceKey, OtlpResource> _resources = new();
 
     private readonly ReaderWriterLockSlim _logsLock = new();
+    // Bounded by the number of unique instrumentation scope names across log producers. Cleared when all logs are cleared.
     private readonly Dictionary<string, OtlpScope> _logScopes = new();
     private readonly CircularBuffer<OtlpLogEntry> _logs;
+    // Bounded by _resources count * MaxAttributeCount. Cleared per-resource or when all logs are cleared.
     private readonly HashSet<(OtlpResource Resource, string PropertyKey)> _logPropertyKeys = new();
+    // Bounded by _resources count * MaxAttributeCount. Cleared per-resource or when all traces are cleared.
     private readonly HashSet<(OtlpResource Resource, string PropertyKey)> _tracePropertyKeys = new();
     private readonly Dictionary<ResourceKey, int> _resourceUnviewedErrorLogs = new();
 
     private readonly ReaderWriterLockSlim _tracesLock = new();
+    // Bounded by the number of unique instrumentation scope names across trace producers. Cleared when all traces are cleared.
     private readonly Dictionary<string, OtlpScope> _traceScopes = new();
     private readonly CircularBuffer<OtlpTrace> _traces;
+    // Bounded by total span link count across traces in _traces. Cleaned up on trace eviction and clear.
     private readonly List<OtlpSpanLink> _spanLinks = new();
     private readonly List<IDisposable> _peerResolverSubscriptions = new();
     internal readonly OtlpContext _otlpContext;
@@ -235,6 +246,12 @@ public sealed partial class TelemetryRepository : IDisposable
         {
             resource.SetUninstrumentedPeer(uninstrumentedPeer);
             return (Resource: resource, IsNew: false);
+        }
+
+        // Check resource limit before adding a new resource.
+        if (_resources.Count >= _otlpContext.Options.MaxResourceCount)
+        {
+            throw new InvalidOperationException($"Resource limit of {_otlpContext.Options.MaxResourceCount} reached. Resource '{key}' will not be added.");
         }
 
         // Slower get or add path.
@@ -792,22 +809,36 @@ public sealed partial class TelemetryRepository : IDisposable
             {
                 // Nothing selected, clear everything.
                 _traces.Clear();
+                _traceScopes.Clear();
+                _tracePropertyKeys.Clear();
+                _spanLinks.Clear();
             }
             else
             {
                 for (var i = _traces.Count - 1; i >= 0; i--)
                 {
+                    var trace = _traces[i];
                     // Remove trace if any span matches one of the resources. This matches filter behavior.
-                    if (MatchResources(_traces[i], resources))
+                    if (MatchResources(trace, resources))
                     {
+                        // Remove span links for the removed trace.
+                        foreach (var span in trace.Spans)
+                        {
+                            foreach (var link in span.Links)
+                            {
+                                _spanLinks.Remove(link);
+                            }
+                        }
+
                         _traces.RemoveAt(i);
                         continue;
                     }
                 }
 
-                // Update HasTraces flag for cleared resources
+                // Remove property keys for cleared resources.
                 foreach (var resource in resources)
                 {
+                    _tracePropertyKeys.RemoveWhere(k => k.Resource.ResourceKey == resource.ResourceKey);
                     SetResourceHasTraces(resource, false);
                 }
             }
@@ -836,6 +867,8 @@ public sealed partial class TelemetryRepository : IDisposable
             {
                 // Nothing selected, clear everything.
                 _logs.Clear();
+                _logScopes.Clear();
+                _logPropertyKeys.Clear();
             }
             else
             {
@@ -848,9 +881,10 @@ public sealed partial class TelemetryRepository : IDisposable
                     }
                 }
 
-                // Update HasLogs flag for cleared resources
+                // Update HasLogs flag and remove property keys for cleared resources.
                 foreach (var resource in resources)
                 {
+                    _logPropertyKeys.RemoveWhere(k => k.Resource.ResourceKey == resource.ResourceKey);
                     SetResourceHasLogs(resource, false);
                     _resourceUnviewedErrorLogs.Remove(resource.ResourceKey);
                 }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -249,6 +249,8 @@ public sealed partial class TelemetryRepository : IDisposable
         }
 
         // Check resource limit before adding a new resource.
+        // Note: This is a soft cap. Concurrent callers may both pass this check and slightly exceed the limit
+        // because _resources is a ConcurrentDictionary and the count check + GetOrAdd are not atomic.
         if (_resources.Count >= _otlpContext.Options.MaxResourceCount)
         {
             throw new InvalidOperationException($"Resource limit of {_otlpContext.Options.MaxResourceCount} reached. Resource '{key}' will not be added.");
@@ -1350,9 +1352,17 @@ public sealed partial class TelemetryRepository : IDisposable
             return null;
         }
 
-        var resourceKey = ResourceKey.Create(name: peer.DisplayName, instanceId: peer.Name);
-        var (resource, _) = GetOrAddResource(resourceKey, uninstrumentedPeer: true);
-        return resource;
+        try
+        {
+            var resourceKey = ResourceKey.Create(name: peer.DisplayName, instanceId: peer.Name);
+            var (resource, _) = GetOrAddResource(resourceKey, uninstrumentedPeer: true);
+            return resource;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogInformation(ex, "Error adding peer resource.");
+            return null;
+        }
     }
 
     private void CalculateTraceUninstrumentedPeers(OtlpTrace trace)
@@ -1372,9 +1382,16 @@ public sealed partial class TelemetryRepository : IDisposable
                     continue;
                 }
 
-                var resourceKey = ResourceKey.Create(name: uninstrumentedPeer.DisplayName, instanceId: uninstrumentedPeer.Name);
-                var (resource, _) = GetOrAddResource(resourceKey, uninstrumentedPeer: true);
-                trace.SetSpanUninstrumentedPeer(span, resource);
+                try
+                {
+                    var resourceKey = ResourceKey.Create(name: uninstrumentedPeer.DisplayName, instanceId: uninstrumentedPeer.Name);
+                    var (resource, _) = GetOrAddResource(resourceKey, uninstrumentedPeer: true);
+                    trace.SetSpanUninstrumentedPeer(span, resource);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogInformation(ex, "Error adding uninstrumented peer resource.");
+                }
             }
             else
             {
@@ -1600,7 +1617,14 @@ public sealed partial class TelemetryRepository : IDisposable
             // When peers change then we need to recalculate the uninstrumented peers of spans.
             foreach (var trace in _traces)
             {
-                CalculateTraceUninstrumentedPeers(trace);
+                try
+                {
+                    CalculateTraceUninstrumentedPeers(trace);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogInformation(ex, "Error recalculating uninstrumented peers.");
+                }
             }
         }
         finally

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryLimitTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryLimitTests.cs
@@ -1,0 +1,280 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Google.Protobuf.Collections;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
+
+namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
+
+public class TelemetryLimitTests
+{
+    private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void AddTraces_ExceedsResourceLimit_ReportsFailure()
+    {
+        var repository = CreateRepository(maxResourceCount: 3);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var addContext = new AddContext();
+            repository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+            {
+                new ResourceSpans
+                {
+                    Resource = CreateResource(name: $"app{i}"),
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Scope = CreateScope(),
+                            Spans = { CreateSpan("trace1", $"span{i}", s_testTime, s_testTime.AddMinutes(1)) }
+                        }
+                    }
+                }
+            });
+            Assert.Equal(0, addContext.FailureCount);
+        }
+
+        Assert.Equal(3, repository.GetResources().Count);
+
+        // Adding a 4th resource should fail.
+        var failContext = new AddContext();
+        repository.AddTraces(failContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "app-over-limit"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan("trace2", "spanX", s_testTime, s_testTime.AddMinutes(1)) }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+        Assert.Equal(3, repository.GetResources().Count);
+    }
+
+    [Fact]
+    public void AddLogs_ExceedsResourceLimit_ReportsFailure()
+    {
+        var repository = CreateRepository(maxResourceCount: 3);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var addContext = new AddContext();
+            repository.AddLogs(addContext, new RepeatedField<ResourceLogs>
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(name: $"app{i}"),
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            Scope = CreateScope(),
+                            LogRecords = { CreateLogRecord() }
+                        }
+                    }
+                }
+            });
+            Assert.Equal(0, addContext.FailureCount);
+        }
+
+        Assert.Equal(3, repository.GetResources().Count);
+
+        // Adding a 4th resource should fail.
+        var failContext = new AddContext();
+        repository.AddLogs(failContext, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app-over-limit"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(),
+                        LogRecords = { CreateLogRecord() }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+        Assert.Equal(3, repository.GetResources().Count);
+    }
+
+    [Fact]
+    public void AddMetrics_ExceedsResourceLimit_ReportsFailure()
+    {
+        var repository = CreateRepository(maxResourceCount: 3);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var addContext = new AddContext();
+            repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(name: $"app{i}"),
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = CreateScope(name: "test-meter"),
+                            Metrics = { CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1)) }
+                        }
+                    }
+                }
+            });
+            Assert.Equal(0, addContext.FailureCount);
+        }
+
+        Assert.Equal(3, repository.GetResources().Count);
+
+        // Adding a 4th resource should fail.
+        var failContext = new AddContext();
+        repository.AddMetrics(failContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "app-over-limit"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1)) }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+        Assert.Equal(3, repository.GetResources().Count);
+    }
+
+    [Fact]
+    public void AddTraces_ExistingResourceAfterLimitReached_Succeeds()
+    {
+        var repository = CreateRepository(maxResourceCount: 2);
+
+        // Add 2 resources to fill up the limit.
+        for (var i = 0; i < 2; i++)
+        {
+            var addContext = new AddContext();
+            repository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+            {
+                new ResourceSpans
+                {
+                    Resource = CreateResource(name: $"app{i}"),
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Scope = CreateScope(),
+                            Spans = { CreateSpan("trace1", $"span{i}", s_testTime, s_testTime.AddMinutes(1)) }
+                        }
+                    }
+                }
+            });
+            Assert.Equal(0, addContext.FailureCount);
+        }
+
+        // Adding data for an existing resource should still succeed.
+        var successContext = new AddContext();
+        repository.AddTraces(successContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "app0"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan("trace2", "spanNew", s_testTime, s_testTime.AddMinutes(2)) }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, successContext.FailureCount);
+        Assert.Equal(1, successContext.SuccessCount);
+    }
+
+    [Fact]
+    public void AddMetrics_ExceedsInstrumentLimit_ReportsFailure()
+    {
+        var repository = CreateRepository();
+
+        // Fill instruments up to the limit.
+        var metrics = new RepeatedField<Metric>();
+        for (var i = 0; i < TelemetryRepository.MaxInstrumentCount; i++)
+        {
+            metrics.Add(CreateSumMetric(metricName: $"metric{i}", startTime: s_testTime.AddMinutes(1)));
+        }
+
+        var addContext = new AddContext();
+        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { metrics }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+
+        var resources = repository.GetResources();
+        var instruments = repository.GetInstrumentsSummaries(resources[0].ResourceKey);
+        Assert.Equal(TelemetryRepository.MaxInstrumentCount, instruments.Count);
+
+        // Adding one more instrument should fail.
+        var failContext = new AddContext();
+        repository.AddMetrics(failContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { CreateSumMetric(metricName: "over-limit-metric", startTime: s_testTime.AddMinutes(2)) }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+
+        instruments = repository.GetInstrumentsSummaries(resources[0].ResourceKey);
+        Assert.Equal(TelemetryRepository.MaxInstrumentCount, instruments.Count);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryLimitTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryLimitTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
+using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
@@ -173,5 +174,329 @@ public class TelemetryLimitTests
 
         instruments = repository.GetInstrumentsSummaries(resources[0].ResourceKey);
         Assert.Equal(TelemetryRepository.MaxInstrumentCount, instruments.Count);
+    }
+
+    [Fact]
+    public void AddLogs_ExceedsResourceLimit_FailureCountIsLogRecordCount()
+    {
+        var repository = CreateRepository(maxResourceCount: 1);
+
+        // Fill the single resource slot.
+        var setupContext = new AddContext();
+        repository.AddLogs(setupContext, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app0"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("logger"),
+                        LogRecords = { CreateLogRecord() }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, setupContext.FailureCount);
+
+        // Attempt to add logs for a new resource with multiple scopes and records.
+        // FailureCount must equal total log records, not number of scopes.
+        var failContext = new AddContext();
+        repository.AddLogs(failContext, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app-over-limit"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("loggerA"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "a1"),
+                            CreateLogRecord(message: "a2"),
+                            CreateLogRecord(message: "a3")
+                        }
+                    },
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("loggerB"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "b1"),
+                            CreateLogRecord(message: "b2")
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(5, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+    }
+
+    [Fact]
+    public void AddMetrics_ExceedsResourceLimit_FailureCountIsDataPointCount()
+    {
+        var repository = CreateRepository(maxResourceCount: 1);
+
+        // Fill the single resource slot.
+        var setupContext = new AddContext();
+        repository.AddMetrics(setupContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "app0"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "meter"),
+                        Metrics = { CreateSumMetric(metricName: "m0", startTime: s_testTime.AddMinutes(1)) }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, setupContext.FailureCount);
+
+        // Attempt to add metrics for a new resource with multiple scopes and metrics.
+        // FailureCount must equal total data points, not number of metrics.
+        var failContext = new AddContext();
+        repository.AddMetrics(failContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "app-over-limit"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "meterA"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "m1", startTime: s_testTime.AddMinutes(1)),
+                            CreateSumMetric(metricName: "m2", startTime: s_testTime.AddMinutes(1)),
+                            CreateSumMetric(metricName: "m3", startTime: s_testTime.AddMinutes(1))
+                        }
+                    },
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "meterB"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "m4", startTime: s_testTime.AddMinutes(1)),
+                            CreateSumMetric(metricName: "m5", startTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        });
+
+        // Each CreateSumMetric produces 1 data point, so 5 metrics = 5 data points.
+        Assert.Equal(5, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+    }
+
+    [Fact]
+    public void AddTraces_ExceedsResourceLimit_FailureCountIsSpanCount()
+    {
+        var repository = CreateRepository(maxResourceCount: 1);
+
+        // Fill the single resource slot.
+        var setupContext = new AddContext();
+        repository.AddTraces(setupContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "app0"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan("trace1", "span0", s_testTime, s_testTime.AddMinutes(1)) }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, setupContext.FailureCount);
+
+        // Attempt to add traces for a new resource with multiple scopes and spans.
+        // FailureCount must equal total spans, not number of scopes.
+        var failContext = new AddContext();
+        repository.AddTraces(failContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "app-over-limit"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan("trace2", "spanA1", s_testTime, s_testTime.AddMinutes(1)),
+                            CreateSpan("trace2", "spanA2", s_testTime, s_testTime.AddMinutes(1))
+                        }
+                    },
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan("trace3", "spanB1", s_testTime, s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(3, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+    }
+
+    [Fact]
+    public void AddLogs_ExceedsScopeLimit_ReportsFailure()
+    {
+        var repository = CreateRepository();
+
+        // Fill scopes up to the limit.
+        var scopeLogs = new RepeatedField<ResourceLogs>();
+        var rl = new ResourceLogs { Resource = CreateResource() };
+        for (var i = 0; i < TelemetryRepository.MaxScopeCount; i++)
+        {
+            rl.ScopeLogs.Add(new ScopeLogs
+            {
+                Scope = CreateScope(name: $"logger{i}"),
+                LogRecords = { CreateLogRecord() }
+            });
+        }
+        scopeLogs.Add(rl);
+
+        var addContext = new AddContext();
+        repository.AddLogs(addContext, scopeLogs);
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Adding one more scope should fail.
+        var failContext = new AddContext();
+        repository.AddLogs(failContext, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "over-limit-logger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "a"),
+                            CreateLogRecord(message: "b"),
+                            CreateLogRecord(message: "c")
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(3, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+    }
+
+    [Fact]
+    public void AddTraces_ExceedsScopeLimit_ReportsFailure()
+    {
+        var repository = CreateRepository();
+
+        // Fill scopes up to the limit.
+        var rs = new ResourceSpans { Resource = CreateResource() };
+        for (var i = 0; i < TelemetryRepository.MaxScopeCount; i++)
+        {
+            rs.ScopeSpans.Add(new ScopeSpans
+            {
+                Scope = CreateScope(name: $"tracer{i}"),
+                Spans = { CreateSpan($"trace{i}", $"span{i}", s_testTime, s_testTime.AddMinutes(1)) }
+            });
+        }
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans> { rs });
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Adding one more scope should fail.
+        var failContext = new AddContext();
+        repository.AddTraces(failContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(name: "over-limit-tracer"),
+                        Spans =
+                        {
+                            CreateSpan("traceX", "spanX1", s_testTime, s_testTime.AddMinutes(1)),
+                            CreateSpan("traceX", "spanX2", s_testTime, s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(2, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
+    }
+
+    [Fact]
+    public void AddMetrics_ExceedsScopeLimit_ReportsFailure()
+    {
+        var repository = CreateRepository();
+
+        // Fill scopes up to the limit.
+        var rm = new ResourceMetrics { Resource = CreateResource() };
+        for (var i = 0; i < TelemetryRepository.MaxScopeCount; i++)
+        {
+            rm.ScopeMetrics.Add(new ScopeMetrics
+            {
+                Scope = CreateScope(name: $"meter{i}"),
+                Metrics = { CreateSumMetric(metricName: $"metric{i}", startTime: s_testTime.AddMinutes(1)) }
+            });
+        }
+
+        var addContext = new AddContext();
+        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics> { rm });
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Adding one more scope should fail. Each metric has 1 data point.
+        var failContext = new AddContext();
+        repository.AddMetrics(failContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "over-limit-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "m1", startTime: s_testTime.AddMinutes(1)),
+                            CreateSumMetric(metricName: "m2", startTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        });
+
+        // 2 metrics × 1 data point each = 2 rejected data points.
+        Assert.Equal(2, failContext.FailureCount);
+        Assert.Equal(0, failContext.SuccessCount);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryLimitTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryLimitTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
-using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
@@ -57,108 +56,6 @@ public class TelemetryLimitTests
                     {
                         Scope = CreateScope(),
                         Spans = { CreateSpan("trace2", "spanX", s_testTime, s_testTime.AddMinutes(1)) }
-                    }
-                }
-            }
-        });
-
-        Assert.Equal(1, failContext.FailureCount);
-        Assert.Equal(0, failContext.SuccessCount);
-        Assert.Equal(3, repository.GetResources().Count);
-    }
-
-    [Fact]
-    public void AddLogs_ExceedsResourceLimit_ReportsFailure()
-    {
-        var repository = CreateRepository(maxResourceCount: 3);
-
-        for (var i = 0; i < 3; i++)
-        {
-            var addContext = new AddContext();
-            repository.AddLogs(addContext, new RepeatedField<ResourceLogs>
-            {
-                new ResourceLogs
-                {
-                    Resource = CreateResource(name: $"app{i}"),
-                    ScopeLogs =
-                    {
-                        new ScopeLogs
-                        {
-                            Scope = CreateScope(),
-                            LogRecords = { CreateLogRecord() }
-                        }
-                    }
-                }
-            });
-            Assert.Equal(0, addContext.FailureCount);
-        }
-
-        Assert.Equal(3, repository.GetResources().Count);
-
-        // Adding a 4th resource should fail.
-        var failContext = new AddContext();
-        repository.AddLogs(failContext, new RepeatedField<ResourceLogs>
-        {
-            new ResourceLogs
-            {
-                Resource = CreateResource(name: "app-over-limit"),
-                ScopeLogs =
-                {
-                    new ScopeLogs
-                    {
-                        Scope = CreateScope(),
-                        LogRecords = { CreateLogRecord() }
-                    }
-                }
-            }
-        });
-
-        Assert.Equal(1, failContext.FailureCount);
-        Assert.Equal(0, failContext.SuccessCount);
-        Assert.Equal(3, repository.GetResources().Count);
-    }
-
-    [Fact]
-    public void AddMetrics_ExceedsResourceLimit_ReportsFailure()
-    {
-        var repository = CreateRepository(maxResourceCount: 3);
-
-        for (var i = 0; i < 3; i++)
-        {
-            var addContext = new AddContext();
-            repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>
-            {
-                new ResourceMetrics
-                {
-                    Resource = CreateResource(name: $"app{i}"),
-                    ScopeMetrics =
-                    {
-                        new ScopeMetrics
-                        {
-                            Scope = CreateScope(name: "test-meter"),
-                            Metrics = { CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1)) }
-                        }
-                    }
-                }
-            });
-            Assert.Equal(0, addContext.FailureCount);
-        }
-
-        Assert.Equal(3, repository.GetResources().Count);
-
-        // Adding a 4th resource should fail.
-        var failContext = new AddContext();
-        repository.AddMetrics(failContext, new RepeatedField<ResourceMetrics>
-        {
-            new ResourceMetrics
-            {
-                Resource = CreateResource(name: "app-over-limit"),
-                ScopeMetrics =
-                {
-                    new ScopeMetrics
-                    {
-                        Scope = CreateScope(name: "test-meter"),
-                        Metrics = { CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1)) }
                     }
                 }
             }

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -238,6 +238,7 @@ internal static class TelemetryTestHelpers
         int? maxSpanEventCount = null,
         int? maxTraceCount = null,
         int? maxLogCount = null,
+        int? maxResourceCount = null,
         TimeSpan? subscriptionMinExecuteInterval = null,
         ILoggerFactory? loggerFactory = null,
         PauseManager? pauseManager = null,
@@ -267,6 +268,10 @@ internal static class TelemetryTestHelpers
         if (maxLogCount != null)
         {
             options.MaxLogCount = maxLogCount.Value;
+        }
+        if (maxResourceCount != null)
+        {
+            options.MaxResourceCount = maxResourceCount.Value;
         }
 
         var repository = new TelemetryRepository(


### PR DESCRIPTION
## Description

Fix unbounded collection growth in `TelemetryRepository` and related OTLP model types that could lead to memory exhaustion in long-running dashboard sessions.

**Problems fixed:**
- `_logScopes`, `_traceScopes`, `_logPropertyKeys`, `_tracePropertyKeys`, and `_spanLinks` were never cleaned up when logs/traces were cleared, causing indefinite accumulation.
- `_resources` had no cap, allowing unbounded growth from dynamic services or high-cardinality peer addresses.
- Per-resource `_instruments`, `_meters`, `_resourceViews` had no caps.
- Per-instrument `Dimensions` and `KnownAttributeValues` had no caps, making high-cardinality metric tags a memory leak vector.
- `ClearMetrics()` did not clear `_meters` (scopes).
- `ClearTraces()` full-clear path did not clear `_spanLinks` (since `CircularBuffer.Clear()` doesn't fire `ItemRemovedForCapacity`).
- Per-resource `ClearTraces()` path did not remove span links for removed traces.

**Changes:**
- Add `MaxResourceCount` option to `TelemetryLimitOptions` (default 10,000). Throws `InvalidOperationException` on limit exceeded, handled by existing callers.
- Clear `_logScopes`/`_logPropertyKeys` in `ClearStructuredLogs` and `_traceScopes`/`_tracePropertyKeys`/`_spanLinks` in `ClearTraces` on full clear.
- Remove per-resource `_logPropertyKeys`/`_tracePropertyKeys` entries and span links on per-resource clear.
- Clear `_meters` alongside `_instruments` in `OtlpResource.ClearMetrics()`.
- Add `internal const` limits on `TelemetryRepository` for resource views, instruments, dimensions, known attribute value keys, and values per key (all 10,000).
- Enforce limits in `OtlpResource.GetView`, `OtlpResource.AddMetrics`, `OtlpInstrument.FindScope`, and `OtlpInstrument.CreateDimensionScope`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
