### PR TITLE
Fix Python debug working directory in VS Code (#16575)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,7 +196,7 @@ extension/dist/
 extension/.localization/
 extension/out/
 extension/node_modules/
-extension/.vscode-test/
+**/.vscode-test/
 extension/.version
 
 # Generated extension localization files (regenerated from XLF during build)

--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -38,6 +38,7 @@ export interface PythonLaunchConfiguration extends ExecutableLaunchConfiguration
 
     module?: string;
     interpreter_path?: string;
+    working_directory?: string;
 }
 
 export function isPythonLaunchConfiguration(obj: any): obj is PythonLaunchConfiguration {

--- a/extension/src/debugger/languages/python.ts
+++ b/extension/src/debugger/languages/python.ts
@@ -10,6 +10,13 @@ function getProjectFile(launchConfig: ExecutableLaunchConfiguration): string {
         if (programPath) {
             return programPath;
         }
+
+        // Module entrypoints don't have a program path; fall back to the working directory
+        // so the central cwd derivation in createDebugSessionConfiguration has something to work with.
+        // The per-callback override below sets `cwd` from `working_directory` when present.
+        if (launchConfig.working_directory) {
+            return launchConfig.working_directory;
+        }
     }
 
     throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
@@ -30,6 +37,12 @@ export const pythonDebuggerExtension: ResourceDebuggerExtension = {
 
         if (launchConfig.interpreter_path) {
             debugConfiguration.python = launchConfig.interpreter_path;
+        }
+
+        // Use the explicit working_directory when provided so .WithWorkingDirectory(...) overrides
+        // and the resource's app directory both flow through to the debugger's cwd.
+        if (launchConfig.working_directory) {
+            debugConfiguration.cwd = launchConfig.working_directory;
         }
 
         // By default, activate support for Jinja debugging

--- a/extension/src/debugger/languages/python.ts
+++ b/extension/src/debugger/languages/python.ts
@@ -11,9 +11,10 @@ function getProjectFile(launchConfig: ExecutableLaunchConfiguration): string {
             return programPath;
         }
 
-        // Module entrypoints don't have a program path; fall back to the working directory
-        // so the central cwd derivation in createDebugSessionConfiguration has something to work with.
-        // The per-callback override below sets `cwd` from `working_directory` when present.
+        // Some Python entrypoints, including module-based and executable-based launches, may not
+        // have a program path; fall back to the working directory so the central cwd derivation
+        // in createDebugSessionConfiguration has something to work with. The per-callback
+        // override below sets `cwd` from `working_directory` when present.
         if (launchConfig.working_directory) {
             return launchConfig.working_directory;
         }

--- a/extension/src/test/pythonDebugger.test.ts
+++ b/extension/src/test/pythonDebugger.test.ts
@@ -1,0 +1,108 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { pythonDebuggerExtension } from '../debugger/languages/python';
+import { AspireResourceExtendedDebugConfiguration, PythonLaunchConfiguration } from '../dcp/types';
+import { AspireDebugSession } from '../debugger/AspireDebugSession';
+
+function createDebugConfig(overrides: Partial<AspireResourceExtendedDebugConfiguration> = {}): AspireResourceExtendedDebugConfiguration {
+    return {
+        runId: '1',
+        debugSessionId: '1',
+        type: 'debugpy',
+        name: 'Test Debug Config',
+        request: 'launch',
+        program: '/apps/myapp/main.py',
+        cwd: '/some/default/cwd',
+        ...overrides
+    };
+}
+
+suite('Python Debugger Extension Tests', () => {
+    teardown(() => sinon.restore());
+
+    test('working_directory overrides cwd in debug configuration', async () => {
+        const launchConfig: PythonLaunchConfiguration = {
+            type: 'python',
+            program_path: '/apps/myapp/main.py',
+            working_directory: '/apps/custom-cwd'
+        };
+
+        const debugConfig = createDebugConfig();
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await pythonDebuggerExtension.createDebugSessionConfigurationCallback!(
+            launchConfig,
+            [],
+            [],
+            { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession },
+            debugConfig
+        );
+
+        assert.strictEqual(debugConfig.cwd, '/apps/custom-cwd');
+    });
+
+    test('cwd is preserved when working_directory is absent', async () => {
+        const launchConfig: PythonLaunchConfiguration = {
+            type: 'python',
+            program_path: '/apps/myapp/main.py'
+        };
+
+        const debugConfig = createDebugConfig({ cwd: '/apps/myapp' });
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await pythonDebuggerExtension.createDebugSessionConfigurationCallback!(
+            launchConfig,
+            [],
+            [],
+            { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession },
+            debugConfig
+        );
+
+        assert.strictEqual(debugConfig.cwd, '/apps/myapp');
+    });
+
+    test('module entrypoint sets module and removes program', async () => {
+        const launchConfig: PythonLaunchConfiguration = {
+            type: 'python',
+            module: 'flask',
+            working_directory: '/apps/myapp'
+        };
+
+        const debugConfig = createDebugConfig();
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await pythonDebuggerExtension.createDebugSessionConfigurationCallback!(
+            launchConfig,
+            [],
+            [],
+            { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession },
+            debugConfig
+        );
+
+        assert.strictEqual(debugConfig.module, 'flask');
+        assert.strictEqual(debugConfig.program, undefined);
+        assert.strictEqual(debugConfig.cwd, '/apps/myapp');
+    });
+
+    test('interpreter_path sets python field', async () => {
+        const launchConfig: PythonLaunchConfiguration = {
+            type: 'python',
+            program_path: '/apps/myapp/main.py',
+            interpreter_path: '/apps/myapp/.venv/bin/python',
+            working_directory: '/apps/myapp'
+        };
+
+        const debugConfig = createDebugConfig();
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await pythonDebuggerExtension.createDebugSessionConfigurationCallback!(
+            launchConfig,
+            [],
+            [],
+            { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession },
+            debugConfig
+        );
+
+        assert.strictEqual((debugConfig as any).python, '/apps/myapp/.venv/bin/python');
+    });
+});

--- a/playground/python/Python.AppHost/AppHost.cs
+++ b/playground/python/Python.AppHost/AppHost.cs
@@ -15,7 +15,8 @@ builder.AddPythonModule("fastapi-app", "../module_only", "uvicorn")
 builder.AddPythonExecutable("fastapi-uvicorn-app", "../module_only", "uvicorn")
     .WithDebugging()
     .WithArgs("api:app", "--reload", "--host=0.0.0.0", "--port=8001")
-    .WithHttpEndpoint(targetPort: 8001);
+    .WithHttpEndpoint(targetPort: 8001)
+    .WithUv();
 
 // Flask app using Flask module directly
 builder.AddPythonModule("flask-app", "../flask_app", "flask")

--- a/src/Aspire.Hosting.Python/PythonAppLaunchConfiguration.cs
+++ b/src/Aspire.Hosting.Python/PythonAppLaunchConfiguration.cs
@@ -16,4 +16,7 @@ internal sealed class PythonLaunchConfiguration() : ExecutableLaunchConfiguratio
 
     [JsonPropertyName("interpreter_path")]
     public string InterpreterPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("working_directory")]
+    public string WorkingDirectory { get; set; } = string.Empty;
 }

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -930,23 +930,28 @@ public static class PythonAppResourceBuilderExtensions
         var entrypointType = entrypointAnnotation.Type;
         var entrypoint = entrypointAnnotation.Entrypoint;
 
