### PR TITLE
Forward aspire run arguments to AppHost

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -76,6 +76,26 @@ internal sealed class AppHostLauncher(
     }
 
     /// <summary>
+    /// Gets the arguments that should be passed through to the AppHost process.
+    /// </summary>
+    internal static string[] GetAppHostArguments(ParseResult parseResult)
+    {
+        return [.. parseResult.UnmatchedTokens];
+    }
+
+    /// <summary>
+    /// Adds AppHost arguments to a child CLI command after a command-line separator.
+    /// </summary>
+    internal static void AddAppHostArguments(List<string> commandArguments, IReadOnlyCollection<string> appHostArguments)
+    {
+        if (appHostArguments.Count > 0)
+        {
+            commandArguments.Add("--");
+            commandArguments.AddRange(appHostArguments);
+        }
+    }
+
+    /// <summary>
     /// Launches an AppHost in detached mode, waits for the backchannel, and displays the result.
     /// </summary>
     /// <param name="passedAppHostProjectFile">The project file passed via --project, or null to auto-discover.</param>

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -139,6 +139,7 @@ internal sealed class RunCommand : BaseCommand
         var format = parseResult.GetValue(AppHostLauncher.s_formatOption);
         var isolated = parseResult.GetValue(AppHostLauncher.s_isolatedOption);
         var isExtensionHost = ExtensionHelper.IsExtensionHost(InteractionService, out _, out _);
+        var appHostArguments = AppHostLauncher.GetAppHostArguments(parseResult);
         var captureProfile = parseResult.GetValue(RootCommand.CaptureProfileOption);
         var captureProfileDelay = TimeSpan.FromSeconds(parseResult.GetValue(RootCommand.CaptureProfileDelayOption));
         var startDebugSession = false;
@@ -187,8 +188,18 @@ internal sealed class RunCommand : BaseCommand
             && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _)
             && string.IsNullOrEmpty(_configuration[KnownConfigNames.ExtensionDebugSessionId]))
         {
+            var debugSessionArgs = new List<string>();
+            AppHostLauncher.AddAppHostArguments(debugSessionArgs, appHostArguments);
             extensionInteractionService.DisplayConsolePlainText(string.Format(CultureInfo.CurrentCulture, startDebugSession ? RunCommandStrings.StartingDebugSessionInExtension : RunCommandStrings.StartingRunSessionInExtension, "run"));
-            await extensionInteractionService.StartDebugSessionAsync(ExecutionContext.WorkingDirectory.FullName, passedAppHostProjectFile?.FullName, startDebugSession, new DebugSessionOptions { Command = "run" });
+            await extensionInteractionService.StartDebugSessionAsync(
+                ExecutionContext.WorkingDirectory.FullName,
+                passedAppHostProjectFile?.FullName,
+                startDebugSession,
+                new DebugSessionOptions
+                {
+                    Command = "run",
+                    Args = debugSessionArgs.Count > 0 ? [.. debugSessionArgs] : null
+                });
             return CommandResult.Success();
         }
 
@@ -268,7 +279,7 @@ internal sealed class RunCommand : BaseCommand
                 Isolated = isolated,
                 StartDebugSession = startDebugSession,
                 EnvironmentVariables = new Dictionary<string, string>(),
-                UnmatchedTokens = parseResult.UnmatchedTokens.ToArray(),
+                UnmatchedTokens = appHostArguments,
                 WorkingDirectory = ExecutionContext.WorkingDirectory,
                 BuildCompletionSource = buildCompletionSource,
                 BackchannelCompletionSource = backchannelCompletionSource,
@@ -1088,7 +1099,8 @@ internal sealed class RunCommand : BaseCommand
         var noBuild = parseResult.GetValue(s_noBuildOption);
         var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
         var globalArgs = RootCommand.GetChildProcessArgs(parseResult);
