### PR TITLE
Remove Aspire MCP repo configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,5 @@
 {
   "servers": {
-    "aspire": {
-      "type": "stdio",
-      "command": "aspire",
-      "args": ["agent", "mcp"]
-    },
     "hex1b": {
       "type": "stdio",
       "command": "dnx",


### PR DESCRIPTION
## Description

Removes the top-level `aspire` MCP server entry from the repository MCP configuration. This leaves the remaining repo-configured MCP servers intact.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
