### PR TITLE
Make CLI log paths clickable

### DIFF
--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -372,7 +372,10 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         if (hasErrors)
         {
             _interactionService.DisplayMessage(KnownEmojis.Warning, AgentCommandStrings.ConfigurationCompletedWithErrors);
-            _interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
+            _interactionService.DisplayMessage(
+                KnownEmojis.PageFacingUp,
+                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(_interactionService, ExecutionContext.LogFilePath)),
+                allowMarkup: true);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -375,10 +375,14 @@ internal sealed class AppHostLauncher(
             }
         }
 
-        interactionService.DisplayMessage(KnownEmojis.MagnifyingGlassTiltedLeft, string.Format(
+        var checkLogsMessage = string.Format(
             CultureInfo.CurrentCulture,
             RunCommandStrings.CheckLogsForDetails,
-            childLogFile));
+            childLogFile);
+        interactionService.DisplayMessage(
+            KnownEmojis.MagnifyingGlassTiltedLeft,
+            ConsoleHelpers.EscapeMarkupWithFileLink(checkLogsMessage, childLogFile),
+            allowMarkup: true);
 
         return ExitCodeConstants.FailedToDotnetRunAppHost;
     }

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -378,10 +378,10 @@ internal sealed class AppHostLauncher(
         var checkLogsMessage = string.Format(
             CultureInfo.CurrentCulture,
             RunCommandStrings.CheckLogsForDetails,
-            childLogFile);
+            MarkupHelpers.SafeFileLink(interactionService, childLogFile));
         interactionService.DisplayMessage(
             KnownEmojis.MagnifyingGlassTiltedLeft,
-            ConsoleHelpers.EscapeMarkupWithFileLink(checkLogsMessage, childLogFile),
+            checkLogsMessage,
             allowMarkup: true);
 
         return ExitCodeConstants.FailedToDotnetRunAppHost;

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -306,9 +306,9 @@ internal sealed class DashboardRunCommand : BaseCommand
         };
     }
 
-    private void RenderDashboardSummary(DashboardInfo info, string logFilePath)
+    internal static void RenderDashboardSummary(IInteractionService interactionService, DashboardInfo info, string logFilePath)
     {
-        _interactionService.DisplayEmptyLine();
+        interactionService.DisplayEmptyLine();
         var grid = new Grid();
         grid.AddColumn();
         grid.AddColumn();
@@ -344,10 +344,10 @@ internal sealed class DashboardRunCommand : BaseCommand
         // Logs row
         grid.AddRow(
             new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(logFilePath));
+            new Markup(ConsoleHelpers.FormatPathAsFileLink(logFilePath)));
 
         var padder = new Padder(grid, new Padding(3, 0));
-        _interactionService.DisplayRenderable(padder);
+        interactionService.DisplayRenderable(padder);
     }
 
     private async Task<int> ExecuteForegroundAsync(string managedPath, List<string> dashboardArgs, DashboardInfo dashboardInfo, IDictionary<string, string>? environmentVariables, CancellationToken cancellationToken)
@@ -457,7 +457,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         }
 
         // Dashboard is ready.
-        RenderDashboardSummary(dashboardInfo, ExecutionContext.LogFilePath);
+        RenderDashboardSummary(_interactionService, dashboardInfo, ExecutionContext.LogFilePath);
         _interactionService.DisplayEmptyLine();
 
         try

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -326,7 +326,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         // Dashboard row
         grid.AddRow(
             new Align(new Markup($"[bold green]{dashboardLabel}[/]:"), HorizontalAlignment.Right),
-            new Markup(MarkupHelpers.SafeLink(_interactionService, info.DashboardUrl)));
+            new Markup(MarkupHelpers.SafeLink(interactionService, info.DashboardUrl)));
         grid.AddRow(Text.Empty, Text.Empty);
 
         // OTLP gRPC row
@@ -344,7 +344,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         // Logs row
         grid.AddRow(
             new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Markup(ConsoleHelpers.FormatPathAsFileLink(logFilePath)));
+            new Markup(MarkupHelpers.SafeFileLink(interactionService, logFilePath)));
 
         var padder = new Padder(grid, new Padding(3, 0));
         interactionService.DisplayRenderable(padder);
@@ -446,7 +446,10 @@ internal sealed class DashboardRunCommand : BaseCommand
                 : DashboardCommandStrings.DashboardStartTimedOut;
 
             _interactionService.DisplayError(exitMessage);
-            _interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
+            _interactionService.DisplayMessage(
+                KnownEmojis.PageFacingUp,
+                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(_interactionService, ExecutionContext.LogFilePath)),
+                allowMarkup: true);
 
             if (!process.HasExited)
             {

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -132,7 +132,11 @@ internal sealed class InitCommand : BaseCommand
 
         if (dropResult != ExitCodeConstants.Success)
         {
-            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
+            InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeCreated);
+            InteractionService.DisplayMessage(
+                KnownEmojis.PageFacingUp,
+                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
+                allowMarkup: true);
             return dropResult;
         }
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -404,7 +404,11 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             if (!resolveResult.Success)
             {
                 InteractionService.DisplayError(resolveResult.ErrorMessage);
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
+                InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeCreated);
+                InteractionService.DisplayMessage(
+                    KnownEmojis.PageFacingUp,
+                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
+                    allowMarkup: true);
                 return ExitCodeConstants.InvalidCommand;
             }
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -290,7 +290,11 @@ internal sealed class RunCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeBuilt, ExecutionContext.LogFilePath));
+                InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeBuilt);
+                InteractionService.DisplayMessage(
+                    KnownEmojis.PageFacingUp,
+                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
+                    allowMarkup: true);
                 return await pendingRun;
             }
 
@@ -464,7 +468,10 @@ internal sealed class RunCommand : BaseCommand
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
             // Don't display raw output - it's already in the log file
-            InteractionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
+            InteractionService.DisplayMessage(
+                KnownEmojis.PageFacingUp,
+                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
+                allowMarkup: true);
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
         catch (ConnectionLostException) when (isExtensionHost)
@@ -480,7 +487,10 @@ internal sealed class RunCommand : BaseCommand
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
             // Don't display raw output - it's already in the log file