-        var additionalArgs = parseResult.UnmatchedTokens.Where(t => t != "--detach").ToList();
+        var appHostArguments = AppHostLauncher.GetAppHostArguments(parseResult);
+        var additionalArgs = new List<string>();
         var captureProfile = parseResult.GetValue(RootCommand.CaptureProfileOption);
         var stopAfterLaunchDelay = captureProfile
             ? TimeSpan.FromSeconds(parseResult.GetValue(RootCommand.CaptureProfileDelayOption))
@@ -1098,6 +1110,8 @@ internal sealed class RunCommand : BaseCommand
         {
             additionalArgs.Add("--no-build");
         }
+
+        AppHostLauncher.AddAppHostArguments(additionalArgs, appHostArguments);
 
         return _appHostLauncher.LaunchDetachedAsync(
             passedAppHostProjectFile,

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -54,7 +54,7 @@ internal sealed class StartCommand : BaseCommand
         var isExtensionHost = false;
         var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
         var globalArgs = RootCommand.GetChildProcessArgs(parseResult);
-        var additionalArgs = parseResult.UnmatchedTokens.ToList();
+        var appHostArguments = AppHostLauncher.GetAppHostArguments(parseResult);
         var captureProfile = parseResult.GetValue(RootCommand.CaptureProfileOption);
         var stopAfterLaunchDelay = captureProfile
             ? TimeSpan.FromSeconds(parseResult.GetValue(RootCommand.CaptureProfileDelayOption))
@@ -101,11 +101,7 @@ internal sealed class StartCommand : BaseCommand
                 }
             }
 
-            if (additionalArgs.Count > 0)
-            {
-                debugSessionArgs.Add("--");
-                debugSessionArgs.AddRange(additionalArgs);
-            }
+            AppHostLauncher.AddAppHostArguments(debugSessionArgs, appHostArguments);
 
             extensionInteractionService.DisplayConsolePlainText(string.Format(CultureInfo.CurrentCulture, startDebugSession ? RunCommandStrings.StartingDebugSessionInExtension : RunCommandStrings.StartingRunSessionInExtension, "start"));
             await extensionInteractionService.StartDebugSessionAsync(
@@ -121,6 +117,8 @@ internal sealed class StartCommand : BaseCommand
             return CommandResult.Success();
         }
 
+        var additionalArgs = new List<string>();
+
         if (noBuild)
         {
             additionalArgs.Add("--no-build");
@@ -130,6 +128,8 @@ internal sealed class StartCommand : BaseCommand
         {
             return CommandResult.Failure(CliExitCodes.InvalidCommand);
         }
+
+        AppHostLauncher.AddAppHostArguments(additionalArgs, appHostArguments);
 
         return await _appHostLauncher.LaunchDetachedAsync(
             passedAppHostProjectFile,

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -617,7 +617,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 // appHostSystemCts is linked to cancellationToken) tears down the guest process. The
                 // launcher will kill the guest's process tree when this token cancels.
                 (guestExitCode, guestOutput) = await ExecuteGuestAppHostAsync(
-                    appHostFile, directory, environmentVariables, enableHotReload, context.NoBuild, rpcClient, launcher, StartBackchannelConnectionAfterGuestAppHostLaunchesAsync, appHostSystemToken);
+                    appHostFile, directory, environmentVariables, enableHotReload, context.NoBuild, rpcClient, launcher, context.UnmatchedTokens, StartBackchannelConnectionAfterGuestAppHostLaunchesAsync, appHostSystemToken);
             }
 
             // If the user cancelled (Ctrl+C), surface that as cancellation instead of a "guest failed"
@@ -1909,6 +1909,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         bool noBuild,
         IAppHostRpcClient rpcClient,
         IGuestProcessLauncher launcher,
+        string[] runArgs,
         Func<Task>? afterAppHostLaunchedAsync,
         CancellationToken cancellationToken)
     {
@@ -1920,7 +1921,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             return (CliExitCodes.FailedToDotnetRunAppHost, new OutputCollector());
         }
 
