### PR TITLE
[contributing.md] use correct path separator in linux commands

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@ These instructions will get you ready to contribute to this project. If you just
 See [machine-requirements.md](/docs/machine-requirements.md).
 ## Build the repo
 
-`.\build.sh` (macOS and Linux) or `.\build.cmd` (Windows)
+`./build.sh` (macOS and Linux) or `.\build.cmd` (Windows)
 
 ## Using the `dotnet` CLI
 
@@ -104,7 +104,7 @@ If you want to try local changes on a separate Aspire based project or solution 
 in a local folder and use it as a package source.
 
 To do so simply execute:
-`.\build.sh -pack` (macOS and Linux) or `.\build.cmd -pack` (Windows)
+`./build.sh -pack` (macOS and Linux) or `.\build.cmd -pack` (Windows)
 
 This will generate all the packages in the folder `./artifacts/packages/Debug/Shipping`. At this point from your solution folder run:
 


### PR DESCRIPTION
## Description

use correct path separator in linux commands

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
