### PR TITLE
Remove obsolete ATS export shims

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs
@@ -85,25 +85,6 @@ public static class AzureBicepResourceExtensions
         return builder.WithEnvironment(name, (IExpressionValue)bicepOutputReference);
     }
 
-    // Keep these ATS-only aliases for backward compatibility with existing polyglot app hosts.
-    // Remove them once callers have migrated to the unified withEnvironment(...) export.
-    // Tracking issue: https://github.com/microsoft/aspire/issues/15734
-    /// <summary>
-    /// Obsolete ATS alias for <see cref="WithEnvironment{T}(IResourceBuilder{T}, string, BicepOutputReference)"/>.
-    /// </summary>
-    /// <typeparam name="T">The resource type.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the environment variable.</param>
-    /// <param name="bicepOutputReference">The reference to the Bicep output.</param>
-    /// <returns>An <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete("ATS compatibility shim. Use withEnvironment instead.")]
-    [AspireExport("withEnvironmentFromOutput", Description = "Sets an environment variable from a Bicep output reference")]
-    internal static IResourceBuilder<T> WithEnvironmentFromOutputShim<T>(this IResourceBuilder<T> builder, string name, BicepOutputReference bicepOutputReference)
-        where T : IResourceWithEnvironment
-    {
-        return builder.WithEnvironment(name, bicepOutputReference);
-    }
-
     /// <summary>
     /// Adds an environment variable to the resource with the value of the secret output from the bicep template.
     /// </summary>
@@ -135,22 +116,6 @@ public static class AzureBicepResourceExtensions
         where T : IResourceWithEnvironment
     {
         return builder.WithEnvironment(name, (IExpressionValue)secretReference);
-    }
-
-    /// <summary>
-    /// Obsolete ATS alias for <see cref="WithEnvironment{T}(IResourceBuilder{T}, string, IAzureKeyVaultSecretReference)"/>.
-    /// </summary>
-    /// <typeparam name="T">The resource type.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the environment variable.</param>
-    /// <param name="secretReference">The key vault secret reference.</param>
-    /// <returns>An <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete("ATS compatibility shim. Use withEnvironment instead.")]
-    [AspireExport("withEnvironmentFromKeyVaultSecret", Description = "Sets an environment variable from an Azure Key Vault secret reference")]
-    internal static IResourceBuilder<T> WithEnvironmentFromKeyVaultSecretShim<T>(this IResourceBuilder<T> builder, string name, IAzureKeyVaultSecretReference secretReference)
-        where T : IResourceWithEnvironment
-    {
-        return builder.WithEnvironment(name, secretReference);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.SqlServer/api/Aspire.Hosting.SqlServer.ats.txt
+++ b/src/Aspire.Hosting.SqlServer/api/Aspire.Hosting.SqlServer.ats.txt
@@ -418,10 +418,6 @@ Aspire.Hosting/withEndpointProxySupport(proxyEnabled: boolean) -> Aspire.Hosting
 Aspire.Hosting/withEntrypoint(entrypoint: string) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource
 Aspire.Hosting/withEnvironment(name: string, value: string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression|Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReference|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource|Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithConnectionString|Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExpressionValue) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
 Aspire.Hosting/withEnvironmentCallback(callback: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
-Aspire.Hosting/withEnvironmentConnectionString(envVarName: string, resource: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithConnectionString) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
-Aspire.Hosting/withEnvironmentEndpoint(name: string, endpointReference: Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReference) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
-Aspire.Hosting/withEnvironmentExpression(name: string, value: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
-Aspire.Hosting/withEnvironmentParameter(name: string, parameter: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
 Aspire.Hosting/withExecutableCommand(command: string) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource
 Aspire.Hosting/withExplicitStart() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource
 Aspire.Hosting/withExternalHttpEndpoints() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -252,20 +252,6 @@ public static class YarpConfigurationBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a route for an existing cluster.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="path">The path to match for this route.</param>
-    /// <param name="cluster">The target cluster for this route.</param>
-    /// <returns>The created route.</returns>
-    [Obsolete("Use addRoute(path, target) instead.")]
-    [AspireExport("IYarpConfigurationBuilder.addRoute", MethodName = "addRouteCluster", Description = "Obsolete compatibility shim for the previous cluster-only addRoute export. Use addRoute(path, target) instead.")]
-    internal static YarpRoute AddRouteCluster(this IYarpConfigurationBuilder builder, string path, YarpCluster cluster)
-    {
-        return builder.AddRoute(path, cluster);
-    }
-
-    /// <summary>
     /// Add a new catch all route to YARP that will target the cluster in parameter.
     /// </summary>
     /// <param name="builder">The builder instance.</param>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -141,25 +141,6 @@ public static class ResourceBuilderExtensions
         });
     }
 
-    // Keep these ATS-only aliases for backward compatibility with existing polyglot app hosts.
-    // Remove them once callers have migrated to the unified withEnvironment(...) export.
-    // Tracking issue: https://github.com/microsoft/aspire/issues/15734
-    /// <summary>
-    /// Obsolete ATS alias for <see cref="WithEnvironment{T}(IResourceBuilder{T}, string, ReferenceExpression)"/>.
-    /// </summary>
-    /// <typeparam name="T">The resource type.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the environment variable.</param>
-    /// <param name="value">The reference expression value.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete("ATS compatibility shim. Use withEnvironment instead.")]
-    [AspireExport("withEnvironmentExpression", Description = "Sets an environment variable from a reference expression")]
-    internal static IResourceBuilder<T> WithEnvironmentExpressionShim<T>(this IResourceBuilder<T> builder, string name, ReferenceExpression value)
-        where T : IResourceWithEnvironment
-    {
-        return builder.WithEnvironment(name, value);
-    }
-
     /// <summary>
     /// Adds an environment variable to the resource.
     /// </summary>
@@ -236,22 +217,6 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Obsolete ATS alias for <see cref="WithEnvironment{T}(IResourceBuilder{T}, string, EndpointReference)"/>.
-    /// </summary>
-    /// <typeparam name="T">The resource type.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the environment variable.</param>
-    /// <param name="endpointReference">The endpoint reference value.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete("ATS compatibility shim. Use withEnvironment instead.")]
-    [AspireExport("withEnvironmentEndpoint", Description = "Sets an environment variable from an endpoint reference")]
-    internal static IResourceBuilder<T> WithEnvironmentEndpointShim<T>(this IResourceBuilder<T> builder, string name, EndpointReference endpointReference)
-        where T : IResourceWithEnvironment
-    {
-        return builder.WithEnvironment(name, endpointReference);
-    }
-
-    /// <summary>
     /// Adds an environment variable to the resource with the URL from the <see cref="ExternalServiceResource"/>.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -318,22 +283,6 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Obsolete ATS alias for <see cref="WithEnvironment{T}(IResourceBuilder{T}, string, IResourceBuilder{ParameterResource})"/>.
-    /// </summary>
-    /// <typeparam name="T">The resource type.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the environment variable.</param>
-    /// <param name="parameter">The parameter resource builder.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete("ATS compatibility shim. Use withEnvironment instead.")]
-    [AspireExport("withEnvironmentParameter", Description = "Sets an environment variable from a parameter resource")]
-    internal static IResourceBuilder<T> WithEnvironmentParameterShim<T>(this IResourceBuilder<T> builder, string name, IResourceBuilder<ParameterResource> parameter)
-        where T : IResourceWithEnvironment
-    {
-        return builder.WithEnvironment(name, parameter);
-    }
-
-    /// <summary>
     /// Adds an environment variable to the resource with the connection string from the referenced resource.
     /// </summary>
     /// <typeparam name="T">The destination resource type.</typeparam>
@@ -358,25 +307,6 @@ public static class ResourceBuilderExtensions
         {
             context.EnvironmentVariables[envVarName] = new ConnectionStringReference(resource.Resource, optional: false);
         });