-        return await _guestRuntime.RunAsync(appHostFile, directory, environmentVariables, watchMode, launcher, cancellationToken, noBuild: noBuild, afterAppHostLaunchedAsync: afterAppHostLaunchedAsync);
+        return await _guestRuntime.RunAsync(appHostFile, directory, environmentVariables, watchMode, launcher, cancellationToken, runArgs: runArgs, noBuild: noBuild, afterAppHostLaunchedAsync: afterAppHostLaunchedAsync);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -15,6 +15,7 @@ namespace Aspire.Cli.Projects;
 /// </summary>
 internal sealed class GuestRuntime
 {
+    private const string ArgsPlaceholder = "{args}";
     private readonly RuntimeSpec _spec;
     private readonly ILogger _logger;
     private readonly FileLoggerProvider? _fileLoggerProvider;
@@ -39,6 +40,8 @@ internal sealed class GuestRuntime
         _fileLoggerProvider = fileLoggerProvider;
         _commandResolver = commandResolver;
         _profilingTelemetry = profilingTelemetry;
+
+        ValidateCommandSpecs(_spec);
     }
 
     /// <summary>
@@ -334,7 +337,7 @@ internal sealed class GuestRuntime
 
         foreach (var arg in args)
         {
-            if (arg == "{args}")
+            if (arg == ArgsPlaceholder)
             {
                 if (additionalArgs is { Length: > 0 })
                 {
@@ -348,16 +351,9 @@ internal sealed class GuestRuntime
                 .Replace("{appHostFile}", appHostFile?.FullName ?? "")
                 .Replace("{appHostDir}", directory.FullName);
 
-            if (replaced.Contains("{args}"))
+            if (replaced.Contains(ArgsPlaceholder, StringComparison.Ordinal))
             {
-                if (additionalArgs is { Length: > 0 })
-                {
-                    replaced = replaced.Replace("{args}", string.Join(" ", additionalArgs));
-                }
-                else
-                {
-                    replaced = replaced.Replace("{args}", "");
-                }
+                ThrowEmbeddedArgsPlaceholder();
             }
 
             if (!string.IsNullOrWhiteSpace(replaced))
@@ -366,11 +362,56 @@ internal sealed class GuestRuntime
             }
         }
 
-        if (additionalArgs is { Length: > 0 } && !args.Any(a => a.Contains("{args}")))
+        if (additionalArgs is { Length: > 0 } && !args.Contains(ArgsPlaceholder))
         {
             result.AddRange(additionalArgs);
         }
 
         return result.ToArray();
+    }
+
+    private static void ValidateCommandSpecs(RuntimeSpec spec)
+    {
+        ValidateCommandSpecs(spec.Initialize);
+        ValidateCommandSpec(spec.InstallDependencies);
+        ValidateCommandSpecs(spec.PreExecute);
+        ValidateCommandSpec(spec.Execute);
+        ValidateCommandSpec(spec.WatchExecute);
+        ValidateCommandSpec(spec.PublishExecute);
+    }
+
+    private static void ValidateCommandSpecs(CommandSpec[]? commandSpecs)
+    {
+        if (commandSpecs is null)
+        {
+            return;
+        }
+
+        foreach (var commandSpec in commandSpecs)
+        {
+            ValidateCommandSpec(commandSpec);
+        }
+    }
+
+    private static void ValidateCommandSpec(CommandSpec? commandSpec)
+    {
+        if (commandSpec is null)
+        {
+            return;
+        }
+
+        foreach (var arg in commandSpec.Args)
+        {
+            if (arg != ArgsPlaceholder &&
+                arg.Contains(ArgsPlaceholder, StringComparison.Ordinal))
+            {
+                ThrowEmbeddedArgsPlaceholder();
+            }
+        }
+    }
+
+    private static void ThrowEmbeddedArgsPlaceholder()
+    {
+        throw new InvalidOperationException("Runtime command specifications must use the {args} placeholder as a standalone argument so forwarded AppHost arguments remain separate process arguments.");
     }
 }

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -143,6 +143,7 @@ internal sealed class GuestRuntime
     /// <param name="watchMode">Whether to run in watch mode for hot reload.</param>
     /// <param name="launcher">Strategy for launching the process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="runArgs">Additional arguments to forward to the AppHost process.</param>
     /// <param name="noBuild">Whether to skip pre-execution build/check commands.</param>
     /// <param name="afterAppHostLaunchedAsync">Callback invoked after the AppHost execute command has launched.</param>
     /// <returns>A tuple of the exit code and captured output (null when launched via extension).</returns>
