### PR TITLE
Fix sticky 'Finding apphosts' notification in VS Code extension

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -51,7 +51,7 @@ internal sealed class ProjectLocator(
     {
         using var activity = telemetry.StartDiagnosticActivity();
 
-        return await interactionService.ShowStatusAsync(InteractionServiceStrings.SearchingProjects, async () =>
+        return await interactionService.ShowStatusAsync(InteractionServiceStrings.FindingAppHosts, async () =>
         {
             var appHostProjects = new List<FileInfo>();
             var unbuildableSuspectedAppHostProjects = new List<FileInfo>();
@@ -63,8 +63,6 @@ internal sealed class ProjectLocator(
                 RecurseSubdirectories = true,
                 IgnoreInaccessible = true
             };
-
-            interactionService.DisplayMessage(KnownEmojis.MagnifyingGlassTiltedLeft, InteractionServiceStrings.FindingAppHosts);
 
             using var validationCancellationTokenSource = stopAfterMultipleBuildableAppHosts
                 ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)


### PR DESCRIPTION
## Description

When the CLI runs inside the VS Code extension, `ProjectLocator.FindAppHostProjectFilesAsync` displayed a "🔍 Finding apphosts..." message via `interactionService.DisplayMessage`. The extension renders `displayMessage` as `vscode.window.showInformationMessage`, which is a sticky toast with no programmatic dismissal — so the notification stayed up indefinitely after the search completed.

The same method was already inside an `ShowStatusAsync` block whose status text was the more generic `"Searching..."`. `ShowStatusAsync` is rendered by the extension as a `vscode.window.withProgress` notification that the CLI dismisses via `Backchannel.ShowStatusAsync(null, ...)` in the `finally` block of `ExtensionInteractionService.ShowStatusAsync`.

This change folds the "Finding AppHosts..." text into the existing `ShowStatusAsync` call and removes the redundant `DisplayMessage`, so the user sees a single progress notification that auto-dismisses when the search completes.

Console UX is unchanged in spirit: previously users saw a `Searching...` spinner plus a persistent `🔍 Finding apphosts...` line; now they see only the spinner labeled `Finding AppHosts...`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No — existing `ProjectLocatorTests` and `ExecCommandTests` (which asserts on `FindingAppHosts`) cover the relevant paths and continue to pass. No new behavior to assert.
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