-    }
-
-    /// <summary>
-    /// Obsolete ATS alias for <see cref="WithEnvironment{T}(IResourceBuilder{T}, string, IResourceBuilder{IResourceWithConnectionString})"/>.
-    /// </summary>
-    /// <typeparam name="T">The destination resource type.</typeparam>
-    /// <param name="builder">The destination resource builder.</param>
-    /// <param name="envVarName">The name of the environment variable.</param>
-    /// <param name="resource">The referenced connection string resource builder.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete("ATS compatibility shim. Use withEnvironment instead.")]
-    [AspireExport("withEnvironmentConnectionString", Description = "Sets an environment variable from a connection string resource")]
-    internal static IResourceBuilder<T> WithEnvironmentConnectionStringShim<T>(
-        this IResourceBuilder<T> builder,
-        string envVarName,
-        IResourceBuilder<IResourceWithConnectionString> resource)
-        where T : IResourceWithEnvironment
-    {
-        return builder.WithEnvironment(envVarName, resource);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/api/Aspire.Hosting.Capabilities.txt
+++ b/src/Aspire.Hosting/api/Aspire.Hosting.Capabilities.txt
@@ -388,10 +388,6 @@ Aspire.Hosting/withEndpointProxySupport(proxyEnabled: boolean) -> Aspire.Hosting
 Aspire.Hosting/withEntrypoint(entrypoint: string) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource
 Aspire.Hosting/withEnvironment(name: string, value: string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression|Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReference|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource|Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithConnectionString|Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExpressionValue) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
 Aspire.Hosting/withEnvironmentCallback(callback: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
-Aspire.Hosting/withEnvironmentConnectionString(envVarName: string, resource: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithConnectionString) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
-Aspire.Hosting/withEnvironmentEndpoint(name: string, endpointReference: Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReference) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
-Aspire.Hosting/withEnvironmentExpression(name: string, value: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
-Aspire.Hosting/withEnvironmentParameter(name: string, parameter: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
 Aspire.Hosting/withExecutableCommand(command: string) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource
 Aspire.Hosting/withExplicitStart() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource
 Aspire.Hosting/withExternalHttpEndpoints() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithFoundryAndAzureContainerApps_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithFoundryAndAzureContainerApps_CreatesCorrectDependencies.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 42
+Total steps defined: 43
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -23,39 +23,40 @@ Steps with no dependencies run first, followed by steps that depend on them.
   7. process-parameters
   8. build-prereq
   9. check-container-runtime
- 10. deploy-prereq
- 11. build-agent
- 12. build-api
- 13. build
- 14. validate-azure-login
- 15. create-provisioning-context
- 16. provision-aca-env-acr
- 17. provision-aca-env
- 18. login-to-acr-aca-env-acr
- 19. provision-foundry-project-acr
- 20. login-to-acr-foundry-project-acr
- 21. push-prereq
- 22. push-api
- 23. provision-api-containerapp
- 24. provision-foundry
- 25. provision-foundry-project
- 26. provision-azure-bicep-resources
- 27. compute-endpoints-foundry-project
- 28. push-agent
- 29. deploy-agent-ha
- 30. print-api-summary
- 31. print-dashboard-url-aca-env
- 32. deploy
- 33. deploy-api
- 34. destroy-prereq
- 35. destroy-azure-azure634f9
- 36. destroy
- 37. diagnostics
- 38. publish-prereq
- 39. publish-azure634f9
- 40. publish
- 41. publish-manifest
- 42. push
+ 10. validate-build-only-container-references
+ 11. deploy-prereq
+ 12. build-agent
+ 13. build-api
+ 14. build
+ 15. validate-azure-login
+ 16. create-provisioning-context
+ 17. provision-aca-env-acr
+ 18. provision-aca-env
+ 19. login-to-acr-aca-env-acr
+ 20. provision-foundry-project-acr
+ 21. login-to-acr-foundry-project-acr
+ 22. push-prereq
+ 23. push-api
+ 24. provision-api-containerapp
+ 25. provision-foundry
+ 26. provision-foundry-project
+ 27. provision-azure-bicep-resources
+ 28. compute-endpoints-foundry-project
+ 29. push-agent
+ 30. deploy-agent-ha
+ 31. print-api-summary
+ 32. print-dashboard-url-aca-env
+ 33. deploy
+ 34. deploy-api
+ 35. destroy-prereq
+ 36. destroy-azure-azure634f9
+ 37. destroy
+ 38. diagnostics
+ 39. publish-prereq
+ 40. publish-azure634f9
+ 41. publish
+ 42. publish-manifest
+ 43. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -121,7 +122,7 @@ Step: deploy-api
 
 Step: deploy-prereq
     Description: Prerequisite step that runs before any deploy operations. Initializes deployment environment and manages deployment state.
-    Dependencies: ✓ process-parameters
+    Dependencies: ✓ process-parameters, ✓ validate-build-only-container-references
 
 Step: destroy
     Description: Aggregation step for all destroy operations. All destroy steps should be required by this step.
@@ -233,7 +234,7 @@ Step: publish-manifest
 
 Step: publish-prereq
     Description: Prerequisite step that runs before any publish operations.
-    Dependencies: ✓ process-parameters
+    Dependencies: ✓ process-parameters, ✓ validate-build-only-container-references
 
 Step: push
     Description: Aggregation step for all push operations. All push steps should be required by this step.
@@ -260,6 +261,10 @@ Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
     Dependencies: ✓ deploy-prereq
     Resource: azure634f9 (AzureEnvironmentResource)
+
+Step: validate-build-only-container-references
+    Description: Validates that build-only containers are consumed by another resource before publish or deploy.
+    Dependencies: none
 
 Step: validate-compute-environments
     Description: Validates compute resource bindings before startup.
@@ -292,26 +297,26 @@ If targeting 'before-start':
 
 If targeting 'build':
   Direct dependencies: build-agent, build-api
-  Total steps: 7
+  Total steps: 8
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-agent | build-api (parallel)
     [3] build
 
 If targeting 'build-agent':
   Direct dependencies: build-prereq, check-container-runtime, deploy-prereq
-  Total steps: 5
+  Total steps: 6
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-agent
 
 If targeting 'build-api':
   Direct dependencies: build-prereq, check-container-runtime, deploy-prereq
-  Total steps: 5
+  Total steps: 6
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api
 
@@ -330,9 +335,9 @@ If targeting 'check-container-runtime':
 
 If targeting 'compute-endpoints-foundry-project':
   Direct dependencies: provision-azure-bicep-resources
-  Total steps: 19
+  Total steps: 20
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -346,18 +351,18 @@ If targeting 'compute-endpoints-foundry-project':
 
 If targeting 'create-provisioning-context':
   Direct dependencies: deploy-prereq, validate-azure-login
-  Total steps: 4
+  Total steps: 5
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
 
 If targeting 'deploy':
   Direct dependencies: build-agent, build-api, compute-endpoints-foundry-project, create-provisioning-context, deploy-agent-ha, print-api-summary, print-dashboard-url-aca-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 25
+  Total steps: 26
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-agent | build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -372,9 +377,9 @@ If targeting 'deploy':
 
 If targeting 'deploy-agent-ha':
   Direct dependencies: deploy-prereq, provision-azure-bicep-resources, push-agent
-  Total steps: 21
+  Total steps: 22
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-agent | build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -388,9 +393,9 @@ If targeting 'deploy-agent-ha':
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 17
+  Total steps: 18
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -403,10 +408,10 @@ If targeting 'deploy-api':
     [10] deploy-api
 
 If targeting 'deploy-prereq':
-  Direct dependencies: process-parameters
-  Total steps: 2
+  Direct dependencies: process-parameters, validate-build-only-container-references
+  Total steps: 3
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
 
 If targeting 'destroy':
@@ -438,9 +443,9 @@ If targeting 'diagnostics':
 
 If targeting 'login-to-acr-aca-env-acr':
   Direct dependencies: provision-aca-env-acr
-  Total steps: 6
+  Total steps: 7
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
@@ -449,9 +454,9 @@ If targeting 'login-to-acr-aca-env-acr':
 
 If targeting 'login-to-acr-foundry-project-acr':
   Direct dependencies: provision-foundry-project-acr
-  Total steps: 6
+  Total steps: 7
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
@@ -474,9 +479,9 @@ If targeting 'prepare-foundry-project-foundry-project':
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-containerapp
-  Total steps: 16
+  Total steps: 17
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -489,9 +494,9 @@ If targeting 'print-api-summary':
 
 If targeting 'print-dashboard-url-aca-env':
   Direct dependencies: provision-aca-env, provision-azure-bicep-resources
-  Total steps: 19
+  Total steps: 20
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -511,9 +516,9 @@ If targeting 'process-parameters':
 
 If targeting 'provision-aca-env':
   Direct dependencies: create-provisioning-context, provision-aca-env-acr
-  Total steps: 6
+  Total steps: 7
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
@@ -522,9 +527,9 @@ If targeting 'provision-aca-env':
 
 If targeting 'provision-aca-env-acr':
   Direct dependencies: create-provisioning-context
-  Total steps: 5
+  Total steps: 6
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
@@ -532,9 +537,9 @@ If targeting 'provision-aca-env-acr':
 
 If targeting 'provision-api-containerapp':
   Direct dependencies: create-provisioning-context, provision-aca-env, push-api
-  Total steps: 15
+  Total steps: 16
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -546,9 +551,9 @@ If targeting 'provision-api-containerapp':
 
 If targeting 'provision-azure-bicep-resources':
   Direct dependencies: create-provisioning-context, deploy-prereq, provision-aca-env, provision-aca-env-acr, provision-api-containerapp, provision-foundry, provision-foundry-project, provision-foundry-project-acr
-  Total steps: 18
+  Total steps: 19
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -561,9 +566,9 @@ If targeting 'provision-azure-bicep-resources':
 
 If targeting 'provision-foundry':
   Direct dependencies: create-provisioning-context
-  Total steps: 5
+  Total steps: 6
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
@@ -571,9 +576,9 @@ If targeting 'provision-foundry':
 
 If targeting 'provision-foundry-project':
   Direct dependencies: create-provisioning-context, provision-foundry, provision-foundry-project-acr
-  Total steps: 7
+  Total steps: 8
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
@@ -582,9 +587,9 @@ If targeting 'provision-foundry-project':
 
 If targeting 'provision-foundry-project-acr':
   Direct dependencies: create-provisioning-context
-  Total steps: 5
+  Total steps: 6
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
@@ -592,18 +597,18 @@ If targeting 'provision-foundry-project-acr':
 
 If targeting 'publish':
   Direct dependencies: publish-azure634f9
-  Total steps: 4
+  Total steps: 5
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] publish-prereq
     [2] publish-azure634f9
     [3] publish
 
 If targeting 'publish-azure634f9':
   Direct dependencies: publish-prereq
-  Total steps: 3
+  Total steps: 4
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] publish-prereq
     [2] publish-azure634f9
 
@@ -614,17 +619,17 @@ If targeting 'publish-manifest':
     [0] publish-manifest
 
 If targeting 'publish-prereq':
-  Direct dependencies: process-parameters
-  Total steps: 2
+  Direct dependencies: process-parameters, validate-build-only-container-references
+  Total steps: 3
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] publish-prereq
 
 If targeting 'push':
   Direct dependencies: push-agent, push-api, push-prereq
-  Total steps: 16
+  Total steps: 17
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-agent | build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -636,9 +641,9 @@ If targeting 'push':
 
 If targeting 'push-agent':
   Direct dependencies: build-agent, push-prereq
-  Total steps: 13
+  Total steps: 14
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-agent | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -649,9 +654,9 @@ If targeting 'push-agent':
 
 If targeting 'push-api':
   Direct dependencies: build-api, push-prereq
-  Total steps: 13
+  Total steps: 14
   Execution order:
-    [0] check-container-runtime | process-parameters (parallel)
+    [0] check-container-runtime | process-parameters | validate-build-only-container-references (parallel)
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
@@ -662,9 +667,9 @@ If targeting 'push-api':
 
 If targeting 'push-prereq':
   Direct dependencies: login-to-acr-aca-env-acr, login-to-acr-foundry-project-acr
-  Total steps: 9
+  Total steps: 10
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
     [3] create-provisioning-context
@@ -680,11 +685,17 @@ If targeting 'validate-azure-container-apps':
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq
-  Total steps: 3
+  Total steps: 4
   Execution order:
-    [0] process-parameters
+    [0] process-parameters | validate-build-only-container-references (parallel)
     [1] deploy-prereq
     [2] validate-azure-login
+
+If targeting 'validate-build-only-container-references':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] validate-build-only-container-references
 
 If targeting 'validate-compute-environments':
   Direct dependencies: none

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -882,20 +882,6 @@ func (s *CSharpAppResource) WithEnvironment(name string, value any) (*IResourceW
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithEnvironmentExpression sets an environment variable from a reference expression
-func (s *CSharpAppResource) WithEnvironmentExpression(name string, value *ReferenceExpression) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithEnvironmentCallback sets environment variables via callback
 func (s *CSharpAppResource) WithEnvironmentCallback(callback func(...any) any) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -905,48 +891,6 @@ func (s *CSharpAppResource) WithEnvironmentCallback(callback func(...any) any) (
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentEndpoint sets an environment variable from an endpoint reference
-func (s *CSharpAppResource) WithEnvironmentEndpoint(name string, endpointReference *EndpointReference) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["endpointReference"] = SerializeValue(endpointReference)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentParameter sets an environment variable from a parameter resource
-func (s *CSharpAppResource) WithEnvironmentParameter(name string, parameter *ParameterResource) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["parameter"] = SerializeValue(parameter)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentConnectionString sets an environment variable from a connection string resource
-func (s *CSharpAppResource) WithEnvironmentConnectionString(envVarName string, resource *IResourceWithConnectionString) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["envVarName"] = SerializeValue(envVarName)
-	reqArgs["resource"] = SerializeValue(resource)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3480,20 +3424,6 @@ func (s *ContainerResource) WithEnvironment(name string, value any) (*IResourceW
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithEnvironmentExpression sets an environment variable from a reference expression
-func (s *ContainerResource) WithEnvironmentExpression(name string, value *ReferenceExpression) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithEnvironmentCallback sets environment variables via callback
 func (s *ContainerResource) WithEnvironmentCallback(callback func(...any) any) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -3503,48 +3433,6 @@ func (s *ContainerResource) WithEnvironmentCallback(callback func(...any) any) (
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentEndpoint sets an environment variable from an endpoint reference
-func (s *ContainerResource) WithEnvironmentEndpoint(name string, endpointReference *EndpointReference) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["endpointReference"] = SerializeValue(endpointReference)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentParameter sets an environment variable from a parameter resource
-func (s *ContainerResource) WithEnvironmentParameter(name string, parameter *ParameterResource) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["parameter"] = SerializeValue(parameter)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentConnectionString sets an environment variable from a connection string resource
-func (s *ContainerResource) WithEnvironmentConnectionString(envVarName string, resource *IResourceWithConnectionString) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["envVarName"] = SerializeValue(envVarName)
-	reqArgs["resource"] = SerializeValue(resource)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5454,20 +5342,6 @@ func (s *DotnetToolResource) WithEnvironment(name string, value any) (*IResource
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithEnvironmentExpression sets an environment variable from a reference expression
-func (s *DotnetToolResource) WithEnvironmentExpression(name string, value *ReferenceExpression) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithEnvironmentCallback sets environment variables via callback
 func (s *DotnetToolResource) WithEnvironmentCallback(callback func(...any) any) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -5477,48 +5351,6 @@ func (s *DotnetToolResource) WithEnvironmentCallback(callback func(...any) any) 
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentEndpoint sets an environment variable from an endpoint reference
-func (s *DotnetToolResource) WithEnvironmentEndpoint(name string, endpointReference *EndpointReference) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["endpointReference"] = SerializeValue(endpointReference)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentParameter sets an environment variable from a parameter resource
-func (s *DotnetToolResource) WithEnvironmentParameter(name string, parameter *ParameterResource) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["parameter"] = SerializeValue(parameter)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentConnectionString sets an environment variable from a connection string resource
-func (s *DotnetToolResource) WithEnvironmentConnectionString(envVarName string, resource *IResourceWithConnectionString) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["envVarName"] = SerializeValue(envVarName)
-	reqArgs["resource"] = SerializeValue(resource)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -7539,20 +7371,6 @@ func (s *ExecutableResource) WithEnvironment(name string, value any) (*IResource
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithEnvironmentExpression sets an environment variable from a reference expression
-func (s *ExecutableResource) WithEnvironmentExpression(name string, value *ReferenceExpression) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithEnvironmentCallback sets environment variables via callback
 func (s *ExecutableResource) WithEnvironmentCallback(callback func(...any) any) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -7562,48 +7380,6 @@ func (s *ExecutableResource) WithEnvironmentCallback(callback func(...any) any) 
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentEndpoint sets an environment variable from an endpoint reference
-func (s *ExecutableResource) WithEnvironmentEndpoint(name string, endpointReference *EndpointReference) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["endpointReference"] = SerializeValue(endpointReference)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentParameter sets an environment variable from a parameter resource
-func (s *ExecutableResource) WithEnvironmentParameter(name string, parameter *ParameterResource) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["parameter"] = SerializeValue(parameter)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentConnectionString sets an environment variable from a connection string resource
-func (s *ExecutableResource) WithEnvironmentConnectionString(envVarName string, resource *IResourceWithConnectionString) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["envVarName"] = SerializeValue(envVarName)
-	reqArgs["resource"] = SerializeValue(resource)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -12442,20 +12218,6 @@ func (s *ProjectResource) WithEnvironment(name string, value any) (*IResourceWit
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithEnvironmentExpression sets an environment variable from a reference expression
-func (s *ProjectResource) WithEnvironmentExpression(name string, value *ReferenceExpression) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithEnvironmentCallback sets environment variables via callback
 func (s *ProjectResource) WithEnvironmentCallback(callback func(...any) any) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -12465,48 +12227,6 @@ func (s *ProjectResource) WithEnvironmentCallback(callback func(...any) any) (*I
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentEndpoint sets an environment variable from an endpoint reference
-func (s *ProjectResource) WithEnvironmentEndpoint(name string, endpointReference *EndpointReference) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["endpointReference"] = SerializeValue(endpointReference)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentParameter sets an environment variable from a parameter resource
-func (s *ProjectResource) WithEnvironmentParameter(name string, parameter *ParameterResource) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["parameter"] = SerializeValue(parameter)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentConnectionString sets an environment variable from a connection string resource
-func (s *ProjectResource) WithEnvironmentConnectionString(envVarName string, resource *IResourceWithConnectionString) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["envVarName"] = SerializeValue(envVarName)
-	reqArgs["resource"] = SerializeValue(resource)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -14689,20 +14409,6 @@ func (s *TestDatabaseResource) WithEnvironment(name string, value any) (*IResour
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithEnvironmentExpression sets an environment variable from a reference expression
-func (s *TestDatabaseResource) WithEnvironmentExpression(name string, value *ReferenceExpression) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithEnvironmentCallback sets environment variables via callback
 func (s *TestDatabaseResource) WithEnvironmentCallback(callback func(...any) any) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -14712,48 +14418,6 @@ func (s *TestDatabaseResource) WithEnvironmentCallback(callback func(...any) any
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentEndpoint sets an environment variable from an endpoint reference
-func (s *TestDatabaseResource) WithEnvironmentEndpoint(name string, endpointReference *EndpointReference) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["endpointReference"] = SerializeValue(endpointReference)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentParameter sets an environment variable from a parameter resource
-func (s *TestDatabaseResource) WithEnvironmentParameter(name string, parameter *ParameterResource) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["parameter"] = SerializeValue(parameter)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentConnectionString sets an environment variable from a connection string resource
-func (s *TestDatabaseResource) WithEnvironmentConnectionString(envVarName string, resource *IResourceWithConnectionString) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["envVarName"] = SerializeValue(envVarName)
-	reqArgs["resource"] = SerializeValue(resource)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16453,20 +16117,6 @@ func (s *TestRedisResource) WithEnvironment(name string, value any) (*IResourceW
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithEnvironmentExpression sets an environment variable from a reference expression
-func (s *TestRedisResource) WithEnvironmentExpression(name string, value *ReferenceExpression) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithEnvironmentCallback sets environment variables via callback
 func (s *TestRedisResource) WithEnvironmentCallback(callback func(...any) any) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -16476,48 +16126,6 @@ func (s *TestRedisResource) WithEnvironmentCallback(callback func(...any) any) (
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentEndpoint sets an environment variable from an endpoint reference
-func (s *TestRedisResource) WithEnvironmentEndpoint(name string, endpointReference *EndpointReference) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["endpointReference"] = SerializeValue(endpointReference)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentParameter sets an environment variable from a parameter resource
-func (s *TestRedisResource) WithEnvironmentParameter(name string, parameter *ParameterResource) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["parameter"] = SerializeValue(parameter)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentConnectionString sets an environment variable from a connection string resource
-func (s *TestRedisResource) WithEnvironmentConnectionString(envVarName string, resource *IResourceWithConnectionString) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["envVarName"] = SerializeValue(envVarName)
-	reqArgs["resource"] = SerializeValue(resource)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -18372,20 +17980,6 @@ func (s *TestVaultResource) WithEnvironment(name string, value any) (*IResourceW
 	return result.(*IResourceWithEnvironment), nil
 }
 
-// WithEnvironmentExpression sets an environment variable from a reference expression
-func (s *TestVaultResource) WithEnvironmentExpression(name string, value *ReferenceExpression) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
 // WithEnvironmentCallback sets environment variables via callback
 func (s *TestVaultResource) WithEnvironmentCallback(callback func(...any) any) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
@@ -18395,48 +17989,6 @@ func (s *TestVaultResource) WithEnvironmentCallback(callback func(...any) any) (
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentEndpoint sets an environment variable from an endpoint reference
-func (s *TestVaultResource) WithEnvironmentEndpoint(name string, endpointReference *EndpointReference) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["endpointReference"] = SerializeValue(endpointReference)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentParameter sets an environment variable from a parameter resource
-func (s *TestVaultResource) WithEnvironmentParameter(name string, parameter *ParameterResource) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["parameter"] = SerializeValue(parameter)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs)
-	if err != nil {
-		return nil, err
-	}
-	return result.(*IResourceWithEnvironment), nil
-}
-
-// WithEnvironmentConnectionString sets an environment variable from a connection string resource
-func (s *TestVaultResource) WithEnvironmentConnectionString(envVarName string, resource *IResourceWithConnectionString) (*IResourceWithEnvironment, error) {
-	reqArgs := map[string]any{
-		"builder": SerializeValue(s.Handle()),
-	}
-	reqArgs["envVarName"] = SerializeValue(envVarName)
-	reqArgs["resource"] = SerializeValue(resource)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1668,16 +1668,6 @@ public class CSharpAppResource extends ProjectResource {
         return this;
     }
 
-    /** Sets an environment variable from a reference expression */
-    public CSharpAppResource withEnvironmentExpression(String name, ReferenceExpression value) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("value", AspireClient.serializeValue(value));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs);
-        return this;
-    }
-
     /** Sets environment variables via callback */
     public CSharpAppResource withEnvironmentCallback(AspireAction1<EnvironmentCallbackContext> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -1692,40 +1682,6 @@ public class CSharpAppResource extends ProjectResource {
         }
         getClient().invokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs);
         return this;
-    }
-
-    /** Sets an environment variable from an endpoint reference */
-    public CSharpAppResource withEnvironmentEndpoint(String name, EndpointReference endpointReference) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("endpointReference", AspireClient.serializeValue(endpointReference));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a parameter resource */
-    public CSharpAppResource withEnvironmentParameter(String name, ParameterResource parameter) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("parameter", AspireClient.serializeValue(parameter));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a connection string resource */
-    public CSharpAppResource withEnvironmentConnectionString(String envVarName, IResourceWithConnectionString resource) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("envVarName", AspireClient.serializeValue(envVarName));
-        reqArgs.put("resource", AspireClient.serializeValue(resource));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs);
-        return this;
-    }
-
-    public CSharpAppResource withEnvironmentConnectionString(String envVarName, ResourceBuilderBase resource) {
-        return withEnvironmentConnectionString(envVarName, new IResourceWithConnectionString(resource.getHandle(), resource.getClient()));
     }
 
     /** Adds arguments */
@@ -4771,16 +4727,6 @@ public class ContainerResource extends ResourceBuilderBase {
         return this;
     }
 
-    /** Sets an environment variable from a reference expression */
-    public ContainerResource withEnvironmentExpression(String name, ReferenceExpression value) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("value", AspireClient.serializeValue(value));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs);
-        return this;
-    }
-
     /** Sets environment variables via callback */
     public ContainerResource withEnvironmentCallback(AspireAction1<EnvironmentCallbackContext> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -4795,40 +4741,6 @@ public class ContainerResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs);
         return this;
-    }
-
-    /** Sets an environment variable from an endpoint reference */
-    public ContainerResource withEnvironmentEndpoint(String name, EndpointReference endpointReference) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("endpointReference", AspireClient.serializeValue(endpointReference));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a parameter resource */
-    public ContainerResource withEnvironmentParameter(String name, ParameterResource parameter) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("parameter", AspireClient.serializeValue(parameter));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a connection string resource */
-    public ContainerResource withEnvironmentConnectionString(String envVarName, IResourceWithConnectionString resource) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("envVarName", AspireClient.serializeValue(envVarName));
-        reqArgs.put("resource", AspireClient.serializeValue(resource));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs);
-        return this;
-    }
-
-    public ContainerResource withEnvironmentConnectionString(String envVarName, ResourceBuilderBase resource) {
-        return withEnvironmentConnectionString(envVarName, new IResourceWithConnectionString(resource.getHandle(), resource.getClient()));
     }
 
     /** Adds arguments */
@@ -6906,16 +6818,6 @@ public class DotnetToolResource extends ExecutableResource {
         return this;
     }
 
-    /** Sets an environment variable from a reference expression */
-    public DotnetToolResource withEnvironmentExpression(String name, ReferenceExpression value) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("value", AspireClient.serializeValue(value));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs);
-        return this;
-    }
-
     /** Sets environment variables via callback */
     public DotnetToolResource withEnvironmentCallback(AspireAction1<EnvironmentCallbackContext> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -6930,40 +6832,6 @@ public class DotnetToolResource extends ExecutableResource {
         }
         getClient().invokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs);
         return this;