@@ -153,6 +154,7 @@ internal sealed class GuestRuntime
         bool watchMode,
         IGuestProcessLauncher launcher,
         CancellationToken cancellationToken,
+        string[]? runArgs = null,
         bool noBuild = false,
         Func<Task>? afterAppHostLaunchedAsync = null)
     {
@@ -174,7 +176,7 @@ internal sealed class GuestRuntime
         var phase = useWatchCommand
             ? ProfilingTelemetry.Values.GuestCommandPhaseWatchExecute
             : ProfilingTelemetry.Values.GuestCommandPhaseExecute;
-        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, null, phase, launcher, cancellationToken, afterLaunchAsync: afterAppHostLaunchedAsync);
+        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, runArgs, phase, launcher, cancellationToken, afterLaunchAsync: afterAppHostLaunchedAsync);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -334,6 +334,16 @@ internal sealed class GuestRuntime
 
         foreach (var arg in args)
         {
+            if (arg == "{args}")
+            {
+                if (additionalArgs is { Length: > 0 })
+                {
+                    result.AddRange(additionalArgs);
+                }
+
+                continue;
+            }
+
             var replaced = arg
                 .Replace("{appHostFile}", appHostFile?.FullName ?? "")
                 .Replace("{appHostDir}", directory.FullName);

--- a/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
@@ -110,8 +110,8 @@ internal sealed class JavaLanguageSupport : ILanguageSupport
                 {
                     Command = "javac",
                     Args = OperatingSystem.IsWindows()
-                        ? ["--enable-preview", "--source", "25", "-d", ".java-build", "@.modules\\sources.txt", "AppHost.java"]
-                        : ["--enable-preview", "--source", "25", "-d", ".java-build", "@.modules/sources.txt", "AppHost.java"]
+                        ? ["--enable-preview", "--source", "25", "-d", ".java-build", "@.aspire\\modules\\sources.txt", "AppHost.java"]
+                        : ["--enable-preview", "--source", "25", "-d", ".java-build", "@.aspire/modules/sources.txt", "AppHost.java"]
                 }
             ],
             Execute = new CommandSpec

--- a/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
@@ -102,16 +102,22 @@ internal sealed class JavaLanguageSupport : ILanguageSupport
             DisplayName = LanguageDisplayName,
             CodeGenLanguage = CodeGenTarget,
             DetectionPatterns = s_detectionPatterns,
-            // No separate install step - compilation happens in Execute
+            // No separate install step - compilation happens in PreExecute
             InstallDependencies = null,
