### PR TITLE
Avoid AppHost discovery when config path is valid

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -208,7 +208,20 @@ internal sealed class ProjectLocator(
             return settingsAppHost;
         }
 
-        logger.LogWarning("Ignoring AppHost path '{AppHostPath}' from settings because it is no longer a valid AppHost project.", settingsAppHost.FullName);
+        var messageSuffix = validationResult.Message is { Length: > 0 } message ? $": {message}" : string.Empty;
+        if (validationResult.IsUnsupported)
+        {
+            logger.LogWarning("Ignoring AppHost path '{AppHostPath}' from settings because it is not supported in the current environment{MessageSuffix}.", settingsAppHost.FullName, messageSuffix);
+        }
+        else if (validationResult.IsPossiblyUnbuildable)
+        {
+            logger.LogWarning("Ignoring AppHost path '{AppHostPath}' from settings because it may not be a buildable AppHost project{MessageSuffix}.", settingsAppHost.FullName, messageSuffix);
+        }
+        else
+        {
+            logger.LogWarning("Ignoring AppHost path '{AppHostPath}' from settings because it is no longer a valid AppHost project{MessageSuffix}.", settingsAppHost.FullName, messageSuffix);
+        }
+
         return null;
     }
 
@@ -406,7 +419,19 @@ internal sealed class ProjectLocator(
             }
         }
 
-        var settingsAppHost = await GetValidatedAppHostProjectFileFromSettingsAsync(silent: true, cancellationToken);
+        var settingsAppHost = await GetValidatedAppHostProjectFileFromSettingsAsync(silent: false, cancellationToken);
+
+        if (settingsAppHost is not null && multipleAppHostProjectsFoundBehavior is not MultipleAppHostProjectsFoundBehavior.None)
+        {
+            logger.LogDebug("Using AppHost path from settings without scanning: {AppHost}", settingsAppHost.FullName);
+
+            if (createSettingsFile)
+            {
+                await CreateSettingsFileAsync(settingsAppHost, cancellationToken);
+            }
+
+            return new AppHostProjectSearchResult(settingsAppHost, [settingsAppHost]);
+        }
 
         logger.LogDebug("No project file specified, searching for apphost projects in {CurrentDirectory}", executionContext.WorkingDirectory);
         var results = await FindAppHostProjectFilesAsync(
@@ -481,7 +506,18 @@ internal sealed class ProjectLocator(
             await CreateSettingsFileAsync(selectedAppHost!, cancellationToken);
         }
 
-        return new AppHostProjectSearchResult(selectedAppHost, results.BuildableAppHost);
+        // Ensure the selected AppHost is always represented in the candidate list so callers
+        // can rely on SelectedProjectFile being present in AllProjectFileCandidates. This
+        // covers cases where the configured settings AppHost is selected but lives outside
+        // the discovered candidate set (e.g. parent directory or excluded by enumeration).
+        var allCandidates = results.BuildableAppHost;
+        if (selectedAppHost is not null
+            && !allCandidates.Any(f => string.Equals(f.FullName, selectedAppHost.FullName, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)))
+        {
+            allCandidates = [.. allCandidates, selectedAppHost];
+        }
+
+        return new AppHostProjectSearchResult(selectedAppHost, allCandidates);
     }
 
     public async Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -419,7 +419,7 @@ internal sealed class ProjectLocator(
             }
         }
 
