### PR TITLE
Fix dashboard static assets for build output

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -135,6 +135,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         preConfigureBuilder?.Invoke(builder);
 
+        // Local build output relies on the static web assets manifest instead of copying all web assets to wwwroot.
+        builder.WebHost.UseStaticWebAssets();
+
 #if !DEBUG
         builder.Logging.AddFilter("Default", LogLevel.Information);
         builder.Logging.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);

--- a/tests/Aspire.Dashboard.Tests/Integration/StaticWebAssetTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StaticWebAssetTests.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Reflection;
+using Aspire.Dashboard.Configuration;
+using Aspire.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Integration;
+
+public sealed class StaticWebAssetTests(ITestOutputHelper testOutputHelper)
+{
+    [Theory]
+    [InlineData("/css/app.css", "text/css")]
+    [InlineData("/js/app.js", "text/javascript")]
+    [InlineData("/framework/blazor.web.js", "text/javascript")]
+    [InlineData("/_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js", "text/javascript")]
+    public async Task DashboardServesStaticWebAssetsWhenRunningFromBuildOutputInProduction(string path, string expectedContentType)
+    {
+        var dashboardAssemblyDirectory = GetDashboardAssemblyDirectory();
+
+        await using var app = new DashboardWebApplication(
+            options: new WebApplicationOptions
+            {
+                ApplicationName = "Aspire.Dashboard",
+                ContentRootPath = dashboardAssemblyDirectory,
+                EnvironmentName = Environments.Production,
+                WebRootPath = Path.Combine(dashboardAssemblyDirectory, "wwwroot")
+            },
+            preConfigureBuilder: builder =>
+            {
+                var sources = ((IConfigurationBuilder)builder.Configuration).Sources;
+                foreach (var item in sources.ToList())
+                {
+                    if (item is EnvironmentVariablesConfigurationSource)
+                    {
+                        sources.Remove(item);
+                    }
+                }
+
+                builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "http://127.0.0.1:0",
+                    [DashboardConfigNames.DashboardOtlpGrpcUrlName.ConfigKey] = "http://127.0.0.1:0",
+                    [DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = nameof(OtlpAuthMode.Unsecured),
+                    [DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.Unsecured),
+                    [DashboardConfigNames.DashboardApiAuthModeName.ConfigKey] = nameof(ApiAuthMode.Unsecured)
+                });
+
+                builder.Services.AddSingleton(IntegrationTestHelpers.CreateLoggerFactory(testOutputHelper));
+            });
+
+        await app.StartAsync().DefaultTimeout();
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
+
+        var response = await client.GetAsync(path).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(expectedContentType, response.Content.Headers.ContentType?.MediaType);
+    }
+
+    private static string GetDashboardAssemblyDirectory()
+    {
+        const string aspireDashboardAssemblyName = "Aspire.Dashboard";
+
+        var currentAssemblyName = Assembly.GetExecutingAssembly().GetName().Name!;
+        var currentAssemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var aspireAssemblyDirectory = currentAssemblyDirectory.Replace(currentAssemblyName, aspireDashboardAssemblyName, StringComparison.Ordinal);
+
+        Assert.True(File.Exists(Path.Combine(aspireAssemblyDirectory, $"{aspireDashboardAssemblyName}.dll")));
+
+        return aspireAssemblyDirectory;
+    }
+}


### PR DESCRIPTION
## Description

Loads the dashboard static web assets manifest explicitly so dashboard build output can serve JS and CSS assets even when launched in `Production`. Without this, local/non-published dashboard output can return the HTML fallback/404 page for assets like `/css/app.css`, `/js/app.js`, `/framework/blazor.web.js`, and the Fluent UI module, leaving the dashboard blank with browser MIME type errors.

Adds regression coverage for the affected asset paths and content types.

Tagging @jamesnk and @adamint for awareness.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No

