### PR TITLE
[release/13.3] Rename pipeline --log-level to --pipeline-log-level to avoid CLI log overlap

### DIFF
--- a/src/Aspire.Cli/Commands/DeployCommand.cs
+++ b/src/Aspire.Cli/Commands/DeployCommand.cs
@@ -51,7 +51,7 @@ internal sealed class DeployCommand : PipelineCommandBase
         }
 
         // Add --log-level and --envionment flags if specified
-        var logLevel = parseResult.GetValue(s_logLevelOption);
+        var logLevel = parseResult.GetValue(s_pipelineLogLevelOption);
 
         if (!string.IsNullOrEmpty(logLevel))
         {

--- a/src/Aspire.Cli/Commands/DestroyCommand.cs
+++ b/src/Aspire.Cli/Commands/DestroyCommand.cs
@@ -50,7 +50,7 @@ internal sealed class DestroyCommand : PipelineCommandBase
             baseArgs.AddRange(["--yes", "true"]);
         }
 
-        var logLevel = parseResult.GetValue(s_logLevelOption);
+        var logLevel = parseResult.GetValue(s_pipelineLogLevelOption);
         if (!string.IsNullOrEmpty(logLevel))
         {
             baseArgs.AddRange(["--log-level", logLevel!]);

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -76,7 +76,7 @@ internal sealed class DoCommand : PipelineCommandBase
         }
 
         // Add --log-level and --environment flags if specified
-        var logLevel = parseResult.GetValue(s_logLevelOption);
+        var logLevel = parseResult.GetValue(s_pipelineLogLevelOption);
         if (!string.IsNullOrEmpty(logLevel))
         {
             baseArgs.AddRange(["--log-level", logLevel!]);

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -42,7 +42,7 @@ internal abstract class PipelineCommandBase : BaseCommand
     private readonly Option<string?> _outputPathOption;
     private readonly Option<bool>? _startDebugSessionOption;
 
-    protected static readonly Option<string?> s_logLevelOption = new("--pipeline-log-level")
+    protected static readonly Option<string?> s_pipelineLogLevelOption = new("--pipeline-log-level")
     {
         Description = SharedCommandStrings.PipelineLogLevelOptionDescription
     };
@@ -98,7 +98,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
         Options.Add(s_appHostOption);
         Options.Add(_outputPathOption);
-        Options.Add(s_logLevelOption);
+        Options.Add(s_pipelineLogLevelOption);
         Options.Add(s_environmentOption);
         Options.Add(s_includeExceptionDetailsOption);
         Options.Add(s_noBuildOption);
@@ -291,7 +291,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
 
             // Check if debug or trace logging is enabled
-            var logLevel = parseResult.GetValue(s_logLevelOption);
+            var logLevel = parseResult.GetValue(s_pipelineLogLevelOption);
             var isDebugOrTraceLoggingEnabled = logLevel?.Equals("debug", StringComparison.OrdinalIgnoreCase) == true ||
                                                  logLevel?.Equals("trace", StringComparison.OrdinalIgnoreCase) == true;
 

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -42,7 +42,7 @@ internal abstract class PipelineCommandBase : BaseCommand
     private readonly Option<string?> _outputPathOption;
     private readonly Option<bool>? _startDebugSessionOption;
 
-    protected static readonly Option<string?> s_logLevelOption = new("--log-level")
+    protected static readonly Option<string?> s_logLevelOption = new("--pipeline-log-level")
     {
         Description = SharedCommandStrings.PipelineLogLevelOptionDescription
     };

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -59,7 +59,7 @@ internal sealed class PublishCommand : PipelineCommandBase
         }
 
         // Add --log-level and --envionment flags if specified
