### PR TITLE
Fix Aspire new empty AppHost language picker

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -115,7 +115,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         _languageOption = new Option<string?>("--language")
         {
-            Description = NewCommandStrings.LanguageOptionDescription
+            Description = NewCommandStrings.LanguageOptionDescription,
+            Recursive = true
         };
         Options.Add(_languageOption);
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -224,22 +224,20 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return (true, selectedLanguageId);
     }
 
-    private ITemplate[] GetTemplatesForPrompt(ITemplate[] availableTemplates, ParseResult parseResult)
+    private ITemplate[] GetTemplatesForTemplateArgument(ITemplate[] availableTemplates, ParseResult parseResult)
     {
         var explicitLanguageId = ParseExplicitLanguageId(parseResult);
-        var templatesForPrompt = availableTemplates
-            .Where(static t => t.ShowInPrompt)
-            .ToList();
+        var templates = availableTemplates.ToList();
 
         if (!string.IsNullOrWhiteSpace(explicitLanguageId))
         {
-            templatesForPrompt = templatesForPrompt
+            templates = templates
                 .Where(t => t.SupportsLanguage(explicitLanguageId))
                 .ToList();
         }
 
         // Sort templates alphabetically by description, keeping empty templates at the end
-        templatesForPrompt.Sort((a, b) =>
+        templates.Sort((a, b) =>
         {
             var aIsEmpty = a.IsEmpty;
             var bIsEmpty = b.IsEmpty;
@@ -252,7 +250,14 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return string.Compare(a.Description, b.Description, StringComparison.OrdinalIgnoreCase);
         });
 
-        return templatesForPrompt.ToArray();
+        return templates.ToArray();
+    }
+
+    private ITemplate[] GetTemplatesForPrompt(ITemplate[] availableTemplates, ParseResult parseResult)
+    {
+        return GetTemplatesForTemplateArgument(availableTemplates, parseResult)
+            .Where(static t => t.ShowInPrompt)
+            .ToArray();
     }
 
     private async Task<ITemplate?> GetProjectTemplateAsync(ITemplate[] availableTemplates, ParseResult parseResult, CancellationToken cancellationToken)
@@ -272,8 +277,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return null;
         }
 
-        var templatesForPrompt = GetTemplatesForPrompt(availableTemplates, parseResult);
-        if (templatesForPrompt.Length == 0)
+        var templatesForTemplateArgument = GetTemplatesForTemplateArgument(availableTemplates, parseResult);
+        if (templatesForTemplateArgument.Length == 0)
         {
             InteractionService.DisplayError("No templates are available for the current environment.");
             return null;
@@ -282,9 +287,16 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
             InteractionService.DisplayError(NewCommandStrings.NonInteractiveTemplateRequired);
-            var templateNames = string.Join(", ", templatesForPrompt.Select(t => t.Name));
+            var templateNames = string.Join(", ", templatesForTemplateArgument.Select(t => t.Name));
             InteractionService.DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveAvailableValues, templateNames));
             throw new NonInteractiveException("template");
+        }
+
+        var templatesForPrompt = GetTemplatesForPrompt(availableTemplates, parseResult);
+        if (templatesForPrompt.Length == 0)
+        {
+            InteractionService.DisplayError("No templates are available for the current environment.");
+            return null;
         }
 
         var result = await _prompter.PromptForTemplateAsync(templatesForPrompt, cancellationToken);

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -152,6 +152,9 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             KnownLanguageId.CSharp => KnownLanguageId.CSharpDisplayName,
             KnownLanguageId.TypeScript => "TypeScript (Node.js)",
             KnownLanguageId.Python => KnownLanguageId.PythonDisplayName,
+            KnownLanguageId.Go => KnownLanguageId.GoDisplayName,
+            KnownLanguageId.Java => KnownLanguageId.JavaDisplayName,
+            KnownLanguageId.Rust => KnownLanguageId.RustDisplayName,
             _ => languageId
         };
     }