+            PreExecute =
+            [
+                new CommandSpec
+                {
+                    Command = "javac",
+                    Args = OperatingSystem.IsWindows()
+                        ? ["--enable-preview", "--source", "25", "-d", ".java-build", "@.modules\\sources.txt", "AppHost.java"]
+                        : ["--enable-preview", "--source", "25", "-d", ".java-build", "@.modules/sources.txt", "AppHost.java"]
+                }
+            ],
             Execute = new CommandSpec
             {
-                // Use a shell to compile and run in sequence
-                // On Windows, use cmd /c; on Unix, use sh -c
-                Command = OperatingSystem.IsWindows() ? "cmd" : "sh",
-                Args = OperatingSystem.IsWindows()
-                    ? ["/c", "if not exist .java-build mkdir .java-build && javac --enable-preview --source 25 -d .java-build @.aspire\\modules\\sources.txt AppHost.java && java --enable-preview -cp .java-build AppHost {args}"]
-                    : ["-c", "mkdir -p .java-build && javac --enable-preview --source 25 -d .java-build @.aspire/modules/sources.txt AppHost.java && java --enable-preview -cp .java-build AppHost {args}"]
+                Command = "java",
+                Args = ["--enable-preview", "-cp", ".java-build", "AppHost", "{args}"]
             }
         };
     }

--- a/src/Aspire.TypeSystem/RuntimeSpec.cs
+++ b/src/Aspire.TypeSystem/RuntimeSpec.cs
@@ -87,7 +87,7 @@ public sealed class CommandSpec
 
     /// <summary>
     /// Gets the arguments for the command.
-    /// Supports placeholders: {appHostFile}, {appHostDir}, {args}
+    /// Supports placeholders: {appHostFile}, {appHostDir}, and {args}. The {args} placeholder must be a standalone argument.
     /// </summary>
     public required string[] Args { get; init; }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -182,10 +182,9 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
 
-        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
-
         var counter = new SequenceCounter();
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
@@ -231,10 +230,5 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
         var runArgsPath = Path.Combine(projectRoot, "run-args.txt");
         Assert.True(File.Exists(runArgsPath), $"Expected forwarded arguments file not found: {runArgsPath}");
         Assert.Equal(["arg1=value1", "--flag", "--", "literal"], File.ReadAllLines(runArgsPath));
-
-        await auto.TypeAsync("exit");
-        await auto.EnterAsync();
-
-        await pendingRun;
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
+using Hex1b.Input;
 using Xunit;
 
 namespace Aspire.Cli.EndToEnd.Tests;
@@ -169,5 +170,71 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
         using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
         return doc.RootElement.GetProperty("sdk").GetProperty("version").GetString()
             ?? throw new InvalidOperationException("Expected aspire.config.json to contain sdk.version.");
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task RunTypeScriptEmptyAppHost_ForwardsArgumentsToAppHostProcess()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        await auto.AspireNewAsync("TsRunArgsApp", counter, template: AspireTemplate.TypeScriptEmptyAppHost);
+
+        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "TsRunArgsApp");
+        File.WriteAllText(Path.Combine(projectRoot, "apphost.ts"), """
+            // Aspire TypeScript AppHost
+            // For more information, see: https://aspire.dev
+
+            import { writeFileSync } from 'node:fs';
+            import { createBuilder } from './.modules/aspire.js';
+
+            writeFileSync('run-args.txt', process.argv.slice(2).join('\n'));
+
+            const builder = await createBuilder();
+
+            await builder.build().run();
+            """);
+
+        await auto.TypeAsync("cd TsRunArgsApp");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire run -- arg1=value1 --flag -- literal");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(s =>
+        {
+            if (s.ContainsText("Select an AppHost to use:"))
+            {
+                throw new InvalidOperationException(
+                    "Unexpected apphost selection prompt detected! " +
+                    "This indicates multiple apphosts were incorrectly detected.");
+            }
+
+            return s.ContainsText("Press CTRL+C to stop the AppHost and exit.");
+        }, timeout: TimeSpan.FromMinutes(3), description: "Press CTRL+C message (aspire run started)");
+
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        var runArgsPath = Path.Combine(projectRoot, "run-args.txt");
+        Assert.True(File.Exists(runArgsPath), $"Expected forwarded arguments file not found: {runArgsPath}");
+        Assert.Equal(["arg1=value1", "--flag", "--", "literal"], File.ReadAllLines(runArgsPath));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -2917,7 +2917,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(["arg1=value1", "--custom-arg"], args);
     }
 