-        var settingsAppHost = await GetValidatedAppHostProjectFileFromSettingsAsync(silent: false, cancellationToken);
+        var settingsAppHost = await GetValidatedAppHostProjectFileFromSettingsAsync(silent: true, cancellationToken);
 
         if (settingsAppHost is not null && multipleAppHostProjectsFoundBehavior is not MultipleAppHostProjectsFoundBehavior.None)
         {

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -222,6 +222,115 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UseOrFindAppHostProjectFileUsesValidSettingsWithoutScanning()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var targetAppHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("TargetAppHost");
+        var targetAppHostProjectFile = new FileInfo(Path.Combine(targetAppHostDirectory.FullName, "TargetAppHost.csproj"));
+        await File.WriteAllTextAsync(targetAppHostProjectFile.FullName, "Not a real apphost");
+
+        var decoyAppHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("DecoyAppHost");
+        var decoyAppHostProjectFile = new FileInfo(Path.Combine(decoyAppHostDirectory.FullName, "DecoyAppHost.csproj"));
+        await File.WriteAllTextAsync(decoyAppHostProjectFile.FullName, "Not a real apphost");
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new
+        {
+            appHost = new
+            {
+                path = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, targetAppHostProjectFile.FullName).Replace(Path.DirectorySeparatorChar, '/')
+            }
+        }));
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(
+            executionContext,
+            languageDiscovery: new ThrowingLanguageDiscovery());
+
+        var result = await projectLocator.UseOrFindAppHostProjectFileAsync(
+            projectFile: null,
+            multipleAppHostProjectsFoundBehavior: MultipleAppHostProjectsFoundBehavior.Prompt,
+            createSettingsFile: false,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(targetAppHostProjectFile.FullName, result.SelectedProjectFile?.FullName);
+        var candidate = Assert.Single(result.AllProjectFileCandidates);
+        Assert.Equal(targetAppHostProjectFile.FullName, candidate.FullName);
+    }
+
+    [Fact]
+    public async Task UseOrFindAppHostProjectFileScansWhenCandidateListingModeHasValidSettings()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var targetAppHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("TargetAppHost");
+        var targetAppHostProjectFile = new FileInfo(Path.Combine(targetAppHostDirectory.FullName, "TargetAppHost.csproj"));
+        await File.WriteAllTextAsync(targetAppHostProjectFile.FullName, "Not a real apphost");
+
+        var otherAppHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("OtherAppHost");
+        var otherAppHostProjectFile = new FileInfo(Path.Combine(otherAppHostDirectory.FullName, "OtherAppHost.csproj"));
+        await File.WriteAllTextAsync(otherAppHostProjectFile.FullName, "Not a real apphost");
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new
+        {
+            appHost = new
+            {
+                path = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, targetAppHostProjectFile.FullName).Replace(Path.DirectorySeparatorChar, '/')
+            }
+        }));
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext);
+
+        var result = await projectLocator.UseOrFindAppHostProjectFileAsync(
+            projectFile: null,
+            multipleAppHostProjectsFoundBehavior: MultipleAppHostProjectsFoundBehavior.None,
+            createSettingsFile: false,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(targetAppHostProjectFile.FullName, result.SelectedProjectFile?.FullName);
+        Assert.Equal(2, result.AllProjectFileCandidates.Count);
+        Assert.Contains(result.AllProjectFileCandidates, file => file.FullName == targetAppHostProjectFile.FullName);
+        Assert.Contains(result.AllProjectFileCandidates, file => file.FullName == otherAppHostProjectFile.FullName);
+    }
+
+    [Fact]
+    public async Task UseOrFindAppHostProjectFileIncludesSettingsAppHostInCandidatesWhenOutsideDiscovery()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Settings AppHost lives in the workspace root.
+        var settingsAppHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "SettingsAppHost.csproj"));
+        await File.WriteAllTextAsync(settingsAppHostFile.FullName, "Not a real apphost");
+
+        // CLI working directory is a subdirectory; discovery from there cannot reach files in the parent.
+        var workingDirectory = workspace.WorkspaceRoot.CreateSubdirectory("WorkingDir");
+
+        var configPath = Path.Combine(workingDirectory.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new
+        {
+            appHost = new
+            {
+                path = "../SettingsAppHost.csproj"
+            }
+        }));
+
+        var executionContext = CreateExecutionContext(workingDirectory);
+        var projectLocator = CreateProjectLocator(executionContext);
+
+        var result = await projectLocator.UseOrFindAppHostProjectFileAsync(
+            projectFile: null,
+            multipleAppHostProjectsFoundBehavior: MultipleAppHostProjectsFoundBehavior.None,
+            createSettingsFile: false,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(settingsAppHostFile.FullName, result.SelectedProjectFile?.FullName);
+        Assert.Contains(result.AllProjectFileCandidates, file => file.FullName == settingsAppHostFile.FullName);
+    }
+
+    [Fact]
     public async Task UseOrFindAppHostProjectFileNormalizesForwardSlashesInSettings()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -801,6 +910,27 @@ builder.Build().Run();");
                 ? Path.Combine(executionContext.HomeDirectory.FullName, ".aspire", AspireConfigFile.FileName)
                 : Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName);
         }