@@ -224,7 +227,9 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     private ITemplate[] GetTemplatesForPrompt(ITemplate[] availableTemplates, ParseResult parseResult)
     {
         var explicitLanguageId = ParseExplicitLanguageId(parseResult);
-        var templatesForPrompt = availableTemplates.ToList();
+        var templatesForPrompt = availableTemplates
+            .Where(static t => t.ShowInPrompt)
+            .ToList();
 
         if (!string.IsNullOrWhiteSpace(explicitLanguageId))
         {

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -200,18 +200,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 return (false, null);
             }
 
-            await _configurationService.SetConfigurationAsync("language", normalizedExplicitLanguageId, isGlobal: false, cancellationToken);
             return (true, normalizedExplicitLanguageId);
-        }
-
-        var configuredLanguageId = await _configurationService.GetConfigurationAsync("language", cancellationToken);
-        if (!string.IsNullOrWhiteSpace(configuredLanguageId))
-        {
-            var normalizedConfiguredLanguageId = NormalizeLanguageId(configuredLanguageId);
-            if (template.SelectableAppHostLanguages.Any(l => l.Equals(normalizedConfiguredLanguageId, StringComparison.OrdinalIgnoreCase)))
-            {
-                return (true, normalizedConfiguredLanguageId);
-            }
         }
 
         if (!_hostEnvironment.SupportsInteractiveInput)
@@ -220,7 +209,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         }
 
         var selectedLanguageId = await PromptForAppHostLanguageAsync(template.SelectableAppHostLanguages, cancellationToken);
-        await _configurationService.SetConfigurationAsync("language", selectedLanguageId, isGlobal: false, cancellationToken);
         return (true, selectedLanguageId);
     }
 

--- a/src/Aspire.Cli/Templating/CallbackTemplate.cs
+++ b/src/Aspire.Cli/Templating/CallbackTemplate.cs
@@ -15,13 +15,16 @@ internal class CallbackTemplate(
     string? languageId = null,
     Func<string, bool>? supportsLanguageCallback = null,
     IReadOnlyList<string>? selectableAppHostLanguages = null,
-    bool isEmpty = false) : ITemplate
+    bool isEmpty = false,
+    bool showInPrompt = true) : ITemplate
 {
     public string Name => name;
 
     public string Description => description;
 
     public bool IsEmpty => isEmpty;
+
+    public bool ShowInPrompt => showInPrompt;
 
     public TemplateRuntime Runtime => runtime;
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -17,6 +17,16 @@ namespace Aspire.Cli.Templating;
 
 internal sealed partial class CliTemplateFactory : ITemplateFactory
 {
+    private static readonly string[] s_emptyAppHostLanguages =
+    [
+        KnownLanguageId.CSharp,
+        KnownLanguageId.TypeScript,
+        KnownLanguageId.Python,
+        KnownLanguageId.Go,
+        KnownLanguageId.Java,
+        KnownLanguageId.Rust
+    ];
+
     private static readonly HashSet<string> s_binaryTemplateExtensions =
     [
         ".png",
@@ -105,17 +115,13 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
 
             new CallbackTemplate(
                 KnownTemplateId.CSharpEmptyAppHost,
-                "Empty AppHost",
+                "Empty AppHost (Choose language...)",
                 projectName => $"./{projectName}",
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
-                supportsLanguageCallback: static languageId =>
-                    languageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.TypeScript, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.Python, StringComparison.OrdinalIgnoreCase),
-                selectableAppHostLanguages: [KnownLanguageId.CSharp, KnownLanguageId.TypeScript, KnownLanguageId.Python],
+                supportsLanguageCallback: IsSelectableEmptyAppHostLanguage,
+                selectableAppHostLanguages: GetSelectableEmptyAppHostLanguages(),
                 isEmpty: true),
 
             new CallbackTemplate(
@@ -126,7 +132,19 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
                 languageId: KnownLanguageId.TypeScript,
-                isEmpty: true),
+                isEmpty: true,
+                showInPrompt: false),
+
+            new CallbackTemplate(
+                KnownTemplateId.PythonEmptyAppHost,
+                "Empty (Python AppHost)",
+                projectName => $"./{projectName}",
+                cmd => AddOptionIfMissing(cmd, _localhostTldOption),
+                ApplyEmptyAppHostTemplateAsync,
+                runtime: TemplateRuntime.Cli,
+                languageId: KnownLanguageId.Python,
+                isEmpty: true,
+                showInPrompt: false),
 
             new CallbackTemplate(
                 KnownTemplateId.JavaEmptyAppHost,
@@ -136,7 +154,8 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
                 languageId: KnownLanguageId.Java,
-                isEmpty: true),
+                isEmpty: true,
+                showInPrompt: false),
 
             new CallbackTemplate(
                 KnownTemplateId.GoEmptyAppHost,
@@ -146,7 +165,19 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
                 languageId: KnownLanguageId.Go,
-                isEmpty: true),
+                isEmpty: true,
+                showInPrompt: false),
+
+            new CallbackTemplate(
+                KnownTemplateId.RustEmptyAppHost,
+                "Empty (Rust AppHost)",
+                projectName => $"./{projectName}",
+                cmd => AddOptionIfMissing(cmd, _localhostTldOption),
+                ApplyEmptyAppHostTemplateAsync,
+                runtime: TemplateRuntime.Cli,
+                languageId: KnownLanguageId.Rust,
+                isEmpty: true,
+                showInPrompt: false),
 
             new CallbackTemplate(
                 KnownTemplateId.PythonStarter,
@@ -172,6 +203,18 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
         ];
 
         return templates.Where(IsTemplateAvailable);
