### PR TITLE
Make AtsJsonCodeWriter a shared internal helper

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -129,6 +129,7 @@
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="Utils\UserSecretsPathHelper.cs" />
     <Compile Include="$(SharedDir)UserSecrets\IsolatedUserSecretsHelper.cs" Link="Utils\IsolatedUserSecretsHelper.cs" />
     <Compile Include="$(SharedDir)UserSecrets\SecretsStore.cs" Link="Secrets\SecretsStore.cs" />
+    <Compile Include="$(SharedDir)Json\AtsJsonCodeWriter.cs" Link="Utils\AtsJsonCodeWriter.cs" />
     <Compile Include="$(SharedDir)Json\JsonFlattener.cs" Link="Utils\JsonFlattener.cs" />
     <Compile Include="$(SharedDir)Otlp\OtlpHelpers.cs" Link="Otlp\OtlpHelpers.cs" />
     <Compile Include="$(SharedDir)Otlp\IOtlpResource.cs" Link="Otlp\IOtlpResource.cs" />

--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -12,7 +12,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
-using Aspire.TypeSystem;
+using Aspire.Shared.Json;
 using Microsoft.Extensions.Logging;
 using Semver;
 using Spectre.Console;

--- a/src/Aspire.Hosting.CodeGeneration.Go/Aspire.Hosting.CodeGeneration.Go.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.Go/Aspire.Hosting.CodeGeneration.Go.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)Json\AtsJsonCodeWriter.cs" Link="AtsJsonCodeWriter.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.TypeSystem\Aspire.TypeSystem.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.Go/AtsGoCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Go/AtsGoCodeGenerator.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Nodes;
+using Aspire.Shared.Json;
 using Aspire.TypeSystem;
 
 namespace Aspire.Hosting.CodeGeneration.Go;

--- a/src/Aspire.Hosting.CodeGeneration.Java/Aspire.Hosting.CodeGeneration.Java.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.Java/Aspire.Hosting.CodeGeneration.Java.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)Json\AtsJsonCodeWriter.cs" Link="AtsJsonCodeWriter.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.TypeSystem\Aspire.TypeSystem.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.Java/AtsJavaCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/AtsJavaCodeGenerator.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Nodes;
+using Aspire.Shared.Json;
 using Aspire.TypeSystem;
 
 namespace Aspire.Hosting.CodeGeneration.Java;

--- a/src/Aspire.Hosting.CodeGeneration.Python/Aspire.Hosting.CodeGeneration.Python.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.Python/Aspire.Hosting.CodeGeneration.Python.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)Json\AtsJsonCodeWriter.cs" Link="AtsJsonCodeWriter.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.TypeSystem\Aspire.TypeSystem.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Nodes;
+using Aspire.Shared.Json;
 using Aspire.TypeSystem;
 
 namespace Aspire.Hosting.CodeGeneration.Python;

--- a/src/Aspire.Hosting.CodeGeneration.Rust/Aspire.Hosting.CodeGeneration.Rust.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/Aspire.Hosting.CodeGeneration.Rust.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)Json\AtsJsonCodeWriter.cs" Link="AtsJsonCodeWriter.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.TypeSystem\Aspire.TypeSystem.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.Rust/AtsRustCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/AtsRustCodeGenerator.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using Aspire.Shared.Json;
 using Aspire.TypeSystem;
 
 namespace Aspire.Hosting.CodeGeneration.Rust;

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Aspire.Hosting.CodeGeneration.TypeScript.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Aspire.Hosting.CodeGeneration.TypeScript.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)AppHostProfilePortGenerator.cs" Link="AppHostProfilePortGenerator.cs" />
+    <Compile Include="$(SharedDir)Json\AtsJsonCodeWriter.cs" Link="AtsJsonCodeWriter.cs" />
     <Compile Include="$(SharedDir)NpmVersionHelper.cs" Link="NpmVersionHelper.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json.Nodes;
+using Aspire.Shared.Json;
 using Aspire.TypeSystem;
 
 namespace Aspire.Hosting.CodeGeneration.TypeScript;

--- a/src/Shared/Json/AtsJsonCodeWriter.cs
+++ b/src/Shared/Json/AtsJsonCodeWriter.cs
@@ -5,12 +5,12 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
-namespace Aspire.TypeSystem;
+namespace Aspire.Shared.Json;
 
 /// <summary>
 /// Provides JSON literal formatting helpers for generated ATS source code.
 /// </summary>
-public static class AtsJsonCodeWriter
+internal static class AtsJsonCodeWriter
 {
     private static readonly JsonSerializerOptions s_relaxedJsonOptions = new()
     {
@@ -20,7 +20,7 @@ public static class AtsJsonCodeWriter
     /// <summary>
     /// Formats a JSON node using relaxed escaping so non-ASCII content remains readable in generated source.
     /// </summary>
-    public static string ToRelaxedJsonString(this JsonNode value)
+    internal static string ToRelaxedJsonString(this JsonNode value)
     {
         return value.ToJsonString(s_relaxedJsonOptions);
     }
@@ -28,7 +28,7 @@ public static class AtsJsonCodeWriter
     /// <summary>
     /// Formats a string literal as JSON using relaxed escaping.
     /// </summary>
-    public static string ToRelaxedJsonString(string value)
+    internal static string ToRelaxedJsonString(string value)
     {
         return JsonValue.Create(value)!.ToJsonString(s_relaxedJsonOptions);
     }


### PR DESCRIPTION
## Description

`AtsJsonCodeWriter` was only used by the CLI and polyglot code generation projects, so exposing it from `Aspire.TypeSystem` added public API that consumers do not need. This moves the implementation to `src\Shared\Json` as an internal helper and link-compiles it into each project that uses it: CLI plus Go, Java, Python, Rust, and TypeScript codegen.

Validation:
- `restore.cmd`
- `dotnet.cmd build` for `Aspire.TypeSystem`, all affected code generation projects, and `Aspire.Cli` with `/p:SkipNativeBuild=true`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