@@ -2949,7 +2949,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedOptions);
         Assert.Equal("run", capturedOptions.Command);
         var debugSessionArgs = capturedOptions.Args;

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -2842,7 +2842,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void RunCommand_ForwardsUnmatchedTokensToAppHost()
+    public void RunCommand_ForwardsArgumentsAfterDoubleDashToAppHost()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
@@ -2852,8 +2852,109 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("run -- --custom-arg value");
 
         Assert.Empty(result.Errors);
-        Assert.Contains("--custom-arg", result.UnmatchedTokens);
-        Assert.Contains("value", result.UnmatchedTokens);
+        Assert.Equal(["--custom-arg", "value"], AppHostLauncher.GetAppHostArguments(result));
+    }
+
+    [Fact]
+    public void RunCommand_PreservesLiteralDoubleDashAppHostArgument()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run -- arg1 -- arg2");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(["arg1", "--", "arg2"], AppHostLauncher.GetAppHostArguments(result));
+    }
+
+    [Fact]
+    public async Task RunCommand_PassesArgumentsAfterDoubleDashToDotNetRunner()
+    {
+        var capturedArgs = new TaskCompletionSource<string[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var backchannelFactory = (IServiceProvider sp) =>
+        {
+            var backchannel = new TestAppHostBackchannel();
+            backchannel.GetAppHostLogEntriesAsyncCallback = ReturnLogEntriesUntilCancelledAsync;
+            return backchannel;
+        };
+
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
+            {
+                capturedArgs.SetResult(args);
+                var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
+                backchannelCompletionSource!.SetResult(backchannel);
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                return 0;
+            };
+            return runner;
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.AppHostBackchannelFactory = backchannelFactory;
+            options.DotNetCliRunnerFactory = runnerFactory;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run -- arg1=value1 --custom-arg");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+
+        var args = await capturedArgs.Task.DefaultTimeout();
+        cts.Cancel();
+
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(["arg1=value1", "--custom-arg"], args);
+    }
+
+    [Fact]
+    public async Task RunCommand_WhenDelegatingToExtension_ForwardsArgumentsAfterDoubleDash()
+    {
+        DebugSessionOptions? capturedOptions = null;
+
+        var extensionInteractionServiceFactory = (IServiceProvider sp) =>
+        {
+            var service = new TestExtensionInteractionService(sp);
+            service.StartDebugSessionCallback = (_, _, _, options) =>
+            {
+                capturedOptions = options;
+            };
+            return service;
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = extensionInteractionServiceFactory;
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run -- arg1=value1 --no-build");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.NotNull(capturedOptions);
+        Assert.Equal("run", capturedOptions.Command);
+        var debugSessionArgs = capturedOptions.Args;
+        Assert.NotNull(debugSessionArgs);
+        Assert.Equal(["--", "arg1=value1", "--no-build"], debugSessionArgs);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
@@ -127,7 +127,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void StartCommand_ForwardsUnmatchedTokensToAppHost()
+    public void StartCommand_ForwardsArgumentsAfterDoubleDashToAppHost()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
@@ -137,8 +137,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("start -- --custom-arg value");
 
         Assert.Empty(result.Errors);
-        Assert.Contains("--custom-arg", result.UnmatchedTokens);
-        Assert.Contains("value", result.UnmatchedTokens);
+        Assert.Equal(["--custom-arg", "value"], AppHostLauncher.GetAppHostArguments(result));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -588,8 +588,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             new Dictionary<string, string>(),
             watchMode: false,
             launcher,
-            runArgs: ["arg1=value1", "--flag"],
-            CancellationToken.None);
+            CancellationToken.None,
+            runArgs: ["arg1=value1", "--flag"]);
 
         Assert.Equal([appHostFile.FullName, "arg1=value1", "--flag"], launcher.LastArgs);
     }
