### PR TITLE
Show AppHost code lenses without opening the panel; add Open Dashboard / View Logs lenses

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -340,11 +340,11 @@
     <trans-unit id="command.openAppHostSource">
       <source xml:lang="en">Open AppHost source</source>
     </trans-unit>
-    <trans-unit id="command.openDashboard">
+    <trans-unit id="command.codeLensOpenDashboard">
       <source xml:lang="en">Open Aspire Dashboard</source>
     </trans-unit>
-    <trans-unit id="command.codeLensOpenDashboard">
-      <source xml:lang="en">Open Aspire dashboard</source>
+    <trans-unit id="command.openDashboard">
+      <source xml:lang="en">Open Aspire Dashboard</source>
     </trans-unit>
     <trans-unit id="command.openTerminal">
       <source xml:lang="en">Open Aspire terminal</source>

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -343,6 +343,9 @@
     <trans-unit id="command.openDashboard">
       <source xml:lang="en">Open Aspire Dashboard</source>
     </trans-unit>
+    <trans-unit id="command.codeLensOpenDashboard">
+      <source xml:lang="en">Open Aspire dashboard</source>
+    </trans-unit>
     <trans-unit id="command.openTerminal">
       <source xml:lang="en">Open Aspire terminal</source>
     </trans-unit>
@@ -507,6 +510,9 @@
     </trans-unit>
     <trans-unit id="command.verifyCliInstalled">
       <source xml:lang="en">Verify Aspire CLI installation</source>
+    </trans-unit>
+    <trans-unit id="command.codeLensViewAppHostLogs">
+      <source xml:lang="en">View Aspire AppHost logs</source>
     </trans-unit>
     <trans-unit id="command.codeLensViewLogs">
       <source xml:lang="en">View Aspire resource logs</source>