-    }
-
-    /** Sets an environment variable from an endpoint reference */
-    public DotnetToolResource withEnvironmentEndpoint(String name, EndpointReference endpointReference) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("endpointReference", AspireClient.serializeValue(endpointReference));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a parameter resource */
-    public DotnetToolResource withEnvironmentParameter(String name, ParameterResource parameter) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("parameter", AspireClient.serializeValue(parameter));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a connection string resource */
-    public DotnetToolResource withEnvironmentConnectionString(String envVarName, IResourceWithConnectionString resource) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("envVarName", AspireClient.serializeValue(envVarName));
-        reqArgs.put("resource", AspireClient.serializeValue(resource));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs);
-        return this;
-    }
-
-    public DotnetToolResource withEnvironmentConnectionString(String envVarName, ResourceBuilderBase resource) {
-        return withEnvironmentConnectionString(envVarName, new IResourceWithConnectionString(resource.getHandle(), resource.getClient()));
     }
 
     /** Adds arguments */
@@ -8966,16 +8834,6 @@ public class ExecutableResource extends ResourceBuilderBase {
         return this;
     }
 
-    /** Sets an environment variable from a reference expression */
-    public ExecutableResource withEnvironmentExpression(String name, ReferenceExpression value) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("value", AspireClient.serializeValue(value));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs);
-        return this;
-    }
-
     /** Sets environment variables via callback */
     public ExecutableResource withEnvironmentCallback(AspireAction1<EnvironmentCallbackContext> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -8990,40 +8848,6 @@ public class ExecutableResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs);
         return this;
