### PR TITLE
Prevent staging update from selecting daily prerelease packages

### DIFF
--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -12,7 +12,7 @@ using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Packaging;
 
-internal class PackageChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null)
+internal class PackageChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null, bool allowPrereleaseFallback = true)
 {
     public string Name { get; } = name;
     public PackageChannelQuality Quality { get; } = quality;
@@ -21,6 +21,7 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
     public bool ConfigureGlobalPackagesFolder { get; } = configureGlobalPackagesFolder;
     public string? CliDownloadBaseUrl { get; } = cliDownloadBaseUrl;
     public string? PinnedVersion { get; } = pinnedVersion;
+    public bool AllowPrereleaseFallback { get; } = allowPrereleaseFallback;
 
     public string SourceDetails { get; } = ComputeSourceDetails(mappings);
 
@@ -170,7 +171,7 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         // In the event that we have no stable packages we fallback to
         // returning prerelease packages. Example a package that is currently
         // in preview (Aspire.Hosting.Docker circa 9.4).
-        if (Quality is PackageChannelQuality.Stable && !packages.Any())
+        if (Quality is PackageChannelQuality.Stable && AllowPrereleaseFallback && !packages.Any())
         {
             packages = await nuGetPackageCache.GetPackagesAsync(
                 workingDirectory: workingDirectory,
@@ -234,7 +235,7 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         // In the event that we have no stable packages we fallback to
         // returning prerelease packages. Example a package that is currently
         // in preview (Aspire.Hosting.Docker circa 9.4).
-        if (Quality is PackageChannelQuality.Stable && !packages.Any())
+        if (Quality is PackageChannelQuality.Stable && AllowPrereleaseFallback && !packages.Any())
         {
             packages = await nuGetPackageCache.GetPackageVersionsAsync(
                 workingDirectory: workingDirectory,
@@ -289,7 +290,7 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
             .SelectMany(mapping => CreateScopedMappings(mapping, requestedPackageIds, logger))
             .ToArray();
 
-        return new PackageChannel(Name, Quality, scopedMappings, nuGetPackageCache, ConfigureGlobalPackagesFolder, CliDownloadBaseUrl, PinnedVersion, logger);
+        return new PackageChannel(Name, Quality, scopedMappings, nuGetPackageCache, ConfigureGlobalPackagesFolder, CliDownloadBaseUrl, PinnedVersion, logger, AllowPrereleaseFallback);
     }
 
     private static IEnumerable<PackageMapping> CreateScopedMappings(PackageMapping mapping, IReadOnlyCollection<string> packageIds, ILogger? logger)
@@ -429,9 +430,9 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
             !string.Equals(mapping.PackageFilter, PackageMapping.AllPackages, StringComparison.Ordinal);
     }
 
-    public static PackageChannel CreateExplicitChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null)
+    public static PackageChannel CreateExplicitChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null, bool allowPrereleaseFallback = true)
     {
-        return new PackageChannel(name, quality, mappings, nuGetPackageCache, configureGlobalPackagesFolder, cliDownloadBaseUrl, pinnedVersion, logger);
+        return new PackageChannel(name, quality, mappings, nuGetPackageCache, configureGlobalPackagesFolder, cliDownloadBaseUrl, pinnedVersion, logger, allowPrereleaseFallback);
     }
 
     public static PackageChannel CreateImplicitChannel(INuGetPackageCache nuGetPackageCache, ILogger? logger = null)

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -103,7 +103,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         {
             new PackageMapping("Aspire*", stagingFeedUrl),
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-        }, nuGetPackageCache, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, logger: logger);
+        }, nuGetPackageCache, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, logger: logger, allowPrereleaseFallback: false);
 
         return stagingChannel;
     }

--- a/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
@@ -4,6 +4,8 @@
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
+using Aspire.Shared;
+using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Packaging;
 
@@ -82,6 +84,33 @@ public class PackageChannelTests
         Assert.Equal(stagingUrl, channel.SourceDetails);
         Assert.Equal(PackageChannelType.Explicit, channel.Type);
         Assert.True(channel.ConfigureGlobalPackagesFolder);