-        var logLevel = parseResult.GetValue(s_logLevelOption);
+        var logLevel = parseResult.GetValue(s_pipelineLogLevelOption);
 
         if (!string.IsNullOrEmpty(logLevel))
         {

--- a/src/Aspire.Cli/Resources/ConsoleActivityLoggerStrings.resx
+++ b/src/Aspire.Cli/Resources/ConsoleActivityLoggerStrings.resx
@@ -142,7 +142,7 @@
     <value>Total time: {0}</value>
   </data>
   <data name="SummaryLogLevelHelp" xml:space="preserve">
-    <value>For more details, add --log-level debug/trace to the command.</value>
+    <value>For more details, add --pipeline-log-level debug/trace to the command.</value>
   </data>
   <data name="PipelineSucceeded" xml:space="preserve">
     <value>Pipeline succeeded</value>

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.cs.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.de.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.es.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.fr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.it.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.ja.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.ko.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.pl.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.pt-BR.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.ru.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.tr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.zh-Hans.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConsoleActivityLoggerStrings.zh-Hant.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SummaryLogLevelHelp">
-        <source>For more details, add --log-level debug/trace to the command.</source>
-        <target state="new">For more details, add --log-level debug/trace to the command.</target>
+        <source>For more details, add --pipeline-log-level debug/trace to the command.</source>
+        <target state="new">For more details, add --pipeline-log-level debug/trace to the command.</target>
         <note />
       </trans-unit>
       <trans-unit id="SummaryStepsSucceeded">

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -509,4 +509,111 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
     }
+
+    [Fact]
+    public async Task DoCommandForwardsPipelineLogLevelAsLogLevelToAppHost()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        string[]? capturedArgs = null;
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
+
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, true, VersionHelper.GetDefaultTemplateVersion());
+                    },
+
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        capturedArgs = args;
+
+                        var completed = new TaskCompletionSource();
+                        var backchannel = new TestAppHostBackchannel
+                        {
+                            RequestStopAsyncCalled = completed
+                        };
+                        backchannelCompletionSource?.SetResult(backchannel);
+                        await completed.Task.DefaultTimeout();
+                        return 0;
+                    }
+                };
+
+                return runner;
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse("do my-step --pipeline-log-level debug");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedArgs);
+        var logLevelIndex = Array.IndexOf(capturedArgs, "--log-level");
+        Assert.True(logLevelIndex >= 0, "Expected --log-level argument to be passed to AppHost");
+        Assert.Equal("debug", capturedArgs[logLevelIndex + 1]);
+        Assert.DoesNotContain("--pipeline-log-level", capturedArgs);
+    }
+
+    [Fact]
+    public async Task DoCommandDoesNotForwardCliLogLevelToAppHost()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        string[]? capturedArgs = null;
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
+
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, true, VersionHelper.GetDefaultTemplateVersion());
+                    },
+
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        capturedArgs = args;
+
+                        var completed = new TaskCompletionSource();
+                        var backchannel = new TestAppHostBackchannel
+                        {
+                            RequestStopAsyncCalled = completed
+                        };
+                        backchannelCompletionSource?.SetResult(backchannel);
+                        await completed.Task.DefaultTimeout();
+                        return 0;
+                    }
+                };
+
+                return runner;
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse("do my-step --log-level Warning");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedArgs);
+        Assert.DoesNotContain("--log-level", capturedArgs);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/aspire/issues/15753

## Description

The pipeline commands (`aspire do`, `aspire publish`, `aspire deploy`, `aspire destroy`) had a `--log-level` option that collided with the global CLI `--log-level` / `-l` option. When a user passed `--log-level Debug` to control pipeline step verbosity, `Program.ParseLoggingOptions()` also picked it up and set CLI internal logging to Debug, flooding the output with mixed CLI framework noise alongside pipeline step output.

This PR renames the pipeline-specific option from `--log-level` to `--pipeline-log-level` so the two concerns are cleanly separated:
- `--log-level` / `-l` (global, recursive) — controls CLI internal logging
- `--pipeline-log-level` (pipeline commands only) — controls pipeline step output verbosity

The value from `--pipeline-log-level` is still forwarded as `--log-level` to the AppHost process, which is correct since the AppHost has its own `--log-level` parameter.

Also updates the help text hint shown on pipeline failure (`"For more details, add --pipeline-log-level debug/trace to the command."`) and adds unit tests verifying the separation and argument forwarding.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
