### PR TITLE
Validate TypeScript AppHosts before startup

### DIFF
--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -136,9 +136,20 @@ internal sealed class GuestRuntime
         IGuestProcessLauncher launcher,
         CancellationToken cancellationToken)
     {
-        var commandSpec = watchMode && _spec.WatchExecute is not null
-            ? _spec.WatchExecute
+        var useWatchCommand = watchMode && _spec.WatchExecute is not null;
+        var commandSpec = useWatchCommand
+            ? _spec.WatchExecute!
             : _spec.Execute;
+
+        await EnsureMigrationFilesExistAsync(directory, cancellationToken);
+        if (!useWatchCommand)
+        {
+            var preExecuteResult = await RunPreExecuteCommandsAsync(appHostFile, directory, environmentVariables, launcher, cancellationToken);
+            if (preExecuteResult.ExitCode != 0)
+            {
+                return preExecuteResult;
+            }
+        }
 
         return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, null, launcher, cancellationToken);
     }
@@ -163,7 +174,43 @@ internal sealed class GuestRuntime
     {
         var commandSpec = _spec.PublishExecute ?? _spec.Execute;
 
+        await EnsureMigrationFilesExistAsync(directory, cancellationToken);
+        var preExecuteResult = await RunPreExecuteCommandsAsync(appHostFile, directory, environmentVariables, launcher, cancellationToken);
+        if (preExecuteResult.ExitCode != 0)
+        {
+            return preExecuteResult;
+        }
+
         return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, publishArgs, launcher, cancellationToken);
+    }
+
+    private async Task<(int ExitCode, OutputCollector? Output)> RunPreExecuteCommandsAsync(
+        FileInfo appHostFile,
+        DirectoryInfo directory,
+        IDictionary<string, string> environmentVariables,
+        IGuestProcessLauncher launcher,
+        CancellationToken cancellationToken)
+    {
+        if (_spec.PreExecute is null or { Length: 0 })
+        {
+            return (0, new OutputCollector());
+        }
+
+        var preExecuteLauncher = launcher is ExtensionGuestLauncher ? CreateDefaultLauncher() : launcher;
+        foreach (var commandSpec in _spec.PreExecute)
+        {
+            var args = ReplacePlaceholders(commandSpec.Args, appHostFile, directory, null);
+            var mergedEnvironment = MergeEnvironmentVariables(environmentVariables, commandSpec);
+
+            _logger.LogDebug("Launching pre-execution command: {Command} {Args}", commandSpec.Command, string.Join(" ", args));
+            var (exitCode, output) = await preExecuteLauncher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken);
+            if (exitCode != 0)
+            {
+                return (exitCode, output ?? new OutputCollector());
+            }
+        }
+
+        return (0, new OutputCollector());
     }
 
     private async Task<(int ExitCode, OutputCollector? Output)> ExecuteCommandAsync(
@@ -177,8 +224,16 @@ internal sealed class GuestRuntime
     {
         var args = ReplacePlaceholders(commandSpec.Args, appHostFile, directory, additionalArgs);
 
-        await EnsureMigrationFilesExistAsync(directory, cancellationToken);
+        var mergedEnvironment = MergeEnvironmentVariables(environmentVariables, commandSpec);
 
+        _logger.LogDebug("Launching: {Command} {Args}", commandSpec.Command, string.Join(" ", args));
+        return await launcher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken);
+    }
+
+    private static Dictionary<string, string> MergeEnvironmentVariables(
+        IDictionary<string, string> environmentVariables,
+        CommandSpec commandSpec)
+    {
         var mergedEnvironment = new Dictionary<string, string>(environmentVariables);
         if (commandSpec.EnvironmentVariables is not null)
         {
@@ -188,8 +243,7 @@ internal sealed class GuestRuntime
             }
         }
 