-            InteractionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
+            InteractionService.DisplayMessage(
+                KnownEmojis.PageFacingUp,
+                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
+                allowMarkup: true);
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
         finally
@@ -597,7 +607,7 @@ internal sealed class RunCommand : BaseCommand
         }
 
         // Logs row
-        grid.AddRow(LabelMarkup(logsLabel), new Markup(ConsoleHelpers.FormatPathAsFileLink(logFilePath)));
+        grid.AddRow(LabelMarkup(logsLabel), new Markup(MarkupHelpers.SafeFileLink(console, logFilePath)));
 
         // PID row (if provided)
         if (pid.HasValue)

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -597,7 +597,7 @@ internal sealed class RunCommand : BaseCommand
         }
 
         // Logs row
-        grid.AddRow(LabelMarkup(logsLabel), new Text(logFilePath));
+        grid.AddRow(LabelMarkup(logsLabel), new Markup(ConsoleHelpers.FormatPathAsFileLink(logFilePath)));
 
         // PID row (if provided)
         if (pid.HasValue)

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -324,7 +324,10 @@ internal static class TelemetryCommandHelpers
             interactionService.DisplayMessage(KnownEmojis.Information, hint);
         }
 
-        interactionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, logFilePath));
+        interactionService.DisplayMessage(
+            KnownEmojis.PageFacingUp,
+            string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(interactionService, logFilePath)),
+            allowMarkup: true);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
+++ b/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
@@ -64,6 +64,7 @@ internal sealed class StartupErrorWriter : IStartupErrorWriter
         }
 
         var prefix = ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.PageFacingUp, _errorConsole);
-        _errorConsole.MarkupLine(prefix + string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _logFilePath.EscapeMarkup()));
+        var message = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _logFilePath);
+        _errorConsole.MarkupLine(prefix + ConsoleHelpers.EscapeMarkupWithFileLink(message, _logFilePath));
     }
 }

--- a/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
+++ b/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
@@ -64,7 +64,11 @@ internal sealed class StartupErrorWriter : IStartupErrorWriter
         }
 
         var prefix = ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.PageFacingUp, _errorConsole);
-        var message = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _logFilePath);
-        _errorConsole.MarkupLine(prefix + ConsoleHelpers.EscapeMarkupWithFileLink(message, _logFilePath));
+        var supportsLinks = _errorConsole.Profile.Capabilities.Links;
+        var message = string.Format(
+            CultureInfo.CurrentCulture,
+            InteractionServiceStrings.SeeLogsAt,
+            MarkupHelpers.SafeFileLink(supportsLinks, _logFilePath));
+        _errorConsole.MarkupLine(prefix + message);
     }
 }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -338,20 +338,10 @@ internal class ConsoleInteractionService : IInteractionService
         return ExitCodeConstants.AppHostIncompatible;
     }
 
-    public void DisplayError(string errorMessage)
+    public void DisplayError(string errorMessage, bool allowMarkup = false)
     {
-        if (TrySplitLogFileReference(errorMessage, out var errorWithoutLogReference, out var logReference))
-        {
-            if (!string.IsNullOrWhiteSpace(errorWithoutLogReference))
-            {
-                DisplayMessage(KnownEmojis.CrossMark, $"[red bold]{errorWithoutLogReference.EscapeMarkup()}[/]", allowMarkup: true);
-            }
-
-            DisplayMessage(KnownEmojis.PageFacingUp, logReference);
-            return;
-        }
-
-        DisplayMessage(KnownEmojis.CrossMark, $"[red bold]{errorMessage.EscapeMarkup()}[/]", allowMarkup: true);
+        var formatted = allowMarkup ? errorMessage : errorMessage.EscapeMarkup();
+        DisplayMessage(KnownEmojis.CrossMark, $"[red bold]{formatted}[/]", allowMarkup: true);
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
@@ -364,7 +354,7 @@ internal class ConsoleInteractionService : IInteractionService
             MessageLogger.LogInformation("{Message}", ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole, replaceEmoji: true) + logMessage);
         }
 
-        var displayMessage = allowMarkup ? message : ConsoleHelpers.EscapeMarkupWithFileLink(message, _executionContext.LogFilePath);
+        var displayMessage = allowMarkup ? message : message.EscapeMarkup();
         MessageConsole.MarkupLine(ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole) + displayMessage);
     }
 
@@ -430,21 +420,6 @@ internal class ConsoleInteractionService : IInteractionService
         return effectiveConsole == ConsoleOutput.Error
             ? System.Console.IsErrorRedirected
             : System.Console.IsOutputRedirected;
-    }
-
-    private bool TrySplitLogFileReference(string message, [NotNullWhen(true)] out string? errorWithoutLogReference, [NotNullWhen(true)] out string? logReference)
-    {
-        logReference = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _executionContext.LogFilePath);
-        var logReferenceIndex = message.LastIndexOf(logReference, StringComparison.Ordinal);
-        if (logReferenceIndex < 0)
-        {
-            errorWithoutLogReference = null;
-            logReference = null;
-            return false;
-        }
-
-        errorWithoutLogReference = message[..logReferenceIndex].TrimEnd();
-        return true;
     }
 
     public void DisplayMarkupLine(string markup)
@@ -596,7 +571,7 @@ internal class ConsoleInteractionService : IInteractionService
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
         MessageLogger.LogInformation("{Message}", message);
-        var displayMessage = allowMarkup ? message : ConsoleHelpers.EscapeMarkupWithFileLink(message, _executionContext.LogFilePath);
+        var displayMessage = allowMarkup ? message : message.EscapeMarkup();
         MessageConsole.MarkupLine($"[dim]{displayMessage}[/]");
     }
 

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -340,6 +340,17 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void DisplayError(string errorMessage)
     {
+        if (TrySplitLogFileReference(errorMessage, out var errorWithoutLogReference, out var logReference))
+        {
+            if (!string.IsNullOrWhiteSpace(errorWithoutLogReference))
+            {
+                DisplayMessage(KnownEmojis.CrossMark, $"[red bold]{errorWithoutLogReference.EscapeMarkup()}[/]", allowMarkup: true);
+            }
+
+            DisplayMessage(KnownEmojis.PageFacingUp, logReference);
+            return;
+        }
+
         DisplayMessage(KnownEmojis.CrossMark, $"[red bold]{errorMessage.EscapeMarkup()}[/]", allowMarkup: true);
     }
 