--- a/extension/package.json
+++ b/extension/package.json
@@ -398,6 +398,16 @@
         "category": "Aspire"
       },
       {
+        "command": "aspire-vscode.codeLensOpenDashboard",
+        "title": "%command.codeLensOpenDashboard%",
+        "category": "Aspire"
+      },
+      {
+        "command": "aspire-vscode.codeLensViewAppHostLogs",
+        "title": "%command.codeLensViewAppHostLogs%",
+        "category": "Aspire"
+      },
+      {
         "command": "aspire-vscode.expandAll",
         "title": "%command.expandAll%",
         "category": "Aspire",
@@ -502,6 +512,14 @@
         },
         {
           "command": "aspire-vscode.codeLensRevealResource",
+          "when": "false"
+        },
+        {
+          "command": "aspire-vscode.codeLensOpenDashboard",
+          "when": "false"
+        },
+        {
+          "command": "aspire-vscode.codeLensViewAppHostLogs",
           "when": "false"
         },
         {

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -161,6 +161,8 @@
   "command.codeLensResourceAction": "Aspire resource action",
   "command.codeLensRevealResource": "Reveal resource in Aspire panel",
   "command.codeLensViewLogs": "View Aspire resource logs",
+  "command.codeLensOpenDashboard": "Open Aspire dashboard",
+  "command.codeLensViewAppHostLogs": "View Aspire AppHost logs",
   "command.expandAll": "Expand all resources",
   "walkthrough.getStarted.title": "Get started with Aspire",
   "walkthrough.getStarted.description": "Learn how to create, run, and monitor distributed applications with Aspire.",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -161,7 +161,7 @@
   "command.codeLensResourceAction": "Aspire resource action",
   "command.codeLensRevealResource": "Reveal resource in Aspire panel",
   "command.codeLensViewLogs": "View Aspire resource logs",
-  "command.codeLensOpenDashboard": "Open Aspire dashboard",
+  "command.codeLensOpenDashboard": "Open Aspire Dashboard",
   "command.codeLensViewAppHostLogs": "View Aspire AppHost logs",
   "command.expandAll": "Expand all resources",
   "walkthrough.getStarted.title": "Get started with Aspire",

--- a/extension/src/editor/AppHostFilePresenceWatcher.ts
+++ b/extension/src/editor/AppHostFilePresenceWatcher.ts
@@ -8,16 +8,47 @@ import { AppHostDataRepository } from '../views/AppHostDataRepository';
  *
  * This is what makes code-lens decorations on a freshly-created AppHost file see live
  * resource state without the user first opening the Aspire side panel.
+ *
+ * The watcher reacts to:
+ *  - editor visibility changes (`onDidChangeVisibleTextEditors`),
+ *  - text edits to a visible document (`onDidChangeTextDocument`, debounced),
+ * so that toggling AppHost-ness by editing the file (e.g. adding the
+ * `DistributedApplication.CreateBuilder` call or the `#:sdk Aspire.AppHost.Sdk`
+ * directive) is picked up without requiring a save or focus change.
  */
 export class AppHostFilePresenceWatcher implements vscode.Disposable {
+    private static readonly _changeDebounceMs = 250;
+
     private readonly _disposables: vscode.Disposable[] = [];
     private _lastValue = false;
+    private _changeTimer: NodeJS.Timeout | undefined;
 
     constructor(private readonly _repository: AppHostDataRepository) {
         this._disposables.push(
             vscode.window.onDidChangeVisibleTextEditors(() => this._update()),
+            vscode.workspace.onDidChangeTextDocument(e => this._onTextDocumentChanged(e)),
         );
         this._update();
+    }
+
+    private _onTextDocumentChanged(event: vscode.TextDocumentChangeEvent): void {
+        // Only re-evaluate when the changed document is currently visible — edits to
+        // background documents cannot change the visible-AppHost state.
+        const isVisible = vscode.window.visibleTextEditors.some(editor => editor.document === event.document);
+        if (!isVisible) {
+            return;
+        }
+        this._scheduleUpdate();
+    }
+
+    private _scheduleUpdate(): void {
+        if (this._changeTimer) {
+            clearTimeout(this._changeTimer);
+        }
+        this._changeTimer = setTimeout(() => {
+            this._changeTimer = undefined;
+            this._update();
+        }, AppHostFilePresenceWatcher._changeDebounceMs);
     }
 
     private _update(): void {
@@ -39,6 +70,10 @@ export class AppHostFilePresenceWatcher implements vscode.Disposable {
     }
 
     dispose(): void {
+        if (this._changeTimer) {
+            clearTimeout(this._changeTimer);
+            this._changeTimer = undefined;
+        }
         this._disposables.forEach(d => d.dispose());
     }
 }

--- a/extension/src/editor/AppHostFilePresenceWatcher.ts
+++ b/extension/src/editor/AppHostFilePresenceWatcher.ts
@@ -1,0 +1,44 @@
+import * as vscode from 'vscode';
+import { getParserForDocument } from './parsers/AppHostResourceParser';
+import { AppHostDataRepository } from '../views/AppHostDataRepository';
+
+/**
+ * Watches the set of visible text editors and reports to {@link AppHostDataRepository}
+ * whether at least one of them is an AppHost file.
+ *
+ * This is what makes code-lens decorations on a freshly-created AppHost file see live
+ * resource state without the user first opening the Aspire side panel.
+ */
+export class AppHostFilePresenceWatcher implements vscode.Disposable {
+    private readonly _disposables: vscode.Disposable[] = [];
+    private _lastValue = false;
+
+    constructor(private readonly _repository: AppHostDataRepository) {
+        this._disposables.push(
+            vscode.window.onDidChangeVisibleTextEditors(() => this._update()),
+        );
+        this._update();
+    }
+
+    private _update(): void {
+        const value = this._anyVisibleEditorIsAppHost();
+        if (value === this._lastValue) {
+            return;
+        }
+        this._lastValue = value;
+        this._repository.setAppHostFileOpen(value);
+    }
+
+    private _anyVisibleEditorIsAppHost(): boolean {
+        for (const editor of vscode.window.visibleTextEditors) {
+            if (getParserForDocument(editor.document)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    dispose(): void {
+        this._disposables.forEach(d => d.dispose());
+    }
+}

--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -58,9 +58,6 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
         }
 
         const resources = parser.parseResources(document);
-        if (resources.length === 0) {
-            return [];
-        }
 
         const appHosts = this._treeProvider.appHosts;
         const workspaceResources = this._treeProvider.workspaceResources;
@@ -70,9 +67,13 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
 
         const lenses: vscode.CodeLens[] = [];
 
-        // Builder-statement lenses (Open Dashboard + View Logs) appear when live data is available.
-        if (hasRunningData) {
-            this._addBuilderStatementLenses(lenses, document, parser, workspaceAppHostPath);
+        // Builder-statement lenses (Open Dashboard + View Logs) appear only when this
+        // document maps to a concretely-running AppHost — independent of whether any
+        // Add* resource calls were found in the file.
+        this._addBuilderStatementLenses(lenses, document, parser, workspaceAppHostPath, workspaceResources);
+
+        if (resources.length === 0) {
+            return lenses;
         }
 
         for (const resource of resources) {
@@ -114,14 +115,21 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
         document: vscode.TextDocument,
         parser: { findBuilderStatementLine?(document: vscode.TextDocument): number | undefined },
         workspaceAppHostPath: string,
+        workspaceResources: readonly ResourceJson[],
     ): void {
         const builderLine = parser.findBuilderStatementLine?.(document);
         if (builderLine === undefined) {
             return;
         }
 
-        // Resolve the AppHost path that this file represents so the commands target the right host.
-        const appHostPath = this._resolveAppHostPathForDocument(document, workspaceAppHostPath);
+        // Only emit the lens when the document maps to a concretely-running AppHost.
+        // This prevents stale lenses on AppHost files whose host is not currently running,
+        // and avoids dispatching commands with a `.cs` source path the CLI cannot resolve.
+        const appHostPath = this._resolveAppHostPathForDocument(document, workspaceAppHostPath, workspaceResources);
+        if (appHostPath === undefined) {
+            return;
+        }
+
         const range = new vscode.Range(builderLine, 0, builderLine, 0);
 
         lenses.push(new vscode.CodeLens(range, {
@@ -140,11 +148,23 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     /**
-     * Determines which running AppHost the given document represents.
-     * Prefers an exact match against `appHosts` (global mode), falls back to the
-     * workspace AppHost path (workspace mode), and finally the document path itself.
+     * Resolves the running-AppHost path that the given document represents, or
+     * `undefined` when the document cannot be tied to a running host.
+     *
+     * Resolution order:
+     *  1. Exact path or same-directory match against {@link AppHostDataRepository.appHosts}
+     *     (covers global mode and any workspace AppHosts that surface there).
+     *  2. The repository's `workspaceAppHostPath` when workspace describe data is live
+     *     and the document lives in the same directory as that AppHost.
+     *
+     * The document path itself is intentionally not used as a fallback — for C#
+     * AppHosts the CLI requires a `.csproj`, not a `.cs` file.
      */
-    private _resolveAppHostPathForDocument(document: vscode.TextDocument, workspaceAppHostPath: string): string {
+    private _resolveAppHostPathForDocument(
+        document: vscode.TextDocument,
+        workspaceAppHostPath: string,
+        workspaceResources: readonly ResourceJson[],
+    ): string | undefined {
         const docPath = document.uri.fsPath;
         const docDir = path.dirname(docPath);
         const match = this._dataRepository.appHosts.find(host => {
@@ -157,10 +177,12 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
         if (match) {
             return match.appHostPath;
         }
-        if (workspaceAppHostPath) {
-            return workspaceAppHostPath;
+        if (workspaceAppHostPath && workspaceResources.length > 0) {
+            if (workspaceAppHostPath === docPath || path.dirname(workspaceAppHostPath) === docDir) {
+                return workspaceAppHostPath;
+            }
         }
-        return docPath;
+        return undefined;
     }
 
     private _addStateLenses(

--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { getParserForDocument } from './parsers/AppHostResourceParser';
 // Import parsers to trigger self-registration
 import './parsers/csharpAppHostParser';
 import './parsers/jsTsAppHostParser';
 import { AspireAppHostTreeProvider } from '../views/AspireAppHostTreeProvider';
-import { ResourceJson, AppHostDisplayInfo, ResourceCommandJson } from '../views/AppHostDataRepository';
+import { AppHostDataRepository, ResourceJson, AppHostDisplayInfo, ResourceCommandJson } from '../views/AppHostDataRepository';
 import { findResourceState, findWorkspaceResourceState } from './resourceStateUtils';
 import { ResourceState, HealthStatus, StateStyle, ResourceType } from './resourceConstants';
 import {
@@ -26,6 +27,8 @@ import {
     codeLensStart,
     codeLensViewLogs,
     codeLensCommand,
+    codeLensOpenDashboard,
+    codeLensViewAppHostLogs,
 } from '../loc/strings';
 
 export class AspireCodeLensProvider implements vscode.CodeLensProvider {
@@ -34,7 +37,10 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
 
     private _disposables: vscode.Disposable[] = [];
 
-    constructor(private readonly _treeProvider: AspireAppHostTreeProvider) {
+    constructor(
+        private readonly _treeProvider: AspireAppHostTreeProvider,
+        private readonly _dataRepository: AppHostDataRepository,
+    ) {
         // Re-compute lenses whenever the polling data changes
         this._disposables.push(
             _treeProvider.onDidChangeTreeData(() => this._onDidChangeCodeLenses.fire())
@@ -63,6 +69,11 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
         const findWorkspace = findWorkspaceResourceState(workspaceResources, workspaceAppHostPath);
 
         const lenses: vscode.CodeLens[] = [];
+
+        // Builder-statement lenses (Open Dashboard + View Logs) appear when live data is available.
+        if (hasRunningData) {
+            this._addBuilderStatementLenses(lenses, document, parser, workspaceAppHostPath);
+        }
 
         for (const resource of resources) {
             // Use statementStartLine to position the CodeLens at the top of a multi-line chain
@@ -96,6 +107,60 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
             tooltip: codeLensDebugPipelineStep,
             arguments: [stepName],
         }));
+    }
+
+    private _addBuilderStatementLenses(
+        lenses: vscode.CodeLens[],
+        document: vscode.TextDocument,
+        parser: { findBuilderStatementLine?(document: vscode.TextDocument): number | undefined },
+        workspaceAppHostPath: string,
+    ): void {
+        const builderLine = parser.findBuilderStatementLine?.(document);
+        if (builderLine === undefined) {
+            return;
+        }
+
+        // Resolve the AppHost path that this file represents so the commands target the right host.
+        const appHostPath = this._resolveAppHostPathForDocument(document, workspaceAppHostPath);
+        const range = new vscode.Range(builderLine, 0, builderLine, 0);
+
+        lenses.push(new vscode.CodeLens(range, {
+            title: codeLensOpenDashboard,
+            command: 'aspire-vscode.codeLensOpenDashboard',
+            tooltip: codeLensOpenDashboard,
+            arguments: [appHostPath],
+        }));
+
+        lenses.push(new vscode.CodeLens(range, {
+            title: codeLensViewAppHostLogs,
+            command: 'aspire-vscode.codeLensViewAppHostLogs',
+            tooltip: codeLensViewAppHostLogs,
+            arguments: [appHostPath],
+        }));
+    }
+
+    /**
+     * Determines which running AppHost the given document represents.
+     * Prefers an exact match against `appHosts` (global mode), falls back to the
+     * workspace AppHost path (workspace mode), and finally the document path itself.
+     */
+    private _resolveAppHostPathForDocument(document: vscode.TextDocument, workspaceAppHostPath: string): string {
+        const docPath = document.uri.fsPath;
+        const docDir = path.dirname(docPath);
+        const match = this._dataRepository.appHosts.find(host => {
+            const hostPath = host.appHostPath;
+            if (!hostPath) {
+                return false;
+            }
+            return hostPath === docPath || path.dirname(hostPath) === docDir;
+        });
+        if (match) {
+            return match.appHostPath;
+        }
+        if (workspaceAppHostPath) {
+            return workspaceAppHostPath;
+        }
+        return docPath;
     }
 
     private _addStateLenses(

--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -77,8 +77,16 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
         }
 
         for (const resource of resources) {
-            // Use statementStartLine to position the CodeLens at the top of a multi-line chain
-            const lensLine = resource.statementStartLine ?? resource.range.start.line;
+            // For pipeline steps the whole statement maps to a single Add*(...) call, so
+            // anchoring at the top of the chain reads naturally. For resources, however,
+            // a single fluent chain can declare several (e.g.
+            // `builder.AddPostgres("pg").AddDatabase("db")`) and collapsing them all to
+            // the chain's start line would stack two state/action lenses on the same
+            // line — the user can't tell which "Stopped" / which "Stop" belongs to which
+            // resource. Anchor each resource lens at its own call line instead.
+            const lensLine = resource.kind === 'pipelineStep'
+                ? (resource.statementStartLine ?? resource.range.start.line)
+                : resource.range.start.line;
             const lineRange = new vscode.Range(lensLine, 0, lensLine, 0);
 
             if (resource.kind === 'pipelineStep') {

--- a/extension/src/editor/AspireGutterDecorationProvider.ts
+++ b/extension/src/editor/AspireGutterDecorationProvider.ts
@@ -50,9 +50,13 @@ function makeGutterSvgUri(category: GutterCategory): vscode.Uri {
             </svg>`;
             break;
         case 'completed':
-            // Pale green checkmark (lighter than running)
+            // Grey hollow circle with a small check inside — conveys "ran, finished cleanly,
+            // not currently active". Deliberately NOT a bright green check so a stopped
+            // resource is never confused with a running one (the previous pale-green check
+            // was visually too similar to 'running' at gutter icon sizes).
             svg = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                <path d="M3 8.5 L6.5 12 L13 4" stroke="#69d1a0" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+                <circle cx="8" cy="8" r="6" fill="none" stroke="#6a737d" stroke-width="1.25"/>
+                <path d="M5 8.5 L7.25 10.5 L11 6" stroke="#6a737d" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>`;
             break;
     }
@@ -166,6 +170,11 @@ export class AspireGutterDecorationProvider implements vscode.Disposable {
             gutterCategories.map(c => [c, []])
         );
 
+        // Track which (line, category) pairs we've already pushed so chained resources
+        // sharing a line don't double-stack identical decorations, and so two resources
+        // declared on the same line keep distinct icons rather than silently overwriting
+        // each other.
+        const seenLineCategories = new Set<string>();
         for (const parsed of resources) {
             if (parsed.kind !== 'resource') {
                 continue;
@@ -178,7 +187,13 @@ export class AspireGutterDecorationProvider implements vscode.Disposable {
 
             const { resource } = match;
             const category = classifyState(resource.state ?? '', resource.stateStyle ?? '', resource.healthStatus ?? '', resource.exitCode);
-            buckets.get(category)!.push({ range: editor.document.lineAt(parsed.range.start.line).range });
+            const line = parsed.range.start.line;
+            const dedupeKey = `${line}:${category}`;
+            if (seenLineCategories.has(dedupeKey)) {
+                continue;
+            }
+            seenLineCategories.add(dedupeKey);
+            buckets.get(category)!.push({ range: editor.document.lineAt(line).range });
         }
 
         for (const [category, options] of buckets) {

--- a/extension/src/editor/parsers/AppHostResourceParser.ts
+++ b/extension/src/editor/parsers/AppHostResourceParser.ts
@@ -28,6 +28,14 @@ export interface AppHostResourceParser {
 
     /** Parse resource definitions from the document. */
     parseResources(document: vscode.TextDocument): ParsedResource[];
+
+    /**
+     * Locates the line containing the builder construction statement
+     * (e.g. `var builder = DistributedApplication.CreateBuilder(args);` for C#,
+     * `const builder = createBuilder();` for TS/JS).
+     * Returns the 0-based line of the start of the statement, or `undefined` if not found.
+     */
+    findBuilderStatementLine?(document: vscode.TextDocument): number | undefined;
 }
 
 const _parsers: AppHostResourceParser[] = [];

--- a/extension/src/editor/parsers/csharpAppHostParser.ts
+++ b/extension/src/editor/parsers/csharpAppHostParser.ts
@@ -50,6 +50,15 @@ class CSharpAppHostParser implements AppHostResourceParser {
         return results;
     }
 
+    findBuilderStatementLine(document: vscode.TextDocument): number | undefined {
+        const text = document.getText();
+        const match = /\bDistributedApplication\.CreateBuilder\b/.exec(text);
+        if (!match) {
+            return undefined;
+        }
+        return findStatementStartLine(text, match.index, document);
+    }
+
 }
 
 // Self-register on import

--- a/extension/src/editor/parsers/csharpAppHostParser.ts
+++ b/extension/src/editor/parsers/csharpAppHostParser.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { AppHostResourceParser, ParsedResource, registerParser } from './AppHostResourceParser';
-import { findStatementStartLine } from './parserUtils';
+import { findStatementStartLine, findFirstMatchOutsideComments } from './parserUtils';
 
 /**
  * C# AppHost resource parser.
@@ -52,7 +52,7 @@ class CSharpAppHostParser implements AppHostResourceParser {
 
     findBuilderStatementLine(document: vscode.TextDocument): number | undefined {
         const text = document.getText();
-        const match = /\bDistributedApplication\.CreateBuilder\b/.exec(text);
+        const match = findFirstMatchOutsideComments(text, /\bDistributedApplication\.CreateBuilder\b/g, document);
         if (!match) {
             return undefined;
         }

--- a/extension/src/editor/parsers/jsTsAppHostParser.ts
+++ b/extension/src/editor/parsers/jsTsAppHostParser.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { AppHostResourceParser, ParsedResource, registerParser } from './AppHostResourceParser';
-import { findStatementStartLine } from './parserUtils';
+import { findStatementStartLine, findFirstMatchOutsideComments } from './parserUtils';
 
 /**
  * JavaScript / TypeScript AppHost resource parser.
@@ -53,7 +53,7 @@ class JsTsAppHostParser implements AppHostResourceParser {
 
     findBuilderStatementLine(document: vscode.TextDocument): number | undefined {
         const text = document.getText();
-        const match = /\bcreateBuilder\s*\(/.exec(text);
+        const match = findFirstMatchOutsideComments(text, /\bcreateBuilder\s*\(/g, document);
         if (!match) {
             return undefined;
         }

--- a/extension/src/editor/parsers/jsTsAppHostParser.ts
+++ b/extension/src/editor/parsers/jsTsAppHostParser.ts
@@ -51,6 +51,15 @@ class JsTsAppHostParser implements AppHostResourceParser {
         return results;
     }
 
+    findBuilderStatementLine(document: vscode.TextDocument): number | undefined {
+        const text = document.getText();
+        const match = /\bcreateBuilder\s*\(/.exec(text);
+        if (!match) {
+            return undefined;
+        }
+        return findStatementStartLine(text, match.index, document);
+    }
+
 }
 
 // Self-register on import

--- a/extension/src/editor/parsers/parserUtils.ts
+++ b/extension/src/editor/parsers/parserUtils.ts
@@ -41,10 +41,17 @@ export function findStatementStartLine(text: string, matchIndex: number, documen
     }
     let line = document.positionAt(start).line;
     const matchLine = document.positionAt(matchIndex).line;
-    // Skip lines that are only closing braces (with optional comment) or comments
+    // Skip lines that are only closing braces (with optional comment), comments,
+    // C# 12 file-scoped top-level directives (e.g. `#:sdk Aspire.AppHost.Sdk`),
+    // or blank lines.
     while (line < matchLine) {
         const lineText = document.lineAt(line).text.trimStart();
-        if (/^\}\s*(\/\/.*)?$/.test(lineText) || lineText.startsWith('//') || lineText.startsWith('/*') || lineText.startsWith('*')) {
+        if (lineText === ''
+            || /^\}\s*(\/\/.*)?$/.test(lineText)
+            || lineText.startsWith('//')
+            || lineText.startsWith('/*')
+            || lineText.startsWith('*')
+            || lineText.startsWith('#:')) {
             line++;
         } else {
             break;

--- a/extension/src/editor/parsers/parserUtils.ts
+++ b/extension/src/editor/parsers/parserUtils.ts
@@ -61,6 +61,27 @@ export function findStatementStartLine(text: string, matchIndex: number, documen
 }
 
 /**
+ * Find the first match of `regex` whose line is not a comment line (// or /* / *).
+ * Used to avoid matching builder-detection patterns inside header/block comments.
+ * The regex must be created with the global flag.
+ */
+export function findFirstMatchOutsideComments(text: string, regex: RegExp, document: vscode.TextDocument): RegExpExecArray | undefined {
+    if (!regex.global) {
+        throw new Error('findFirstMatchOutsideComments requires a global regex');
+    }
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(text)) !== null) {
+        const line = document.positionAt(match.index).line;
+        const lineText = document.lineAt(line).text.trimStart();
+        if (lineText.startsWith('//') || lineText.startsWith('/*') || lineText.startsWith('*')) {
+            continue;
+        }
+        return match;
+    }
+    return undefined;
+}
+
+/**
  * Starting from a '}' at closeBraceIdx, walk backwards to find the matching '{'.
  * Returns the index of '{', or -1 if not found.
  */

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -32,6 +32,7 @@ import { installCliStableCommand, installCliDailyCommand, verifyCliInstalledComm
 import { AspireMcpServerDefinitionProvider } from './mcp/AspireMcpServerDefinitionProvider';
 import { AspireCodeLensProvider } from './editor/AspireCodeLensProvider';
 import { AspireGutterDecorationProvider } from './editor/AspireGutterDecorationProvider';
+import { AppHostFilePresenceWatcher } from './editor/AppHostFilePresenceWatcher';
 import { getSupportedLanguageIds } from './editor/parsers/AppHostResourceParser';
 import { readGitCommitSha } from './utils/versionInfo';
 
@@ -95,6 +96,11 @@ export async function activate(context: vscode.ExtensionContext) {
     dataRepository.setPanelVisible(e.visible);
   });
 
+  // Also drive data sources based on whether an AppHost file is currently visible in any editor.
+  // This makes resource code-lens decorations on a fresh AppHost file work without first opening the panel.
+  const appHostFilePresenceWatcher = new AppHostFilePresenceWatcher(dataRepository);
+  context.subscriptions.push(appHostFilePresenceWatcher);
+
   const refreshRunningAppHostsRegistration = vscode.commands.registerCommand('aspire-vscode.refreshRunningAppHosts', () => dataRepository.refresh());
   const switchToGlobalViewRegistration = vscode.commands.registerCommand('aspire-vscode.switchToGlobalView', () => dataRepository.setViewMode('global'));
   const switchToWorkspaceViewRegistration = vscode.commands.registerCommand('aspire-vscode.switchToWorkspaceView', () => dataRepository.setViewMode('workspace'));
@@ -124,7 +130,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(appHostTreeView, refreshRunningAppHostsRegistration, switchToGlobalViewRegistration, switchToWorkspaceViewRegistration, openDashboardRegistration, openAppHostSourceRegistration, stopAppHostRegistration, stopResourceRegistration, startResourceRegistration, restartResourceRegistration, viewResourceLogsRegistration, executeResourceCommandRegistration, copyEndpointUrlRegistration, openInExternalBrowserRegistration, openInIntegratedBrowserRegistration, copyResourceNameRegistration, copyPidRegistration, copyAppHostPathRegistration, expandAllRegistration, { dispose: () => { appHostTreeProvider.dispose(); dataRepository.dispose(); } });
 
   // CodeLens provider — shows Debug on pipeline steps, resource state on resources
-  const codeLensProvider = new AspireCodeLensProvider(appHostTreeProvider);
+  const codeLensProvider = new AspireCodeLensProvider(appHostTreeProvider, dataRepository);
   const languageFilters = getSupportedLanguageIds().map(lang => ({ language: lang, scheme: 'file' }));
   const codeLensRegistration = vscode.languages.registerCodeLensProvider(languageFilters, codeLensProvider);
   const codeLensDebugPipelineStepRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensDebugPipelineStep', (stepName: string) => editorCommandProvider.tryExecuteDoAppHost(false, stepName));
@@ -149,7 +155,19 @@ export async function activate(context: vscode.ExtensionContext) {
       appHostTreeView.reveal(element, { select: true, focus: true });
     }
   });
-  context.subscriptions.push(codeLensRegistration, codeLensDebugPipelineStepRegistration, codeLensResourceActionRegistration, codeLensViewLogsRegistration, codeLensRevealResourceRegistration, codeLensProvider);
+  const codeLensOpenDashboardRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensOpenDashboard', (appHostPath?: string) => {
+    const element = appHostPath ? appHostTreeProvider.findAppHostElement(appHostPath) : undefined;
+    return appHostTreeProvider.openDashboard(element);
+  });
+  const codeLensViewAppHostLogsRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensViewAppHostLogs', (appHostPath?: string) => {
+    let command = 'logs';
+    if (appHostPath) {
+      command += ` --apphost "${appHostPath}"`;
+    }
+    command += ' --follow';
+    terminalProvider.sendAspireCommandToAspireTerminal(command);
+  });
+  context.subscriptions.push(codeLensRegistration, codeLensDebugPipelineStepRegistration, codeLensResourceActionRegistration, codeLensViewLogsRegistration, codeLensRevealResourceRegistration, codeLensOpenDashboardRegistration, codeLensViewAppHostLogsRegistration, codeLensProvider);
 
   // Gutter decorations — colored dots next to resources showing runtime state
   const gutterDecorationProvider = new AspireGutterDecorationProvider(appHostTreeProvider);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -160,12 +160,12 @@ export async function activate(context: vscode.ExtensionContext) {
     return appHostTreeProvider.openDashboard(element);
   });
   const codeLensViewAppHostLogsRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensViewAppHostLogs', (appHostPath?: string) => {
-    let command = 'logs';
+    const additionalArgs: string[] = [];
     if (appHostPath) {
-      command += ` --apphost "${appHostPath}"`;
+      additionalArgs.push('--apphost', appHostPath);
     }
-    command += ' --follow';
-    terminalProvider.sendAspireCommandToAspireTerminal(command);
+    additionalArgs.push('--follow');
+    terminalProvider.sendAspireCommandToAspireTerminal('logs', true, additionalArgs);
   });
   context.subscriptions.push(codeLensRegistration, codeLensDebugPipelineStepRegistration, codeLensResourceActionRegistration, codeLensViewLogsRegistration, codeLensRevealResourceRegistration, codeLensOpenDashboardRegistration, codeLensViewAppHostLogsRegistration, codeLensProvider);
 

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -110,22 +110,27 @@ export const enterPipelineStep = vscode.l10n.t('Enter the pipeline step to execu
 export const appHostSourceNotFound = vscode.l10n.t('Could not determine the AppHost source file to open.');
 export const appHostSourceOpenFailed = (path: string) => vscode.l10n.t('Failed to open AppHost source file: {0}', path);
 
-// CodeLens strings
-export const codeLensDebugPipelineStep = vscode.l10n.t('$(bug) Debug pipeline step');
-export const codeLensResourceRunning = vscode.l10n.t('$(pass) Running');
-export const codeLensResourceRunningWarning = vscode.l10n.t('$(warning) Running');
-export const codeLensResourceRunningError = vscode.l10n.t('$(error) Running');
-export const codeLensResourceStarting = vscode.l10n.t('$(loading~spin) Starting');
-export const codeLensResourceStopping = vscode.l10n.t('$(loading~spin) Stopping');
-export const codeLensResourceNotStarted = vscode.l10n.t('$(circle-outline) Not Started');
-export const codeLensResourceWaiting = vscode.l10n.t('$(loading~spin) Waiting');
-export const codeLensResourceStopped = vscode.l10n.t('$(circle-outline) Stopped');
-export const codeLensResourceStoppedWithExitCode = (exitCode: number) => vscode.l10n.t('$(circle-outline) Stopped (Exit Code: {0})', exitCode);
-export const codeLensResourceStoppedError = vscode.l10n.t('$(error) Stopped');
-export const codeLensResourceStoppedErrorWithExitCode = (exitCode: number) => vscode.l10n.t('$(error) Stopped (Exit Code: {0})', exitCode);
-export const codeLensResourceError = vscode.l10n.t('$(error) Error');
-export const codeLensRestart = vscode.l10n.t('$(debug-restart) Restart');
-export const codeLensStop = vscode.l10n.t('$(debug-stop) Stop');
-export const codeLensStart = vscode.l10n.t('$(debug-start) Start');
-export const codeLensViewLogs = vscode.l10n.t('$(output) Logs');
-export const codeLensCommand = (name: string) => vscode.l10n.t('$(terminal) {0}', name);
+// CodeLens strings.
+// The "\u200A" between the codicon and the label is U+200A HAIR SPACE; it adds
+// roughly one extra pixel of breathing room between the icon and the text in the
+// CodeLens title. The CodeLens API exposes no other typography control.
+export const codeLensDebugPipelineStep = vscode.l10n.t('$(bug)\u200A Debug pipeline step');
+export const codeLensResourceRunning = vscode.l10n.t('$(pass)\u200A Running');
+export const codeLensResourceRunningWarning = vscode.l10n.t('$(warning)\u200A Running');
+export const codeLensResourceRunningError = vscode.l10n.t('$(error)\u200A Running');
+export const codeLensResourceStarting = vscode.l10n.t('$(loading~spin)\u200A Starting');
+export const codeLensResourceStopping = vscode.l10n.t('$(loading~spin)\u200A Stopping');
+export const codeLensResourceNotStarted = vscode.l10n.t('$(circle-outline)\u200A Not Started');
+export const codeLensResourceWaiting = vscode.l10n.t('$(loading~spin)\u200A Waiting');
+export const codeLensResourceStopped = vscode.l10n.t('$(circle-outline)\u200A Stopped');
+export const codeLensResourceStoppedWithExitCode = (exitCode: number) => vscode.l10n.t('$(circle-outline)\u200A Stopped (Exit Code: {0})', exitCode);
+export const codeLensResourceStoppedError = vscode.l10n.t('$(error)\u200A Stopped');
+export const codeLensResourceStoppedErrorWithExitCode = (exitCode: number) => vscode.l10n.t('$(error)\u200A Stopped (Exit Code: {0})', exitCode);
+export const codeLensResourceError = vscode.l10n.t('$(error)\u200A Error');
+export const codeLensRestart = vscode.l10n.t('$(debug-restart)\u200A Restart');
+export const codeLensStop = vscode.l10n.t('$(debug-stop)\u200A Stop');
+export const codeLensStart = vscode.l10n.t('$(debug-start)\u200A Start');
+export const codeLensViewLogs = vscode.l10n.t('$(output)\u200A Logs');
+export const codeLensCommand = (name: string) => vscode.l10n.t('$(terminal)\u200A {0}', name);
+export const codeLensOpenDashboard = vscode.l10n.t('$(dashboard)\u200A Open Dashboard');
+export const codeLensViewAppHostLogs = vscode.l10n.t('$(output)\u200A View Logs');

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -158,6 +158,90 @@ suite('AppHostDataRepository', () => {
     });
 });
 
+suite('AppHostDataRepository AppHost-file gate', () => {
+    let terminalProvider: AspireTerminalProvider;
+    let subscriptions: vscode.Disposable[];
+    let getCliPathStub: sinon.SinonStub;
+    let spawnStub: sinon.SinonStub;
+
+    setup(() => {
+        subscriptions = [];
+        terminalProvider = new AspireTerminalProvider(subscriptions);
+        getCliPathStub = sinon.stub(terminalProvider, 'getAspireCliExecutablePath').resolves('aspire');
+        spawnStub = sinon.stub(cliModule, 'spawnCliProcess');
+        spawnStub.callsFake(() => new TestChildProcess());
+    });
+
+    teardown(() => {
+        spawnStub.restore();
+        getCliPathStub.restore();
+        subscriptions.forEach(subscription => subscription.dispose());
+    });
+
+    test('opening AppHost file with hidden panel starts describe watch', async () => {
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setAppHostFileOpen(true);
+        await waitForMicrotasks();
+
+        assert.strictEqual(spawnStub.calledOnce, true);
+        assert.deepStrictEqual(spawnStub.firstCall.args[2], ['describe', '--follow', '--format', 'json']);
+
+        repository.dispose();
+    });
+
+    test('closing all AppHost files with hidden panel stops describe watch', async () => {
+        const childProcess = new TestChildProcess();
+        spawnStub.returns(childProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setAppHostFileOpen(true);
+        await waitForMicrotasks();
+
+        repository.setAppHostFileOpen(false);
+
+        assert.strictEqual(childProcess.killed, true);
+
+        repository.dispose();
+    });
+
+    test('describe watch stays alive while either gate is open', async () => {
+        const childProcess = new TestChildProcess();
+        spawnStub.returns(childProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setAppHostFileOpen(true);
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        // Closing the AppHost file should not stop the watch while the panel is still visible.
+        repository.setAppHostFileOpen(false);
+        assert.strictEqual(childProcess.killed, false);
+
+        // Hiding the panel now stops it.
+        repository.setPanelVisible(false);
+        assert.strictEqual(childProcess.killed, true);
+
+        repository.dispose();
+    });
+
+    test('redundant setAppHostFileOpen calls do not respawn describe', async () => {
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setAppHostFileOpen(true);
+        repository.setAppHostFileOpen(true);
+        await waitForMicrotasks();
+
+        assert.strictEqual(spawnStub.calledOnce, true);
+
+        repository.dispose();
+    });
+});
+
 async function waitForMicrotasks(): Promise<void> {
     await Promise.resolve();
     await Promise.resolve();

--- a/extension/src/test/appHostFilePresenceWatcher.test.ts
+++ b/extension/src/test/appHostFilePresenceWatcher.test.ts
@@ -1,0 +1,235 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { AppHostFilePresenceWatcher } from '../editor/AppHostFilePresenceWatcher';
+import { AppHostDataRepository } from '../views/AppHostDataRepository';
+import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+// Import parsers so they self-register before the watcher consults them.
+import '../editor/parsers/csharpAppHostParser';
+import '../editor/parsers/jsTsAppHostParser';
+
+interface CapturedListeners {
+    visibilityListeners: Array<(editors: readonly vscode.TextEditor[]) => void>;
+    documentListeners: Array<(event: vscode.TextDocumentChangeEvent) => void>;
+}
+
+function makeEditor(filePath: string, content: string): vscode.TextEditor {
+    const lines = content.split('\n');
+    const document = {
+        uri: vscode.Uri.file(filePath),
+        fileName: filePath,
+        languageId: filePath.endsWith('.cs') ? 'csharp' : filePath.endsWith('.ts') ? 'typescript' : 'javascript',
+        version: 1,
+        isDirty: false,
+        isClosed: false,
+        eol: vscode.EndOfLine.LF,
+        lineCount: lines.length,
+        encoding: 'utf-8',
+        save: () => Promise.resolve(false),
+        lineAt: (lineOrPos: number | vscode.Position) => {
+            const lineNum = typeof lineOrPos === 'number' ? lineOrPos : lineOrPos.line;
+            const text = lines[lineNum] || '';
+            return {
+                lineNumber: lineNum,
+                text,
+                range: new vscode.Range(lineNum, 0, lineNum, text.length),
+                rangeIncludingLineBreak: new vscode.Range(lineNum, 0, lineNum + 1, 0),
+                firstNonWhitespaceCharacterIndex: text.search(/\S/),
+                isEmptyOrWhitespace: text.trim().length === 0,
+            } as vscode.TextLine;
+        },
+        offsetAt: (position: vscode.Position) => {
+            let offset = 0;
+            for (let i = 0; i < position.line && i < lines.length; i++) {
+                offset += lines[i].length + 1;
+            }
+            return offset + position.character;
+        },
+        positionAt: (offset: number) => {
+            let remaining = offset;
+            for (let i = 0; i < lines.length; i++) {
+                if (remaining <= lines[i].length) {
+                    return new vscode.Position(i, remaining);
+                }
+                remaining -= lines[i].length + 1;
+            }
+            return new vscode.Position(lines.length - 1, lines[lines.length - 1].length);
+        },
+        getText: () => content,
+        getWordRangeAtPosition: () => undefined,
+        validateRange: (range: vscode.Range) => range,
+        validatePosition: (position: vscode.Position) => position,
+        notebook: undefined as any,
+        isUntitled: false,
+    } as unknown as vscode.TextDocument;
+    return { document } as unknown as vscode.TextEditor;
+}
+
+const appHostCsContent = 'var builder = DistributedApplication.CreateBuilder(args);\nbuilder.AddRedis("cache");\nbuilder.Build().Run();';
+const nonAppHostCsContent = 'using System;\nclass Program { static void Main() { } }';
+
+suite('AppHostFilePresenceWatcher', () => {
+    let captured: CapturedListeners;
+    let visibleEditorsStub: sinon.SinonStub;
+    let onDidChangeVisibleStub: sinon.SinonStub;
+    let onDidChangeTextStub: sinon.SinonStub;
+    let repository: AppHostDataRepository;
+    let setOpenSpy: sinon.SinonSpy;
+    let clock: sinon.SinonFakeTimers;
+    let visibleEditors: vscode.TextEditor[];
+
+    setup(() => {
+        captured = { visibilityListeners: [], documentListeners: [] };
+        visibleEditors = [];
+
+        visibleEditorsStub = sinon.stub(vscode.window, 'visibleTextEditors').get(() => visibleEditors);
+        onDidChangeVisibleStub = sinon.stub(vscode.window, 'onDidChangeVisibleTextEditors').callsFake(((listener: (editors: readonly vscode.TextEditor[]) => void) => {
+            captured.visibilityListeners.push(listener);
+            return { dispose: () => { } };
+        }) as any);
+        onDidChangeTextStub = sinon.stub(vscode.workspace, 'onDidChangeTextDocument').callsFake(((listener: (event: vscode.TextDocumentChangeEvent) => void) => {
+            captured.documentListeners.push(listener);
+            return { dispose: () => { } };
+        }) as any);
+
+        const terminalProvider = new AspireTerminalProvider([]);
+        repository = new AppHostDataRepository(terminalProvider);
+        setOpenSpy = sinon.spy(repository, 'setAppHostFileOpen');
+        clock = sinon.useFakeTimers();
+    });
+
+    teardown(() => {
+        clock.restore();
+        setOpenSpy.restore();
+        repository.dispose();
+        onDidChangeTextStub.restore();
+        onDidChangeVisibleStub.restore();
+        visibleEditorsStub.restore();
+    });
+
+    test('constructor evaluates visible editors and reports false when none are AppHost files', () => {
+        visibleEditors = [makeEditor('/test/Program.cs', nonAppHostCsContent)];
+
+        const watcher = new AppHostFilePresenceWatcher(repository);
+
+        // No call expected because the cached "_lastValue" starts at false.
+        assert.strictEqual(setOpenSpy.called, false);
+        watcher.dispose();
+    });
+
+    test('constructor reports true when an AppHost file is already visible', () => {
+        visibleEditors = [makeEditor('/test/AppHost.cs', appHostCsContent)];
+
+        const watcher = new AppHostFilePresenceWatcher(repository);
+
+        assert.strictEqual(setOpenSpy.calledOnce, true);
+        assert.strictEqual(setOpenSpy.firstCall.args[0], true);
+        watcher.dispose();
+    });
+
+    test('becoming-AppHost transition via visibility change reports true', () => {
+        const watcher = new AppHostFilePresenceWatcher(repository);
+        assert.strictEqual(setOpenSpy.called, false);
+
+        visibleEditors = [makeEditor('/test/AppHost.cs', appHostCsContent)];
+        captured.visibilityListeners.forEach(l => l(visibleEditors));
+
+        assert.strictEqual(setOpenSpy.calledOnce, true);
+        assert.strictEqual(setOpenSpy.firstCall.args[0], true);
+        watcher.dispose();
+    });
+
+    test('all-non-AppHost transition reports false', () => {
+        visibleEditors = [makeEditor('/test/AppHost.cs', appHostCsContent)];
+        const watcher = new AppHostFilePresenceWatcher(repository);
+        assert.strictEqual(setOpenSpy.lastCall.args[0], true);
+
+        visibleEditors = [makeEditor('/test/Program.cs', nonAppHostCsContent)];
+        captured.visibilityListeners.forEach(l => l(visibleEditors));
+
+        assert.strictEqual(setOpenSpy.callCount, 2);
+        assert.strictEqual(setOpenSpy.secondCall.args[0], false);
+        watcher.dispose();
+    });
+
+    test('redundant visibility events with same value do not re-notify', () => {
+        visibleEditors = [makeEditor('/test/AppHost.cs', appHostCsContent)];
+        const watcher = new AppHostFilePresenceWatcher(repository);
+        const initialCalls = setOpenSpy.callCount;
+
+        captured.visibilityListeners.forEach(l => l(visibleEditors));
+        captured.visibilityListeners.forEach(l => l(visibleEditors));
+
+        assert.strictEqual(setOpenSpy.callCount, initialCalls);
+        watcher.dispose();
+    });
+
+    test('document edit on a visible non-AppHost file that becomes AppHost reports true after debounce', () => {
+        const editor = makeEditor('/test/Program.cs', nonAppHostCsContent);
+        visibleEditors = [editor];
+        const watcher = new AppHostFilePresenceWatcher(repository);
+        assert.strictEqual(setOpenSpy.called, false);
+
+        // Mutate the document content to look like an AppHost.
+        const upgraded = makeEditor('/test/Program.cs', appHostCsContent);
+        visibleEditors = [upgraded];
+        captured.documentListeners.forEach(l => l({ document: upgraded.document, contentChanges: [], reason: undefined } as any));
+
+        // Listener is debounced; nothing fires yet.
+        assert.strictEqual(setOpenSpy.called, false);
+
+        clock.tick(300);
+
+        assert.strictEqual(setOpenSpy.calledOnce, true);
+        assert.strictEqual(setOpenSpy.firstCall.args[0], true);
+        watcher.dispose();
+    });
+
+    test('document edit on a non-visible document is ignored', () => {
+        const visible = makeEditor('/test/Program.cs', nonAppHostCsContent);
+        visibleEditors = [visible];
+        const watcher = new AppHostFilePresenceWatcher(repository);
+
+        const offscreen = makeEditor('/elsewhere/AppHost.cs', appHostCsContent);
+        captured.documentListeners.forEach(l => l({ document: offscreen.document, contentChanges: [], reason: undefined } as any));
+        clock.tick(500);
+
+        assert.strictEqual(setOpenSpy.called, false);
+        watcher.dispose();
+    });
+
+    test('rapid edits coalesce into a single update', () => {
+        const editor = makeEditor('/test/AppHost.cs', appHostCsContent);
+        visibleEditors = [editor];
+        const watcher = new AppHostFilePresenceWatcher(repository);
+        const initial = setOpenSpy.callCount;
+
+        // Switch to non-AppHost while firing several rapid edits.
+        const downgraded = makeEditor('/test/AppHost.cs', nonAppHostCsContent);
+        visibleEditors = [downgraded];
+        for (let i = 0; i < 5; i++) {
+            captured.documentListeners.forEach(l => l({ document: downgraded.document, contentChanges: [], reason: undefined } as any));
+            clock.tick(50);
+        }
+        clock.tick(300);
+
+        assert.strictEqual(setOpenSpy.callCount, initial + 1);
+        assert.strictEqual(setOpenSpy.lastCall.args[0], false);
+        watcher.dispose();
+    });
+
+    test('dispose removes listeners and pending timer', () => {
+        const editor = makeEditor('/test/Program.cs', nonAppHostCsContent);
+        visibleEditors = [editor];
+        const watcher = new AppHostFilePresenceWatcher(repository);
+
+        const upgraded = makeEditor('/test/Program.cs', appHostCsContent);
+        visibleEditors = [upgraded];
+        captured.documentListeners.forEach(l => l({ document: upgraded.document, contentChanges: [], reason: undefined } as any));
+
+        watcher.dispose();
+        clock.tick(500);
+
+        assert.strictEqual(setOpenSpy.called, false);
+    });
+});

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -531,3 +531,121 @@ suite('buildResourceDescription', () => {
         assert.strictEqual(buildResourceDescription(makeResource({ healthReports: {} })), 'Project');
     });
 });
+
+suite('AspireAppHostTreeProvider.findAppHostElement', () => {
+    test('returns undefined when given empty path', () => {
+        const provider = makeTreeProvider([makeAppHost({ appHostPath: '/repo/AppHost/AppHost.csproj' })]);
+        assert.strictEqual(provider.findAppHostElement(''), undefined);
+        provider.dispose();
+    });
+
+    test('returns undefined when no AppHosts are tracked (global mode)', () => {
+        const provider = makeTreeProvider([]);
+        assert.strictEqual(provider.findAppHostElement('/repo/AppHost/AppHost.csproj'), undefined);
+        provider.dispose();
+    });
+
+    test('matches an AppHostItem by exact path (global mode)', () => {
+        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const provider = makeTreeProvider([makeAppHost({ appHostPath: hostPath })]);
+
+        const result = provider.findAppHostElement(hostPath);
+
+        assert.ok(result, 'Expected to find an AppHostItem');
+        provider.dispose();
+    });
+
+    test('matches an AppHostItem by same-directory path (global mode)', () => {
+        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const docPath = '/repo/AppHost/AppHost.cs';
+        const provider = makeTreeProvider([makeAppHost({ appHostPath: hostPath })]);
+
+        const result = provider.findAppHostElement(docPath);
+
+        assert.ok(result, 'Expected to find an AppHostItem via directory match');
+        provider.dispose();
+    });
+
+    test('returns undefined when AppHost lives in a different directory', () => {
+        const provider = makeTreeProvider([makeAppHost({ appHostPath: '/elsewhere/Other.csproj' })]);
+
+        const result = provider.findAppHostElement('/repo/AppHost/AppHost.cs');
+
+        assert.strictEqual(result, undefined);
+        provider.dispose();
+    });
+
+    test('matches WorkspaceResourcesItem by exact path (workspace mode)', () => {
+        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [],
+            workspaceResources: [makeResource()],
+            workspaceAppHostPath: hostPath,
+            workspaceAppHostName: undefined,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider());
+
+        const result = provider.findAppHostElement(hostPath);
+
+        assert.ok(result, 'Expected to find a WorkspaceResourcesItem');
+        provider.dispose();
+    });
+
+    test('matches WorkspaceResourcesItem by same-directory path (workspace mode)', () => {
+        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [],
+            workspaceResources: [makeResource()],
+            workspaceAppHostPath: hostPath,
+            workspaceAppHostName: undefined,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider());
+
+        const result = provider.findAppHostElement('/repo/AppHost/AppHost.cs');
+
+        assert.ok(result, 'Expected to find a WorkspaceResourcesItem via directory match');
+        provider.dispose();
+    });
+
+    test('returns undefined for workspace mode without resources', () => {
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [],
+            workspaceResources: [],
+            workspaceAppHostPath: '/repo/AppHost/AppHost.csproj',
+            workspaceAppHostName: undefined,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider());
+
+        const result = provider.findAppHostElement('/repo/AppHost/AppHost.csproj');
+
+        // Workspace tree builds no top-level item when there are no resources, so no match.
+        assert.strictEqual(result, undefined);
+        provider.dispose();
+    });
+
+    test('matches the right AppHostItem when multiple are tracked', () => {
+        const hostA = '/repo/A/A.csproj';
+        const hostB = '/repo/B/B.csproj';
+        const provider = makeTreeProvider([
+            makeAppHost({ appHostPath: hostA, appHostPid: 111 }),
+            makeAppHost({ appHostPath: hostB, appHostPid: 222 }),
+        ]);
+
+        const resultA = provider.findAppHostElement('/repo/A/A.cs');
+        const resultB = provider.findAppHostElement(hostB);
+
+        assert.ok(resultA);
+        assert.ok(resultB);
+        assert.notStrictEqual(resultA, resultB, 'Expected distinct items for distinct AppHosts');
+        provider.dispose();
+    });
+});

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -441,9 +441,9 @@ suite('getResourceIcon', () => {
         assert.strictEqual(icon.id, 'error');
     });
 
-    test('Finished with exit code 0 shows green pass', () => {
+    test('Finished with exit code 0 shows hollow circle (stopped)', () => {
         const icon = getResourceIcon(makeResource({ state: ResourceState.Finished, exitCode: 0 }));
-        assert.strictEqual(icon.id, 'pass');
+        assert.strictEqual(icon.id, 'circle-outline');
     });
 
     test('FailedToStart shows error icon', () => {
@@ -476,9 +476,9 @@ suite('getResourceIcon', () => {
         assert.strictEqual(icon.id, 'record');
     });
 
-    test('Finished shows green pass', () => {
+    test('Finished shows hollow circle (stopped)', () => {
         const icon = getResourceIcon(makeResource({ state: ResourceState.Finished }));
-        assert.strictEqual(icon.id, 'pass');
+        assert.strictEqual(icon.id, 'circle-outline');
     });
 
     test('null state shows record', () => {

--- a/extension/src/test/aspireCodeLensProvider.test.ts
+++ b/extension/src/test/aspireCodeLensProvider.test.ts
@@ -1,0 +1,302 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { AspireCodeLensProvider } from '../editor/AspireCodeLensProvider';
+import { AspireAppHostTreeProvider } from '../views/AspireAppHostTreeProvider';
+import { AppHostDataRepository, AppHostDisplayInfo, ResourceJson } from '../views/AppHostDataRepository';
+import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+// Import parsers so they self-register before the provider consults them.
+import '../editor/parsers/csharpAppHostParser';
+import '../editor/parsers/jsTsAppHostParser';
+
+function createMockDocument(content: string, filePath: string): vscode.TextDocument {
+    const lines = content.split('\n');
+    return {
+        uri: vscode.Uri.file(filePath),
+        fileName: filePath,
+        isUntitled: false,
+        languageId: filePath.endsWith('.cs') ? 'csharp' : filePath.endsWith('.ts') ? 'typescript' : 'javascript',
+        version: 1,
+        isDirty: false,
+        isClosed: false,
+        eol: vscode.EndOfLine.LF,
+        lineCount: lines.length,
+        encoding: 'utf-8',
+        save: () => Promise.resolve(false),
+        lineAt: (lineOrPos: number | vscode.Position) => {
+            const lineNum = typeof lineOrPos === 'number' ? lineOrPos : lineOrPos.line;
+            const text = lines[lineNum] || '';
+            return {
+                lineNumber: lineNum,
+                text,
+                range: new vscode.Range(lineNum, 0, lineNum, text.length),
+                rangeIncludingLineBreak: new vscode.Range(lineNum, 0, lineNum + 1, 0),
+                firstNonWhitespaceCharacterIndex: text.search(/\S/),
+                isEmptyOrWhitespace: text.trim().length === 0,
+            } as vscode.TextLine;
+        },
+        offsetAt: (position: vscode.Position) => {
+            let offset = 0;
+            for (let i = 0; i < position.line && i < lines.length; i++) {
+                offset += lines[i].length + 1;
+            }
+            return offset + position.character;
+        },
+        positionAt: (offset: number) => {
+            let remaining = offset;
+            for (let i = 0; i < lines.length; i++) {
+                if (remaining <= lines[i].length) {
+                    return new vscode.Position(i, remaining);
+                }
+                remaining -= lines[i].length + 1;
+            }
+            return new vscode.Position(lines.length - 1, lines[lines.length - 1].length);
+        },
+        getText: (range?: vscode.Range) => {
+            if (!range) {
+                return content;
+            }
+            const startOffset = lines.slice(0, range.start.line).reduce((sum, l) => sum + l.length + 1, 0) + range.start.character;
+            const endOffset = lines.slice(0, range.end.line).reduce((sum, l) => sum + l.length + 1, 0) + range.end.character;
+            return content.substring(startOffset, endOffset);
+        },
+        getWordRangeAtPosition: () => undefined,
+        validateRange: (range: vscode.Range) => range,
+        validatePosition: (position: vscode.Position) => position,
+        notebook: undefined as any,
+    } as vscode.TextDocument;
+}
+
+function makeAppHost(appHostPath: string): AppHostDisplayInfo {
+    return {
+        appHostPid: 1234,
+        appHostPath,
+        cliPid: undefined,
+        dashboardUrl: undefined,
+        resources: [],
+        appHostName: 'Test',
+    } as unknown as AppHostDisplayInfo;
+}
+
+function makeResource(name: string): ResourceJson {
+    return {
+        name,
+        displayName: name,
+        type: 'container',
+        state: 'Running',
+        stateStyle: '',
+        commands: {},
+        endpoints: [],
+    } as unknown as ResourceJson;
+}
+
+interface TestHarness {
+    provider: AspireCodeLensProvider;
+    appHostsStub: sinon.SinonStub;
+    workspaceResourcesStub: sinon.SinonStub;
+    workspaceAppHostPathStub: sinon.SinonStub;
+    repository: AppHostDataRepository;
+    treeProvider: AspireAppHostTreeProvider;
+    dispose(): void;
+}
+
+function createHarness(opts: {
+    appHosts?: AppHostDisplayInfo[];
+    workspaceResources?: ResourceJson[];
+    workspaceAppHostPath?: string;
+}): TestHarness {
+    const subs: vscode.Disposable[] = [];
+    const terminalProvider = new AspireTerminalProvider(subs);
+    const repository = new AppHostDataRepository(terminalProvider);
+    const treeProvider = new AspireAppHostTreeProvider(repository, terminalProvider);
+
+    const appHostsStub = sinon.stub(repository, 'appHosts').get(() => opts.appHosts ?? []);
+    const workspaceResourcesStub = sinon.stub(repository, 'workspaceResources').get(() => opts.workspaceResources ?? []);
+    const workspaceAppHostPathStub = sinon.stub(repository, 'workspaceAppHostPath').get(() => opts.workspaceAppHostPath);
+
+    const provider = new AspireCodeLensProvider(treeProvider, repository);
+
+    return {
+        provider,
+        appHostsStub,
+        workspaceResourcesStub,
+        workspaceAppHostPathStub,
+        repository,
+        treeProvider,
+        dispose() {
+            workspaceAppHostPathStub.restore();
+            workspaceResourcesStub.restore();
+            appHostsStub.restore();
+            treeProvider.dispose();
+            repository.dispose();
+            subs.forEach(s => s.dispose());
+        },
+    };
+}
+
+const APP_HOST_DOC = 'var builder = DistributedApplication.CreateBuilder(args);\nbuilder.AddRedis("cache");\nbuilder.Build().Run();';
+const APP_HOST_NO_RESOURCES = 'var builder = DistributedApplication.CreateBuilder(args);\nbuilder.Build().Run();';
+
+const cancellationToken = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose: () => { } }) } as vscode.CancellationToken;
+
+suite('AspireCodeLensProvider builder lens', () => {
+    let getConfigStub: sinon.SinonStub;
+
+    setup(() => {
+        getConfigStub = sinon.stub(vscode.workspace, 'getConfiguration').returns({
+            get: () => true,
+            has: () => true,
+            inspect: () => undefined,
+            update: () => Promise.resolve(),
+        } as any);
+    });
+
+    teardown(() => {
+        getConfigStub.restore();
+    });
+
+    test('emits builder lenses when document matches a running global AppHost', () => {
+        const docPath = '/repo/AppHost/AppHost.cs';
+        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const harness = createHarness({ appHosts: [makeAppHost(hostPath)] });
+
+        const doc = createMockDocument(APP_HOST_DOC, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const builderLenses = lenses.filter(l =>
+            l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
+            l.command?.command === 'aspire-vscode.codeLensViewAppHostLogs'
+        );
+
+        assert.strictEqual(builderLenses.length, 2);
+        assert.deepStrictEqual(builderLenses[0].command?.arguments, [hostPath]);
+        assert.deepStrictEqual(builderLenses[1].command?.arguments, [hostPath]);
+        harness.dispose();
+    });
+
+    test('does not emit builder lenses when no AppHost is running', () => {
+        const harness = createHarness({});
+
+        const doc = createMockDocument(APP_HOST_DOC, '/repo/AppHost/AppHost.cs');
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const builderLenses = lenses.filter(l =>
+            l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
+            l.command?.command === 'aspire-vscode.codeLensViewAppHostLogs'
+        );
+
+        assert.strictEqual(builderLenses.length, 0);
+        harness.dispose();
+    });
+
+    test('does not emit builder lenses when running AppHost is in an unrelated directory', () => {
+        const harness = createHarness({ appHosts: [makeAppHost('/elsewhere/Other.csproj')] });
+
+        const doc = createMockDocument(APP_HOST_DOC, '/repo/AppHost/AppHost.cs');
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const builderLenses = lenses.filter(l =>
+            l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
+            l.command?.command === 'aspire-vscode.codeLensViewAppHostLogs'
+        );
+
+        assert.strictEqual(builderLenses.length, 0);
+        harness.dispose();
+    });
+
+    test('emits builder lenses for AppHost file with no Add* calls when host is running', () => {
+        const docPath = '/repo/AppHost/AppHost.cs';
+        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const harness = createHarness({ appHosts: [makeAppHost(hostPath)] });
+
+        const doc = createMockDocument(APP_HOST_NO_RESOURCES, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const builderLenses = lenses.filter(l =>
+            l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
+            l.command?.command === 'aspire-vscode.codeLensViewAppHostLogs'
+        );
+
+        assert.strictEqual(builderLenses.length, 2);
+        harness.dispose();
+    });
+
+    test('emits builder lenses for workspace AppHost when document matches workspace path and resources are live', () => {
+        const docPath = '/repo/AppHost/AppHost.cs';
+        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [makeResource('cache')],
+        });
+
+        const doc = createMockDocument(APP_HOST_DOC, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const builderLenses = lenses.filter(l =>
+            l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
+            l.command?.command === 'aspire-vscode.codeLensViewAppHostLogs'
+        );
+
+        assert.strictEqual(builderLenses.length, 2);
+        assert.deepStrictEqual(builderLenses[0].command?.arguments, [hostPath]);
+        harness.dispose();
+    });
+
+    test('does not emit builder lenses when workspaceAppHostPath is set but no workspace resources are live', () => {
+        const harness = createHarness({
+            workspaceAppHostPath: '/repo/AppHost/AppHost.csproj',
+            workspaceResources: [],
+        });
+
+        const doc = createMockDocument(APP_HOST_DOC, '/repo/AppHost/AppHost.cs');
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const builderLenses = lenses.filter(l =>
+            l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
+            l.command?.command === 'aspire-vscode.codeLensViewAppHostLogs'
+        );
+
+        assert.strictEqual(builderLenses.length, 0);
+        harness.dispose();
+    });
+
+    test('does not emit builder lenses when workspace AppHost is in a different directory', () => {
+        const harness = createHarness({
+            workspaceAppHostPath: '/elsewhere/Other.csproj',
+            workspaceResources: [makeResource('cache')],
+        });
+
+        const doc = createMockDocument(APP_HOST_DOC, '/repo/AppHost/AppHost.cs');
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const builderLenses = lenses.filter(l =>
+            l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
+            l.command?.command === 'aspire-vscode.codeLensViewAppHostLogs'
+        );
+
+        assert.strictEqual(builderLenses.length, 0);
+        harness.dispose();
+    });
+
+    test('returns empty array for non-AppHost documents', () => {
+        const harness = createHarness({ appHosts: [makeAppHost('/repo/AppHost/AppHost.csproj')] });
+
+        const doc = createMockDocument('using System;\nclass Program { }', '/repo/AppHost/Program.cs');
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+
+        assert.strictEqual(lenses.length, 0);
+        harness.dispose();
+    });
+
+    test('builder lens points at the builder line, not the resource line', () => {
+        const docPath = '/repo/AppHost/AppHost.cs';
+        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const harness = createHarness({ appHosts: [makeAppHost(hostPath)] });
+
+        const doc = createMockDocument(APP_HOST_DOC, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const builderLenses = lenses.filter(l =>
+            l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
+            l.command?.command === 'aspire-vscode.codeLensViewAppHostLogs'
+        );
+
+        // Builder line is line 0 in our fixture document.
+        for (const lens of builderLenses) {
+            assert.strictEqual(lens.range.start.line, 0);
+        }
+        harness.dispose();
+    });
+});

--- a/extension/src/test/aspireCodeLensProvider.test.ts
+++ b/extension/src/test/aspireCodeLensProvider.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { AspireCodeLensProvider } from '../editor/AspireCodeLensProvider';
@@ -8,6 +9,13 @@ import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 // Import parsers so they self-register before the provider consults them.
 import '../editor/parsers/csharpAppHostParser';
 import '../editor/parsers/jsTsAppHostParser';
+
+// Build platform-native paths so dirname comparison works on Windows too
+// (vscode.Uri.file('/foo/bar').fsPath becomes '\\foo\\bar' on Windows, so we
+// need the host paths to use the same separator).
+function p(...segments: string[]): string {
+    return path.join(path.sep, ...segments);
+}
 
 function createMockDocument(content: string, filePath: string): vscode.TextDocument {
     const lines = content.split('\n');
@@ -156,8 +164,8 @@ suite('AspireCodeLensProvider builder lens', () => {
     });
 
     test('emits builder lenses when document matches a running global AppHost', () => {
-        const docPath = '/repo/AppHost/AppHost.cs';
-        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
         const harness = createHarness({ appHosts: [makeAppHost(hostPath)] });
 
         const doc = createMockDocument(APP_HOST_DOC, docPath);
@@ -176,7 +184,7 @@ suite('AspireCodeLensProvider builder lens', () => {
     test('does not emit builder lenses when no AppHost is running', () => {
         const harness = createHarness({});
 
-        const doc = createMockDocument(APP_HOST_DOC, '/repo/AppHost/AppHost.cs');
+        const doc = createMockDocument(APP_HOST_DOC, p('repo', 'AppHost', 'AppHost.cs'));
         const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
         const builderLenses = lenses.filter(l =>
             l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
@@ -188,9 +196,9 @@ suite('AspireCodeLensProvider builder lens', () => {
     });
 
     test('does not emit builder lenses when running AppHost is in an unrelated directory', () => {
-        const harness = createHarness({ appHosts: [makeAppHost('/elsewhere/Other.csproj')] });
+        const harness = createHarness({ appHosts: [makeAppHost(p('elsewhere', 'Other.csproj'))] });
 
-        const doc = createMockDocument(APP_HOST_DOC, '/repo/AppHost/AppHost.cs');
+        const doc = createMockDocument(APP_HOST_DOC, p('repo', 'AppHost', 'AppHost.cs'));
         const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
         const builderLenses = lenses.filter(l =>
             l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
@@ -202,8 +210,8 @@ suite('AspireCodeLensProvider builder lens', () => {
     });
 
     test('emits builder lenses for AppHost file with no Add* calls when host is running', () => {
-        const docPath = '/repo/AppHost/AppHost.cs';
-        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
         const harness = createHarness({ appHosts: [makeAppHost(hostPath)] });
 
         const doc = createMockDocument(APP_HOST_NO_RESOURCES, docPath);
@@ -218,8 +226,8 @@ suite('AspireCodeLensProvider builder lens', () => {
     });
 
     test('emits builder lenses for workspace AppHost when document matches workspace path and resources are live', () => {
-        const docPath = '/repo/AppHost/AppHost.cs';
-        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
         const harness = createHarness({
             workspaceAppHostPath: hostPath,
             workspaceResources: [makeResource('cache')],
@@ -239,11 +247,11 @@ suite('AspireCodeLensProvider builder lens', () => {
 
     test('does not emit builder lenses when workspaceAppHostPath is set but no workspace resources are live', () => {
         const harness = createHarness({
-            workspaceAppHostPath: '/repo/AppHost/AppHost.csproj',
+            workspaceAppHostPath: p('repo', 'AppHost', 'AppHost.csproj'),
             workspaceResources: [],
         });
 
-        const doc = createMockDocument(APP_HOST_DOC, '/repo/AppHost/AppHost.cs');
+        const doc = createMockDocument(APP_HOST_DOC, p('repo', 'AppHost', 'AppHost.cs'));
         const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
         const builderLenses = lenses.filter(l =>
             l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
@@ -256,11 +264,11 @@ suite('AspireCodeLensProvider builder lens', () => {
 
     test('does not emit builder lenses when workspace AppHost is in a different directory', () => {
         const harness = createHarness({
-            workspaceAppHostPath: '/elsewhere/Other.csproj',
+            workspaceAppHostPath: p('elsewhere', 'Other.csproj'),
             workspaceResources: [makeResource('cache')],
         });
 
-        const doc = createMockDocument(APP_HOST_DOC, '/repo/AppHost/AppHost.cs');
+        const doc = createMockDocument(APP_HOST_DOC, p('repo', 'AppHost', 'AppHost.cs'));
         const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
         const builderLenses = lenses.filter(l =>
             l.command?.command === 'aspire-vscode.codeLensOpenDashboard' ||
@@ -272,9 +280,9 @@ suite('AspireCodeLensProvider builder lens', () => {
     });
 
     test('returns empty array for non-AppHost documents', () => {
-        const harness = createHarness({ appHosts: [makeAppHost('/repo/AppHost/AppHost.csproj')] });
+        const harness = createHarness({ appHosts: [makeAppHost(p('repo', 'AppHost', 'AppHost.csproj'))] });
 
-        const doc = createMockDocument('using System;\nclass Program { }', '/repo/AppHost/Program.cs');
+        const doc = createMockDocument('using System;\nclass Program { }', p('repo', 'AppHost', 'Program.cs'));
         const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
 
         assert.strictEqual(lenses.length, 0);
@@ -282,8 +290,8 @@ suite('AspireCodeLensProvider builder lens', () => {
     });
 
     test('builder lens points at the builder line, not the resource line', () => {
-        const docPath = '/repo/AppHost/AppHost.cs';
-        const hostPath = '/repo/AppHost/AppHost.csproj';
+        const docPath = p('repo', 'AppHost', 'AppHost.cs');
+        const hostPath = p('repo', 'AppHost', 'AppHost.csproj');
         const harness = createHarness({ appHosts: [makeAppHost(hostPath)] });
 
         const doc = createMockDocument(APP_HOST_DOC, docPath);

--- a/extension/src/test/parsers.test.ts
+++ b/extension/src/test/parsers.test.ts
@@ -1858,3 +1858,75 @@ suite('JsTsAppHostParser', () => {
         assert.strictEqual(resources[2].name, 'pg');
     });
 });
+
+// ============================================================
+// findBuilderStatementLine tests
+// ============================================================
+suite('findBuilderStatementLine', () => {
+    function getCSharpParser() {
+        return getAllParsers().find(p => p.getSupportedExtensions().includes('.cs'))!;
+    }
+
+    function getJsTsParser() {
+        return getAllParsers().find(p => p.getSupportedExtensions().includes('.ts'))!;
+    }
+
+    test('C# parser finds builder line for var declaration', () => {
+        const parser = getCSharpParser();
+        const doc = createMockDocument(
+            [
+                '// header comment',
+                'var builder = DistributedApplication.CreateBuilder(args);',
+                'builder.AddRedis("cache");',
+            ].join('\n'),
+            '/test/AppHost.cs'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), 1);
+    });
+
+    test('C# parser finds builder line for #:sdk file with leading directives', () => {
+        const parser = getCSharpParser();
+        const doc = createMockDocument(
+            [
+                '#:sdk Aspire.AppHost.Sdk',
+                '',
+                'var builder = DistributedApplication.CreateBuilder(args);',
+                'builder.AddRedis("cache");',
+            ].join('\n'),
+            '/test/AppHost.cs'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), 2);
+    });
+
+    test('C# parser returns undefined when no CreateBuilder is present', () => {
+        const parser = getCSharpParser();
+        const doc = createMockDocument(
+            'using System;\nclass Foo { }',
+            '/test/Foo.cs'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), undefined);
+    });
+
+    test('JS/TS parser finds builder line for createBuilder call', () => {
+        const parser = getJsTsParser();
+        const doc = createMockDocument(
+            [
+                'import { createBuilder } from "@aspire/sdk";',
+                '',
+                'const builder = createBuilder();',
+                'await builder.addRedis("cache");',
+            ].join('\n'),
+            '/test/apphost.ts'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), 2);
+    });
+
+    test('JS/TS parser returns undefined when no createBuilder call is present', () => {
+        const parser = getJsTsParser();
+        const doc = createMockDocument(
+            'import express from "express";\nconst app = express();',
+            '/test/server.ts'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), undefined);
+    });
+});

--- a/extension/src/test/parsers.test.ts
+++ b/extension/src/test/parsers.test.ts
@@ -1929,4 +1929,57 @@ suite('findBuilderStatementLine', () => {
         );
         assert.strictEqual(parser.findBuilderStatementLine?.(doc), undefined);
     });
+
+    test('C# parser skips DistributedApplication.CreateBuilder occurrences in comments', () => {
+        const parser = getCSharpParser();
+        const doc = createMockDocument(
+            [
+                '// Example: var b = DistributedApplication.CreateBuilder(args);',
+                '/* DistributedApplication.CreateBuilder reference in block comment */',
+                'var builder = DistributedApplication.CreateBuilder(args);',
+                'builder.AddRedis("cache");',
+            ].join('\n'),
+            '/test/AppHost.cs'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), 2);
+    });
+
+    test('C# parser returns undefined when only commented CreateBuilder is present', () => {
+        const parser = getCSharpParser();
+        const doc = createMockDocument(
+            [
+                '// var builder = DistributedApplication.CreateBuilder(args);',
+                'class Foo { }',
+            ].join('\n'),
+            '/test/Foo.cs'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), undefined);
+    });
+
+    test('JS/TS parser skips createBuilder occurrences in comments', () => {
+        const parser = getJsTsParser();
+        const doc = createMockDocument(
+            [
+                '// usage: const b = createBuilder();',
+                'import { createBuilder } from "@aspire/sdk";',
+                '',
+                'const builder = createBuilder();',
+                'await builder.addRedis("cache");',
+            ].join('\n'),
+            '/test/apphost.ts'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), 3);
+    });
+
+    test('JS/TS parser returns undefined when only commented createBuilder is present', () => {
+        const parser = getJsTsParser();
+        const doc = createMockDocument(
+            [
+                '// const builder = createBuilder();',
+                'const x = 1;',
+            ].join('\n'),
+            '/test/foo.ts'
+        );
+        assert.strictEqual(parser.findBuilderStatementLine?.(doc), undefined);
+    });
 });

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -98,13 +98,15 @@ export class AspireTerminalProvider implements vscode.Disposable {
         const aspireTerminal = this.getAspireTerminal();
         extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${command}`);
 
-        // Clear any pre-existing text in the terminal input buffer before sending the command.
-        // Unix (bash/zsh): Ctrl+U (\x15) clears the current line via unix-line-discard.
-        // Windows (PowerShell): Escape (\x1b) clears the current line in PSReadLine's default Windows edit mode.
-        // Sending \x1b alone (without a trailing bracket sequence) via a separate sendText call is safe —
-        // PSReadLine's escape-sequence timeout ensures it is processed as a standalone Escape keypress.
-        const clearSequence = process.platform === 'win32' ? '\x1b' : '\x15';
-        aspireTerminal.terminal.sendText(clearSequence, false);
+        // Send Ctrl+C (\x03 / ETX) before the new command. This serves two purposes:
+        //  1. If a previous Aspire command (e.g. `aspire logs ... --follow`) is still
+        //     running in the foreground of the terminal, the new command would otherwise
+        //     be delivered to that process's stdin instead of the shell. Ctrl+C sends
+        //     SIGINT to interrupt it so the shell prompt comes back.
+        //  2. At an idle shell prompt, Ctrl+C cancels any pre-existing typed text on the
+        //     current line (bash/zsh as SIGINT-on-empty-line cancels input; PSReadLine
+        //     treats it as a cancel) — preserving the previous "clear input buffer" intent.
+        aspireTerminal.terminal.sendText('\x03', false);
 
         aspireTerminal.terminal.sendText(command);
         if (showTerminal) {

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -67,6 +67,7 @@ export class AppHostDataRepository {
     // ── Mode / panel state ──
     private _viewMode: ViewMode = 'workspace';
     private _panelVisible = false;
+    private _appHostFileOpen = false;
 
     // ── Workspace mode state (describe --follow) ──
     private _workspaceResources: Map<string, ResourceJson> = new Map();
@@ -159,6 +160,21 @@ export class AppHostDataRepository {
         this._syncPolling();
     }
 
+    /**
+     * Signals whether at least one visible editor currently shows an AppHost file.
+     *
+     * When `true`, the repository will run the same data-source(s) it would when the
+     * tree-view panel is visible.  This lets code-lens decorations on a freshly-created
+     * AppHost file show live resource state without the user first opening the panel.
+     */
+    setAppHostFileOpen(open: boolean): void {
+        if (this._appHostFileOpen === open) {
+            return;
+        }
+        this._appHostFileOpen = open;
+        this._syncPolling();
+    }
+
     refresh(): void {
         this._stopDescribeWatch();
         this._workspaceResources.clear();
@@ -189,12 +205,17 @@ export class AppHostDataRepository {
 
     // ── PS polling lifecycle ──
 
+    /** Either source is active when the panel is visible **or** an AppHost file is open in the editor. */
+    private get _dataActive(): boolean {
+        return this._panelVisible || this._appHostFileOpen;
+    }
+
     private get _shouldPoll(): boolean {
-        return this._panelVisible && this._viewMode === 'global';
+        return this._dataActive && this._viewMode === 'global';
     }
 
     private get _shouldWatchWorkspace(): boolean {
-        return this._panelVisible && this._viewMode === 'workspace';
+        return this._dataActive && this._viewMode === 'workspace';
     }
 
     private _syncPolling(): void {

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -357,6 +357,42 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         return this._findResourceInTree(allChildren, resourceName);
     }
 
+    /**
+     * Finds the {@link AppHostItem} (global mode) or {@link WorkspaceResourcesItem}
+     * (workspace mode) that corresponds to the given AppHost path.
+     *
+     * Matching prefers an exact path match, then falls back to same-directory match,
+     * which is needed because C# AppHost paths point at the `.csproj` file while a
+     * code lens lives in the sibling `.cs` source.
+     */
+    findAppHostElement(appHostPath: string): TreeElement | undefined {
+        if (!appHostPath) {
+            return undefined;
+        }
+        const targetDir = path.dirname(appHostPath);
+        const elements = this.getChildren();
+        for (const element of elements) {
+            if (element instanceof AppHostItem) {
+                const hostPath = element.appHost.appHostPath;
+                if (!hostPath) {
+                    continue;
+                }
+                if (hostPath === appHostPath || path.dirname(hostPath) === targetDir) {
+                    return element;
+                }
+            } else if (element instanceof WorkspaceResourcesItem) {
+                const hostPath = element.appHostPath;
+                if (!hostPath) {
+                    continue;
+                }
+                if (hostPath === appHostPath || path.dirname(hostPath) === targetDir) {
+                    return element;
+                }
+            }
+        }
+        return undefined;
+    }
+
     private _findResourceInTree(elements: TreeElement[], resourceName: string): TreeElement | undefined {
         for (const element of elements) {
             if (element instanceof ResourceItem) {

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -212,7 +212,11 @@ export function getResourceIcon(resource: ResourceJson): vscode.ThemeIcon {
             if (resource.stateStyle === StateStyle.Error || (resource.exitCode != null && resource.exitCode !== 0)) {
                 return new vscode.ThemeIcon('error', new vscode.ThemeColor('list.errorForeground'));
             }
-            return new vscode.ThemeIcon('pass', new vscode.ThemeColor('charts.green'));
+            // Use a hollow circle (matches the `$(circle-outline)` codicon shown in the
+            // "Stopped" code-lens label) instead of a green check, so a stopped/finished
+            // resource is never visually confused with a Running one (both used to render
+            // as a green check, just in slightly different greens).
+            return new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('descriptionForeground'));
         case ResourceState.FailedToStart:
         case ResourceState.RuntimeUnhealthy:
             return new vscode.ThemeIcon('error', new vscode.ThemeColor('list.errorForeground'));


### PR DESCRIPTION
## Description

Two related fixes for the Aspire VS Code extension's CodeLens experience on AppHost files, plus a small visual polish.

### 1. Show resource code lenses without first opening the side panel if the user has an apphost file open

When a brand-new C# (or TypeScript/JavaScript) AppHost file was opened, the resource state code lenses (`Running`, `Stop`, `Restart`, `Logs`, etc.) didn't appear and no live data was fetched until the user opened the **Running AppHosts** side panel. The data repository was gating both `aspire describe --follow` and `aspire ps` polling solely on panel visibility.

This change opens the gates so they react to either signal:

- New `AppHostFilePresenceWatcher` watches `vscode.window.visibleTextEditors` and reports to `AppHostDataRepository.setAppHostFileOpen` whenever any visible editor is detected as an AppHost file by the existing parsers.
- `AppHostDataRepository._dataActive` is now `true` when **either** the panel is visible **or** an AppHost file is open. The describe/ps lifecycle now follows the union of both gates, so polling auto-starts when an AppHost file is focused and auto-stops when both gates close.

### 2. New AppHost-level lenses on the builder statement
<img width="578" height="79" alt="image" src="https://github.com/user-attachments/assets/41ed5632-5089-417a-bae7-7dc4f6382c20" />

The lens row now also surfaces actions for the AppHost as a whole (not just per-resource) directly above the `var builder = DistributedApplication.CreateBuilder(args);` (C#) / `const builder = createBuilder(...)` (TS/JS) line:

- `Open Dashboard` — routes through the existing `openDashboard` flow, targeting the AppHost matched by file path / directory so the right host opens in multi-host scenarios.
- `View Logs` — runs `aspire logs --apphost <path> --follow` for the AppHost as a whole.

Implementation notes:

- `AppHostResourceParser` gains an optional `findBuilderStatementLine(document)` hook, with C# and TS/JS implementations.
- New `aspire-vscode.codeLensOpenDashboard` and `aspire-vscode.codeLensViewAppHostLogs` commands wire the lenses through the existing tree provider and terminal helpers. Both are registered in `package.json` and hidden from the command palette via `when: false`.
- `AspireAppHostTreeProvider.findAppHostElement(appHostPath)` is added to map a file path back to the right `AppHostItem` / `WorkspaceResourcesItem`, with a same-directory fallback (since C# host paths point to the `.csproj` while the lens lives in the sibling `.cs` source).
- `findStatementStartLine` now also skips `#:`-style C# 12 file-scoped directives and blank lines so the builder lens lands on the actual statement, not on an SDK directive.

### 3. Tighter icon-to-label spacing in lens titles
<img width="578" height="79" alt="image" src="https://github.com/user-attachments/assets/cb7a3877-bf46-47bf-bb93-c732898b27fd" />

The CodeLens API exposes no typography knobs. To bring the codicon visually closer to its label, all 20 lens titles in [extension/src/loc/strings.ts](extension/src/loc/strings.ts) now insert `\u200A` (HAIR SPACE) between the codicon and the text. This adds roughly one pixel of breathing room without breaking translation or wrapping.

### Tests

- New tests in [extension/src/test/appHostDataRepository.test.ts](extension/src/test/appHostDataRepository.test.ts) cover the dual-gate behavior (open file with hidden panel starts watch; closing both gates stops it; redundant calls don't respawn).
- New tests in [extension/src/test/parsers.test.ts](extension/src/test/parsers.test.ts) cover `findBuilderStatementLine` for both parsers, including `#:sdk` files.

Full extension test suite passes locally (351/351).

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