+    }
+
+    private IReadOnlyList<string> GetSelectableEmptyAppHostLanguages()
+    {
+        return s_emptyAppHostLanguages
+            .Where(IsSelectableEmptyAppHostLanguage)
+            .ToArray();
+    }
+
+    private bool IsSelectableEmptyAppHostLanguage(string languageId)
+    {
+        return _languageDiscovery.GetLanguageById(new LanguageId(languageId)) is not null;
     }
 
     private bool IsTemplateAvailable(ITemplate template)

--- a/src/Aspire.Cli/Templating/ITemplate.cs
+++ b/src/Aspire.Cli/Templating/ITemplate.cs
@@ -26,6 +26,11 @@ internal interface ITemplate
     bool IsEmpty { get; }
 
     /// <summary>
+    /// Gets a value indicating whether this template should be shown in the interactive template picker.
+    /// </summary>
+    bool ShowInPrompt { get; }
+
+    /// <summary>
     /// Gets the runtime model used to execute this template.
     /// </summary>
     TemplateRuntime Runtime { get; }

--- a/src/Aspire.Cli/Templating/KnownTemplateId.cs
+++ b/src/Aspire.Cli/Templating/KnownTemplateId.cs
@@ -19,6 +19,11 @@ internal static class KnownTemplateId
     public const string TypeScriptEmptyAppHost = "aspire-ts-empty";
 
     /// <summary>
+    /// The template ID for the CLI Python empty AppHost template.
+    /// </summary>
+    public const string PythonEmptyAppHost = "aspire-py-empty";
+
+    /// <summary>
     /// The template ID for the dotnet empty AppHost template.
     /// </summary>
     public const string DotNetEmptyAppHost = "aspire";
@@ -42,6 +47,11 @@ internal static class KnownTemplateId
     /// The template ID for the CLI Go empty AppHost template.
     /// </summary>
     public const string GoEmptyAppHost = "aspire-go-empty";
+
+    /// <summary>
+    /// The template ID for the CLI Rust empty AppHost template.
+    /// </summary>
+    public const string RustEmptyAppHost = "aspire-rust-empty";
 
     /// <summary>
     /// The template ID for the Go starter template (Redis + Go HTTP API).

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1494,6 +1494,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandNonInteractiveWithoutTemplate_DisplaysErrorWithAvailableTemplates()
     {
         TestInteractionService? testInteractionService = null;
+        string? availableTemplatesMessage = null;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CreateServiceCollection(workspace, options =>
@@ -1506,8 +1507,18 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = (sp) =>
             {
-                testInteractionService = new TestInteractionService();
+                testInteractionService = new TestInteractionService
+                {
+                    DisplaySubtleMessageCallback = message => availableTemplatesMessage = message
+                };
                 return testInteractionService;
+            };
+
+            options.FeatureFlagsFactory = _ =>
+            {
+                var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotJava, true);
+                return features;
             };
 
         });