@@ -353,7 +364,7 @@ internal class ConsoleInteractionService : IInteractionService
             MessageLogger.LogInformation("{Message}", ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole, replaceEmoji: true) + logMessage);
         }
 
-        var displayMessage = allowMarkup ? message : message.EscapeMarkup();
+        var displayMessage = allowMarkup ? message : ConsoleHelpers.EscapeMarkupWithFileLink(message, _executionContext.LogFilePath);
         MessageConsole.MarkupLine(ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole) + displayMessage);
     }
 
@@ -419,6 +430,21 @@ internal class ConsoleInteractionService : IInteractionService
         return effectiveConsole == ConsoleOutput.Error
             ? System.Console.IsErrorRedirected
             : System.Console.IsOutputRedirected;
+    }
+
+    private bool TrySplitLogFileReference(string message, [NotNullWhen(true)] out string? errorWithoutLogReference, [NotNullWhen(true)] out string? logReference)
+    {
+        logReference = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _executionContext.LogFilePath);
+        var logReferenceIndex = message.LastIndexOf(logReference, StringComparison.Ordinal);
+        if (logReferenceIndex < 0)
+        {
+            errorWithoutLogReference = null;
+            logReference = null;
+            return false;
+        }
+
+        errorWithoutLogReference = message[..logReferenceIndex].TrimEnd();
+        return true;
     }
 
     public void DisplayMarkupLine(string markup)
@@ -570,7 +596,7 @@ internal class ConsoleInteractionService : IInteractionService
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
         MessageLogger.LogInformation("{Message}", message);
-        var displayMessage = allowMarkup ? message : message.EscapeMarkup();
+        var displayMessage = allowMarkup ? message : ConsoleHelpers.EscapeMarkupWithFileLink(message, _executionContext.LogFilePath);
         MessageConsole.MarkupLine($"[dim]{displayMessage}[/]");
     }
 

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -337,7 +337,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         return _consoleInteractionService.DisplayIncompatibleVersionError(ex, appHostHostingSdkVersion);
     }
 
-    public void DisplayError(string errorMessage)
+    public void DisplayError(string errorMessage, bool allowMarkup = false)
     {
         // Serialize the local console write onto the same channel as the backchannel call so
         // it stays ordered with prior queued operations (e.g. DisplayLines). Otherwise the
@@ -347,7 +347,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
             await Backchannel.DisplayErrorAsync(errorMessage.RemoveSpectreFormatting(), _cancellationToken);
-            _consoleInteractionService.DisplayError(errorMessage);
+            _consoleInteractionService.DisplayError(errorMessage, allowMarkup);
         });
         Debug.Assert(result);
     }

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -18,7 +18,7 @@ internal interface IInteractionService
     Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull;
     Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion);