+    }
+
+    private sealed class ThrowingLanguageDiscovery : ILanguageDiscovery
+    {
+        public Task<IEnumerable<LanguageInfo>> GetAvailableLanguagesAsync(CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Recursive AppHost discovery should not run when a valid configured AppHost path exists.");
+
+        public Task<string?> GetPackageForLanguageAsync(LanguageId languageId, CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(null);
+
+        public Task<LanguageId?> DetectLanguageAsync(DirectoryInfo directory, CancellationToken cancellationToken = default)
+            => Task.FromResult<LanguageId?>(null);
+
+        public Task<LanguageId?> DetectLanguageRecursiveAsync(DirectoryInfo directory, CancellationToken cancellationToken = default)
+            => Task.FromResult<LanguageId?>(null);
+
+        public LanguageInfo? GetLanguageById(LanguageId languageId)
+            => null;
+
+        public LanguageInfo? GetLanguageByFile(FileInfo file)
+            => null;
     }
 
     private static ProjectLocator CreateProjectLocatorWithSingleFileEnabled(CliExecutionContext executionContext, Func<FileInfo, AppHostValidationResult>? validateCallback = null)
@@ -1510,12 +1640,13 @@ builder.Build().Run();");
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
         var projectLocator = CreateProjectLocator(executionContext);
 
-        // With Prompt behavior and a valid cached selection, should use the cached one
+        // With Prompt behavior and a valid cached selection, should use the cached one without scanning
         var result = await projectLocator.UseOrFindAppHostProjectFileAsync(null, MultipleAppHostProjectsFoundBehavior.Prompt, createSettingsFile: false, CancellationToken.None).DefaultTimeout();
 
         Assert.NotNull(result.SelectedProjectFile);
         Assert.Equal(appHost1File.FullName, result.SelectedProjectFile!.FullName);
-        Assert.Equal(2, result.AllProjectFileCandidates.Count);
+        var candidate = Assert.Single(result.AllProjectFileCandidates);
+        Assert.Equal(appHost1File.FullName, candidate.FullName);
     }
 
     private static ProjectLocator CreateProjectLocator(

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -260,6 +260,131 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UseOrFindAppHostProjectFileUsesValidSettingsWithoutScanningInThrowMode()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var targetAppHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("TargetAppHost");
+        var targetAppHostProjectFile = new FileInfo(Path.Combine(targetAppHostDirectory.FullName, "TargetAppHost.csproj"));
+        await File.WriteAllTextAsync(targetAppHostProjectFile.FullName, "Not a real apphost");
+
+        var decoyAppHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("DecoyAppHost");
+        var decoyAppHostProjectFile = new FileInfo(Path.Combine(decoyAppHostDirectory.FullName, "DecoyAppHost.csproj"));
+        await File.WriteAllTextAsync(decoyAppHostProjectFile.FullName, "Not a real apphost");
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new
+        {
+            appHost = new
+            {
+                path = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, targetAppHostProjectFile.FullName).Replace(Path.DirectorySeparatorChar, '/')
+            }
+        }));
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(
+            executionContext,
+            languageDiscovery: new ThrowingLanguageDiscovery());
+
+        var result = await projectLocator.UseOrFindAppHostProjectFileAsync(
+            projectFile: null,
+            multipleAppHostProjectsFoundBehavior: MultipleAppHostProjectsFoundBehavior.Throw,
+            createSettingsFile: false,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(targetAppHostProjectFile.FullName, result.SelectedProjectFile?.FullName);
+        var candidate = Assert.Single(result.AllProjectFileCandidates);
+        Assert.Equal(targetAppHostProjectFile.FullName, candidate.FullName);
+    }
+
+    [Fact]
+    public async Task UseOrFindAppHostProjectFileUsesValidGuestAppHostSettingsWithoutScanning()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var guestAppHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        await File.WriteAllTextAsync(guestAppHostFile.FullName, "// guest apphost");
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new
+        {
+            appHost = new
+            {
+                path = "apphost.ts"
+            }
+        }));
+
+        var projectFactory = new GuestAppHostFileProjectFactory("apphost.ts");
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(
+            executionContext,
+            projectFactory: projectFactory,
+            languageDiscovery: new ThrowingLanguageDiscovery());
+
+        var result = await projectLocator.UseOrFindAppHostProjectFileAsync(
+            projectFile: null,
+            multipleAppHostProjectsFoundBehavior: MultipleAppHostProjectsFoundBehavior.Prompt,
+            createSettingsFile: false,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(guestAppHostFile.FullName, result.SelectedProjectFile?.FullName);
+        var candidate = Assert.Single(result.AllProjectFileCandidates);
+        Assert.Equal(guestAppHostFile.FullName, candidate.FullName);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task UseOrFindAppHostProjectFileFallsBackToDiscoveryWhenConfiguredAppHostIsInvalid(bool isUnsupported, bool isPossiblyUnbuildable)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configuredAppHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("ConfiguredAppHost");
+        var configuredAppHostProjectFile = new FileInfo(Path.Combine(configuredAppHostDirectory.FullName, "ConfiguredAppHost.csproj"));
+        await File.WriteAllTextAsync(configuredAppHostProjectFile.FullName, "Not a real apphost");
+
+        var realAppHostProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "RealAppHost.csproj"));
+        await File.WriteAllTextAsync(realAppHostProjectFile.FullName, "Not a real apphost");
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new
+        {
+            appHost = new
+            {
+                path = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, configuredAppHostProjectFile.FullName).Replace(Path.DirectorySeparatorChar, '/')
+            }
+        }));
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = projectFile =>
+            {
+                if (projectFile.FullName == realAppHostProjectFile.FullName)
+                {
+                    return new AppHostValidationResult(IsValid: true);
+                }
+                if (projectFile.FullName == configuredAppHostProjectFile.FullName)
+                {
+                    return new AppHostValidationResult(IsValid: false, IsUnsupported: isUnsupported, IsPossiblyUnbuildable: isPossiblyUnbuildable);
+                }
+                return new AppHostValidationResult(IsValid: false);
+            }
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var result = await projectLocator.UseOrFindAppHostProjectFileAsync(
+            projectFile: null,
+            multipleAppHostProjectsFoundBehavior: MultipleAppHostProjectsFoundBehavior.None,
+            createSettingsFile: false,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(realAppHostProjectFile.FullName, result.SelectedProjectFile?.FullName);
+    }
+
+    [Fact]
     public async Task UseOrFindAppHostProjectFileScansWhenCandidateListingModeHasValidSettings()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -931,6 +1056,74 @@ builder.Build().Run();");
 
         public LanguageInfo? GetLanguageByFile(FileInfo file)
             => null;