@@ -1522,6 +1533,9 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(testInteractionService);
         Assert.Contains(testInteractionService.DisplayedErrors,
             e => string.Equals(e, NewCommandStrings.NonInteractiveTemplateRequired, StringComparison.Ordinal));
+        Assert.NotNull(availableTemplatesMessage);
+        Assert.Contains(KnownTemplateId.TypeScriptEmptyAppHost, availableTemplatesMessage);
+        Assert.Contains(KnownTemplateId.JavaEmptyAppHost, availableTemplatesMessage);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1044,6 +1044,34 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithExplicitLanguageAfterEmptyTemplateSubcommandCreatesTypeScriptAppHost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? scaffoldedLanguageId = null;
+
+        var services = CreateServiceCollection(workspace);
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                scaffoldedLanguageId = context.Language.LanguageId.Value;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output . --language typescript --localhost-tld false --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(KnownLanguageId.TypeScript, scaffoldedLanguageId);
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
+    }
+
+    [Fact]
     public async Task NewCommandWithExplicitJavaEmptyTemplateCreatesJavaAppHost()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -817,6 +817,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain((KnownTemplateId.JavaEmptyAppHost, "Empty (Java AppHost)"), promptedTemplates);
         Assert.Contains((KnownTemplateId.TypeScriptStarter, "Starter App (Express/React, TypeScript AppHost)"), promptedTemplates);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
+        Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json")));
     }
 
     [Fact]
@@ -983,6 +984,63 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains(KnownLanguageId.JavaDisplayName, promptedLanguages);
         Assert.DoesNotContain(KnownLanguageId.GoDisplayName, promptedLanguages);
         Assert.DoesNotContain(KnownLanguageId.RustDisplayName, promptedLanguages);