-        string programPath;
-        string module;
-
-        if (entrypointType == EntrypointType.Script)
-        {
-            programPath = Path.GetFullPath(entrypoint, builder.Resource.WorkingDirectory);
-            module = string.Empty;
-        }
-        else
-        {
-            programPath = builder.Resource.WorkingDirectory;
-            module = entrypoint;
-        }
-
         builder.WithDebugSupport(
             mode =>
             {
+                // Compute paths inside the lambda so a later WithWorkingDirectory(...) override is respected.
+                var workingDirectory = builder.Resource.WorkingDirectory;
+
+                string programPath;
+                string module;
+
+                if (entrypointType == EntrypointType.Script)
+                {
+                    programPath = Path.GetFullPath(entrypoint, workingDirectory);
+                    module = string.Empty;
+                }
+                else
+                {
+                    // For Module entrypoints, the working_directory field carries the cwd to the
+                    // debugger; ProgramPath is left empty (the extension drops `program` when `module` is set).
+                    programPath = string.Empty;
+                    module = entrypoint;
+                }
+
                 string interpreterPath;
                 if (!builder.Resource.TryGetLastAnnotation<PythonEnvironmentAnnotation>(out var annotation) || annotation.VirtualEnvironment is null)
                 {
@@ -956,7 +961,7 @@ public static class PythonAppResourceBuilderExtensions
                 {
                     var venvPath = Path.IsPathRooted(annotation.VirtualEnvironment.VirtualEnvironmentPath)
                         ? annotation.VirtualEnvironment.VirtualEnvironmentPath
-                        : Path.GetFullPath(annotation.VirtualEnvironment.VirtualEnvironmentPath, builder.Resource.WorkingDirectory);
+                        : Path.GetFullPath(annotation.VirtualEnvironment.VirtualEnvironmentPath, workingDirectory);
 
                     if (OperatingSystem.IsWindows())
                     {
@@ -973,7 +978,8 @@ public static class PythonAppResourceBuilderExtensions
                     ProgramPath = programPath,
                     Module = module,
                     Mode = mode,
-                    InterpreterPath = interpreterPath
+                    InterpreterPath = interpreterPath,
+                    WorkingDirectory = workingDirectory
                 };
             },
             "python",

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -946,9 +946,12 @@ public static class PythonAppResourceBuilderExtensions
                 }
                 else
                 {
-                    // For Module entrypoints, the working_directory field carries the cwd to the
-                    // debugger; ProgramPath is left empty (the extension drops `program` when `module` is set).
-                    programPath = string.Empty;
+                    // For Module and Executable entrypoints the new `working_directory` field on the launch
+                    // configuration carries the cwd to the Python debugger. Older versions of the VS Code
+                    // extension only look at `program_path`/`project_path` to derive the cwd and don't
+                    // understand `working_directory`, so to preserve backward compatibility we still
+                    // populate `ProgramPath` with the working directory like the previous behavior.
+                    programPath = workingDirectory;
                     module = entrypoint;
                 }
 

--- a/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
@@ -4,6 +4,7 @@
 #pragma warning disable CS0612
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // Type is for evaluation purposes only
+#pragma warning disable ASPIREEXTENSION001 // SupportsDebuggingAnnotation is experimental
 
 using Microsoft.Extensions.DependencyInjection;
 using Aspire.Hosting.Utils;
@@ -1491,6 +1492,88 @@ public class AddPythonAppTests(ITestOutputHelper outputHelper)
         // Verify "-m" and module name were removed but other args remain
         Assert.Collection(commandArguments,
             arg => Assert.Equal("run", arg));
+    }
+
+    [Fact]
+    public void WithDebugSupport_PopulatesWorkingDirectory_ForScriptEntrypoint()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var appDirectory = Path.Combine(tempDir.Path, "myapp");
+        Directory.CreateDirectory(appDirectory);
+        var virtualEnvironmentPath = Path.Combine(tempDir.Path, ".venv");
+        Directory.CreateDirectory(virtualEnvironmentPath);
+
+        var pythonApp = builder.AddPythonApp("myapp", appDirectory, "main.py")
+            .WithVirtualEnvironment(virtualEnvironmentPath);
+
+        var launchConfig = InvokeLaunchConfigurationAnnotator(pythonApp.Resource);
+
+        Assert.Equal(appDirectory, launchConfig.WorkingDirectory);
+        Assert.Equal(Path.Combine(appDirectory, "main.py"), launchConfig.ProgramPath);
+        Assert.Equal(string.Empty, launchConfig.Module);
+    }
+
+    [Fact]
+    public void WithDebugSupport_PopulatesWorkingDirectory_ForModuleEntrypoint()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var appDirectory = Path.Combine(tempDir.Path, "myapp");
+        Directory.CreateDirectory(appDirectory);
+        var virtualEnvironmentPath = Path.Combine(tempDir.Path, ".venv");
+        Directory.CreateDirectory(virtualEnvironmentPath);
+
+        var pythonApp = builder.AddPythonModule("myapp", appDirectory, "flask")
+            .WithVirtualEnvironment(virtualEnvironmentPath);
+
+        var launchConfig = InvokeLaunchConfigurationAnnotator(pythonApp.Resource);
+
+        Assert.Equal(appDirectory, launchConfig.WorkingDirectory);
+        Assert.Equal("flask", launchConfig.Module);
+        // ProgramPath must be empty for module entrypoints; the working_directory field
+        // now carries the cwd to the debugger instead of being smuggled through program_path.
+        Assert.Equal(string.Empty, launchConfig.ProgramPath);
+    }
+
+    [Fact]
+    public void WithDebugSupport_PropagatesWorkingDirectoryOverride()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var appDirectory = Path.Combine(tempDir.Path, "myapp");
+        Directory.CreateDirectory(appDirectory);
+        var virtualEnvironmentPath = Path.Combine(tempDir.Path, ".venv");
+        Directory.CreateDirectory(virtualEnvironmentPath);
+        var customWorkingDirectory = Path.Combine(tempDir.Path, "custom");
+        Directory.CreateDirectory(customWorkingDirectory);
+
+        var pythonApp = builder.AddPythonApp("myapp", appDirectory, "main.py")
+            .WithVirtualEnvironment(virtualEnvironmentPath)
+            .WithWorkingDirectory(customWorkingDirectory);
+
+        var launchConfig = InvokeLaunchConfigurationAnnotator(pythonApp.Resource);
+
+        var expectedWorkingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(
+            Path.Combine(builder.AppHostDirectory, customWorkingDirectory));
+        Assert.Equal(expectedWorkingDirectory, launchConfig.WorkingDirectory);
+        Assert.Equal(Path.Combine(expectedWorkingDirectory, "main.py"), launchConfig.ProgramPath);
+    }
+
+    private static PythonLaunchConfiguration InvokeLaunchConfigurationAnnotator(IResource resource)
+    {
+        Assert.True(resource.TryGetLastAnnotation<SupportsDebuggingAnnotation>(out var supportsDebugging));
+
+        var exe = Executable.Create("test", "python");
+        supportsDebugging.LaunchConfigurationAnnotator(exe, ExecutableLaunchMode.Debug);
+
+        Assert.True(exe.TryGetAnnotationAsObjectList<PythonLaunchConfiguration>(
+            Executable.LaunchConfigurationsAnnotation,
+            out var launchConfigs));
+        return Assert.Single(launchConfigs);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
@@ -1533,9 +1533,61 @@ public class AddPythonAppTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(appDirectory, launchConfig.WorkingDirectory);
         Assert.Equal("flask", launchConfig.Module);
-        // ProgramPath must be empty for module entrypoints; the working_directory field
-        // now carries the cwd to the debugger instead of being smuggled through program_path.
-        Assert.Equal(string.Empty, launchConfig.ProgramPath);
+        // ProgramPath continues to mirror the working directory for module entrypoints to
+        // preserve compatibility with older VS Code extensions that derive cwd from program_path
+        // when they don't yet understand the new working_directory field.
+        Assert.Equal(appDirectory, launchConfig.ProgramPath);
+    }
+
+    [Fact]
+    public void WithDebugSupport_PopulatesWorkingDirectory_ForExecutableEntrypoint()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var appDirectory = Path.Combine(tempDir.Path, "myapp");
+        Directory.CreateDirectory(appDirectory);
+        var virtualEnvironmentPath = Path.Combine(tempDir.Path, ".venv");
+        Directory.CreateDirectory(virtualEnvironmentPath);
+
+        var pythonApp = builder.AddPythonExecutable("myapp", appDirectory, "uvicorn")
+            .WithVirtualEnvironment(virtualEnvironmentPath)
+            .WithDebugging();
+
+        var launchConfig = InvokeLaunchConfigurationAnnotator(pythonApp.Resource);
+
+        Assert.Equal(appDirectory, launchConfig.WorkingDirectory);
+        Assert.Equal("uvicorn", launchConfig.Module);
+        // ProgramPath continues to mirror the working directory for executable entrypoints (same code
+        // path as Module) to preserve compatibility with older VS Code extensions.
+        Assert.Equal(appDirectory, launchConfig.ProgramPath);
+    }
+
+    [Fact]
+    public void WithDebugSupport_PropagatesWorkingDirectoryOverride_ForExecutableEntrypoint()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        var appDirectory = Path.Combine(tempDir.Path, "myapp");
+        Directory.CreateDirectory(appDirectory);
+        var virtualEnvironmentPath = Path.Combine(tempDir.Path, ".venv");
+        Directory.CreateDirectory(virtualEnvironmentPath);
+        var customWorkingDirectory = Path.Combine(tempDir.Path, "custom");
+        Directory.CreateDirectory(customWorkingDirectory);
+
+        var pythonApp = builder.AddPythonExecutable("myapp", appDirectory, "uvicorn")
+            .WithVirtualEnvironment(virtualEnvironmentPath)
+            .WithDebugging()
+            .WithWorkingDirectory(customWorkingDirectory);
+
+        var launchConfig = InvokeLaunchConfigurationAnnotator(pythonApp.Resource);
+
+        var expectedWorkingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(
+            Path.Combine(builder.AppHostDirectory, customWorkingDirectory));
+        Assert.Equal(expectedWorkingDirectory, launchConfig.WorkingDirectory);
+        Assert.Equal("uvicorn", launchConfig.Module);
+        Assert.Equal(expectedWorkingDirectory, launchConfig.ProgramPath);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adds working_directory to python projects for IDE run to match CLI behavior. Tested with the `python` playground sample.

Fixes #16575

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