-    void DisplayError(string errorMessage);
+    void DisplayError(string errorMessage, bool allowMarkup = false);
     void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false);
     void DisplayPlainText(string text);
     void DisplayRawText(string text, ConsoleOutput? consoleOverride = null);

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -295,7 +295,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The project could not be built. See logs at {0}.
+        ///   Looks up a localized string similar to The project could not be built..
         /// </summary>
         public static string ProjectCouldNotBeBuilt {
             get {
@@ -304,7 +304,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The app could not be created. See logs at {0}.
+        ///   Looks up a localized string similar to The app could not be created..
         /// </summary>
         public static string ProjectCouldNotBeCreated {
             get {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -195,10 +195,10 @@
     <value>The project argument was not specified and no AppHost project files were detected.</value>
   </data>
   <data name="ProjectCouldNotBeBuilt" xml:space="preserve">
-    <value>The project could not be built. See logs at {0}</value>
+    <value>The project could not be built.</value>
   </data>
   <data name="ProjectCouldNotBeCreated" xml:space="preserve">
-    <value>The app could not be created. See logs at {0}</value>
+    <value>The app could not be created.</value>
   </data>
   <data name="OperationCancelled" xml:space="preserve">
     <value>The operation was canceled.</value>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">Projekt se nepovedlo sestavit. Protokoly najdete na {0}</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">Das Projekt konnte nicht erstellt werden. Protokolle unter {0} anzeigen.</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">No se pudo compilar el proyecto. Consulte los registros en {0}</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">Désolé, le projet n’a pas pu être généré. Consultez les journaux à l’emplacement {0}</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">Non è possibile compilare il progetto. Consultare i log in {0}</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">プロジェクトを構築できませんでした。{0} でログを表示する</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">프로젝트를 빌드할 수 없습니다. {0}에서 로그 보기</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">Nie można skompilować projektu. Zobacz dzienniki pod adresem {0}</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">O projeto não pôde ser compilado. Ver logs em {0}</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">Не удалось выполнить сборку проекта. См. журналы по адресу {0}</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">Proje oluşturulamadı. {0} adresinde günlüklere bakın</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">无法生成项目。请参阅 {0} 处的日志</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../InteractionServiceStrings.resx">
     <body>
@@ -128,13 +128,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. See logs at {0}</source>
-        <target state="translated">無法建置專案。請參閱 {0} 中的記錄</target>
+        <source>The project could not be built.</source>
+        <target state="new">The project could not be built.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeCreated">
-        <source>The app could not be created. See logs at {0}</source>
-        <target state="new">The app could not be created. See logs at {0}</target>
+        <source>The app could not be created.</source>
+        <target state="new">The app could not be created.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">

--- a/src/Aspire.Cli/Utils/ConsoleHelpers.cs
+++ b/src/Aspire.Cli/Utils/ConsoleHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Aspire.Cli.Interaction;
 using Spectre.Console;
 
@@ -36,5 +37,60 @@ internal static class ConsoleHelpers
         }
 
         return spectreEmojiText + new string(' ', padding);
+    }
+
+    /// <summary>
+    /// Escapes a message as Spectre markup while hyperlinking each occurrence of the specified file path.
+    /// </summary>
+    public static string EscapeMarkupWithFileLink(string message, string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        if (filePath.Length == 0)
+        {
+            return message.EscapeMarkup();
+        }
+
+        var index = message.IndexOf(filePath, StringComparison.Ordinal);
+        if (index < 0)
+        {
+            return message.EscapeMarkup();
+        }
+
+        var linkedPath = FormatPathAsFileLink(filePath);
+        var builder = new StringBuilder(message.Length + linkedPath.Length);
+        var nextIndex = 0;
+
+        while (index >= 0)
+        {
+            builder.Append(message[nextIndex..index].EscapeMarkup());
+            builder.Append(linkedPath);
+            nextIndex = index + filePath.Length;
+            index = message.IndexOf(filePath, nextIndex, StringComparison.Ordinal);
+        }
+
+        builder.Append(message[nextIndex..].EscapeMarkup());
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Formats a file path as Spectre link markup using a file URI target.
+    /// </summary>
+    public static string FormatPathAsFileLink(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        if (filePath.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var fileUri = new Uri(Path.GetFullPath(filePath)).AbsoluteUri
+            .Replace("[", "%5B", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+
+        return $"[link={fileUri.EscapeMarkup()}]{filePath.EscapeMarkup()}[/]";
     }
 }

--- a/src/Aspire.Cli/Utils/ConsoleHelpers.cs
+++ b/src/Aspire.Cli/Utils/ConsoleHelpers.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text;
 using Aspire.Cli.Interaction;
 using Spectre.Console;
 
@@ -38,59 +37,5 @@ internal static class ConsoleHelpers
 
         return spectreEmojiText + new string(' ', padding);
     }
-
-    /// <summary>
-    /// Escapes a message as Spectre markup while hyperlinking each occurrence of the specified file path.
-    /// </summary>
-    public static string EscapeMarkupWithFileLink(string message, string filePath)
-    {
-        ArgumentNullException.ThrowIfNull(message);
-        ArgumentNullException.ThrowIfNull(filePath);
-
-        if (filePath.Length == 0)
-        {
-            return message.EscapeMarkup();
-        }
-
-        var index = message.IndexOf(filePath, StringComparison.Ordinal);
-        if (index < 0)
-        {
-            return message.EscapeMarkup();
-        }
-
-        var linkedPath = FormatPathAsFileLink(filePath);
-        var builder = new StringBuilder(message.Length + linkedPath.Length);
-        var nextIndex = 0;
-
-        while (index >= 0)
-        {
-            builder.Append(message[nextIndex..index].EscapeMarkup());
-            builder.Append(linkedPath);
-            nextIndex = index + filePath.Length;
-            index = message.IndexOf(filePath, nextIndex, StringComparison.Ordinal);
-        }
-
-        builder.Append(message[nextIndex..].EscapeMarkup());
-
-        return builder.ToString();
-    }
-
-    /// <summary>
-    /// Formats a file path as Spectre link markup using a file URI target.
-    /// </summary>
-    public static string FormatPathAsFileLink(string filePath)
-    {
-        ArgumentNullException.ThrowIfNull(filePath);
-
-        if (filePath.Length == 0)
-        {
-            return string.Empty;
-        }
-
-        var fileUri = new Uri(Path.GetFullPath(filePath)).AbsoluteUri
-            .Replace("[", "%5B", StringComparison.Ordinal)
-            .Replace("]", "%5D", StringComparison.Ordinal);
-
-        return $"[link={fileUri.EscapeMarkup()}]{filePath.EscapeMarkup()}[/]";
-    }
 }
+

--- a/src/Aspire.Cli/Utils/MarkupHelpers.cs
+++ b/src/Aspire.Cli/Utils/MarkupHelpers.cs
@@ -37,4 +37,47 @@ internal static class MarkupHelpers
 
         return noTitle ? link : $"{title} ({link})";
     }
+
+    /// <summary>
+    /// Builds a clickable file-link markup string for the specified file path
+    /// when the console supports links, otherwise returns a plain-text fallback.
+    /// The displayed text is the original <paramref name="filePath"/> and the
+    /// link target is a <c>file://</c> URI built from the absolute path.
+    /// </summary>
+    public static string SafeFileLink(IInteractionService interactionService, string filePath)
+    {
+        return SafeFileLink(interactionService.SupportsLinks, filePath);
+    }
+
+    /// <summary>
+    /// Builds a clickable file-link markup string for the specified file path
+    /// when the console supports links, otherwise returns a plain-text fallback.
+    /// The displayed text is the original <paramref name="filePath"/> and the
+    /// link target is a <c>file://</c> URI built from the absolute path.
+    /// </summary>
+    public static string SafeFileLink(bool supportsLinks, string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return string.Empty;
+        }
+
+        if (!supportsLinks)
+        {
+            return filePath.EscapeMarkup();
+        }
+
+        // Uri.AbsoluteUri does not percent-encode '[' or ']' inside the path component
+        // (those characters are reserved by RFC 3986 for IP-literals only, but the BCL
+        // is permissive in file paths). Spectre.Console treats unescaped brackets inside
+        // a [link=...] markup tag as the start of a new tag, which corrupts the
+        // hyperlink. Replacing them with their percent-encoded forms keeps both the
+        // OSC 8 hyperlink and the surrounding markup well-formed.
+        var fileUri = new Uri(Path.GetFullPath(filePath)).AbsoluteUri
+            .Replace("[", "%5B", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+
+        return SafeLink(supportsLinks: true, fileUri, filePath);
+    }
 }
+

--- a/src/Aspire.Cli/Utils/MarkupHelpers.cs
+++ b/src/Aspire.Cli/Utils/MarkupHelpers.cs
@@ -67,17 +67,8 @@ internal static class MarkupHelpers
             return filePath.EscapeMarkup();
         }
 