+    }
+
+    [Fact]
+    public async Task GetPackagesAsync_StableChannelWithoutPrereleaseFallback_DoesNotReturnPrereleasePackages()
+    {
+        var cache = new FakeNuGetPackageCache
+        {
+            GetPackagesAsyncCallback = (_, packageId, _, prerelease, _, _, _) =>
+            {
+                var packages = prerelease
+                    ? new[] { new NuGetPackageCli { Id = packageId, Version = "13.3.0-preview.1.26200.1", Source = "daily" } }
+                    : [];
+
+                return Task.FromResult<IEnumerable<NuGetPackageCli>>(packages);
+            }
+        };
+
+        var channel = PackageChannel.CreateExplicitChannel(
+            PackageChannelNames.Staging,
+            PackageChannelQuality.Stable,
+            [new PackageMapping("Aspire*", "https://example.com/nuget/v3/index.json")],
+            cache,
+            allowPrereleaseFallback: false);
+
+        var packages = await channel.GetPackagesAsync("Aspire.AppHost.Sdk", new DirectoryInfo(Environment.CurrentDirectory), CancellationToken.None).DefaultTimeout();
+
+        Assert.Empty(packages);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -83,6 +83,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var stagingChannel = channels.First(c => c.Name == "staging");
         Assert.Equal(PackageChannelQuality.Stable, stagingChannel.Quality);
         Assert.True(stagingChannel.ConfigureGlobalPackagesFolder);
+        Assert.False(stagingChannel.AllowPrereleaseFallback);
         Assert.NotNull(stagingChannel.Mappings);
         
         var aspireMapping = stagingChannel.Mappings!.FirstOrDefault(m => m.PackageFilter == "Aspire*");

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -522,6 +522,83 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UpdateProjectFileAsync_StagingStableChannel_DoesNotUsePrereleaseFallback()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostFolder = workspace.CreateDirectory("UpdateTester.AppHost");
+        var appHostProjectFile = new FileInfo(Path.Combine(appHostFolder.FullName, "UpdateTester.AppHost.csproj"));
+
+        await File.WriteAllTextAsync(
+            appHostProjectFile.FullName,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <Sdk Name="Aspire.AppHost.Sdk" Version="13.3.0" />
+            </Project>
+            """);
+
+        var prereleaseSearchInvoked = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
+        {
+            config.EnabledFeatures = [KnownFeatures.StagingChannelEnabled];
+            config.ConfigurationCallback = values =>
+            {
+                values["overrideStagingFeed"] = "https://example.com/nuget/v3/index.json";
+            };
+
+            config.DotNetCliRunnerFactory = (sp) =>
+            {
+                return new TestDotNetCliRunner()
+                {
+                    SearchPackagesAsyncCallback = (_, query, _, prerelease, _, _, _, _, _, _) =>
+                    {
+                        Assert.Equal("Aspire.AppHost.Sdk", query);
+
+                        if (prerelease)
+                        {
+                            prereleaseSearchInvoked = true;
+                            return (0, [new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "13.4.0-preview.1.26201.1", Source = "daily" }]);
+                        }
+
+                        return (0, []);
+                    },
+
+                    GetProjectItemsAndPropertiesAsyncCallback = (projectFile, _, _, _, _) =>
+                    {
+                        if (projectFile.FullName != appHostProjectFile.FullName)
+                        {
+                            throw new InvalidOperationException("Unexpected project file.");
+                        }
+
+                        var itemsAndProperties = new JsonObject();
+                        itemsAndProperties.WithSdkVersion("13.3.0");
+
+                        var json = itemsAndProperties.ToJsonString();
+                        var document = JsonDocument.Parse(json);
+                        return (0, document);
+                    }
+                };
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var packagingService = provider.GetRequiredService<IPackagingService>();
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+        var selectedChannel = channels.Single(c => c.Name == PackageChannelNames.Staging);
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+
+        var exception = await Assert.ThrowsAsync<ProjectUpdaterException>(async () =>
+        {
+            await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
+        });
+
+        Assert.False(selectedChannel.AllowPrereleaseFallback);
+        Assert.False(prereleaseSearchInvoked);
+        Assert.Contains("Aspire.AppHost.Sdk", exception.Message);
+        Assert.Contains("staging", exception.Message);
+    }
+
+    [Fact]
     public async Task UpdateProjectFileAsync_DiamondDependency_DoesNotDuplicateUpdates()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/TestServices/FakeNuGetPackageCache.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeNuGetPackageCache.cs
@@ -11,6 +11,7 @@ internal sealed class FakeNuGetPackageCache : INuGetPackageCache
     public Func<DirectoryInfo, bool, FileInfo?, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetTemplatePackagesAsyncCallback { get; set; }
     public Func<DirectoryInfo, bool, FileInfo?, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetIntegrationPackagesAsyncCallback { get; set; }
     public Func<DirectoryInfo, bool, FileInfo?, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetCliPackagesAsyncCallback { get; set; }
+    public Func<DirectoryInfo, string, Func<string, bool>?, bool, FileInfo?, bool, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetPackagesAsyncCallback { get; set; }
     public Func<DirectoryInfo, string, bool, FileInfo?, bool, CancellationToken, Task<IEnumerable<NuGetPackage>>>? GetPackageVersionsAsyncCallback { get; set; }
 
     public Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
@@ -26,7 +27,8 @@ internal sealed class FakeNuGetPackageCache : INuGetPackageCache
            ?? Task.FromResult<IEnumerable<NuGetPackage>>([]);
 
     public Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-        => Task.FromResult<IEnumerable<NuGetPackage>>([]);
+        => GetPackagesAsyncCallback?.Invoke(workingDirectory, packageId, filter, prerelease, nugetConfigFile, useCache, cancellationToken)
+           ?? Task.FromResult<IEnumerable<NuGetPackage>>([]);
 
     public Task<IEnumerable<NuGetPackage>> GetPackageVersionsAsync(DirectoryInfo workingDirectory, string exactPackageId, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
         => GetPackageVersionsAsyncCallback?.Invoke(workingDirectory, exactPackageId, prerelease, nugetConfigFile, useCache, cancellationToken)


### PR DESCRIPTION
## Description

Fixes #16652

Prevents `aspire update --channel staging` from silently selecting daily prerelease packages when the staging channel is configured for stable package resolution. Staging package channels now disable the stable-channel prerelease fallback, so a missing stable package fails clearly instead of falling through to daily prerelease packages. The existing fallback remains available for the normal stable channel.

Validation:

- `dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.GetPackagesAsync_StableChannelWithoutPrereleaseFallback_DoesNotReturnPrereleasePackages" --filter-method "*.GetChannelsAsync_WhenStagingChannelEnabled_IncludesStagingChannelWithOverrideFeed" --filter-method "*.UpdateProjectFileAsync_StagingStableChannel_DoesNotUsePrereleaseFallback" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