-        _logger.LogDebug("Launching: {Command} {Args}", commandSpec.Command, string.Join(" ", args));
-        return await launcher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken);
+        return mergedEnvironment;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -176,7 +176,7 @@ internal static class TypeScriptAppHostToolchainResolver
                 TypeScriptAppHostToolchain.Yarn => new CommandSpec
                 {
                     Command = "yarn",
-                    Args = ["exec", "tsc", "--noEmit", "-p", tsConfigFileName]
+                    Args = ["run", "tsc", "--noEmit", "-p", tsConfigFileName]
                 },
                 TypeScriptAppHostToolchain.Pnpm => new CommandSpec
                 {
@@ -197,11 +197,11 @@ internal static class TypeScriptAppHostToolchainResolver
                 Command = "bun",
                 Args = ["run", "{appHostFile}"]
             },
-            TypeScriptAppHostToolchain.Yarn => new CommandSpec
-            {
-                Command = "yarn",
-                Args = ["exec", "tsx", "--tsconfig", tsConfigFileName, "{appHostFile}"]
-            },
+                TypeScriptAppHostToolchain.Yarn => new CommandSpec
+                {
+                    Command = "yarn",
+                    Args = ["run", "tsx", "--tsconfig", tsConfigFileName, "{appHostFile}"]
+                },
             TypeScriptAppHostToolchain.Pnpm => new CommandSpec
             {
                 Command = "pnpm",
@@ -242,7 +242,7 @@ internal static class TypeScriptAppHostToolchainResolver
                     "--ext", "ts",
                     "--ignore", "node_modules/",
                     "--ignore", ".modules/",
-                    "--exec", $"yarn exec tsc --noEmit -p {tsConfigFileName} && yarn exec tsx --tsconfig {tsConfigFileName} \"{{appHostFile}}\""
+                    "--exec", $"yarn run tsc --noEmit -p {tsConfigFileName} && yarn run tsx --tsconfig {tsConfigFileName} \"{{appHostFile}}\""
                 ]
             },
             TypeScriptAppHostToolchain.Pnpm => new CommandSpec

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -144,6 +144,7 @@ internal static class TypeScriptAppHostToolchainResolver
             DetectionPatterns = baseRuntimeSpec.DetectionPatterns,
             Initialize = baseRuntimeSpec.Initialize,
             InstallDependencies = CreateInstallCommand(toolchain),
+            PreExecute = CreatePreExecuteCommands(toolchain, tsConfigFileName),
             Execute = CreateExecuteCommand(toolchain, tsConfigFileName),
             WatchExecute = CreateWatchCommand(toolchain, tsConfigFileName),
             PublishExecute = baseRuntimeSpec.PublishExecute,
@@ -159,6 +160,32 @@ internal static class TypeScriptAppHostToolchainResolver
             Command = GetCommandName(toolchain),
             Args = ["install"]
         };
+    }
+
+    private static CommandSpec[] CreatePreExecuteCommands(TypeScriptAppHostToolchain toolchain, string tsConfigFileName)
+    {
+        return
+        [
+            toolchain switch
+            {
+                TypeScriptAppHostToolchain.Bun => new CommandSpec
+                {
+                    Command = "bun",
+                    Args = ["x", "tsc", "--noEmit", "-p", tsConfigFileName]
+                },
+                TypeScriptAppHostToolchain.Yarn => new CommandSpec
+                {
+                    Command = "yarn",
+                    Args = ["exec", "tsc", "--noEmit", "-p", tsConfigFileName]
+                },
+                TypeScriptAppHostToolchain.Pnpm => new CommandSpec
+                {
+                    Command = "pnpm",
+                    Args = ["exec", "tsc", "--noEmit", "-p", tsConfigFileName]
+                },
+                _ => throw new ArgumentOutOfRangeException(nameof(toolchain), toolchain, null)
+            }
+        ];
     }
 
     private static CommandSpec CreateExecuteCommand(TypeScriptAppHostToolchain toolchain, string tsConfigFileName)