-        // Uri.AbsoluteUri does not percent-encode '[' or ']' inside the path component
-        // (those characters are reserved by RFC 3986 for IP-literals only, but the BCL
-        // is permissive in file paths). Spectre.Console treats unescaped brackets inside
-        // a [link=...] markup tag as the start of a new tag, which corrupts the
-        // hyperlink. Replacing them with their percent-encoded forms keeps both the
-        // OSC 8 hyperlink and the surrounding markup well-formed.
-        var fileUri = new Uri(Path.GetFullPath(filePath)).AbsoluteUri
-            .Replace("[", "%5B", StringComparison.Ordinal)
-            .Replace("]", "%5D", StringComparison.Ordinal);
+        var fileUri = new Uri(Path.GetFullPath(filePath)).AbsoluteUri;
 
         return SafeLink(supportsLinks: true, fileUri, filePath);
     }
 }
-

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text;
 using Aspire.Cli.Commands;
 using Aspire.Cli.DotNet;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
@@ -11,6 +13,8 @@ using Aspire.Cli.Tests.Utils;
 using Aspire.Shared;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -421,6 +425,53 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, executionContext, browserToken: "abc123");
 
         Assert.Equal("http://localhost:18888/login?t=abc123", info.DashboardUrl);
+    }
+
+    [Fact]
+    public void RenderDashboardSummary_RendersLogsPathAsClickableFileLink()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.TrueColor,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        });
+        console.Profile.Width = int.MaxValue;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var logFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "cli [dashboard].log");
+        var executionContext = new CliExecutionContext(
+            workingDirectory: workspace.WorkspaceRoot,
+            hivesDirectory: workspace.WorkspaceRoot,
+            cacheDirectory: workspace.WorkspaceRoot,
+            sdksDirectory: workspace.WorkspaceRoot,
+            logsDirectory: workspace.WorkspaceRoot,
+            logFilePath: logFilePath);
+
+        var interactionService = new ConsoleInteractionService(
+            new ConsoleEnvironment(console, console),
+            executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
+            NullLoggerFactory.Instance);
+
+        var dashboardInfo = new DashboardRunCommand.DashboardInfo(
+            DashboardUrl: "http://localhost:18888",
+            OtlpGrpcUrl: "http://localhost:4317",
+            OtlpHttpUrl: "http://localhost:4318");
+
+        DashboardRunCommand.RenderDashboardSummary(interactionService, dashboardInfo, logFilePath);
+
+        var outputString = output.ToString();
+        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
+            .Replace("[", "%5B", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+
+        Assert.Contains("Logs", outputString);
+        Assert.Contains($";{fileUri}\u001b\\", outputString);
+        Assert.Contains(logFilePath, outputString);
+        Assert.Contains("\u001b]8;;\u001b\\", outputString);
     }
 
     private (IServiceCollection Services, string ManagedPath, TestProcessExecutionFactory ExecutionFactory) CreateServicesWithLayout(

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -464,6 +464,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         DashboardRunCommand.RenderDashboardSummary(interactionService, dashboardInfo, logFilePath);
 
         var outputString = output.ToString();
+        // SafeFileLink percent-encodes brackets so the resulting OSC 8 hyperlink target
+        // is valid; mirror that here so the assertion exactly matches what was emitted.
         var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
             .Replace("[", "%5B", StringComparison.Ordinal)
             .Replace("]", "%5D", StringComparison.Ordinal);

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -464,16 +464,10 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         DashboardRunCommand.RenderDashboardSummary(interactionService, dashboardInfo, logFilePath);
 
         var outputString = output.ToString();
-        // SafeFileLink percent-encodes brackets so the resulting OSC 8 hyperlink target
-        // is valid; mirror that here so the assertion exactly matches what was emitted.
-        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
-            .Replace("[", "%5B", StringComparison.Ordinal)
-            .Replace("]", "%5D", StringComparison.Ordinal);
+        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri;
 
         Assert.Contains("Logs", outputString);
-        Assert.Contains($";{fileUri}\u001b\\", outputString);
-        Assert.Contains(logFilePath, outputString);
-        Assert.Contains("\u001b]8;;\u001b\\", outputString);
+        TerminalLinkAssert.ContainsLink(outputString, fileUri, logFilePath);
     }
 
     private (IServiceCollection Services, string ManagedPath, TestProcessExecutionFactory ExecutionFactory) CreateServicesWithLayout(

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -954,7 +954,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false) => action();
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false) => action();
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
-    public void DisplayError(string errorMessage) => DisplayedErrors.Add(errorMessage);
+    public void DisplayError(string errorMessage, bool allowMarkup = false) => DisplayedErrors.Add(errorMessage);
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
     public void DisplaySuccess(string message, bool allowMarkup = false) { }
     public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
@@ -22,6 +23,8 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -424,6 +427,54 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout(TestConstants.LongTimeoutDuration);
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public void RenderAppHostSummary_RendersLogsPathAsClickableFileLink()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.TrueColor,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        });
+        console.Profile.Width = int.MaxValue;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var logFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "cli [run].log");
+        var executionContext = new CliExecutionContext(
+            workingDirectory: workspace.WorkspaceRoot,
+            hivesDirectory: workspace.WorkspaceRoot,
+            cacheDirectory: workspace.WorkspaceRoot,
+            sdksDirectory: workspace.WorkspaceRoot,
+            logsDirectory: workspace.WorkspaceRoot,
+            logFilePath: logFilePath);
+
+        var interactionService = new ConsoleInteractionService(
+            new ConsoleEnvironment(console, console),
+            executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
+            NullLoggerFactory.Instance);
+
+        RunCommand.RenderAppHostSummary(
+            interactionService,
+            "AppHost.csproj",
+            dashboardUrl: "http://localhost:1234",
+            codespacesUrl: null,
+            logFilePath,
+            isExtensionHost: false);
+
+        var outputString = output.ToString();
+        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
+            .Replace("[", "%5B", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+
+        Assert.Contains("Logs", outputString);
+        Assert.Contains($";{fileUri}\u001b\\", outputString);
+        Assert.Contains(logFilePath, outputString);
+        Assert.Contains("\u001b]8;;\u001b\\", outputString);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -467,6 +467,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             isExtensionHost: false);
 
         var outputString = output.ToString();
+        // SafeFileLink percent-encodes brackets so the resulting OSC 8 hyperlink target
+        // is valid; mirror that here so the assertion exactly matches what was emitted.
         var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
             .Replace("[", "%5B", StringComparison.Ordinal)
             .Replace("]", "%5D", StringComparison.Ordinal);

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -467,16 +467,10 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             isExtensionHost: false);
 
         var outputString = output.ToString();
