### PR TITLE
Stage native CLI tool packages deterministically

### DIFF
--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -181,25 +181,9 @@ extends:
 
               - pwsh: |
                   $ErrorActionPreference = 'Stop'
-                  $downloadRoot = "$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)"
-                  $shippingDir = "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping"
-                  New-Item -ItemType Directory -Path $shippingDir -Force | Out-Null
-
-                  $packages = @(Get-ChildItem -Path $downloadRoot -Filter "Aspire.Cli*.nupkg" -File -Recurse |
-                    Where-Object { $_.Name -notmatch '\.symbols\.' } |
-                    Sort-Object FullName)
-                  if ($packages.Count -eq 0) {
-                    throw "No native CLI tool packages were downloaded to $downloadRoot."
-                  }
-
-                  foreach ($packageGroup in $packages | Group-Object Name) {
-                    $package = $packageGroup.Group[0]
-                    if ($packageGroup.Count -gt 1) {
-                      Write-Host "Using $($package.FullName) for duplicate package name $($packageGroup.Name)."
-                    }
-
-                    Copy-Item -LiteralPath $package.FullName -Destination (Join-Path $shippingDir $package.Name) -Force
-                  }
+                  & "$(Build.SourcesDirectory)/eng/scripts/stage-native-cli-tool-packages.ps1" `
+                    -DownloadRoot "$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)" `
+                    -ShippingDir "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping"
                 displayName: 🟣Stage Native CLI Tool Packages
 
               - task: PowerShell@2

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -269,25 +269,9 @@ extends:
 
               - pwsh: |
                   $ErrorActionPreference = 'Stop'
-                  $downloadRoot = "$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)"
-                  $shippingDir = "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping"
-                  New-Item -ItemType Directory -Path $shippingDir -Force | Out-Null
-
-                  $packages = @(Get-ChildItem -Path $downloadRoot -Filter "Aspire.Cli*.nupkg" -File -Recurse |
-                    Where-Object { $_.Name -notmatch '\.symbols\.' } |
-                    Sort-Object FullName)
-                  if ($packages.Count -eq 0) {
-                    throw "No native CLI tool packages were downloaded to $downloadRoot."
-                  }
-
-                  foreach ($packageGroup in $packages | Group-Object Name) {
-                    $package = $packageGroup.Group[0]
-                    if ($packageGroup.Count -gt 1) {
-                      Write-Host "Using $($package.FullName) for duplicate package name $($packageGroup.Name)."
-                    }
-
-                    Copy-Item -LiteralPath $package.FullName -Destination (Join-Path $shippingDir $package.Name) -Force
-                  }
+                  & "$(Build.SourcesDirectory)/eng/scripts/stage-native-cli-tool-packages.ps1" `
+                    -DownloadRoot "$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)" `
+                    -ShippingDir "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping"
                 displayName: 🟣Stage Native CLI Tool Packages
 
               - task: PowerShell@2

