### PR TITLE
Disable VS Code extension auto-restore by default

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -750,7 +750,7 @@
         },
         "aspire.enableAutoRestore": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "%configuration.aspire.enableAutoRestore%",
           "scope": "window"
         }

--- a/extension/src/utils/settings.ts
+++ b/extension/src/utils/settings.ts
@@ -17,5 +17,5 @@ export function getRegisterMcpServerInWorkspace(): boolean {
 }
 
 export function getEnableAutoRestore(): boolean {
-    return getAspireConfig().get<boolean>('enableAutoRestore', true);
+    return getAspireConfig().get<boolean>('enableAutoRestore', false);
 }


### PR DESCRIPTION
## Description

Changes the default value of the `aspire.enableAutoRestore` VS Code extension setting from `true` to `false`. The extension will no longer automatically run `aspire restore` when the workspace opens or when `aspire.config.json` changes. Users who want this behavior can opt in via the setting.

Fixes #16338

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