-        // SafeFileLink percent-encodes brackets so the resulting OSC 8 hyperlink target
-        // is valid; mirror that here so the assertion exactly matches what was emitted.
-        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
-            .Replace("[", "%5B", StringComparison.Ordinal)
-            .Replace("]", "%5D", StringComparison.Ordinal);
+        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri;
 
         Assert.Contains("Logs", outputString);
-        Assert.Contains($";{fileUri}\u001b\\", outputString);
-        Assert.Contains(logFilePath, outputString);
-        Assert.Contains("\u001b]8;;\u001b\\", outputString);
+        TerminalLinkAssert.ContainsLink(outputString, fileUri, logFilePath);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1754,7 +1754,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, preSelected, optional, binding, cancellationToken);
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) 
         => _innerService.DisplayIncompatibleVersionError(ex, appHostHostingVersion);
-    public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);
+    public void DisplayError(string errorMessage, bool allowMarkup = false) => _innerService.DisplayError(errorMessage, allowMarkup);
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) => _innerService.DisplayMessage(emoji, message, allowMarkup);
     public void DisplayPlainText(string text) => _innerService.DisplayPlainText(text);
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) => _innerService.DisplayRawText(text, consoleOverride);

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -20,8 +20,8 @@ public class ConsoleInteractionServiceTests
     private static readonly DirectoryInfo s_runtimeDirectory = s_tempRoot.CreateSubdirectory("runtimes");
     private static readonly DirectoryInfo s_logsDirectory = s_tempRoot.CreateSubdirectory("logs");
 
-    private static CliExecutionContext CreateExecutionContext(bool debugMode = false) =>
-        new(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), s_runtimeDirectory, s_logsDirectory, "test.log", debugMode: debugMode);
+    private static CliExecutionContext CreateExecutionContext(bool debugMode = false, string? logFilePath = null) =>
+        new(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), s_runtimeDirectory, s_logsDirectory, logFilePath ?? "test.log", debugMode: debugMode);
 
     private static ConsoleInteractionService CreateInteractionService(IAnsiConsole console, CliExecutionContext? executionContext = null, ICliHostEnvironment? hostEnvironment = null)
     {
@@ -474,6 +474,66 @@ public class ConsoleInteractionServiceTests
         Assert.Null(exception);
         var outputString = output.ToString();
         Assert.Contains("C:\\Users\\test [Dev]\\logs\\aspire.log", outputString);
+    }
+
+    [Fact]
+    public void DisplayMessage_WithCurrentLogFilePath_RendersClickableFileLink()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.TrueColor,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        });
+        console.Profile.Width = int.MaxValue;
+
+        var logFilePath = Path.Combine(s_logsDirectory.FullName, "cli [dev team].log");
+        var interactionService = CreateInteractionService(console, CreateExecutionContext(logFilePath: logFilePath));
+
+        interactionService.DisplayMessage(KnownEmojis.PageFacingUp, $"See logs at {logFilePath}");
+
+        var outputString = output.ToString();
+        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
+            .Replace("[", "%5B", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+        Assert.Contains($";{fileUri}\u001b\\", outputString);
+        Assert.Contains(logFilePath, outputString);
+        Assert.Contains("\u001b]8;;\u001b\\", outputString);
+    }
+
+    [Fact]
+    public void DisplayError_WithCurrentLogFilePath_RendersClickableFileLink()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.TrueColor,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        });
+        console.Profile.Width = int.MaxValue;
+
+        var logFilePath = Path.Combine(s_logsDirectory.FullName, "cli [dev team].log");
+        var interactionService = CreateInteractionService(console, CreateExecutionContext(logFilePath: logFilePath));
+
+        interactionService.DisplayError($"The project could not be built. See logs at {logFilePath}");
+
+        var outputString = output.ToString();
+        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
+            .Replace("[", "%5B", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+        var lines = outputString.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(2, lines.Length);
+        Assert.Contains("The project could not be built.", lines[0]);
+        Assert.DoesNotContain(logFilePath, lines[0]);
+        Assert.Contains("See logs at", lines[1]);
+        Assert.Contains($";{fileUri}\u001b\\", outputString);
+        Assert.Contains(logFilePath, outputString);
+        Assert.Contains("\u001b]8;;\u001b\\", outputString);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -477,7 +477,7 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
-    public void DisplayMessage_WithCurrentLogFilePath_RendersClickableFileLink()
+    public void DisplayMessage_WithFileLinkMarkup_RendersClickableLinkWhenAllowMarkup()
     {
         var output = new StringBuilder();
         var console = AnsiConsole.Create(new AnsiConsoleSettings
@@ -487,12 +487,17 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output)),
             Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
         });
+        console.Profile.Capabilities.Links = true;
         console.Profile.Width = int.MaxValue;
 
         var logFilePath = Path.Combine(s_logsDirectory.FullName, "cli [dev team].log");
         var interactionService = CreateInteractionService(console, CreateExecutionContext(logFilePath: logFilePath));
 
-        interactionService.DisplayMessage(KnownEmojis.PageFacingUp, $"See logs at {logFilePath}");
+        var fileLinkMarkup = MarkupHelpers.SafeFileLink(interactionService, logFilePath);
+        interactionService.DisplayMessage(
+            KnownEmojis.PageFacingUp,
+            $"See logs at {fileLinkMarkup}",
+            allowMarkup: true);
 
         var outputString = output.ToString();
         var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
@@ -504,7 +509,7 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
-    public void DisplayError_WithCurrentLogFilePath_RendersClickableFileLink()
+    public void DisplayError_WithAllowMarkup_RendersMarkupAsIs()
     {
         var output = new StringBuilder();
         var console = AnsiConsole.Create(new AnsiConsoleSettings
@@ -514,26 +519,45 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output)),
             Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
         });
+        console.Profile.Capabilities.Links = true;
         console.Profile.Width = int.MaxValue;
 
         var logFilePath = Path.Combine(s_logsDirectory.FullName, "cli [dev team].log");
         var interactionService = CreateInteractionService(console, CreateExecutionContext(logFilePath: logFilePath));
 