@@ -613,8 +613,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             new Dictionary<string, string>(),
             watchMode: false,
             launcher,
-            runArgs: ["arg1=value1", "--flag", "--", "literal"],
-            CancellationToken.None);
+            CancellationToken.None,
+            runArgs: ["arg1=value1", "--flag", "--", "literal"]);
 
         Assert.Equal([appHostFile.FullName, "arg1=value1", "--flag", "--", "literal"], launcher.LastArgs);
     }
@@ -638,8 +638,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             new Dictionary<string, string>(),
             watchMode: false,
             launcher,
-            runArgs: ["arg with spaces", "; rm -rf important", "--flag=value"],
-            CancellationToken.None);
+            CancellationToken.None,
+            runArgs: ["arg with spaces", "; rm -rf important", "--flag=value"]);
 
         Assert.Equal([appHostFile.FullName, "arg with spaces", "; rm -rf important", "--flag=value"], launcher.LastArgs);
     }

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -392,7 +392,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), ["--output", "/out"], launcher, cancellationToken: CancellationToken.None);
 
         Assert.Equal("publish-cmd", launcher.LastCommand);
-        Assert.Contains(launcher.LastArgs, a => a.Contains("--output") && a.Contains("/out"));
+        Assert.Equal([appHostFile.FullName, "--output", "/out"], launcher.LastArgs);
     }
 
     [Fact]
@@ -592,6 +592,31 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             CancellationToken.None);
 
         Assert.Equal([appHostFile.FullName, "arg1=value1", "--flag"], launcher.LastArgs);