+    }
+
+    [Fact]
+    public async Task NewCommandWithEmptyTemplateIgnoresConfiguredLanguage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json"), """
+            {
+              "language": "typescript/nodejs"
+            }
+            """);
+
+        var languagePrompted = false;
+        string? scaffoldedLanguageId = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.FeatureFlagsFactory = _ =>
+            {
+                var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotJava, true);
+                return features;
+            };
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
+                {
+                    if (promptText == "Which language would you like to use?")
+                    {
+                        languagePrompted = true;
+                        return choices.Cast<object>().Single(choice => string.Equals(choiceFormatter(choice), KnownLanguageId.JavaDisplayName, StringComparison.Ordinal));
+                    }
+
+                    return choices.Cast<object>().First();
+                }
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                scaffoldedLanguageId = context.Language.LanguageId.Value;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "AppHost.java"), "package aspire;");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output .");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(languagePrompted);
+        Assert.Equal(KnownLanguageId.Java, scaffoldedLanguageId);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -767,6 +767,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var services = CreateServiceCollection(workspace, options =>
         {
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.FeatureFlagsFactory = _ =>
+            {
+                var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotJava, true);
+                return features;
+            };
             options.InteractionServiceFactory = _ => new TestInteractionService
             {
                 PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
@@ -808,6 +814,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(promptedTemplates);
         Assert.Contains((KnownTemplateId.CSharpEmptyAppHost, "Empty AppHost (Choose language...)"), promptedTemplates);
         Assert.DoesNotContain((KnownTemplateId.TypeScriptEmptyAppHost, "Empty (TypeScript AppHost)"), promptedTemplates);
+        Assert.DoesNotContain((KnownTemplateId.JavaEmptyAppHost, "Empty (Java AppHost)"), promptedTemplates);
         Assert.Contains((KnownTemplateId.TypeScriptStarter, "Starter App (Express/React, TypeScript AppHost)"), promptedTemplates);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
     }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -46,7 +46,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.FeatureFlagsFactory = _ =>
             {
                 var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotGo, true);
                 features.SetFeature(KnownFeatures.ExperimentalPolyglotJava, true);
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotPython, true);
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotRust, true);
                 return features;
             };
 
@@ -55,9 +58,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var command = provider.GetRequiredService<NewCommand>();
         Assert.NotEmpty(command.Subcommands);
-        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.CSharpEmptyAppHost && subcommand.Description == "Empty AppHost");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.CSharpEmptyAppHost && subcommand.Description == "Empty AppHost (Choose language...)");
         Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.TypeScriptEmptyAppHost && subcommand.Description == "Empty (TypeScript AppHost)");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.PythonEmptyAppHost && subcommand.Description == "Empty (Python AppHost)");
         Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.JavaEmptyAppHost && subcommand.Description == "Empty (Java AppHost)");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.GoEmptyAppHost && subcommand.Description == "Empty (Go AppHost)");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.RustEmptyAppHost && subcommand.Description == "Empty (Rust AppHost)");
     }
 
     [Fact]
@@ -763,7 +769,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.InteractionServiceFactory = _ => new TestInteractionService
             {
-                PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) => choices.Cast<object>().First()
+                PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
+                    promptText == "Which language would you like to use?"
+                        ? choices.Cast<object>().Single(choice => choiceFormatter(choice).Contains("TypeScript", StringComparison.Ordinal))
+                        : choices.Cast<object>().First()
             };
             options.NewCommandPrompterFactory = (sp) =>
             {
@@ -772,7 +781,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 prompter.PromptForTemplateCallback = templates =>
                 {
                     promptedTemplates = templates.Select(t => (t.Name, t.Description)).ToArray();
-                    return templates.Single(t => t.Name.Equals(KnownTemplateId.TypeScriptEmptyAppHost, StringComparison.OrdinalIgnoreCase));
+                    return templates.Single(t => t.Name.Equals(KnownTemplateId.CSharpEmptyAppHost, StringComparison.OrdinalIgnoreCase));
                 };
 
                 return prompter;
@@ -797,8 +806,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal(KnownLanguageId.TypeScript, scaffoldedLanguageId);
         Assert.NotNull(promptedTemplates);
-        Assert.Contains((KnownTemplateId.CSharpEmptyAppHost, "Empty AppHost"), promptedTemplates);
-        Assert.Contains((KnownTemplateId.TypeScriptEmptyAppHost, "Empty (TypeScript AppHost)"), promptedTemplates);
+        Assert.Contains((KnownTemplateId.CSharpEmptyAppHost, "Empty AppHost (Choose language...)"), promptedTemplates);
+        Assert.DoesNotContain((KnownTemplateId.TypeScriptEmptyAppHost, "Empty (TypeScript AppHost)"), promptedTemplates);
         Assert.Contains((KnownTemplateId.TypeScriptStarter, "Starter App (Express/React, TypeScript AppHost)"), promptedTemplates);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
     }
@@ -817,12 +826,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Contains(command.Subcommands, subcommand => subcommand.Name == "aspire-test");
         Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.DotNetEmptyAppHost && subcommand.Description == "Empty (C# AppHost, dotnet template)");
-        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.CSharpEmptyAppHost && subcommand.Description == "Empty AppHost");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.CSharpEmptyAppHost && subcommand.Description == "Empty AppHost (Choose language...)");
         Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.TypeScriptEmptyAppHost && subcommand.Description == "Empty (TypeScript AppHost)");
     }
 
     [Fact]
-    public async Task NewCommandWithoutTemplatePromptsWithDistinctLanguageSpecificEmptyDescriptions()
+    public async Task NewCommandWithoutTemplatePromptsWithSingleGenericEmptyTemplate()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         string[]? promptedTemplateDescriptions = null;
@@ -830,6 +839,15 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var services = CreateServiceCollection(workspace, options =>
         {
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.FeatureFlagsFactory = _ =>
+            {
+                var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotGo, true);
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotJava, true);
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotPython, true);
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotRust, true);
+                return features;
+            };
             options.InteractionServiceFactory = _ => new TestInteractionService();
             options.NewCommandPrompterFactory = (sp) =>
             {
@@ -838,7 +856,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 prompter.PromptForTemplateCallback = templates =>
                 {
                     promptedTemplateDescriptions = templates
-                        .Where(t => t.Name is KnownTemplateId.CSharpEmptyAppHost or KnownTemplateId.TypeScriptEmptyAppHost)
+                        .Where(t => t.IsEmpty)
                         .Select(t => t.Description)
                         .ToArray();
                     return templates.Single(t => t.Name.Equals(KnownTemplateId.CSharpEmptyAppHost, StringComparison.OrdinalIgnoreCase));
@@ -855,8 +873,109 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.NotNull(promptedTemplateDescriptions);
-        Assert.Contains("Empty AppHost", promptedTemplateDescriptions);
-        Assert.Contains("Empty (TypeScript AppHost)", promptedTemplateDescriptions);
+        Assert.Equal(["Empty AppHost (Choose language...)"], promptedTemplateDescriptions);
+    }
+
+    [Fact]
+    public async Task NewCommandWithEmptyTemplateOmitsDisabledLanguagesFromLanguagePrompt()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string[]? promptedLanguages = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
+                {
+                    if (promptText == "Which language would you like to use?")
+                    {
+                        promptedLanguages = choices.Cast<object>()
+                            .Select(choice => choiceFormatter(choice))
+                            .ToArray();
+                    }
+
+                    return choices.Cast<object>().First();
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output .");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.NotNull(promptedLanguages);
+        Assert.Contains(KnownLanguageId.CSharpDisplayName, promptedLanguages);
+        Assert.Contains("TypeScript (Node.js)", promptedLanguages);
+        Assert.DoesNotContain(KnownLanguageId.PythonDisplayName, promptedLanguages);
+        Assert.DoesNotContain(KnownLanguageId.JavaDisplayName, promptedLanguages);
+        Assert.DoesNotContain(KnownLanguageId.GoDisplayName, promptedLanguages);
+        Assert.DoesNotContain(KnownLanguageId.RustDisplayName, promptedLanguages);
+    }
+
+    [Fact]
+    public async Task NewCommandWithEmptyTemplatePromptsForEnabledLanguages()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string[]? promptedLanguages = null;
+        string? scaffoldedLanguageId = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.FeatureFlagsFactory = _ =>
+            {
+                var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotJava, true);
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotPython, true);
+                return features;
+            };
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
+                {
+                    var formattedChoices = choices.Cast<object>()
+                        .Select(choice => choiceFormatter(choice))
+                        .ToArray();
+
+                    if (promptText == "Which language would you like to use?")
+                    {
+                        promptedLanguages = formattedChoices;
+                        return choices.Cast<object>().Single(choice => string.Equals(choiceFormatter(choice), KnownLanguageId.JavaDisplayName, StringComparison.Ordinal));
+                    }
+
+                    return choices.Cast<object>().First();
+                }
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                scaffoldedLanguageId = context.Language.LanguageId.Value;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "AppHost.java"), "package aspire;");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output .");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(KnownLanguageId.Java, scaffoldedLanguageId);
+        Assert.NotNull(promptedLanguages);
+        Assert.Contains(KnownLanguageId.CSharpDisplayName, promptedLanguages);
+        Assert.Contains("TypeScript (Node.js)", promptedLanguages);
+        Assert.Contains(KnownLanguageId.PythonDisplayName, promptedLanguages);
+        Assert.Contains(KnownLanguageId.JavaDisplayName, promptedLanguages);
+        Assert.DoesNotContain(KnownLanguageId.GoDisplayName, promptedLanguages);
+        Assert.DoesNotContain(KnownLanguageId.RustDisplayName, promptedLanguages);
     }
 
     [Fact]
@@ -894,6 +1013,42 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal(KnownLanguageId.Java, scaffoldedLanguageId);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.java")));
+    }
+
+    [Fact]
+    public async Task NewCommandWithExplicitPythonEmptyTemplateCreatesPythonAppHost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? scaffoldedLanguageId = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.FeatureFlagsFactory = _ =>
+            {
+                var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotPython, true);
+                return features;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                scaffoldedLanguageId = context.Language.LanguageId.Value;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.py"), "# test apphost");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-py-empty --name TestApp --output . --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(KnownLanguageId.Python, scaffoldedLanguageId);
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.py")));
     }
 
     [Fact]

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -584,20 +584,24 @@ internal static class Hex1bAutomatorTestHelpers
                 break;
 
             case AspireTemplate.TypeScriptEmptyAppHost:
-                await auto.TypeAsync("Empty (TypeScript");
+                await auto.TypeAsync("Empty AppHost");
+                await auto.EnterAsync();
                 await auto.WaitUntilAsync(
-                    s => new CellPatternSearcher().Find("> Empty (TypeScript AppHost)").Search(s).Count > 0,
-                    timeout: TimeSpan.FromSeconds(5),
-                    description: "TypeScript Empty AppHost template selected");
+                    s => new CellPatternSearcher().Find("Which language would you like to use?").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(10),
+                    description: "AppHost language prompt");
+                await auto.TypeAsync("TypeScript");
                 await auto.EnterAsync();
                 break;
 
             case AspireTemplate.JavaEmptyAppHost:
-                await auto.TypeAsync("Empty (Java AppHost)");
+                await auto.TypeAsync("Empty AppHost");
+                await auto.EnterAsync();
                 await auto.WaitUntilAsync(
-                    s => new CellPatternSearcher().Find("> Empty (Java AppHost)").Search(s).Count > 0,
-                    timeout: TimeSpan.FromSeconds(5),
-                    description: "Java Empty AppHost template selected");
+                    s => new CellPatternSearcher().Find("Which language would you like to use?").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(10),
+                    description: "AppHost language prompt");
+                await auto.TypeAsync("Java");
                 await auto.EnterAsync();
                 break;
 

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -52,7 +52,7 @@ internal enum AspireTemplate
 
     /// <summary>
     /// Empty (TypeScript AppHost).
-    /// Prompts: template, project name, output path, URLs. No language, Redis, or test project prompt.
+    /// Prompts: template, language, project name, output path, URLs. No Redis or test project prompt.
     /// </summary>
     TypeScriptEmptyAppHost,
 
@@ -63,8 +63,8 @@ internal enum AspireTemplate
     EmptyAppHost,
 
     /// <summary>
-    /// Empty (Java AppHost) — visible only when experimental Java support is enabled.
-    /// Prompts: template, project name, output path, URLs. No Redis or test project prompt.
+    /// Empty (Java AppHost) — visible only in the language picker when experimental Java support is enabled.
+    /// Prompts: template, language, project name, output path, URLs. No Redis or test project prompt.
     /// </summary>
     JavaEmptyAppHost,
 }
@@ -456,18 +456,18 @@ internal static class Hex1bTestHelpers
                 break;
 
             case AspireTemplate.TypeScriptEmptyAppHost:
-                var typeScriptEmptyAppHostSelected = new CellPatternSearcher()
-                    .Find("> Empty (TypeScript AppHost)");
-                builder.Type("Empty (TypeScript")
-                    .WaitUntil(s => typeScriptEmptyAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                builder.Type("Empty AppHost")
+                    .Enter()
+                    .WaitUntil(s => waitingForAppHostLanguagePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                    .Type("TypeScript")
                     .Enter();
                 break;
 
             case AspireTemplate.JavaEmptyAppHost:
-                var javaEmptyAppHostSelected = new CellPatternSearcher()
-                    .Find("> Empty (Java AppHost)");
-                builder.Type("Empty (Java AppHost)")
-                    .WaitUntil(s => javaEmptyAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                builder.Type("Empty AppHost")
+                    .Enter()
+                    .WaitUntil(s => waitingForAppHostLanguagePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                    .Type("Java")
                     .Enter();
                 break;
         }


### PR DESCRIPTION
## Description

Updates `aspire new` so empty AppHost creation has one interactive top-level entry: `Empty AppHost (Choose language...)`. The follow-up language picker now only includes enabled AppHost languages, while language-specific shortcut callback templates remain registered for direct/non-interactive creation.

Also adds missing direct shortcut template IDs for Python and Rust empty AppHosts and updates the `aspire new` unit tests plus shared E2E helper selection logic for the new flow.

Fixes #16661
Fixes #16662

Validation:

- `.\restore.cmd`
- `dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.NewCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build tests\Aspire.Cli.EndToEnd.Tests\Aspire.Cli.EndToEnd.Tests.csproj /p:SkipNativeBuild=true`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