-        interactionService.DisplayError($"The project could not be built. See logs at {logFilePath}");
+        var fileLinkMarkup = MarkupHelpers.SafeFileLink(interactionService, logFilePath);
+        interactionService.DisplayError($"Build failed. Logs: {fileLinkMarkup}", allowMarkup: true);
 
         var outputString = output.ToString();
         var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
             .Replace("[", "%5B", StringComparison.Ordinal)
             .Replace("]", "%5D", StringComparison.Ordinal);
-        var lines = outputString.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries);
-
-        Assert.Equal(2, lines.Length);
-        Assert.Contains("The project could not be built.", lines[0]);
-        Assert.DoesNotContain(logFilePath, lines[0]);
-        Assert.Contains("See logs at", lines[1]);
-        Assert.Contains($";{fileUri}\u001b\\", outputString);
+        Assert.Contains("Build failed.", outputString);
         Assert.Contains(logFilePath, outputString);
+        Assert.Contains($";{fileUri}\u001b\\", outputString);
         Assert.Contains("\u001b]8;;\u001b\\", outputString);
+    }
+
+    [Fact]
+    public void DisplayError_WithoutAllowMarkup_EscapesBrackets()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+
+        var interactionService = CreateInteractionService(console);
+
+        // Bracket characters in the error message would normally break Spectre markup parsing,
+        // but DisplayError escapes them by default.
+        var message = "Build failed for [Project Alpha].";
+        var exception = Record.Exception(() => interactionService.DisplayError(message));
+
+        Assert.Null(exception);
+        Assert.Contains("Build failed for [Project Alpha].", output.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console;
@@ -500,12 +501,8 @@ public class ConsoleInteractionServiceTests
             allowMarkup: true);
 
         var outputString = output.ToString();
-        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
-            .Replace("[", "%5B", StringComparison.Ordinal)
-            .Replace("]", "%5D", StringComparison.Ordinal);
-        Assert.Contains($";{fileUri}\u001b\\", outputString);
-        Assert.Contains(logFilePath, outputString);
-        Assert.Contains("\u001b]8;;\u001b\\", outputString);
+        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri;
+        TerminalLinkAssert.ContainsLink(outputString, fileUri, logFilePath);
     }
 
     [Fact]
@@ -529,13 +526,9 @@ public class ConsoleInteractionServiceTests
         interactionService.DisplayError($"Build failed. Logs: {fileLinkMarkup}", allowMarkup: true);
 
         var outputString = output.ToString();
-        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri
-            .Replace("[", "%5B", StringComparison.Ordinal)
-            .Replace("]", "%5D", StringComparison.Ordinal);
+        var fileUri = new Uri(Path.GetFullPath(logFilePath)).AbsoluteUri;
         Assert.Contains("Build failed.", outputString);
-        Assert.Contains(logFilePath, outputString);
-        Assert.Contains($";{fileUri}\u001b\\", outputString);
-        Assert.Contains("\u001b]8;;\u001b\\", outputString);
+        TerminalLinkAssert.ContainsLink(outputString, fileUri, logFilePath);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -164,7 +164,7 @@ public class ExtensionGuestLauncherTests
         public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull => throw new NotImplementedException();
         public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull => throw new NotImplementedException();
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => throw new NotImplementedException();
-        public void DisplayError(string errorMessage) => throw new NotImplementedException();
+        public void DisplayError(string errorMessage, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplaySuccess(string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -443,7 +443,7 @@ public class DotNetTemplateFactoryTests
             => throw new NotImplementedException();
 
         public void DisplaySuccess(string message, bool allowMarkup = false) { }
-        public void DisplayError(string message) { }
+        public void DisplayError(string message, bool allowMarkup = false) { }
         public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
         public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) { }
         public void DisplayCancellationMessage() { }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -76,7 +76,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         return 0;
     }
 
-    public void DisplayError(string errorMessage)
+    public void DisplayError(string errorMessage, bool allowMarkup = false)
     {
         DisplayErrorCallback?.Invoke(errorMessage);
     }

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -175,7 +175,7 @@ internal sealed class TestInteractionService : IInteractionService
         return 0;
     }
 
-    public void DisplayError(string errorMessage)
+    public void DisplayError(string errorMessage, bool allowMarkup = false)
     {
         DisplayedErrors.Add(errorMessage);
     }

--- a/tests/Aspire.Cli.Tests/Utils/MarkupHelpersTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkupHelpersTests.cs
@@ -101,4 +101,70 @@ public class MarkupHelpersTests
         }
         return console;
     }