+    }
+
+    [Fact]
+    public async Task RunAsync_ExpandsArgsPlaceholderAsSeparateArguments()
+    {
+        var spec = CreateTestSpec(execute: new CommandSpec
+        {
+            Command = "test-cmd",
+            Args = ["{appHostFile}", "{args}"]
+        });
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        await runtime.RunAsync(
+            appHostFile,
+            directory,
+            new Dictionary<string, string>(),
+            watchMode: false,
+            launcher,
+            runArgs: ["arg1=value1", "--flag", "--", "literal"],
+            CancellationToken.None);
+
+        Assert.Equal([appHostFile.FullName, "arg1=value1", "--flag", "--", "literal"], launcher.LastArgs);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -620,6 +620,60 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunAsync_ArgsPlaceholderPreservesArgumentBoundaries()
+    {
+        var spec = CreateTestSpec(execute: new CommandSpec
+        {
+            Command = "test-cmd",
+            Args = ["{appHostFile}", "{args}"]
+        });
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        await runtime.RunAsync(
+            appHostFile,
+            directory,
+            new Dictionary<string, string>(),
+            watchMode: false,
+            launcher,
+            runArgs: ["arg with spaces", "; rm -rf important", "--flag=value"],
+            CancellationToken.None);
+
+        Assert.Equal([appHostFile.FullName, "arg with spaces", "; rm -rf important", "--flag=value"], launcher.LastArgs);
+    }
+
+    [Fact]
+    public void Constructor_RejectsEmbeddedArgsPlaceholder()
+    {
+        var spec = CreateTestSpec(execute: new CommandSpec
+        {
+            Command = "test-cmd",
+            Args = ["prefix-{args}"]
+        });
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CreateRuntime(spec));
+        Assert.Contains("{args} placeholder as a standalone argument", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_RejectsEmbeddedArgsPlaceholderEvenWithoutRunArgs()
+    {
+        var spec = CreateTestSpec(preExecute:
+        [
+            new CommandSpec
+            {
+                Command = "test-cmd",
+                Args = ["prefix-{args}"]
+            }
+        ]);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CreateRuntime(spec));
+        Assert.Contains("{args} placeholder as a standalone argument", exception.Message);
+    }
+
+    [Fact]
     public async Task PublishAsync_AdditionalArgsAppendedWhenNoPlaceholder()
     {
         var spec = CreateTestSpec(execute: new CommandSpec

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -570,6 +570,31 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunAsync_AppendsRunArgsWhenNoPlaceholder()
+    {
+        var spec = CreateTestSpec(execute: new CommandSpec
+        {
+            Command = "test-cmd",
+            Args = ["{appHostFile}"]
+        });
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        await runtime.RunAsync(
+            appHostFile,
+            directory,
+            new Dictionary<string, string>(),
+            watchMode: false,
+            launcher,
+            runArgs: ["arg1=value1", "--flag"],
+            CancellationToken.None);
+
+        Assert.Equal([appHostFile.FullName, "arg1=value1", "--flag"], launcher.LastArgs);
+    }
+
+    [Fact]
     public async Task PublishAsync_AdditionalArgsAppendedWhenNoPlaceholder()
     {
         var spec = CreateTestSpec(execute: new CommandSpec

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/JavaLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/JavaLanguageSupportTests.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TypeSystem;
+
+namespace Aspire.Hosting.CodeGeneration.Java.Tests;
+
+public class JavaLanguageSupportTests
+{
+    [Fact]
+    public void GetRuntimeSpec_CompilesBeforeRunningJavaDirectly()
+    {
+        var spec = CreateLanguageSupport().GetRuntimeSpec();
+
+        var preExecute = Assert.Single(spec.PreExecute!);
+        Assert.Equal("javac", preExecute.Command);
+        Assert.All(preExecute.Args, arg => Assert.DoesNotContain("{args}", arg));
+
+        Assert.Equal("java", spec.Execute.Command);
+        Assert.Equal(["--enable-preview", "-cp", ".java-build", "AppHost", "{args}"], spec.Execute.Args);
+    }
+
+    private static ILanguageSupport CreateLanguageSupport()
+    {
+        var languageSupportType = typeof(AtsJavaCodeGenerator).Assembly.GetTypes().Single(type =>
+            !type.IsAbstract &&
+            !type.IsInterface &&
+            typeof(ILanguageSupport).IsAssignableFrom(type));
+
+        return Assert.IsAssignableFrom<ILanguageSupport>(Activator.CreateInstance(languageSupportType, nonPublic: true));
+    }
+}

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/JavaLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/JavaLanguageSupportTests.cs
@@ -14,7 +14,10 @@ public class JavaLanguageSupportTests
 
         var preExecute = Assert.Single(spec.PreExecute!);
         Assert.Equal("javac", preExecute.Command);
-        Assert.All(preExecute.Args, arg => Assert.DoesNotContain("{args}", arg));
+        Assert.Equal(OperatingSystem.IsWindows()
+            ? ["--enable-preview", "--source", "25", "-d", ".java-build", "@.aspire\\modules\\sources.txt", "AppHost.java"]
+            : ["--enable-preview", "--source", "25", "-d", ".java-build", "@.aspire/modules/sources.txt", "AppHost.java"],
+            preExecute.Args);
 
         Assert.Equal("java", spec.Execute.Command);
         Assert.Equal(["--enable-preview", "-cp", ".java-build", "AppHost", "{args}"], spec.Execute.Args);


### PR DESCRIPTION
## Description

`aspire run -- <args>` should pass those arguments through to the AppHost process so AppHosts can read them from their normal process argument APIs. This change preserves `System.CommandLine` unmatched tokens from the command separator and threads them through C# AppHost launches, guest-language AppHost launches, detached `run`/`start` child invocations, and extension debug-session delegation.

The forwarding path adds the `--` separator only when reconstructing a child CLI invocation, while preserving literal `--` values that are part of the AppHost arguments. Coverage includes focused CLI unit tests for parser behavior, C# `dotnet run` argument placement, extension delegation, guest runtime execution, and a TypeScript CLI E2E test that verifies a guest `apphost.ts` receives forwarded arguments.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