-    }
-
-    /** Sets an environment variable from an endpoint reference */
-    public ExecutableResource withEnvironmentEndpoint(String name, EndpointReference endpointReference) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("endpointReference", AspireClient.serializeValue(endpointReference));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a parameter resource */
-    public ExecutableResource withEnvironmentParameter(String name, ParameterResource parameter) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("parameter", AspireClient.serializeValue(parameter));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a connection string resource */
-    public ExecutableResource withEnvironmentConnectionString(String envVarName, IResourceWithConnectionString resource) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("envVarName", AspireClient.serializeValue(envVarName));
-        reqArgs.put("resource", AspireClient.serializeValue(resource));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs);
-        return this;
-    }
-
-    public ExecutableResource withEnvironmentConnectionString(String envVarName, ResourceBuilderBase resource) {
-        return withEnvironmentConnectionString(envVarName, new IResourceWithConnectionString(resource.getHandle(), resource.getClient()));
     }
 
     /** Adds arguments */
@@ -14342,16 +14166,6 @@ public class ProjectResource extends ResourceBuilderBase {
         return this;
     }
 
-    /** Sets an environment variable from a reference expression */
-    public ProjectResource withEnvironmentExpression(String name, ReferenceExpression value) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("value", AspireClient.serializeValue(value));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs);
-        return this;
-    }
-
     /** Sets environment variables via callback */
     public ProjectResource withEnvironmentCallback(AspireAction1<EnvironmentCallbackContext> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -14366,40 +14180,6 @@ public class ProjectResource extends ResourceBuilderBase {
         }
         getClient().invokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs);
         return this;
-    }
-
-    /** Sets an environment variable from an endpoint reference */
-    public ProjectResource withEnvironmentEndpoint(String name, EndpointReference endpointReference) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("endpointReference", AspireClient.serializeValue(endpointReference));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a parameter resource */
-    public ProjectResource withEnvironmentParameter(String name, ParameterResource parameter) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("parameter", AspireClient.serializeValue(parameter));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a connection string resource */
-    public ProjectResource withEnvironmentConnectionString(String envVarName, IResourceWithConnectionString resource) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("envVarName", AspireClient.serializeValue(envVarName));
-        reqArgs.put("resource", AspireClient.serializeValue(resource));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs);
-        return this;
-    }
-
-    public ProjectResource withEnvironmentConnectionString(String envVarName, ResourceBuilderBase resource) {
-        return withEnvironmentConnectionString(envVarName, new IResourceWithConnectionString(resource.getHandle(), resource.getClient()));
     }
 
     /** Adds arguments */
@@ -17030,16 +16810,6 @@ public class TestDatabaseResource extends ContainerResource {
         return this;
     }
 
-    /** Sets an environment variable from a reference expression */
-    public TestDatabaseResource withEnvironmentExpression(String name, ReferenceExpression value) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("value", AspireClient.serializeValue(value));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs);
-        return this;
-    }
-
     /** Sets environment variables via callback */
     public TestDatabaseResource withEnvironmentCallback(AspireAction1<EnvironmentCallbackContext> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -17054,40 +16824,6 @@ public class TestDatabaseResource extends ContainerResource {
         }
         getClient().invokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs);
         return this;
-    }
-
-    /** Sets an environment variable from an endpoint reference */
-    public TestDatabaseResource withEnvironmentEndpoint(String name, EndpointReference endpointReference) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("endpointReference", AspireClient.serializeValue(endpointReference));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a parameter resource */
-    public TestDatabaseResource withEnvironmentParameter(String name, ParameterResource parameter) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("parameter", AspireClient.serializeValue(parameter));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a connection string resource */
-    public TestDatabaseResource withEnvironmentConnectionString(String envVarName, IResourceWithConnectionString resource) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("envVarName", AspireClient.serializeValue(envVarName));
-        reqArgs.put("resource", AspireClient.serializeValue(resource));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs);
-        return this;
-    }
-
-    public TestDatabaseResource withEnvironmentConnectionString(String envVarName, ResourceBuilderBase resource) {
-        return withEnvironmentConnectionString(envVarName, new IResourceWithConnectionString(resource.getHandle(), resource.getClient()));
     }
 
     /** Adds arguments */
@@ -18963,16 +18699,6 @@ public class TestRedisResource extends ContainerResource {
         return this;
     }
 
-    /** Sets an environment variable from a reference expression */
-    public TestRedisResource withEnvironmentExpression(String name, ReferenceExpression value) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("value", AspireClient.serializeValue(value));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs);
-        return this;
-    }
-
     /** Sets environment variables via callback */
     public TestRedisResource withEnvironmentCallback(AspireAction1<EnvironmentCallbackContext> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -18987,40 +18713,6 @@ public class TestRedisResource extends ContainerResource {
         }
         getClient().invokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs);
         return this;