@@ -191,7 +218,17 @@ internal static class TypeScriptAppHostToolchainResolver
             TypeScriptAppHostToolchain.Bun => new CommandSpec
             {
                 Command = "bun",
-                Args = ["--watch", "run", "{appHostFile}"]
+                Args =
+                [
+                    "x",
+                    "nodemon",
+                    "--signal", "SIGTERM",
+                    "--watch", ".",
+                    "--ext", "ts",
+                    "--ignore", "node_modules/",
+                    "--ignore", ".modules/",
+                    "--exec", $"bun x tsc --noEmit -p {tsConfigFileName} && bun run \"{{appHostFile}}\""
+                ]
             },
             TypeScriptAppHostToolchain.Yarn => new CommandSpec
             {
@@ -205,7 +242,7 @@ internal static class TypeScriptAppHostToolchainResolver
                     "--ext", "ts",
                     "--ignore", "node_modules/",
                     "--ignore", ".modules/",
-                    "--exec", $"yarn exec tsx --tsconfig {tsConfigFileName} {{appHostFile}}"
+                    "--exec", $"yarn exec tsc --noEmit -p {tsConfigFileName} && yarn exec tsx --tsconfig {tsConfigFileName} \"{{appHostFile}}\""
                 ]
             },
             TypeScriptAppHostToolchain.Pnpm => new CommandSpec
@@ -220,7 +257,7 @@ internal static class TypeScriptAppHostToolchainResolver
                     "--ext", "ts",
                     "--ignore", "node_modules/",
                     "--ignore", ".modules/",
-                    "--exec", $"pnpm exec tsx --tsconfig {tsConfigFileName} {{appHostFile}}"
+                    "--exec", $"pnpm exec tsc --noEmit -p {tsConfigFileName} && pnpm exec tsx --tsconfig {tsConfigFileName} \"{{appHostFile}}\""
                 ]
             },
             _ => throw new ArgumentOutOfRangeException(nameof(toolchain), toolchain, null)

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -171,7 +171,7 @@ internal static class TypeScriptAppHostToolchainResolver
                 TypeScriptAppHostToolchain.Bun => new CommandSpec
                 {
                     Command = "bun",
-                    Args = ["x", "tsc", "--noEmit", "-p", tsConfigFileName]
+                    Args = ["run", "tsc", "--noEmit", "-p", tsConfigFileName]
                 },
                 TypeScriptAppHostToolchain.Yarn => new CommandSpec
                 {
@@ -227,7 +227,7 @@ internal static class TypeScriptAppHostToolchainResolver
                     "--ext", "ts",
                     "--ignore", "node_modules/",
                     "--ignore", ".modules/",
-                    "--exec", $"bun x tsc --noEmit -p {tsConfigFileName} && bun run \"{{appHostFile}}\""
+                    "--exec", $"bun run tsc --noEmit -p {tsConfigFileName} && bun run \"{{appHostFile}}\""
                 ]
             },
             TypeScriptAppHostToolchain.Yarn => new CommandSpec

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -220,7 +220,7 @@ internal static class TypeScriptAppHostToolchainResolver
                 Command = "bun",
                 Args =
                 [
-                    "x",
+                    "run",
                     "nodemon",
                     "--signal", "SIGTERM",
                     "--watch", ".",

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -266,6 +266,14 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
                 Command = "npm",
                 Args = ["install"]
             },
+            PreExecute =
+            [
+                new CommandSpec
+                {
+                    Command = "npx",
+                    Args = ["--no-install", "tsc", "--noEmit", "-p", AppHostTsConfigFileName]
+                }
+            ],
             Execute = new CommandSpec
             {
                 Command = "npx",
@@ -282,7 +290,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
                     "--ext", "ts",
                     "--ignore", "node_modules/",
                     "--ignore", ".modules/",
-                    "--exec", $"npx --no-install tsx --tsconfig {AppHostTsConfigFileName} {{appHostFile}}"
+                    "--exec", $"npx --no-install tsc --noEmit -p {AppHostTsConfigFileName} && npx --no-install tsx --tsconfig {AppHostTsConfigFileName} \"{{appHostFile}}\""
                 ]
             },
             MigrationFiles = new Dictionary<string, string>