+
+    [Fact]
+    public void SafeFileLink_WithEmptyPath_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, MarkupHelpers.SafeFileLink(supportsLinks: true, string.Empty));
+        Assert.Equal(string.Empty, MarkupHelpers.SafeFileLink(supportsLinks: false, string.Empty));
+    }
+
+    [Fact]
+    public void SafeFileLink_WhenNoLinkSupport_ReturnsEscapedPath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "logs", "cli [Dev].log");
+
+        var result = MarkupHelpers.SafeFileLink(supportsLinks: false, path);
+
+        Assert.Equal(path.EscapeMarkup(), result);
+        Assert.DoesNotContain("[link", result);
+    }
+
+    [Fact]
+    public void SafeFileLink_WhenSupportsLinks_BuildsLinkMarkupWithFileUri()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "logs", "aspire.log");
+
+        var result = MarkupHelpers.SafeFileLink(supportsLinks: true, path);
+
+        var expectedUri = new Uri(Path.GetFullPath(path)).AbsoluteUri;
+        Assert.Equal($"[link={expectedUri}]{path.EscapeMarkup()}[/]", result);
+    }
+
+    [Fact]
+    public void SafeFileLink_WhenSupportsLinks_PercentEncodesBracketsInUri()
+    {
+        // Bracket characters in file paths are not percent-encoded by Uri.AbsoluteUri,
+        // but they would otherwise be parsed by Spectre.Console as the start of a new
+        // markup tag inside [link=...]. SafeFileLink must encode them to keep both the
+        // OSC 8 hyperlink and the surrounding markup well-formed.
+        var path = Path.Combine(Path.GetTempPath(), "logs", "cli [Dev].log");
+
+        var result = MarkupHelpers.SafeFileLink(supportsLinks: true, path);
+
+        var expectedUri = new Uri(Path.GetFullPath(path)).AbsoluteUri
+            .Replace("[", "%5B", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+        Assert.Contains("%5B", expectedUri);
+        Assert.Contains("%5D", expectedUri);
+        Assert.Equal($"[link={expectedUri}]{path.EscapeMarkup()}[/]", result);
+    }
+
+    [Fact]
+    public void SafeFileLink_WhenSupportsLinks_ProducesValidMarkup()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "logs", "cli [Dev].log");
+        var result = MarkupHelpers.SafeFileLink(supportsLinks: true, path);
+
+        var output = new StringBuilder();
+        var console = CreateAnsiConsole(output, ansi: true);
+        console.MarkupLine(result);
+
+        var rendered = output.ToString().Trim();
+        var fileUri = new Uri(Path.GetFullPath(path)).AbsoluteUri
+            .Replace("[", "%5B", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+        var pattern = $"\\x1b]8;id=\\d+;{Regex.Escape(fileUri)}\\x1b\\\\{Regex.Escape(path)}\\x1b]8;;\\x1b\\\\";
+        Assert.Matches(pattern, rendered);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/MarkupHelpersTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkupHelpersTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
-using System.Text.RegularExpressions;
 using Aspire.Cli.Utils;
 using Spectre.Console;
 
@@ -59,11 +58,7 @@ public class MarkupHelpersTests
         console.MarkupLine(result);
 
         var rendered = output.ToString().Trim();
-        // OSC 8 format: ESC]8;id=N;url ESC\ text ESC]8;; ESC\
-        var escapedLink = Regex.Escape(link);
-        var escapedText = Regex.Escape(expectedText);
-        var pattern = $"\\x1b]8;id=\\d+;{escapedLink}\\x1b\\\\{escapedText}\\x1b]8;;\\x1b\\\\";
-        Assert.Matches(pattern, rendered);
+        TerminalLinkAssert.ContainsLink(rendered, link, expectedText);
     }
 
     [Theory]
@@ -132,22 +127,14 @@ public class MarkupHelpersTests
     }
 
     [Fact]
-    public void SafeFileLink_WhenSupportsLinks_PercentEncodesBracketsInUri()
+    public void SafeFileLink_WhenSupportsLinks_EscapesBracketsInUriMarkup()
     {
-        // Bracket characters in file paths are not percent-encoded by Uri.AbsoluteUri,
-        // but they would otherwise be parsed by Spectre.Console as the start of a new
-        // markup tag inside [link=...]. SafeFileLink must encode them to keep both the
-        // OSC 8 hyperlink and the surrounding markup well-formed.
         var path = Path.Combine(Path.GetTempPath(), "logs", "cli [Dev].log");
 
         var result = MarkupHelpers.SafeFileLink(supportsLinks: true, path);
 
-        var expectedUri = new Uri(Path.GetFullPath(path)).AbsoluteUri
-            .Replace("[", "%5B", StringComparison.Ordinal)
-            .Replace("]", "%5D", StringComparison.Ordinal);
-        Assert.Contains("%5B", expectedUri);
-        Assert.Contains("%5D", expectedUri);
-        Assert.Equal($"[link={expectedUri}]{path.EscapeMarkup()}[/]", result);
+        var expectedUri = new Uri(Path.GetFullPath(path)).AbsoluteUri;
+        Assert.Equal($"[link={expectedUri.EscapeMarkup()}]{path.EscapeMarkup()}[/]", result);
     }
 
     [Fact]
@@ -161,10 +148,7 @@ public class MarkupHelpersTests
         console.MarkupLine(result);
 
         var rendered = output.ToString().Trim();
-        var fileUri = new Uri(Path.GetFullPath(path)).AbsoluteUri
-            .Replace("[", "%5B", StringComparison.Ordinal)
-            .Replace("]", "%5D", StringComparison.Ordinal);
-        var pattern = $"\\x1b]8;id=\\d+;{Regex.Escape(fileUri)}\\x1b\\\\{Regex.Escape(path)}\\x1b]8;;\\x1b\\\\";
-        Assert.Matches(pattern, rendered);
+        var fileUri = new Uri(Path.GetFullPath(path)).AbsoluteUri;
+        TerminalLinkAssert.ContainsLink(rendered, fileUri, path);
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/TerminalLinkAssert.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TerminalLinkAssert.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+
+namespace Aspire.Cli.Tests.Utils;
+
+internal static class TerminalLinkAssert
+{
+    public static void ContainsLink(string output, string link, string text)
+    {
+        output = Regex.Replace(output, @"\x1b\[[0-9;]*m", string.Empty);
+
+        var pattern = $@"\x1b]8;id=\d+;{Regex.Escape(link)}\x1b\\{Regex.Escape(text)}\x1b]8;;\x1b\\";
+        Assert.Matches(pattern, output);
+    }
+}


### PR DESCRIPTION
## Description

Adds clickable terminal hyperlinks to Aspire CLI log file references. This centralizes file-link markup formatting for the current CLI log file path, applies it to CLI messages and startup error output, and preserves the existing neutral `📄 See logs at ...` styling when an error message includes a log reference.

Validation:

```powershell
.\.dotnet\dotnet.exe test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ConsoleInteractionServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

**Before this PR**

`aspire new` with error:

<img width="1674" height="297" alt="image" src="https://github.com/user-attachments/assets/f0a8a713-4ab0-41e8-a853-c8250c0747fe" />

`aspire run` with logs:

<img width="1434" height="472" alt="image" src="https://github.com/user-attachments/assets/9acdd557-a7bf-4442-b8a0-89d1a11c857b" />

**After this PR:**

`aspire new` with error:

<img width="1674" height="297" alt="image" src="https://github.com/user-attachments/assets/097e4c17-bfa4-4aba-87a6-85fc7035ba5e" />

`aspire run` with logs:

<img width="1446" height="497" alt="image" src="https://github.com/user-attachments/assets/dd963c9c-83d0-4101-b1ce-eeb325782b1a" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