--- a/eng/scripts/stage-native-cli-tool-packages.ps1
+++ b/eng/scripts/stage-native-cli-tool-packages.ps1
@@ -1,0 +1,97 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$DownloadRoot,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ShippingDir,
+
+  [string]$CanonicalPointerArtifactName = 'native_archives_win_x64'
+)
+
+$ErrorActionPreference = 'Stop'
+
+New-Item -ItemType Directory -Path $ShippingDir -Force | Out-Null
+
+$packages = @(Get-ChildItem -Path $DownloadRoot -Filter "Aspire.Cli*.nupkg" -File -Recurse |
+  Where-Object { $_.Name -notmatch '\.symbols\.' } |
+  Sort-Object FullName)
+if ($packages.Count -eq 0) {
+  throw "No native CLI tool packages were downloaded to $DownloadRoot."
+}
+
+$packageVersionPattern = '(?<Version>\d+(?:\.\d+){1,3}(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)'
+$pointerPackagePattern = "^Aspire\.Cli\.$packageVersionPattern\.nupkg$"
+
+$classifiedPackages = @(
+  foreach ($package in $packages) {
+    $pathParts = $package.FullName.Split([char[]]@('\', '/'), [System.StringSplitOptions]::RemoveEmptyEntries)
+    $nativeArchiveRoot = @($pathParts | Where-Object { $_ -like 'native_archives_*' } | Select-Object -First 1)
+
+    if ($nativeArchiveRoot.Count -eq 0) {
+      Write-Warning "Skipping Aspire.Cli package outside native archive artifacts: $($package.FullName)"
+      continue
+    }
+
+    $artifactName = $nativeArchiveRoot[0]
+    $artifactRid = $artifactName.Substring('native_archives_'.Length).Replace('_', '-')
+    $artifactRidPattern = [System.Text.RegularExpressions.Regex]::Escape($artifactRid)
+    $ridPackagePattern = "^Aspire\.Cli\.$artifactRidPattern\.$packageVersionPattern\.nupkg$"
+
+    $isPointerPackage = $false
+    $packageVersion = $null
+
+    if ($package.Name -match $pointerPackagePattern) {
+      $isPointerPackage = $true
+      $packageVersion = $Matches.Version
+    } elseif ($package.Name -match $ridPackagePattern) {
+      $packageVersion = $Matches.Version
+    }
+
+    if ($null -eq $packageVersion) {
+      throw "Unexpected Aspire.Cli package '$($package.FullName)' in artifact '$artifactName'. Expected either an Aspire.Cli pointer package or an Aspire.Cli.$artifactRid RID-specific package."
+    }
+
+    [pscustomobject]@{
+      File = $package
+      PackageName = $package.Name
+      PackageVersion = $packageVersion
+      ArtifactName = $artifactName
+      ArtifactRid = $artifactRid
+      IsPointerPackage = $isPointerPackage
+    }
+  }
+)
+
+if ($classifiedPackages.Count -eq 0) {
+  throw "No native CLI tool packages were found under native_archives_<rid> artifacts in $DownloadRoot."
+}
+
+$canonicalPointerPackages = @($classifiedPackages | Where-Object { $_.IsPointerPackage -and $_.ArtifactName -eq $CanonicalPointerArtifactName })
+if ($canonicalPointerPackages.Count -ne 1) {
+  throw "Expected exactly one canonical Aspire.Cli pointer package from $CanonicalPointerArtifactName, but found $($canonicalPointerPackages.Count): $($canonicalPointerPackages.File.FullName -join ', ')"
+}
+
+$skippedPointerPackages = @($classifiedPackages | Where-Object { $_.IsPointerPackage -and $_.ArtifactName -ne $CanonicalPointerArtifactName })
+foreach ($package in $skippedPointerPackages) {
+  Write-Host "Skipping non-canonical Aspire.Cli pointer package from $($package.ArtifactName): $($package.File.FullName)"
+}
+
+$canonicalPointerVersion = $canonicalPointerPackages[0].PackageVersion
+$ridPackages = @($classifiedPackages | Where-Object { -not $_.IsPointerPackage })
+$duplicateRidPackageGroups = @($ridPackages | Group-Object ArtifactRid | Where-Object { $_.Count -gt 1 })
+if ($duplicateRidPackageGroups.Count -gt 0) {
+  $details = @($duplicateRidPackageGroups | ForEach-Object { "$($_.Name): $($_.Group.File.FullName -join ', ')" })
+  throw "Expected exactly one Aspire.Cli RID-specific package per RID, but found duplicates: $($details -join '; ')"
+}
+
+$ridPackageVersionMismatches = @($ridPackages | Where-Object { $_.PackageVersion -ne $canonicalPointerVersion })
+if ($ridPackageVersionMismatches.Count -gt 0) {
+  $details = @($ridPackageVersionMismatches | ForEach-Object { "$($_.PackageName) has version $($_.PackageVersion)" })
+  throw "All Aspire.Cli RID-specific packages must match canonical pointer package version $canonicalPointerVersion from $CanonicalPointerArtifactName, but found mismatches: $($details -join '; ')"
+}
+
+$packagesToStage = @($canonicalPointerPackages[0]) + $ridPackages
+foreach ($packageToStage in $packagesToStage) {
+  $package = $packageToStage.File
+  Copy-Item -LiteralPath $package.FullName -Destination (Join-Path $ShippingDir $package.Name) -Force
+}

--- a/tests/Infrastructure.Tests/PowerShellScripts/StageNativeCliToolPackagesTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/StageNativeCliToolPackagesTests.cs
@@ -1,0 +1,304 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+public sealed class StageNativeCliToolPackagesTests : IDisposable
+{
+    private const string PackageVersion = "13.4.0-preview.1.26229.13";
+    private const string DifferentPackageVersion = "13.4.1-preview.1.26229.13";
+
+    private static readonly string[] s_productionRids =
+    [
+        "linux-x64",
+        "linux-arm64",
+        "linux-musl-x64",
+        "osx-x64",
+        "osx-arm64",
+        "win-x64",
+        "win-arm64"
+    ];
+
+    private readonly TestTempDirectory _tempDir = new();
+    private readonly string _scriptPath;
+    private readonly ITestOutputHelper _output;
+
+    public StageNativeCliToolPackagesTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _scriptPath = Path.Combine(FindRepoRoot(), "eng", "scripts", "stage-native-cli-tool-packages.ps1");
+    }
+
+    public void Dispose() => _tempDir.Dispose();
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task StagesCanonicalPointerAndRidPackages()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        foreach (var rid in s_productionRids)
+        {
+            CreateNativeArchivePackages(downloadRoot, rid);
+        }
+        CreatePackage(downloadRoot, "unrelated", "Release", "Shipping", $"Aspire.Cli.{PackageVersion}.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        result.EnsureSuccessful();
+
+        var stagedPackageNames = GetStagedPackageNames(shippingDir);
+        Assert.Equal(
+            [
+                $"Aspire.Cli.{PackageVersion}.nupkg",
+                $"Aspire.Cli.linux-arm64.{PackageVersion}.nupkg",
+                $"Aspire.Cli.linux-musl-x64.{PackageVersion}.nupkg",
+                $"Aspire.Cli.linux-x64.{PackageVersion}.nupkg",
+                $"Aspire.Cli.osx-arm64.{PackageVersion}.nupkg",
+                $"Aspire.Cli.osx-x64.{PackageVersion}.nupkg",
+                $"Aspire.Cli.win-arm64.{PackageVersion}.nupkg",
+                $"Aspire.Cli.win-x64.{PackageVersion}.nupkg"
+            ],
+            stagedPackageNames);
+        Assert.Contains("Skipping non-canonical Aspire.Cli pointer package", result.Output);
+        Assert.Contains("Skipping Aspire.Cli package outside native archive artifacts", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsWhenCanonicalPointerPackageIsMissing()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "linux-x64");
+        CreateNativeArchivePackage(downloadRoot, "win-x64", $"Aspire.Cli.win-x64.{PackageVersion}.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Expected exactly one canonical Aspire.Cli pointer package", result.Output);
+        Assert.Contains("native_archives_win_x64", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsWhenDuplicateCanonicalPointerPackagesAreDownloaded()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "win-x64");
+        CreatePackage(downloadRoot, "native_archives_win_x64", "Duplicate", "Shipping", $"Aspire.Cli.{PackageVersion}.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Expected exactly one canonical Aspire.Cli pointer package", result.Output);
+        Assert.Contains("but found 2", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsWhenRidPackageDoesNotMatchNativeArchiveRoot()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "win-x64");
+        CreateNativeArchivePackage(downloadRoot, "linux-x64", $"Aspire.Cli.osx-x64.{PackageVersion}.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Unexpected Aspire.Cli package", result.Output);
+        Assert.Contains("Aspire.Cli.linux-x64 RID-specific package", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsWhenRidPackageNameIsMalformed()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "win-x64");
+        CreateNativeArchivePackage(downloadRoot, "linux-x64", "Aspire.Cli.linux-x64.13x.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Unexpected Aspire.Cli package", result.Output);
+        Assert.Contains("Aspire.Cli.linux-x64 RID-specific package", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsWhenDuplicateRidPackagesAreDownloaded()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "win-x64");
+        CreateNativeArchivePackage(downloadRoot, "linux-x64", $"Aspire.Cli.linux-x64.{PackageVersion}.nupkg");
+        CreatePackage(downloadRoot, "native_archives_linux_x64", "Duplicate", "Shipping", $"Aspire.Cli.linux-x64.{PackageVersion}.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Expected exactly one Aspire.Cli RID-specific package per RID", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsWhenDuplicateRidPackagesHaveDifferentVersions()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "win-x64");
+        CreateNativeArchivePackage(downloadRoot, "linux-x64", $"Aspire.Cli.linux-x64.{PackageVersion}.nupkg");
+        CreateNativeArchivePackage(downloadRoot, "linux-x64", $"Aspire.Cli.linux-x64.{DifferentPackageVersion}.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("Expected exactly one Aspire.Cli RID-specific package per RID", result.Output);
+        Assert.Contains($"Aspire.Cli.linux-x64.{PackageVersion}.nupkg", result.Output);
+        Assert.Contains($"Aspire.Cli.linux-x64.{DifferentPackageVersion}.nupkg", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsWhenRidPackageVersionDoesNotMatchCanonicalPointerPackage()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "win-x64");
+        CreateNativeArchivePackage(downloadRoot, "linux-x64", $"Aspire.Cli.linux-x64.{DifferentPackageVersion}.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("must match canonical pointer", result.Output);
+        Assert.Contains(PackageVersion, result.Output);
+        Assert.Contains($"Aspire.Cli.linux-x64.{DifferentPackageVersion}.nupkg", result.Output);
+        Assert.Contains(DifferentPackageVersion, result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsWhenNoPackagesAreUnderNativeArchiveArtifacts()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreatePackage(downloadRoot, "unrelated", "Release", "Shipping", $"Aspire.Cli.{PackageVersion}.nupkg");
+        CreatePackage(downloadRoot, "also-unrelated", "Release", "Shipping", $"Aspire.Cli.linux-x64.{PackageVersion}.nupkg");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("No native CLI tool packages were found", result.Output);
+        Assert.Contains("native_archives_<rid>", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task UsesConfiguredCanonicalPointerArtifactName()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "linux-x64");
+        CreateNativeArchivePackage(downloadRoot, "win-x64", $"Aspire.Cli.win-x64.{PackageVersion}.nupkg");
+
+        var result = await RunScript(
+            downloadRoot,
+            shippingDir,
+            "-CanonicalPointerArtifactName", "native_archives_linux_x64");
+
+        result.EnsureSuccessful();
+
+        var stagedPackageNames = GetStagedPackageNames(shippingDir);
+        Assert.Equal(
+            [
+                $"Aspire.Cli.{PackageVersion}.nupkg",
+                $"Aspire.Cli.linux-x64.{PackageVersion}.nupkg",
+                $"Aspire.Cli.win-x64.{PackageVersion}.nupkg"
+            ],
+            stagedPackageNames);
+    }
+
+    private async Task<CommandResult> RunScript(string downloadRoot, string shippingDir, params string[] additionalArgs)
+    {
+        using var cmd = new PowerShellCommand(_scriptPath, _output)
+            .WithTimeout(TimeSpan.FromMinutes(2));
+
+        var args = new List<string>
+        {
+            "-DownloadRoot", $"\"{downloadRoot}\"",
+            "-ShippingDir", $"\"{shippingDir}\""
+        };
+        args.AddRange(additionalArgs);
+
+        return await cmd.ExecuteAsync([.. args]);
+    }
+
+    private string CreateDownloadRoot()
+    {
+        var path = Path.Combine(_tempDir.Path, Path.GetRandomFileName(), "download");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private string CreateShippingDir()
+    {
+        return Path.Combine(_tempDir.Path, Path.GetRandomFileName(), "shipping");
+    }
+
+    private static void CreateNativeArchivePackages(string downloadRoot, string rid)
+    {
+        CreateNativeArchivePackage(downloadRoot, rid, $"Aspire.Cli.{PackageVersion}.nupkg");
+        CreateNativeArchivePackage(downloadRoot, rid, $"Aspire.Cli.{rid}.{PackageVersion}.nupkg");
+    }
+
+    private static void CreateNativeArchivePackage(string downloadRoot, string rid, string packageName)
+    {
+        CreatePackage(downloadRoot, $"native_archives_{rid.Replace('-', '_')}", "Release", "Shipping", packageName);
+    }
+
+    private static void CreatePackage(string downloadRoot, params string[] pathParts)
+    {
+        var path = Path.Combine([downloadRoot, .. pathParts]);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "package");
+    }
+
+    private static string[] GetStagedPackageNames(string shippingDir)
+    {
+        return Directory.GetFiles(shippingDir, "Aspire.Cli*.nupkg")
+            .Select(Path.GetFileName)
+            .Order(StringComparer.Ordinal)
+            .ToArray()!;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Aspire.slnx")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new InvalidOperationException("Could not find repository root");
+    }
+}


### PR DESCRIPTION
## Description

Adds deterministic staging for native Aspire CLI tool packages in the Azure DevOps publishing pipeline.

The pipeline now calls a shared PowerShell script that stages exactly one canonical `Aspire.Cli` pointer package and one RID-specific package per native archive artifact, while failing fast on missing pointer packages, RID/package mismatches, duplicate RID packages, and version mismatches. Both official and unofficial Azure DevOps pipeline definitions use the same script.

Validation:

- `./restore.sh`
- `./build.sh --build /p:SkipNativeBuild=true`
- `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-build --no-launch-profile -- --filter-class "*.StageNativeCliToolPackagesTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
