### PR TITLE
Sign .js files with 3PartyScriptsSHA2 for VS signing compliance

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -14,8 +14,8 @@
     <!-- add missing entry for .msi, this can be removed once aspire uses arcade 10.0 -->
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" Condition="!@(FileExtensionSignInfo->AnyHaveMetadataValue('Identity', '.msi'))" />
 
-    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
-    <FileExtensionSignInfo Update=".js" CertificateName="None" />
+    <!-- Sign 3rd-party JS files (e.g., Bootstrap in project templates) for VS signing compliance. -->
+    <FileExtensionSignInfo Update=".js" CertificateName="3PartyScriptsSHA2" />
     <!-- Remove .py files from being signed. See https://github.com/microsoft/aspire/issues/13004 -->
     <FileExtensionSignInfo Update=".py" CertificateName="None" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

The VS signing scan flags 8 unsigned JS files in the `Aspire.ProjectTemplates` NuGet package (Bootstrap library + eslint config files). These ship inside `Aspire.vsix` which is installed with Visual Studio.

**Unsigned files (payload `mswebtoolsaspire`):**
- `bootstrap.js`
- `bootstrap.min.js`
- `bootstrap.bundle.js`
- `bootstrap.bundle.min.js`
- `bootstrap.esm.js`
- `bootstrap.esm.min.js`
- `eslint.config.js`
- `eslint.config_1.js`

## Root Cause

`eng/Signing.props` has `FileExtensionSignInfo` for `.js` set to `CertificateName="None"`, which skips all JS file signing. The original comment stated JS files are not used in Windows Script Host, but VS signing compliance requires all signable files to carry their own Authenticode signature.

## Fix

Change `.js` `CertificateName` from `None` to `3PartyScriptsSHA2` (the correct Arcade SDK certificate for 3rd-party/OSS script files). This signs all JS files with Authenticode during the build, so the `Aspire.ProjectTemplates` NuGet and by extension the `Aspire.vsix` ships properly signed JS content.

## Verification

After this merges and a new official build flows through `dotnet-project-system` into VS, the `mswebtoolsaspire` payload should no longer appear in the VS signing scan.