-    }
-
-    /** Sets an environment variable from an endpoint reference */
-    public TestRedisResource withEnvironmentEndpoint(String name, EndpointReference endpointReference) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("endpointReference", AspireClient.serializeValue(endpointReference));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a parameter resource */
-    public TestRedisResource withEnvironmentParameter(String name, ParameterResource parameter) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("parameter", AspireClient.serializeValue(parameter));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a connection string resource */
-    public TestRedisResource withEnvironmentConnectionString(String envVarName, IResourceWithConnectionString resource) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("envVarName", AspireClient.serializeValue(envVarName));
-        reqArgs.put("resource", AspireClient.serializeValue(resource));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs);
-        return this;
-    }
-
-    public TestRedisResource withEnvironmentConnectionString(String envVarName, ResourceBuilderBase resource) {
-        return withEnvironmentConnectionString(envVarName, new IResourceWithConnectionString(resource.getHandle(), resource.getClient()));
     }
 
     public TestRedisResource withConnectionProperty(String name, String value) {
@@ -20989,16 +20681,6 @@ public class TestVaultResource extends ContainerResource {
         return this;
     }
 
-    /** Sets an environment variable from a reference expression */
-    public TestVaultResource withEnvironmentExpression(String name, ReferenceExpression value) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("value", AspireClient.serializeValue(value));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentExpression", reqArgs);
-        return this;
-    }
-
     /** Sets environment variables via callback */
     public TestVaultResource withEnvironmentCallback(AspireAction1<EnvironmentCallbackContext> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -21013,40 +20695,6 @@ public class TestVaultResource extends ContainerResource {
         }
         getClient().invokeCapability("Aspire.Hosting/withEnvironmentCallback", reqArgs);
         return this;
-    }
-
-    /** Sets an environment variable from an endpoint reference */
-    public TestVaultResource withEnvironmentEndpoint(String name, EndpointReference endpointReference) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("endpointReference", AspireClient.serializeValue(endpointReference));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentEndpoint", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a parameter resource */
-    public TestVaultResource withEnvironmentParameter(String name, ParameterResource parameter) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("name", AspireClient.serializeValue(name));
-        reqArgs.put("parameter", AspireClient.serializeValue(parameter));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentParameter", reqArgs);
-        return this;
-    }
-
-    /** Sets an environment variable from a connection string resource */
-    public TestVaultResource withEnvironmentConnectionString(String envVarName, IResourceWithConnectionString resource) {
-        Map<String, Object> reqArgs = new HashMap<>();
-        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
-        reqArgs.put("envVarName", AspireClient.serializeValue(envVarName));
-        reqArgs.put("resource", AspireClient.serializeValue(resource));
-        getClient().invokeCapability("Aspire.Hosting/withEnvironmentConnectionString", reqArgs);
-        return this;
-    }
-
-    public TestVaultResource withEnvironmentConnectionString(String envVarName, ResourceBuilderBase resource) {
-        return withEnvironmentConnectionString(envVarName, new IResourceWithConnectionString(resource.getHandle(), resource.getClient()));
     }
 
     /** Adds arguments */

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -5954,22 +5954,6 @@ class AbstractResourceWithEnvironment(AbstractResource):
         """Sets environment variables via callback"""
 
     @abc.abstractmethod
-    def with_env_expression(self, name: str, value: ReferenceExpression) -> typing.Self:
-        """Sets an environment variable from a reference expression"""
-
-    @abc.abstractmethod
-    def with_env_endpoint(self, name: str, endpoint_reference: EndpointReference) -> typing.Self:
-        """Sets an environment variable from an endpoint reference"""
-
-    @abc.abstractmethod
-    def with_env_parameter(self, name: str, parameter: ParameterResource) -> typing.Self:
-        """Sets an environment variable from a parameter resource"""
-
-    @abc.abstractmethod
-    def with_env_connection_string(self, env_var_name: str, resource: AbstractResourceWithConnectionString) -> typing.Self:
-        """Sets an environment variable from a connection string resource"""
-
-    @abc.abstractmethod
     def with_reference_env(self, options: ReferenceEnvironmentInjectionOptions) -> typing.Self:
         """Configures which reference values are injected into environment variables"""
 
@@ -6977,10 +6961,6 @@ class ContainerResourceKwargs(_BaseResourceKwargs, total=False):
     publish_as_connection_string: typing.Literal[True]
     env: tuple[str, str | ReferenceExpression | EndpointReference | ParameterResource | AbstractResourceWithConnectionString | AbstractExpressionValue]
     env_callback: typing.Callable[[EnvironmentCallbackContext], None]
-    env_expression: tuple[str, ReferenceExpression]
-    env_endpoint: tuple[str, EndpointReference]
-    env_parameter: tuple[str, ParameterResource]
-    env_connection_string: tuple[str, AbstractResourceWithConnectionString]
     args: typing.Iterable[str]
     args_callback: typing.Callable[[CommandLineArgsCallbackContext], None]
     reference_env: ReferenceEnvironmentInjectionOptions