+    }
+
+    private sealed class GuestAppHostFileProjectFactory : IAppHostProjectFactory
+    {
+        private readonly string _supportedFileName;
+        private readonly GuestAppHostTestProject _project;
+
+        public GuestAppHostFileProjectFactory(string supportedFileName)
+        {
+            _supportedFileName = supportedFileName;
+            _project = new GuestAppHostTestProject(supportedFileName);
+        }
+
+        public IAppHostProject GetProject(LanguageInfo language) => _project;
+
+        public IAppHostProject GetProject(FileInfo appHostFile)
+            => TryGetProject(appHostFile) ?? throw new NotSupportedException($"No handler available for AppHost file '{appHostFile.Name}'.");
+
+        public IAppHostProject? TryGetProject(FileInfo appHostFile)
+            => appHostFile.Name.Equals(_supportedFileName, StringComparison.OrdinalIgnoreCase) ? _project : null;
+
+        public IAppHostProject? GetProjectByLanguageId(string languageId)
+            => string.Equals(languageId, _project.LanguageId, StringComparison.OrdinalIgnoreCase) ? _project : null;
+
+        public IEnumerable<IAppHostProject> GetAllProjects() => [_project];
+
+        private sealed class GuestAppHostTestProject(string supportedFileName) : IAppHostProject
+        {
+            public bool IsUnsupported { get; set; }
+            public string LanguageId => "typescript";
+            public string DisplayName => "TypeScript";
+            public string? AppHostFileName => supportedFileName;
+
+            public bool IsUsingProjectReferences(FileInfo appHostFile) => false;
+
+            public Task<string[]> GetDetectionPatternsAsync(CancellationToken cancellationToken)
+                => Task.FromResult<string[]>([supportedFileName]);
+
+            public bool CanHandle(FileInfo appHostFile)
+                => appHostFile.Name.Equals(supportedFileName, StringComparison.OrdinalIgnoreCase);
+
+            public Task ScaffoldAsync(DirectoryInfo directory, string? projectName, CancellationToken cancellationToken)
+                => throw new NotImplementedException();
+
+            public Task<int> RunAsync(AppHostProjectContext context, CancellationToken cancellationToken)
+                => throw new NotImplementedException();
+
+            public Task<int> PublishAsync(PublishContext context, CancellationToken cancellationToken)
+                => throw new NotImplementedException();
+
+            public Task<IReadOnlyList<(string PackageId, string Version)>> GetPackageReferencesAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+                => throw new NotImplementedException();
+
+            public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+                => Task.FromResult(new AppHostValidationResult(IsValid: appHostFile.Name.Equals(supportedFileName, StringComparison.OrdinalIgnoreCase)));
+
+            public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)
+                => throw new NotImplementedException();
+
+            public Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken)
+                => throw new NotImplementedException();
+
+            public Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
+                => Task.FromResult(RunningInstanceResult.NoRunningInstance);
+
+            public Task<string?> GetUserSecretsIdAsync(FileInfo appHostFile, bool autoInit, CancellationToken cancellationToken)
+                => Task.FromResult<string?>(null);
+        }
     }
 
     private static ProjectLocator CreateProjectLocatorWithSingleFileEnabled(CliExecutionContext executionContext, Func<FileInfo, AppHostValidationResult>? validateCallback = null)


### PR DESCRIPTION
## Description

Updates AppHost resolution so a valid AppHost path from `aspire.config.json` is validated and used directly for normal CLI resolution instead of continuing into recursive AppHost discovery. This avoids expensive scanning when TypeScript or Python AppHosts already have a configured path.

The change also preserves candidate-listing behavior for callers that intentionally request all AppHost candidates, while still selecting the configured AppHost when it is among the discovered candidates. Stale or invalid configured paths now fall back to discovery instead of being accepted blindly.

Validation:

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.UseOrFindAppHostProjectFileFallsBackWhenSettingsFileSpecifiesExistingNonAppHost" --filter-method "*.UseOrFindAppHostProjectFileScansWhenCandidateListingModeHasValidSettings" --filter-method "*.UseOrFindAppHostProjectFileUsesValidSettingsWithoutScanning" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ProjectLocatorTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.RunCommandTests" --filter-class "*.ExtensionInternalCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Manual TypeScript AppHost repro in `~/tmp/Issue16595ConfiguredAppHost` confirmed the configured `apphost.ts` is used without scanning.

Fixes #16595

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