--- a/src/Aspire.TypeSystem/RuntimeSpec.cs
+++ b/src/Aspire.TypeSystem/RuntimeSpec.cs
@@ -40,6 +40,11 @@ public sealed class RuntimeSpec
     public CommandSpec? InstallDependencies { get; init; }
 
     /// <summary>
+    /// Gets the commands to run before executing the AppHost. Null if no pre-execution validation is needed.
+    /// </summary>
+    public CommandSpec[]? PreExecute { get; init; }
+
+    /// <summary>
     /// Gets the command to execute the AppHost for run.
     /// </summary>
     public required CommandSpec Execute { get; init; }

--- a/src/Aspire.TypeSystem/RuntimeSpec.cs
+++ b/src/Aspire.TypeSystem/RuntimeSpec.cs
@@ -40,7 +40,8 @@ public sealed class RuntimeSpec
     public CommandSpec? InstallDependencies { get; init; }
 
     /// <summary>
-    /// Gets the commands to run before executing the AppHost. Null if no pre-execution validation is needed.
+    /// Gets the commands to run before executing or publishing the AppHost. Null if no pre-execution validation is needed.
+    /// Watch-mode validation should be part of <see cref="WatchExecute" /> when needed.
     /// </summary>
     public CommandSpec[]? PreExecute { get; init; }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployTypeScriptTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesDeployTypeScriptTests.cs
@@ -96,9 +96,11 @@ const chartVersion = await builder.addParameter("chartversion");
 
 // Add Kubernetes environment with Helm deployment
 const k8sEnv = await builder.addKubernetesEnvironment("env");
-await k8sEnv.withHelm(async (helm) => {
-    await helm.withNamespace(k8sNamespace);
-    await helm.withChartVersion(chartVersion);
+await k8sEnv.withHelm({
+    configure: async (helm) => {
+        await helm.withNamespace(k8sNamespace);
+        await helm.withChartVersion(chartVersion);
+    },
 });
 
 await builder.build().run();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
@@ -240,7 +240,7 @@ public sealed class TypeScriptPublishTests(ITestOutputHelper output)
             const builder = await createBuilder();
 
             const compose = await builder.addDockerComposeEnvironment("compose");
-            await compose.withDashboard(false);
+            await compose.withDashboard({ enabled: false });
 
             const container = await builder.addContainer("my-container", "nginx:alpine");
             await container.withBindMount("/host/path/data", "/container/data");

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -28,7 +28,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         CommandSpec? execute = null,
         CommandSpec? watchExecute = null,
         CommandSpec? publishExecute = null,
-        CommandSpec? installDependencies = null)
+        CommandSpec? installDependencies = null,
+        CommandSpec[]? preExecute = null)
     {
         return new RuntimeSpec
         {
@@ -43,7 +44,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             },
             WatchExecute = watchExecute,
             PublishExecute = publishExecute,
-            InstallDependencies = installDependencies
+            InstallDependencies = installDependencies,
+            PreExecute = preExecute
         };
     }
 
@@ -112,6 +114,72 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunAsync_WatchModeWithWatchExecute_SkipsPreExecute()
+    {
+        var spec = CreateTestSpec(
+            execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] },
+            watchExecute: new CommandSpec { Command = "watch-cmd", Args = ["--watch", "{appHostFile}"] },
+            preExecute:
+            [
+                new CommandSpec { Command = "typecheck-cmd", Args = ["--noEmit"] }
+            ]);
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        var (exitCode, _) = await runtime.RunAsync(appHostFile, directory, new Dictionary<string, string>(), watchMode: true, launcher, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+        var call = Assert.Single(launcher.Calls);
+        Assert.Equal("watch-cmd", call.Command);
+    }
+
+    [Fact]
+    public async Task RunAsync_RunsPreExecuteBeforeExecute()
+    {
+        var spec = CreateTestSpec(
+            execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] },
+            preExecute:
+            [
+                new CommandSpec { Command = "typecheck-cmd", Args = ["--project", "{appHostDir}"] }
+            ]);
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        await runtime.RunAsync(appHostFile, directory, new Dictionary<string, string>(), watchMode: false, launcher, CancellationToken.None);
+
+        Assert.Equal(2, launcher.Calls.Count);
+        Assert.Equal("typecheck-cmd", launcher.Calls[0].Command);
+        Assert.Equal(["--project", directory.FullName], launcher.Calls[0].Args);
+        Assert.Equal("run-cmd", launcher.Calls[1].Command);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenPreExecuteFails_DoesNotExecute()
+    {
+        var spec = CreateTestSpec(
+            execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] },
+            preExecute:
+            [
+                new CommandSpec { Command = "typecheck-cmd", Args = ["--noEmit"] }
+            ]);
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        launcher.ExitCodes.Enqueue(2);
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        var (exitCode, _) = await runtime.RunAsync(appHostFile, directory, new Dictionary<string, string>(), watchMode: false, launcher, CancellationToken.None);
+
+        Assert.Equal(2, exitCode);
+        var call = Assert.Single(launcher.Calls);
+        Assert.Equal("typecheck-cmd", call.Command);
+    }
+
+    [Fact]
     public async Task RunAsync_WatchModeWithoutWatchSpec_FallsBackToExecute()
     {
         var spec = CreateTestSpec(execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] });