@@ -7303,54 +7283,6 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         rpc_args['callback'] = self._client.register_callback(callback)
         result = self._client.invoke_capability(
             'Aspire.Hosting/withEnvironmentCallback',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_expression(self, name: str, value: ReferenceExpression) -> typing.Self:
-        """Sets an environment variable from a reference expression"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['value'] = value
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_endpoint(self, name: str, endpoint_reference: EndpointReference) -> typing.Self:
-        """Sets an environment variable from an endpoint reference"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['endpointReference'] = endpoint_reference
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_parameter(self, name: str, parameter: ParameterResource) -> typing.Self:
-        """Sets an environment variable from a parameter resource"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['parameter'] = parameter
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_connection_string(self, env_var_name: str, resource: AbstractResourceWithConnectionString) -> typing.Self:
-        """Sets an environment variable from a connection string resource"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['envVarName'] = env_var_name
-        rpc_args['resource'] = resource
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentConnectionString',
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -7977,38 +7909,6 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'env_callback'. Expected: Callable[[EnvironmentCallbackContext], None]")
-        if _env_expression := kwargs.pop("env_expression", None):
-            if _validate_tuple_types(_env_expression, (str, ReferenceExpression)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, ReferenceExpression], _env_expression)[0]
-                rpc_args["value"] = typing.cast(tuple[str, ReferenceExpression], _env_expression)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentExpression', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_expression'. Expected: (str, ReferenceExpression)")
-        if _env_endpoint := kwargs.pop("env_endpoint", None):
-            if _validate_tuple_types(_env_endpoint, (str, EndpointReference)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, EndpointReference], _env_endpoint)[0]
-                rpc_args["endpointReference"] = typing.cast(tuple[str, EndpointReference], _env_endpoint)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentEndpoint', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_endpoint'. Expected: (str, EndpointReference)")
-        if _env_parameter := kwargs.pop("env_parameter", None):
-            if _validate_tuple_types(_env_parameter, (str, ParameterResource)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, ParameterResource], _env_parameter)[0]
-                rpc_args["parameter"] = typing.cast(tuple[str, ParameterResource], _env_parameter)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentParameter', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_parameter'. Expected: (str, ParameterResource)")
-        if _env_connection_string := kwargs.pop("env_connection_string", None):
-            if _validate_tuple_types(_env_connection_string, (str, AbstractResourceWithConnectionString)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["envVarName"] = typing.cast(tuple[str, AbstractResourceWithConnectionString], _env_connection_string)[0]
-                rpc_args["resource"] = typing.cast(tuple[str, AbstractResourceWithConnectionString], _env_connection_string)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentConnectionString', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_connection_string'. Expected: (str, AbstractResourceWithConnectionString)")
         if _args := kwargs.pop("args", None):
             if _validate_type(_args, typing.Iterable[str]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -8320,10 +8220,6 @@ class ProjectResourceKwargs(_BaseResourceKwargs, total=False):
     publish_as_docker_file: typing.Callable[[ContainerResource], None] | typing.Literal[True]
     env: tuple[str, str | ReferenceExpression | EndpointReference | ParameterResource | AbstractResourceWithConnectionString | AbstractExpressionValue]
     env_callback: typing.Callable[[EnvironmentCallbackContext], None]
-    env_expression: tuple[str, ReferenceExpression]
-    env_endpoint: tuple[str, EndpointReference]
-    env_parameter: tuple[str, ParameterResource]
-    env_connection_string: tuple[str, AbstractResourceWithConnectionString]
     args: typing.Iterable[str]
     args_callback: typing.Callable[[CommandLineArgsCallbackContext], None]
     reference_env: ReferenceEnvironmentInjectionOptions
@@ -8453,54 +8349,6 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         rpc_args['callback'] = self._client.register_callback(callback)
         result = self._client.invoke_capability(
             'Aspire.Hosting/withEnvironmentCallback',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_expression(self, name: str, value: ReferenceExpression) -> typing.Self:
-        """Sets an environment variable from a reference expression"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['value'] = value
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_endpoint(self, name: str, endpoint_reference: EndpointReference) -> typing.Self:
-        """Sets an environment variable from an endpoint reference"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['endpointReference'] = endpoint_reference
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_parameter(self, name: str, parameter: ParameterResource) -> typing.Self:
-        """Sets an environment variable from a parameter resource"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['parameter'] = parameter
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_connection_string(self, env_var_name: str, resource: AbstractResourceWithConnectionString) -> typing.Self:
-        """Sets an environment variable from a connection string resource"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['envVarName'] = env_var_name
-        rpc_args['resource'] = resource
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentConnectionString',
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -8984,38 +8832,6 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'env_callback'. Expected: Callable[[EnvironmentCallbackContext], None]")
-        if _env_expression := kwargs.pop("env_expression", None):
-            if _validate_tuple_types(_env_expression, (str, ReferenceExpression)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, ReferenceExpression], _env_expression)[0]
-                rpc_args["value"] = typing.cast(tuple[str, ReferenceExpression], _env_expression)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentExpression', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_expression'. Expected: (str, ReferenceExpression)")
-        if _env_endpoint := kwargs.pop("env_endpoint", None):
-            if _validate_tuple_types(_env_endpoint, (str, EndpointReference)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, EndpointReference], _env_endpoint)[0]
-                rpc_args["endpointReference"] = typing.cast(tuple[str, EndpointReference], _env_endpoint)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentEndpoint', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_endpoint'. Expected: (str, EndpointReference)")
-        if _env_parameter := kwargs.pop("env_parameter", None):
-            if _validate_tuple_types(_env_parameter, (str, ParameterResource)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, ParameterResource], _env_parameter)[0]
-                rpc_args["parameter"] = typing.cast(tuple[str, ParameterResource], _env_parameter)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentParameter', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_parameter'. Expected: (str, ParameterResource)")
-        if _env_connection_string := kwargs.pop("env_connection_string", None):
-            if _validate_tuple_types(_env_connection_string, (str, AbstractResourceWithConnectionString)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["envVarName"] = typing.cast(tuple[str, AbstractResourceWithConnectionString], _env_connection_string)[0]
-                rpc_args["resource"] = typing.cast(tuple[str, AbstractResourceWithConnectionString], _env_connection_string)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentConnectionString', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_connection_string'. Expected: (str, AbstractResourceWithConnectionString)")
         if _args := kwargs.pop("args", None):
             if _validate_type(_args, typing.Iterable[str]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -9336,10 +9152,6 @@ class ExecutableResourceKwargs(_BaseResourceKwargs, total=False):
     otlp_exporter: OtlpProtocol | typing.Literal[True]
     env: tuple[str, str | ReferenceExpression | EndpointReference | ParameterResource | AbstractResourceWithConnectionString | AbstractExpressionValue]
     env_callback: typing.Callable[[EnvironmentCallbackContext], None]
-    env_expression: tuple[str, ReferenceExpression]
-    env_endpoint: tuple[str, EndpointReference]
-    env_parameter: tuple[str, ParameterResource]
-    env_connection_string: tuple[str, AbstractResourceWithConnectionString]
     args: typing.Iterable[str]
     args_callback: typing.Callable[[CommandLineArgsCallbackContext], None]
     reference_env: ReferenceEnvironmentInjectionOptions
@@ -9468,54 +9280,6 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         rpc_args['callback'] = self._client.register_callback(callback)
         result = self._client.invoke_capability(
             'Aspire.Hosting/withEnvironmentCallback',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_expression(self, name: str, value: ReferenceExpression) -> typing.Self:
-        """Sets an environment variable from a reference expression"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['value'] = value
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_endpoint(self, name: str, endpoint_reference: EndpointReference) -> typing.Self:
-        """Sets an environment variable from an endpoint reference"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['endpointReference'] = endpoint_reference
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_parameter(self, name: str, parameter: ParameterResource) -> typing.Self:
-        """Sets an environment variable from a parameter resource"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['name'] = name
-        rpc_args['parameter'] = parameter
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpc_args,
-        )
-        self._handle = self._wrap_builder(result)
-        return self
-
-    def with_env_connection_string(self, env_var_name: str, resource: AbstractResourceWithConnectionString) -> typing.Self:
-        """Sets an environment variable from a connection string resource"""
-        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['envVarName'] = env_var_name
-        rpc_args['resource'] = resource
-        result = self._client.invoke_capability(
-            'Aspire.Hosting/withEnvironmentConnectionString',
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -9985,38 +9749,6 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'env_callback'. Expected: Callable[[EnvironmentCallbackContext], None]")
-        if _env_expression := kwargs.pop("env_expression", None):
-            if _validate_tuple_types(_env_expression, (str, ReferenceExpression)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, ReferenceExpression], _env_expression)[0]
-                rpc_args["value"] = typing.cast(tuple[str, ReferenceExpression], _env_expression)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentExpression', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_expression'. Expected: (str, ReferenceExpression)")
-        if _env_endpoint := kwargs.pop("env_endpoint", None):
-            if _validate_tuple_types(_env_endpoint, (str, EndpointReference)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, EndpointReference], _env_endpoint)[0]
-                rpc_args["endpointReference"] = typing.cast(tuple[str, EndpointReference], _env_endpoint)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentEndpoint', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_endpoint'. Expected: (str, EndpointReference)")
-        if _env_parameter := kwargs.pop("env_parameter", None):
-            if _validate_tuple_types(_env_parameter, (str, ParameterResource)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["name"] = typing.cast(tuple[str, ParameterResource], _env_parameter)[0]
-                rpc_args["parameter"] = typing.cast(tuple[str, ParameterResource], _env_parameter)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentParameter', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_parameter'. Expected: (str, ParameterResource)")
-        if _env_connection_string := kwargs.pop("env_connection_string", None):
-            if _validate_tuple_types(_env_connection_string, (str, AbstractResourceWithConnectionString)):
-                rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["envVarName"] = typing.cast(tuple[str, AbstractResourceWithConnectionString], _env_connection_string)[0]
-                rpc_args["resource"] = typing.cast(tuple[str, AbstractResourceWithConnectionString], _env_connection_string)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentConnectionString', rpc_args))
-            else:
-                raise TypeError("Invalid type for option 'env_connection_string'. Expected: (str, AbstractResourceWithConnectionString)")
         if _args := kwargs.pop("args", None):
             if _validate_type(_args, typing.Iterable[str]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -1337,17 +1337,6 @@ impl CSharpAppResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Sets an environment variable from a reference expression
-    pub fn with_environment_expression(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentExpression", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Sets environment variables via callback
     pub fn with_environment_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -1355,39 +1344,6 @@ impl CSharpAppResource {
         let callback_id = register_callback(callback);
         args.insert("callback".to_string(), Value::String(callback_id));
         let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from an endpoint reference
-    pub fn with_environment_endpoint(&self, name: &str, endpoint_reference: &EndpointReference) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("endpointReference".to_string(), endpoint_reference.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a parameter resource
-    pub fn with_environment_parameter(&self, name: &str, parameter: &ParameterResource) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("parameter".to_string(), parameter.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentParameter", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a connection string resource
-    pub fn with_environment_connection_string(&self, env_var_name: &str, resource: &IResourceWithConnectionString) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("envVarName".to_string(), serde_json::to_value(&env_var_name).unwrap_or(Value::Null));
-        args.insert("resource".to_string(), resource.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -3546,17 +3502,6 @@ impl ContainerResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Sets an environment variable from a reference expression
-    pub fn with_environment_expression(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentExpression", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Sets environment variables via callback
     pub fn with_environment_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -3564,39 +3509,6 @@ impl ContainerResource {
         let callback_id = register_callback(callback);
         args.insert("callback".to_string(), Value::String(callback_id));
         let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from an endpoint reference
-    pub fn with_environment_endpoint(&self, name: &str, endpoint_reference: &EndpointReference) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("endpointReference".to_string(), endpoint_reference.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a parameter resource
-    pub fn with_environment_parameter(&self, name: &str, parameter: &ParameterResource) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("parameter".to_string(), parameter.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentParameter", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a connection string resource
-    pub fn with_environment_connection_string(&self, env_var_name: &str, resource: &IResourceWithConnectionString) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("envVarName".to_string(), serde_json::to_value(&env_var_name).unwrap_or(Value::Null));
-        args.insert("resource".to_string(), resource.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -5268,17 +5180,6 @@ impl DotnetToolResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Sets an environment variable from a reference expression
-    pub fn with_environment_expression(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentExpression", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Sets environment variables via callback
     pub fn with_environment_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -5286,39 +5187,6 @@ impl DotnetToolResource {
         let callback_id = register_callback(callback);
         args.insert("callback".to_string(), Value::String(callback_id));
         let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from an endpoint reference
-    pub fn with_environment_endpoint(&self, name: &str, endpoint_reference: &EndpointReference) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("endpointReference".to_string(), endpoint_reference.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a parameter resource
-    pub fn with_environment_parameter(&self, name: &str, parameter: &ParameterResource) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("parameter".to_string(), parameter.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentParameter", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a connection string resource
-    pub fn with_environment_connection_string(&self, env_var_name: &str, resource: &IResourceWithConnectionString) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("envVarName".to_string(), serde_json::to_value(&env_var_name).unwrap_or(Value::Null));
-        args.insert("resource".to_string(), resource.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -6987,17 +6855,6 @@ impl ExecutableResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Sets an environment variable from a reference expression
-    pub fn with_environment_expression(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentExpression", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Sets environment variables via callback
     pub fn with_environment_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7005,39 +6862,6 @@ impl ExecutableResource {
         let callback_id = register_callback(callback);
         args.insert("callback".to_string(), Value::String(callback_id));
         let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from an endpoint reference
-    pub fn with_environment_endpoint(&self, name: &str, endpoint_reference: &EndpointReference) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("endpointReference".to_string(), endpoint_reference.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a parameter resource
-    pub fn with_environment_parameter(&self, name: &str, parameter: &ParameterResource) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("parameter".to_string(), parameter.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentParameter", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a connection string resource
-    pub fn with_environment_connection_string(&self, env_var_name: &str, resource: &IResourceWithConnectionString) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("envVarName".to_string(), serde_json::to_value(&env_var_name).unwrap_or(Value::Null));
-        args.insert("resource".to_string(), resource.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -11552,17 +11376,6 @@ impl ProjectResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Sets an environment variable from a reference expression
-    pub fn with_environment_expression(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentExpression", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Sets environment variables via callback
     pub fn with_environment_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -11570,39 +11383,6 @@ impl ProjectResource {
         let callback_id = register_callback(callback);
         args.insert("callback".to_string(), Value::String(callback_id));
         let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from an endpoint reference
-    pub fn with_environment_endpoint(&self, name: &str, endpoint_reference: &EndpointReference) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("endpointReference".to_string(), endpoint_reference.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a parameter resource
-    pub fn with_environment_parameter(&self, name: &str, parameter: &ParameterResource) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("parameter".to_string(), parameter.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentParameter", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a connection string resource
-    pub fn with_environment_connection_string(&self, env_var_name: &str, resource: &IResourceWithConnectionString) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("envVarName".to_string(), serde_json::to_value(&env_var_name).unwrap_or(Value::Null));
-        args.insert("resource".to_string(), resource.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -13522,17 +13302,6 @@ impl TestDatabaseResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Sets an environment variable from a reference expression
-    pub fn with_environment_expression(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentExpression", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Sets environment variables via callback
     pub fn with_environment_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -13540,39 +13309,6 @@ impl TestDatabaseResource {
         let callback_id = register_callback(callback);
         args.insert("callback".to_string(), Value::String(callback_id));
         let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from an endpoint reference
-    pub fn with_environment_endpoint(&self, name: &str, endpoint_reference: &EndpointReference) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("endpointReference".to_string(), endpoint_reference.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a parameter resource
-    pub fn with_environment_parameter(&self, name: &str, parameter: &ParameterResource) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("parameter".to_string(), parameter.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentParameter", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a connection string resource
-    pub fn with_environment_connection_string(&self, env_var_name: &str, resource: &IResourceWithConnectionString) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("envVarName".to_string(), serde_json::to_value(&env_var_name).unwrap_or(Value::Null));
-        args.insert("resource".to_string(), resource.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -14960,17 +14696,6 @@ impl TestRedisResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Sets an environment variable from a reference expression
-    pub fn with_environment_expression(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentExpression", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Sets environment variables via callback
     pub fn with_environment_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -14978,39 +14703,6 @@ impl TestRedisResource {
         let callback_id = register_callback(callback);
         args.insert("callback".to_string(), Value::String(callback_id));
         let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from an endpoint reference
-    pub fn with_environment_endpoint(&self, name: &str, endpoint_reference: &EndpointReference) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("endpointReference".to_string(), endpoint_reference.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a parameter resource
-    pub fn with_environment_parameter(&self, name: &str, parameter: &ParameterResource) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("parameter".to_string(), parameter.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentParameter", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a connection string resource
-    pub fn with_environment_connection_string(&self, env_var_name: &str, resource: &IResourceWithConnectionString) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("envVarName".to_string(), serde_json::to_value(&env_var_name).unwrap_or(Value::Null));
-        args.insert("resource".to_string(), resource.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -16504,17 +16196,6 @@ impl TestVaultResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
-    /// Sets an environment variable from a reference expression
-    pub fn with_environment_expression(&self, name: &str, value: ReferenceExpression) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentExpression", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
     /// Sets environment variables via callback
     pub fn with_environment_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -16522,39 +16203,6 @@ impl TestVaultResource {
         let callback_id = register_callback(callback);
         args.insert("callback".to_string(), Value::String(callback_id));
         let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentCallback", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from an endpoint reference
-    pub fn with_environment_endpoint(&self, name: &str, endpoint_reference: &EndpointReference) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("endpointReference".to_string(), endpoint_reference.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentEndpoint", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a parameter resource
-    pub fn with_environment_parameter(&self, name: &str, parameter: &ParameterResource) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
-        args.insert("parameter".to_string(), parameter.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentParameter", args)?;
-        let handle: Handle = serde_json::from_value(result)?;
-        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
-    }
-
-    /// Sets an environment variable from a connection string resource
-    pub fn with_environment_connection_string(&self, env_var_name: &str, resource: &IResourceWithConnectionString) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
-        let mut args: HashMap<String, Value> = HashMap::new();
-        args.insert("builder".to_string(), self.handle.to_json());
-        args.insert("envVarName".to_string(), serde_json::to_value(&env_var_name).unwrap_or(Value::Null));
-        args.insert("resource".to_string(), resource.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withEnvironmentConnectionString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -880,18 +880,6 @@ public class AtsTypeScriptCodeGeneratorTests
     }
 
     [Fact]
-    public void TwoPassScanning_GeneratesDeprecatedJSDocForObsoleteExports()
-    {
-        var atsContext = CreateContextFromBothAssemblies();
-
-        var files = _generator.GenerateDistributedApplication(atsContext);
-        var aspireTs = files["aspire.ts"];
-
-        Assert.Contains("@deprecated ATS compatibility shim. Use withEnvironment instead.", aspireTs);
-        Assert.Contains("withEnvironmentExpression(name: string, value: ReferenceExpression)", aspireTs);
-    }
-
-    [Fact]
     public void TwoPassScanning_DeduplicatesExpandedUnionTypes()
     {
         var atsContext = CreateContextFromBothAssemblies();

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
@@ -574,62 +574,6 @@
     ]
   },
   {
-    CapabilityId: Aspire.Hosting/withEnvironmentConnectionString,
-    MethodName: withEnvironmentConnectionString,
-    TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
-      IsInterface: true
-    },
-    ExpandedTargetTypes: [
-      {
-        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-        IsInterface: false
-      }
-    ]
-  },
-  {
-    CapabilityId: Aspire.Hosting/withEnvironmentEndpoint,
-    MethodName: withEnvironmentEndpoint,
-    TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
-      IsInterface: true
-    },
-    ExpandedTargetTypes: [
-      {
-        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-        IsInterface: false
-      }
-    ]
-  },
-  {
-    CapabilityId: Aspire.Hosting/withEnvironmentExpression,
-    MethodName: withEnvironmentExpression,
-    TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
-      IsInterface: true
-    },
-    ExpandedTargetTypes: [
-      {
-        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-        IsInterface: false
-      }
-    ]
-  },
-  {
-    CapabilityId: Aspire.Hosting/withEnvironmentParameter,
-    MethodName: withEnvironmentParameter,
-    TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
-      IsInterface: true
-    },
-    ExpandedTargetTypes: [
-      {
-        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-        IsInterface: false
-      }
-    ]
-  },
-  {
     CapabilityId: Aspire.Hosting/withExplicitStart,
     MethodName: withExplicitStart,
     TargetType: {

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -8830,28 +8830,8 @@ export interface ContainerResource {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): ContainerResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ContainerResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ContainerResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ContainerResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ContainerResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ContainerResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): ContainerResourcePromise;
     /** Sets command-line arguments via callback */
@@ -9051,28 +9031,8 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): ContainerResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ContainerResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ContainerResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ContainerResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ContainerResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ContainerResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): ContainerResourcePromise;
     /** Sets command-line arguments via callback */
@@ -9636,20 +9596,6 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ContainerResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new ContainerResourceImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ContainerResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -9666,51 +9612,6 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<ContainerResource> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new ContainerResourceImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<ContainerResource> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new ContainerResourceImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<ContainerResource> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new ContainerResourceImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -11043,24 +10944,8 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ContainerResourcePromise {
-        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withArgs(args: string[]): ContainerResourcePromise {
@@ -11379,28 +11264,8 @@ export interface CSharpAppResource {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): CSharpAppResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): CSharpAppResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): CSharpAppResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): CSharpAppResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): CSharpAppResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): CSharpAppResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): CSharpAppResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): CSharpAppResourcePromise;
     /** Sets command-line arguments via callback */
@@ -11568,28 +11433,8 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): CSharpAppResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): CSharpAppResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): CSharpAppResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): CSharpAppResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): CSharpAppResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): CSharpAppResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): CSharpAppResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): CSharpAppResourcePromise;
     /** Sets command-line arguments via callback */
@@ -11913,20 +11758,6 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<CSharpAppResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new CSharpAppResourceImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<CSharpAppResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -11943,51 +11774,6 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<CSharpAppResource> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new CSharpAppResourceImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<CSharpAppResource> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new CSharpAppResourceImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<CSharpAppResource> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new CSharpAppResourceImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -13253,24 +13039,8 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): CSharpAppResourcePromise {
-        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withArgs(args: string[]): CSharpAppResourcePromise {
@@ -13601,28 +13371,8 @@ export interface DotnetToolResource {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): DotnetToolResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): DotnetToolResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): DotnetToolResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): DotnetToolResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): DotnetToolResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): DotnetToolResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): DotnetToolResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): DotnetToolResourcePromise;
     /** Sets command-line arguments via callback */
@@ -13800,28 +13550,8 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): DotnetToolResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): DotnetToolResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): DotnetToolResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): DotnetToolResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): DotnetToolResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): DotnetToolResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): DotnetToolResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): DotnetToolResourcePromise;
     /** Sets command-line arguments via callback */
@@ -14225,20 +13955,6 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<DotnetToolResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new DotnetToolResourceImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<DotnetToolResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -14255,51 +13971,6 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<DotnetToolResource> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new DotnetToolResourceImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<DotnetToolResource> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new DotnetToolResourceImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<DotnetToolResource> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new DotnetToolResourceImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -15574,24 +15245,8 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): DotnetToolResourcePromise {
-        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withArgs(args: string[]): DotnetToolResourcePromise {
@@ -15906,28 +15561,8 @@ export interface ExecutableResource {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ExecutableResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): ExecutableResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ExecutableResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ExecutableResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ExecutableResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ExecutableResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ExecutableResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): ExecutableResourcePromise;
     /** Sets command-line arguments via callback */
@@ -16093,28 +15728,8 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ExecutableResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): ExecutableResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ExecutableResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ExecutableResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ExecutableResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ExecutableResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ExecutableResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): ExecutableResourcePromise;
     /** Sets command-line arguments via callback */
@@ -16434,20 +16049,6 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ExecutableResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new ExecutableResourceImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ExecutableResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -16464,51 +16065,6 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<ExecutableResource> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new ExecutableResourceImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<ExecutableResource> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new ExecutableResourceImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<ExecutableResource> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new ExecutableResourceImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -17759,24 +17315,8 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ExecutableResourcePromise {
-        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withArgs(args: string[]): ExecutableResourcePromise {
@@ -20379,28 +19919,8 @@ export interface ProjectResource {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ProjectResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): ProjectResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ProjectResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ProjectResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ProjectResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ProjectResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ProjectResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): ProjectResourcePromise;
     /** Sets command-line arguments via callback */
@@ -20568,28 +20088,8 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ProjectResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): ProjectResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ProjectResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ProjectResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ProjectResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ProjectResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ProjectResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): ProjectResourcePromise;
     /** Sets command-line arguments via callback */
@@ -20913,20 +20413,6 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ProjectResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new ProjectResourceImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ProjectResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -20943,51 +20429,6 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<ProjectResource> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new ProjectResourceImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<ProjectResource> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new ProjectResourceImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<ProjectResource> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new ProjectResourceImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -22253,24 +21694,8 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ProjectResourcePromise {
-        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withArgs(args: string[]): ProjectResourcePromise {
@@ -22621,28 +22046,8 @@ export interface TestDatabaseResource {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestDatabaseResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): TestDatabaseResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestDatabaseResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestDatabaseResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestDatabaseResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestDatabaseResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): TestDatabaseResourcePromise;
     /** Sets command-line arguments via callback */
@@ -22842,28 +22247,8 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestDatabaseResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): TestDatabaseResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestDatabaseResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestDatabaseResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestDatabaseResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestDatabaseResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): TestDatabaseResourcePromise;
     /** Sets command-line arguments via callback */
@@ -23427,20 +22812,6 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<TestDatabaseResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new TestDatabaseResourceImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<TestDatabaseResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -23457,51 +22828,6 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<TestDatabaseResource> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new TestDatabaseResourceImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<TestDatabaseResource> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new TestDatabaseResourceImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<TestDatabaseResource> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new TestDatabaseResourceImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -24834,24 +24160,8 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestDatabaseResourcePromise {
-        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withArgs(args: string[]): TestDatabaseResourcePromise {
@@ -25202,28 +24512,8 @@ export interface TestRedisResource {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestRedisResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): TestRedisResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestRedisResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestRedisResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestRedisResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestRedisResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestRedisResourcePromise;
     /** Adds a connection property with a string or reference expression value */
     withConnectionProperty(name: string, value: string | ReferenceExpression): TestRedisResourcePromise;
     /** Adds arguments */
@@ -25453,28 +24743,8 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestRedisResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): TestRedisResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestRedisResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestRedisResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestRedisResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestRedisResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestRedisResourcePromise;
     /** Adds a connection property with a string or reference expression value */
     withConnectionProperty(name: string, value: string | ReferenceExpression): TestRedisResourcePromise;
     /** Adds arguments */
@@ -26068,20 +25338,6 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<TestRedisResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new TestRedisResourceImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<TestRedisResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -26098,51 +25354,6 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<TestRedisResource> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new TestRedisResourceImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<TestRedisResource> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new TestRedisResourceImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<TestRedisResource> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new TestRedisResourceImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -27673,24 +26884,8 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestRedisResourcePromise {
-        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withConnectionProperty(name: string, value: string | ReferenceExpression): TestRedisResourcePromise {
@@ -28101,28 +27296,8 @@ export interface TestVaultResource {
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestVaultResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): TestVaultResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestVaultResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestVaultResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestVaultResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestVaultResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestVaultResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): TestVaultResourcePromise;
     /** Sets command-line arguments via callback */
@@ -28324,28 +27499,8 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestVaultResourcePromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): TestVaultResourcePromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestVaultResourcePromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestVaultResourcePromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestVaultResourcePromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestVaultResourcePromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestVaultResourcePromise;
     /** Adds arguments */
     withArgs(args: string[]): TestVaultResourcePromise;
     /** Sets command-line arguments via callback */
@@ -28911,20 +28066,6 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<TestVaultResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new TestVaultResourceImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<TestVaultResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -28941,51 +28082,6 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<TestVaultResource> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new TestVaultResourceImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<TestVaultResource> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new TestVaultResourceImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<TestVaultResource> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new TestVaultResourceImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -30332,24 +29428,8 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): TestVaultResourcePromise {
-        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withArgs(args: string[]): TestVaultResourcePromise {
@@ -32737,28 +31817,8 @@ export interface ResourceWithEnvironment {
     withOtlpExporter(options?: WithOtlpExporterOptions): ResourceWithEnvironmentPromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): ResourceWithEnvironmentPromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ResourceWithEnvironmentPromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ResourceWithEnvironmentPromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ResourceWithEnvironmentPromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ResourceWithEnvironmentPromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ResourceWithEnvironmentPromise;
     /** Configures which reference values are injected into environment variables */
     withReferenceEnvironment(options: ReferenceEnvironmentInjectionOptions): ResourceWithEnvironmentPromise;
     /** Adds a reference to another resource */
@@ -32782,28 +31842,8 @@ export interface ResourceWithEnvironmentPromise extends PromiseLike<ResourceWith
     withOtlpExporter(options?: WithOtlpExporterOptions): ResourceWithEnvironmentPromise;
     /** Sets an environment variable */
     withEnvironment(name: string, value: string | ReferenceExpression | EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression | Awaitable<EndpointReference | ParameterResource | ResourceWithConnectionString | TestRedisResource | EndpointReferenceExpression>): ResourceWithEnvironmentPromise;
-    /**
-     * Sets an environment variable from a reference expression
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ResourceWithEnvironmentPromise;
     /** Sets environment variables via callback */
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ResourceWithEnvironmentPromise;
-    /**
-     * Sets an environment variable from an endpoint reference
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ResourceWithEnvironmentPromise;
-    /**
-     * Sets an environment variable from a parameter resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ResourceWithEnvironmentPromise;
-    /**
-     * Sets an environment variable from a connection string resource
-     * @deprecated ATS compatibility shim. Use withEnvironment instead.
-     */
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ResourceWithEnvironmentPromise;
     /** Configures which reference values are injected into environment variables */
     withReferenceEnvironment(options: ReferenceEnvironmentInjectionOptions): ResourceWithEnvironmentPromise;
     /** Adds a reference to another resource */
@@ -32863,20 +31903,6 @@ class ResourceWithEnvironmentImpl extends ResourceBuilderBase<IResourceWithEnvir
     }
 
     /** @internal */
-    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ResourceWithEnvironment> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
-        const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
-            'Aspire.Hosting/withEnvironmentExpression',
-            rpcArgs
-        );
-        return new ResourceWithEnvironmentImpl(result, this._client);
-    }
-
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ResourceWithEnvironmentPromise {
-        return new ResourceWithEnvironmentPromiseImpl(this._withEnvironmentExpressionInternal(name, value), this._client);
-    }
-
-    /** @internal */
     private async _withEnvironmentCallbackInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ResourceWithEnvironment> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
@@ -32893,51 +31919,6 @@ class ResourceWithEnvironmentImpl extends ResourceBuilderBase<IResourceWithEnvir
 
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ResourceWithEnvironmentPromise {
         return new ResourceWithEnvironmentPromiseImpl(this._withEnvironmentCallbackInternal(callback), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentEndpointInternal(name: string, endpointReference: Awaitable<EndpointReference>): Promise<ResourceWithEnvironment> {
-        endpointReference = isPromiseLike(endpointReference) ? await endpointReference : endpointReference;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpointReference };
-        const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
-            'Aspire.Hosting/withEnvironmentEndpoint',
-            rpcArgs
-        );
-        return new ResourceWithEnvironmentImpl(result, this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ResourceWithEnvironmentPromise {
-        return new ResourceWithEnvironmentPromiseImpl(this._withEnvironmentEndpointInternal(name, endpointReference), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentParameterInternal(name: string, parameter: Awaitable<ParameterResource>): Promise<ResourceWithEnvironment> {
-        parameter = isPromiseLike(parameter) ? await parameter : parameter;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, parameter };
-        const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
-            'Aspire.Hosting/withEnvironmentParameter',
-            rpcArgs
-        );
-        return new ResourceWithEnvironmentImpl(result, this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ResourceWithEnvironmentPromise {
-        return new ResourceWithEnvironmentPromiseImpl(this._withEnvironmentParameterInternal(name, parameter), this._client);
-    }
-
-    /** @internal */
-    private async _withEnvironmentConnectionStringInternal(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): Promise<ResourceWithEnvironment> {
-        resource = isPromiseLike(resource) ? await resource : resource;
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, envVarName, resource };
-        const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
-            'Aspire.Hosting/withEnvironmentConnectionString',
-            rpcArgs
-        );
-        return new ResourceWithEnvironmentImpl(result, this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ResourceWithEnvironmentPromise {
-        return new ResourceWithEnvironmentPromiseImpl(this._withEnvironmentConnectionStringInternal(envVarName, resource), this._client);
     }
 
     /** @internal */
@@ -33094,24 +32075,8 @@ class ResourceWithEnvironmentPromiseImpl implements ResourceWithEnvironmentPromi
         return new ResourceWithEnvironmentPromiseImpl(this._promise.then(obj => obj.withEnvironment(name, value)), this._client);
     }
 
-    withEnvironmentExpression(name: string, value: ReferenceExpression): ResourceWithEnvironmentPromise {
-        return new ResourceWithEnvironmentPromiseImpl(this._promise.then(obj => obj.withEnvironmentExpression(name, value)), this._client);
-    }
-
     withEnvironmentCallback(callback: (arg: EnvironmentCallbackContext) => Promise<void>): ResourceWithEnvironmentPromise {
         return new ResourceWithEnvironmentPromiseImpl(this._promise.then(obj => obj.withEnvironmentCallback(callback)), this._client);
-    }
-
-    withEnvironmentEndpoint(name: string, endpointReference: Awaitable<EndpointReference>): ResourceWithEnvironmentPromise {
-        return new ResourceWithEnvironmentPromiseImpl(this._promise.then(obj => obj.withEnvironmentEndpoint(name, endpointReference)), this._client);
-    }
-
-    withEnvironmentParameter(name: string, parameter: Awaitable<ParameterResource>): ResourceWithEnvironmentPromise {
-        return new ResourceWithEnvironmentPromiseImpl(this._promise.then(obj => obj.withEnvironmentParameter(name, parameter)), this._client);
-    }
-
-    withEnvironmentConnectionString(envVarName: string, resource: Awaitable<ResourceWithConnectionString | TestRedisResource>): ResourceWithEnvironmentPromise {
-        return new ResourceWithEnvironmentPromiseImpl(this._promise.then(obj => obj.withEnvironmentConnectionString(envVarName, resource)), this._client);
     }
 
     withReferenceEnvironment(options: ReferenceEnvironmentInjectionOptions): ResourceWithEnvironmentPromise {


### PR DESCRIPTION
## Description

The ATS surface had several obsolete compatibility shims that continued to generate extra polyglot SDK methods even after the unified `withEnvironment` and `addRoute` exports were available. This removes those obsolete internal exports so generated SDKs expose the unified methods instead of deprecated aliases.

This deletes the obsolete environment and YARP shim methods, updates the capability text baselines, and refreshes generated snapshots across TypeScript, Python, Java, Rust, and Go.

Reported during 13.3 validation as confusing

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No