@@ -141,6 +209,28 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("publish-cmd", launcher.LastCommand);
         Assert.Contains(launcher.LastArgs, a => a.Contains("--output") && a.Contains("/out"));
+    }
+
+    [Fact]
+    public async Task PublishAsync_RunsPreExecuteBeforePublishExecute()
+    {
+        var spec = CreateTestSpec(
+            execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] },
+            publishExecute: new CommandSpec { Command = "publish-cmd", Args = ["{appHostFile}", "{args}"] },
+            preExecute:
+            [
+                new CommandSpec { Command = "typecheck-cmd", Args = ["--project", "{appHostDir}"] }
+            ]);
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), ["--output", "/out"], launcher, CancellationToken.None);
+
+        Assert.Equal(2, launcher.Calls.Count);
+        Assert.Equal("typecheck-cmd", launcher.Calls[0].Command);
+        Assert.Equal("publish-cmd", launcher.Calls[1].Command);
     }
 
     [Fact]
@@ -527,6 +617,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
 
     private sealed class RecordingLauncher : IGuestProcessLauncher
     {
+        public List<(string Command, string[] Args)> Calls { get; } = [];
+        public Queue<int> ExitCodes { get; } = [];
         public string LastCommand { get; private set; } = string.Empty;
         public string[] LastArgs { get; private set; } = [];
         public DirectoryInfo? LastWorkingDirectory { get; private set; }
@@ -539,11 +631,13 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             IDictionary<string, string> environmentVariables,
             CancellationToken cancellationToken)
         {
+            Calls.Add((command, args));
             LastCommand = command;
             LastArgs = args;
             LastWorkingDirectory = workingDirectory;
             LastEnvironmentVariables = new Dictionary<string, string>(environmentVariables);
-            return Task.FromResult<(int, OutputCollector?)>((0, new OutputCollector()));
+            var exitCode = ExitCodes.Count > 0 ? ExitCodes.Dequeue() : 0;
+            return Task.FromResult<(int, OutputCollector?)>((exitCode, new OutputCollector()));
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -179,11 +179,14 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
         Assert.NotNull(runtimeSpec.InstallDependencies);
         Assert.Equal("bun", runtimeSpec.InstallDependencies?.Command);
         Assert.Equal(["install"], runtimeSpec.InstallDependencies!.Args);
+        var preExecute = Assert.Single(runtimeSpec.PreExecute!);
+        Assert.Equal("bun", preExecute.Command);
+        Assert.Equal(["x", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"], preExecute.Args);
         Assert.Equal("bun", runtimeSpec.Execute.Command);
         Assert.Equal(["run", "{appHostFile}"], runtimeSpec.Execute.Args);
         Assert.NotNull(runtimeSpec.WatchExecute);
         Assert.Equal("bun", runtimeSpec.WatchExecute?.Command);
-        Assert.Equal(["--watch", "run", "{appHostFile}"], runtimeSpec.WatchExecute!.Args);
+        Assert.Contains("bun x tsc --noEmit -p tsconfig.apphost.json && bun run \"{appHostFile}\"", runtimeSpec.WatchExecute!.Args);
         Assert.Equal("node", runtimeSpec.ExtensionLaunchCapability);
     }
 
@@ -194,10 +197,29 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
 
         var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Yarn);
 
+        var preExecute = Assert.Single(runtimeSpec.PreExecute!);
+        Assert.Equal("yarn", preExecute.Command);
+        Assert.Equal(["exec", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"], preExecute.Args);
         Assert.Equal("yarn", runtimeSpec.Execute.Command);
         Assert.Equal(["exec", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}"], runtimeSpec.Execute.Args);
         Assert.Equal("yarn", runtimeSpec.WatchExecute?.Command);
-        Assert.Contains("yarn exec tsx --tsconfig tsconfig.apphost.json {appHostFile}", runtimeSpec.WatchExecute?.Args ?? []);
+        Assert.Contains("yarn exec tsc --noEmit -p tsconfig.apphost.json && yarn exec tsx --tsconfig tsconfig.apphost.json \"{appHostFile}\"", runtimeSpec.WatchExecute?.Args ?? []);
+    }
+
+    [Fact]
+    public void ApplyToRuntimeSpec_WhenPnpmSelected_UsesPnpmTypeCheckCommands()
+    {
+        var baseRuntimeSpec = CreateBaseRuntimeSpec();
+
+        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Pnpm);
+
+        var preExecute = Assert.Single(runtimeSpec.PreExecute!);
+        Assert.Equal("pnpm", preExecute.Command);
+        Assert.Equal(["exec", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"], preExecute.Args);
+        Assert.Equal("pnpm", runtimeSpec.Execute.Command);
+        Assert.Equal(["exec", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}"], runtimeSpec.Execute.Args);
+        Assert.Equal("pnpm", runtimeSpec.WatchExecute?.Command);
+        Assert.Contains("pnpm exec tsc --noEmit -p tsconfig.apphost.json && pnpm exec tsx --tsconfig tsconfig.apphost.json \"{appHostFile}\"", runtimeSpec.WatchExecute?.Args ?? []);
     }
 
     private static RuntimeSpec CreateBaseRuntimeSpec()
@@ -213,6 +235,14 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
                 Command = "npm",
                 Args = ["install"]
             },
+            PreExecute =
+            [
+                new CommandSpec
+                {
+                    Command = "npx",
+                    Args = ["--no-install", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"]
+                }
+            ],
             Execute = new CommandSpec
             {
                 Command = "npx",

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -181,12 +181,12 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
         Assert.Equal(["install"], runtimeSpec.InstallDependencies!.Args);
         var preExecute = Assert.Single(runtimeSpec.PreExecute!);
         Assert.Equal("bun", preExecute.Command);
-        Assert.Equal(["x", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"], preExecute.Args);
+        Assert.Equal(["run", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"], preExecute.Args);
         Assert.Equal("bun", runtimeSpec.Execute.Command);
         Assert.Equal(["run", "{appHostFile}"], runtimeSpec.Execute.Args);
         Assert.NotNull(runtimeSpec.WatchExecute);
         Assert.Equal("bun", runtimeSpec.WatchExecute?.Command);
-        Assert.Contains("bun x tsc --noEmit -p tsconfig.apphost.json && bun run \"{appHostFile}\"", runtimeSpec.WatchExecute!.Args);
+        Assert.Contains("bun run tsc --noEmit -p tsconfig.apphost.json && bun run \"{appHostFile}\"", runtimeSpec.WatchExecute!.Args);
         Assert.Equal("node", runtimeSpec.ExtensionLaunchCapability);
     }
 

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -199,11 +199,11 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
 
         var preExecute = Assert.Single(runtimeSpec.PreExecute!);
         Assert.Equal("yarn", preExecute.Command);
-        Assert.Equal(["exec", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"], preExecute.Args);
+        Assert.Equal(["run", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"], preExecute.Args);
         Assert.Equal("yarn", runtimeSpec.Execute.Command);
-        Assert.Equal(["exec", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}"], runtimeSpec.Execute.Args);
+        Assert.Equal(["run", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}"], runtimeSpec.Execute.Args);
         Assert.Equal("yarn", runtimeSpec.WatchExecute?.Command);
-        Assert.Contains("yarn exec tsc --noEmit -p tsconfig.apphost.json && yarn exec tsx --tsconfig tsconfig.apphost.json \"{appHostFile}\"", runtimeSpec.WatchExecute?.Args ?? []);
+        Assert.Contains("yarn run tsc --noEmit -p tsconfig.apphost.json && yarn run tsx --tsconfig tsconfig.apphost.json \"{appHostFile}\"", runtimeSpec.WatchExecute?.Args ?? []);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -186,7 +186,18 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
         Assert.Equal(["run", "{appHostFile}"], runtimeSpec.Execute.Args);
         Assert.NotNull(runtimeSpec.WatchExecute);
         Assert.Equal("bun", runtimeSpec.WatchExecute?.Command);
-        Assert.Contains("bun run tsc --noEmit -p tsconfig.apphost.json && bun run \"{appHostFile}\"", runtimeSpec.WatchExecute!.Args);
+        Assert.Equal(
+            [
+                "run",
+                "nodemon",
+                "--signal", "SIGTERM",
+                "--watch", ".",
+                "--ext", "ts",
+                "--ignore", "node_modules/",
+                "--ignore", ".modules/",
+                "--exec", "bun run tsc --noEmit -p tsconfig.apphost.json && bun run \"{appHostFile}\""
+            ],
+            runtimeSpec.WatchExecute!.Args);
         Assert.Equal("node", runtimeSpec.ExtensionLaunchCapability);
     }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -231,10 +231,13 @@ public sealed class TypeScriptLanguageSupportTests
     public void GetRuntimeSpec_UsesAppHostSpecificTsConfig()
     {
         var runtimeSpec = _languageSupport.GetRuntimeSpec();
+        var preExecute = Assert.Single(runtimeSpec.PreExecute!);
         var watchExecute = Assert.IsType<CommandSpec>(runtimeSpec.WatchExecute);
 
+        Assert.Equal("npx", preExecute.Command);
+        Assert.Equal(new[] { "--no-install", "tsc", "--noEmit", "-p", "tsconfig.apphost.json" }, preExecute.Args);
         Assert.Equal(new[] { "--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}" }, runtimeSpec.Execute.Args);
-        Assert.Contains("npx --no-install tsx --tsconfig tsconfig.apphost.json {appHostFile}", watchExecute.Args);
+        Assert.Contains("npx --no-install tsc --noEmit -p tsconfig.apphost.json && npx --no-install tsx --tsconfig tsconfig.apphost.json \"{appHostFile}\"", watchExecute.Args);
     }
 
     private static JsonObject ParseJson(string content) => JsonNode.Parse(content)!.AsObject();


### PR DESCRIPTION
## Description

TypeScript AppHosts currently run through `tsx`, which transpiles without type validation. This means `aspire run` and `aspire start` can launch the dashboard even when the AppHost has TypeScript compile errors, leaving users with a partially started and confusing app.

This adds a `PreExecute` runtime hook and uses it for TypeScript AppHosts to run `tsc --noEmit -p tsconfig.apphost.json` before normal run and publish execution. Watch mode embeds the same validation into the nodemon restart command so the watcher can still start when there are initial type errors and recover as the user edits.

Measured startup impact on a new React TypeScript AppHost template: the added `tsc --noEmit -p tsconfig.apphost.json` validation costs about **0.8s** on warm runs, with a cold first run around **1.0s**.

Example compile error:

```ts
const shouldBeNumber: number = "not a number";
```

With this change, `aspire run` stops before the AppHost starts and displays the `tsc` diagnostic:

```text
apphost.ts(22,7): error TS2322: Type 'string' is not assignable to type 'number'.
```

Fixes #16645

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
