### PR TITLE
Fix aspire init template install for non-stable CLI builds (#16654)

### DIFF
--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Agents;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
+using Aspire.Cli.Exceptions;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -296,24 +297,46 @@ internal sealed class InitCommand : BaseCommand
             return ExitCodeConstants.Success;
         }
 
+        // Resolve the channel-aware template package version + feed mapping. This makes init
+        // honor the global `channel` configuration (matching `aspire new`) and ensures the
+        // staging/daily/PR feed is queried for non-stable CLI builds. PR hives are intentionally
+        // excluded — init should produce the same template on every machine for a given CLI build.
+        TemplatePackageSelection selection;
+        try
+        {
+            var query = new TemplatePackageQuery(
+                ChannelOverride: null,
+                VersionOverride: null,
+                SourceOverride: null,
+                IncludePrHives: false);
+
+            selection = await _templateNuGetConfigService.ResolveTemplatePackageAsync(query, cancellationToken);
+        }
+        catch (ChannelNotFoundException ex)
+        {
+            InteractionService.DisplayError(ex.Message);
+            return ExitCodeConstants.FailedToInstallTemplates;
+        }
+        catch (EmptyChoicesException ex)
+        {
+            InteractionService.DisplayError(ex.Message);
+            return ExitCodeConstants.FailedToInstallTemplates;
+        }
+
         // The aspire-apphost template ships in the Aspire.ProjectTemplates package.
         // `dotnet new` does not install templates implicitly, so on a fresh machine
         // (or after a CLI update) the template will be missing. Install first.
-        var aspireVersion = VersionHelper.GetDefaultTemplateVersion();
-        var installResult = await InteractionService.ShowStatusAsync(
+        var installOutcome = await _templateNuGetConfigService.InstallTemplatePackageAsync(
+            selection,
+            _runner,
             "Installing Aspire project templates...",
-            () => _runner.InstallTemplateAsync(
-                packageName: "Aspire.ProjectTemplates",
-                version: aspireVersion,
-                nugetConfigFile: null,
-                nugetSource: null,
-                force: true,
-                options: new ProcessInvocationOptions(),
-                cancellationToken: cancellationToken));
+            statusEmoji: null,
+            cancellationToken);
 
-        if (installResult.ExitCode != 0)
+        if (installOutcome.ExitCode != 0)
         {
-            InteractionService.DisplayError($"Failed to install Aspire.ProjectTemplates (exit code {installResult.ExitCode}).");
+            InteractionService.DisplayLines(installOutcome.OutputLines);
+            InteractionService.DisplayError($"Failed to install Aspire.ProjectTemplates (exit code {installOutcome.ExitCode}).");
             return ExitCodeConstants.FailedToInstallTemplates;
         }
 

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Exceptions;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.NuGet;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Scaffolding;
@@ -322,6 +323,15 @@ internal sealed class InitCommand : BaseCommand
             InteractionService.DisplayError(ex.Message);
             return ExitCodeConstants.FailedToInstallTemplates;
         }
+        catch (NuGetPackageCacheException ex)
+        {
+            // Surface NuGet feed search failures (offline, inaccessible feed, etc.) with a friendly error
+            // instead of letting them bubble up to the top-level "unexpected error" handler. The pre-extraction
+            // init code went straight to `dotnet new install` and never invoked a NuGet search, so this catch
+            // restores parity with the prior init failure mode for these scenarios.
+            InteractionService.DisplayError(ex.Message);
+            return ExitCodeConstants.FailedToInstallTemplates;
+        }
 
         // The aspire-apphost template ships in the Aspire.ProjectTemplates package.
         // `dotnet new` does not install templates implicitly, so on a fresh machine
@@ -336,7 +346,7 @@ internal sealed class InitCommand : BaseCommand
         if (installOutcome.ExitCode != 0)
         {
             InteractionService.DisplayLines(installOutcome.OutputLines);
-            InteractionService.DisplayError($"Failed to install Aspire.ProjectTemplates (exit code {installOutcome.ExitCode}).");
+            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode, _executionContext.LogFilePath));
             return ExitCodeConstants.FailedToInstallTemplates;
         }
 

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -450,11 +450,9 @@ internal class DotNetTemplateFactory(
     {
         try
         {
-            // Some templates have additional arguments that need to be applied to the `dotnet new` command
-            // when it is executed. This callback will get those arguments and potentially prompt for them.
-            // Run before resolving the template package so prompt/error precedence is unchanged.
-            var extraArgs = await extraArgsCallback(parseResult, cancellationToken);
-
+            // Resolve the template package first, matching the pre-extraction order in
+            // release/13.3. Surfacing channel/version errors before prompting for extra args
+            // avoids discarding answers the user just gave.
             var query = new TemplatePackageQuery(
                 ChannelOverride: inputs.Channel,
                 VersionOverride: inputs.Version,
@@ -462,6 +460,10 @@ internal class DotNetTemplateFactory(
                 IncludePrHives: true);
 
             var selectedTemplateDetails = await templateNuGetConfigService.ResolveTemplatePackageAsync(query, cancellationToken);
+
+            // Some templates have additional arguments that need to be applied to the `dotnet new` command
+            // when it is executed. This callback will get those arguments and potentially prompt for them.
+            var extraArgs = await extraArgsCallback(parseResult, cancellationToken);
 
             var installOutcome = await templateNuGetConfigService.InstallTemplatePackageAsync(
                 selectedTemplateDetails,

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -9,14 +9,10 @@ using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
-using NuGetPackage = Aspire.Shared.NuGetPackageCli;
-using Semver;
-using Spectre.Console;
 
 namespace Aspire.Cli.Templating;
 
@@ -24,13 +20,10 @@ internal class DotNetTemplateFactory(
     IInteractionService interactionService,
     IDotNetCliRunner runner,
     ICertificateService certificateService,
-    IPackagingService packagingService,
     INewCommandPrompter prompter,
-    ITemplateVersionPrompter templateVersionPrompter,
     CliExecutionContext executionContext,
     IDotNetSdkInstaller sdkInstaller,
     IFeatures features,
-    IConfigurationService configurationService,
     AspireCliTelemetry telemetry,
     ICliHostEnvironment hostEnvironment,
     TemplateNuGetConfigService templateNuGetConfigService)
@@ -457,50 +450,34 @@ internal class DotNetTemplateFactory(
     {
         try
         {
-            var source = inputs.Source;
-            var selectedTemplateDetails = await GetProjectTemplatesVersionAsync(inputs, cancellationToken: cancellationToken);
-
             // Some templates have additional arguments that need to be applied to the `dotnet new` command
             // when it is executed. This callback will get those arguments and potentially prompt for them.
+            // Run before resolving the template package so prompt/error precedence is unchanged.
             var extraArgs = await extraArgsCallback(parseResult, cancellationToken);
-            using var temporaryConfig = selectedTemplateDetails.Channel.Type == PackageChannelType.Explicit ? await TemporaryNuGetConfig.CreateAsync(selectedTemplateDetails.Channel.Mappings!) : null;
 
-            var templateInstallCollector = new OutputCollector();
-            var templateInstallResult = await interactionService.ShowStatusAsync<(int ExitCode, string? TemplateVersion)>(
+            var query = new TemplatePackageQuery(
+                ChannelOverride: inputs.Channel,
+                VersionOverride: inputs.Version,
+                SourceOverride: inputs.Source,
+                IncludePrHives: true);
+
+            var selectedTemplateDetails = await templateNuGetConfigService.ResolveTemplatePackageAsync(query, cancellationToken);
+
+            var installOutcome = await templateNuGetConfigService.InstallTemplatePackageAsync(
+                selectedTemplateDetails,
+                runner,
                 TemplatingStrings.GettingTemplates,
-                async () =>
-                {
-                    var options = new ProcessInvocationOptions()
-                    {
-                        StandardOutputCallback = templateInstallCollector.AppendOutput,
-                        StandardErrorCallback = templateInstallCollector.AppendOutput,
-                    };
+                statusEmoji: KnownEmojis.Ice,
+                cancellationToken);
 
-                    // Whilst we install the templates - if we are using an explicit channel we need to
-                    // generate a temporary NuGet.config file to make sure we install the right package
-                    // from the right feed. If we are using an implicit channel then we just use the
-                    // ambient configuration (although we should still specify the source) because
-                    // the user would have selected it.
-
-                    var result = await runner.InstallTemplateAsync(
-                        packageName: "Aspire.ProjectTemplates",
-                        version: selectedTemplateDetails.Package.Version,
-                        nugetConfigFile: temporaryConfig?.ConfigFile,
-                        nugetSource: selectedTemplateDetails.Package.Source,
-                        force: true,
-                        options: options,
-                        cancellationToken: cancellationToken);
-                    return result;
-                }, emoji: KnownEmojis.Ice);
-
-            if (templateInstallResult.ExitCode != 0)
+            if (installOutcome.ExitCode != 0)
             {
-                interactionService.DisplayLines(templateInstallCollector.GetLines());
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, templateInstallResult.ExitCode, executionContext.LogFilePath));
+                interactionService.DisplayLines(installOutcome.OutputLines);
+                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode, executionContext.LogFilePath));
                 return new TemplateResult(ExitCodeConstants.FailedToInstallTemplates);
             }
 
-            interactionService.DisplayMessage(KnownEmojis.Package, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.UsingProjectTemplatesVersion, templateInstallResult.TemplateVersion));
+            interactionService.DisplayMessage(KnownEmojis.Package, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.UsingProjectTemplatesVersion, installOutcome.TemplateVersion));
 
             var newProjectCollector = new OutputCollector();
             var newProjectExitCode = await interactionService.ShowStatusAsync(
@@ -614,102 +591,4 @@ internal class DotNetTemplateFactory(
 
         return outputPath;
     }
-
-    private async Task<(NuGetPackage Package, PackageChannel Channel)> GetProjectTemplatesVersionAsync(TemplateInputs inputs, CancellationToken cancellationToken)
-    {
-        var allChannels = await packagingService.GetChannelsAsync(cancellationToken);
-
-        // Check if channel was provided via inputs (highest priority)
-        var channelName = inputs.Channel;
-
-        // If no channel in inputs, check for global channel setting
-        if (string.IsNullOrEmpty(channelName))
-        {
-            channelName = await configurationService.GetConfigurationAsync("channel", cancellationToken);
-        }
-
-        IEnumerable<PackageChannel> channels;
-        var hasPrHives = executionContext.GetPrHiveCount() > 0;
-        bool hasChannelSetting = !string.IsNullOrEmpty(channelName);
-
-        if (hasChannelSetting)
-        {
-            // If --channel option is provided or global channel setting exists, find the matching channel
-            // (--channel option takes precedence over global setting)
-            var matchingChannel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
-            if (matchingChannel is null)
-            {
-                throw new Exceptions.ChannelNotFoundException($"No channel found matching '{channelName}'. Valid options are: {string.Join(", ", allChannels.Select(c => c.Name))}");
-            }
-            channels = new[] { matchingChannel };
-        }
-        else
-        {
-            // If there are hives (PR build directories), include all channels.
-            // Otherwise, only use the implicit/default channel to avoid prompting.
-            channels = hasPrHives
-                ? allChannels
-                : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
-        }
-
-        var packagesFromChannels = await interactionService.ShowStatusAsync(TemplatingStrings.SearchingForAvailableTemplateVersions, async () =>
-        {
-            var results = new List<(NuGetPackage Package, PackageChannel Channel)>();
-            var packagesFromChannelsLock = new object();
-
-            await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
-            {
-                var templatePackages = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, ct);
-                lock (packagesFromChannelsLock)
-                {
-                    results.AddRange(templatePackages.Select(p => (p, channel)));
-                }
-            });
-
-            return results;
-        });
-
-        if (!packagesFromChannels.Any())
-        {
-            throw new EmptyChoicesException(TemplatingStrings.NoTemplateVersionsFound);
-        }
-
-        var orderedPackagesFromChannels = packagesFromChannels.OrderByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer);
-
-        if (inputs.Version is { } version)
-        {
-            var explicitPackageFromChannel = orderedPackagesFromChannels.FirstOrDefault(p => p.Package.Version == version);
-            if (explicitPackageFromChannel.Package is not null)
-            {
-                return explicitPackageFromChannel;
-            }
-        }
-
-        if (VersionHelper.TryGetCurrentCliVersionMatch(
-            orderedPackagesFromChannels,
-            p => p.Package.Version,
-            out var cliVersionPackageFromChannel,
-            channelName: channelName,
-            hasPrHives: hasPrHives))
-        {
-            return cliVersionPackageFromChannel;
-        }
-
-        // If channel was specified via --channel option or global setting (but no --version),
-        // automatically select the highest version from that channel without prompting
-        if (hasChannelSetting)
-        {
-            return orderedPackagesFromChannels.First();
-        }
-
-        // In non-interactive mode, automatically select the highest version
-        if (!hostEnvironment.SupportsInteractiveInput)
-        {
-            return orderedPackagesFromChannels.First();
-        }
-
-        var selectedPackageFromChannel = await templateVersionPrompter.PromptForTemplatesVersionAsync(orderedPackagesFromChannels, cancellationToken);
-        return selectedPackageFromChannel;
-    }
-
 }

--- a/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
+++ b/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
@@ -267,6 +267,11 @@ internal sealed class TemplateNuGetConfigService(
         // from the right feed. If we are using an implicit channel then we just use the
         // ambient configuration (although we should still specify the source) because
         // the user would have selected it.
+        //
+        // The temporary config is disposed when this method returns. That is intentional —
+        // only `dotnet new install` consumes the config; the subsequent `dotnet new <template>`
+        // call (in DotNetTemplateFactory and InitCommand) operates against the already-installed
+        // template hive and uses the ambient NuGet configuration.
         using var temporaryConfig = selection.Channel.Type == PackageChannelType.Explicit
             ? await TemporaryNuGetConfig.CreateAsync(selection.Channel.Mappings!)
             : null;

--- a/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
+++ b/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
@@ -1,21 +1,34 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.DotNet;
+using Aspire.Cli.Exceptions;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Utils;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Templating;
 
 /// <summary>
-/// Handles NuGet.config creation and updates for template output directories.
+/// Handles NuGet.config creation and updates for template output directories,
+/// and provides channel-aware template package resolution and installation.
 /// </summary>
 internal sealed class TemplateNuGetConfigService(
     IInteractionService interactionService,
     CliExecutionContext executionContext,
     IPackagingService packagingService,
-    IConfigurationService configurationService)
+    IConfigurationService configurationService,
+    ITemplateVersionPrompter templateVersionPrompter,
+    ICliHostEnvironment hostEnvironment)
 {
+    /// <summary>
+    /// The name of the NuGet package that ships the Aspire project templates.
+    /// </summary>
+    public const string TemplatesPackageName = "Aspire.ProjectTemplates";
+
     /// <summary>
     /// Applies NuGet.config create/update behavior for a resolved package channel.
     /// </summary>
@@ -127,4 +140,191 @@ internal sealed class TemplateNuGetConfigService(
         await NuGetConfigMerger.CreateOrUpdateAsync(new DirectoryInfo(outputPath), matchingChannel, cancellationToken: cancellationToken);
         return true;
     }
+
+    /// <summary>
+    /// Resolves the channel and template package version that should be used to install Aspire project templates.
+    /// </summary>
+    /// <param name="query">Inputs that control channel/version selection.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The selected template package and the channel it was resolved from.</returns>
+    /// <exception cref="ChannelNotFoundException">Thrown when <paramref name="query"/> specifies a channel name that does not match any configured channel.</exception>
+    /// <exception cref="EmptyChoicesException">Thrown when no template package versions are available across the considered channels.</exception>
+    public async Task<TemplatePackageSelection> ResolveTemplatePackageAsync(TemplatePackageQuery query, CancellationToken cancellationToken)
+    {
+        var allChannels = await packagingService.GetChannelsAsync(cancellationToken);
+
+        // Channel override (e.g. --channel) takes priority over the global setting.
+        var channelName = query.ChannelOverride;
+        if (string.IsNullOrEmpty(channelName))
+        {
+            channelName = await configurationService.GetConfigurationAsync("channel", cancellationToken);
+        }
+
+        // Honor PR hives only when the caller opts in. Init suppresses this so a developer
+        // with stale ~/.aspire/hives/* doesn't get a different template than on a clean machine.
+        var hasPrHives = query.IncludePrHives && executionContext.GetPrHiveCount() > 0;
+        var hasChannelSetting = !string.IsNullOrEmpty(channelName);
+
+        IEnumerable<PackageChannel> channels;
+        if (hasChannelSetting)
+        {
+            var matchingChannel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
+            if (matchingChannel is null)
+            {
+                throw new ChannelNotFoundException($"No channel found matching '{channelName}'. Valid options are: {string.Join(", ", allChannels.Select(c => c.Name))}");
+            }
+            channels = new[] { matchingChannel };
+        }
+        else
+        {
+            // If there are hives (PR build directories), include all channels.
+            // Otherwise, only use the implicit/default channel to avoid prompting.
+            channels = hasPrHives
+                ? allChannels
+                : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
+        }
+
+        var packagesFromChannels = await interactionService.ShowStatusAsync(Resources.TemplatingStrings.SearchingForAvailableTemplateVersions, async () =>
+        {
+            var results = new List<(NuGetPackage Package, PackageChannel Channel)>();
+            var resultsLock = new object();
+
+            await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
+            {
+                var templatePackages = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, ct);
+                lock (resultsLock)
+                {
+                    results.AddRange(templatePackages.Select(p => (p, channel)));
+                }
+            });
+
+            return results;
+        });
+
+        if (!packagesFromChannels.Any())
+        {
+            throw new EmptyChoicesException(Resources.TemplatingStrings.NoTemplateVersionsFound);
+        }
+
+        var orderedPackagesFromChannels = packagesFromChannels.OrderByDescending(p => Semver.SemVersion.Parse(p.Package.Version), Semver.SemVersion.PrecedenceComparer);
+
+        if (query.VersionOverride is { } version)
+        {
+            var explicitMatch = orderedPackagesFromChannels.FirstOrDefault(p => p.Package.Version == version);
+            if (explicitMatch.Package is not null)
+            {
+                return new TemplatePackageSelection(explicitMatch.Package, explicitMatch.Channel);
+            }
+        }
+
+        if (VersionHelper.TryGetCurrentCliVersionMatch(
+            orderedPackagesFromChannels,
+            p => p.Package.Version,
+            out var cliVersionMatch,
+            channelName: channelName,
+            hasPrHives: hasPrHives))
+        {
+            return new TemplatePackageSelection(cliVersionMatch.Package, cliVersionMatch.Channel);
+        }
+
+        // If channel was specified via --channel option or global setting (but no --version),
+        // automatically select the highest version from that channel without prompting.
+        if (hasChannelSetting)
+        {
+            var first = orderedPackagesFromChannels.First();
+            return new TemplatePackageSelection(first.Package, first.Channel);
+        }
+
+        // In non-interactive mode, automatically select the highest version.
+        if (!hostEnvironment.SupportsInteractiveInput)
+        {
+            var first = orderedPackagesFromChannels.First();
+            return new TemplatePackageSelection(first.Package, first.Channel);
+        }
+
+        var prompted = await templateVersionPrompter.PromptForTemplatesVersionAsync(orderedPackagesFromChannels, cancellationToken);
+        return new TemplatePackageSelection(prompted.Package, prompted.Channel);
+    }
+
+    /// <summary>
+    /// Installs the resolved Aspire project templates package, generating a temporary NuGet.config from the channel mappings when the channel is explicit.
+    /// </summary>
+    /// <param name="selection">The template package + channel returned by <see cref="ResolveTemplatePackageAsync"/>.</param>
+    /// <param name="runner">The .NET CLI runner used to invoke <c>dotnet new install</c>. Passed in (rather than injected) because the runner has a transient DI lifetime.</param>
+    /// <param name="statusMessage">Status text shown while the install runs.</param>
+    /// <param name="statusEmoji">Optional emoji prefix shown next to the status message.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The install exit code, the parsed template version (if available), and the captured stdout/stderr lines.</returns>
+    public async Task<TemplateInstallOutcome> InstallTemplatePackageAsync(
+        TemplatePackageSelection selection,
+        IDotNetCliRunner runner,
+        string statusMessage,
+        KnownEmoji? statusEmoji,
+        CancellationToken cancellationToken)
+    {
+        // Whilst we install the templates - if we are using an explicit channel we need to
+        // generate a temporary NuGet.config file to make sure we install the right package
+        // from the right feed. If we are using an implicit channel then we just use the
+        // ambient configuration (although we should still specify the source) because
+        // the user would have selected it.
+        using var temporaryConfig = selection.Channel.Type == PackageChannelType.Explicit
+            ? await TemporaryNuGetConfig.CreateAsync(selection.Channel.Mappings!)
+            : null;
+
+        var collector = new OutputCollector();
+
+        var (exitCode, templateVersion) = await interactionService.ShowStatusAsync<(int ExitCode, string? TemplateVersion)>(
+            statusMessage,
+            async () =>
+            {
+                var options = new ProcessInvocationOptions
+                {
+                    StandardOutputCallback = collector.AppendOutput,
+                    StandardErrorCallback = collector.AppendOutput,
+                };
+
+                return await runner.InstallTemplateAsync(
+                    packageName: TemplatesPackageName,
+                    version: selection.Package.Version,
+                    nugetConfigFile: temporaryConfig?.ConfigFile,
+                    nugetSource: selection.Package.Source,
+                    force: true,
+                    options: options,
+                    cancellationToken: cancellationToken);
+            },
+            emoji: statusEmoji);
+
+        return new TemplateInstallOutcome(exitCode, templateVersion, collector.GetLines().ToArray());
+    }
 }
+
+/// <summary>
+/// Inputs that control how <see cref="TemplateNuGetConfigService.ResolveTemplatePackageAsync"/> picks a channel and version.
+/// </summary>
+/// <param name="ChannelOverride">Optional channel name override (e.g. from <c>--channel</c>). When null, the global <c>channel</c> configuration is consulted.</param>
+/// <param name="VersionOverride">Optional explicit template version (e.g. from <c>--version</c>).</param>
+/// <param name="SourceOverride">Optional source override carried for symmetry with <see cref="TemplateInputs"/>; not consulted by resolution today.</param>
+/// <param name="IncludePrHives">When true (e.g. for <c>aspire new</c>), local PR hive directories under <c>~/.aspire/hives</c> participate in channel discovery; when false (e.g. for <c>aspire init</c>), they are ignored.</param>
+internal sealed record TemplatePackageQuery(
+    string? ChannelOverride,
+    string? VersionOverride,
+    string? SourceOverride,
+    bool IncludePrHives);
+
+/// <summary>
+/// The template package and channel selected by <see cref="TemplateNuGetConfigService.ResolveTemplatePackageAsync"/>.
+/// </summary>
+/// <param name="Package">The selected template package (id, version, source).</param>
+/// <param name="Channel">The channel that produced <paramref name="Package"/>.</param>
+internal sealed record TemplatePackageSelection(NuGetPackage Package, PackageChannel Channel);
+
+/// <summary>
+/// Result of <see cref="TemplateNuGetConfigService.InstallTemplatePackageAsync"/>.
+/// </summary>
+/// <param name="ExitCode">Exit code from <c>dotnet new install</c>.</param>
+/// <param name="TemplateVersion">Parsed template version (when the install reported one).</param>
+/// <param name="OutputLines">Captured stdout/stderr lines from the install process for diagnostic display by the caller.</param>
+internal sealed record TemplateInstallOutcome(
+    int ExitCode,
+    string? TemplateVersion,
+    IReadOnlyList<(Aspire.Cli.Utils.OutputLineStream Stream, string Line)> OutputLines);

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Scaffolding;
@@ -652,6 +653,56 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.FailedToInstallTemplates, exitCode);
         Assert.Contains(interactionService.DisplayedErrors, e => e.Contains("missing-channel", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenChannelTemplateSearchFails_DisplaysFriendlyError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var interactionService = new TestInteractionService();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+
+            // Fake cache throws NuGetPackageCacheException to simulate offline / inaccessible feed.
+            options.PackagingServiceFactory = _ =>
+            {
+                var fakeCache = new FakeNuGetPackageCache
+                {
+                    GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                        throw new NuGetPackageCacheException("Package search failed: simulated network failure")
+                };
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache);
+                return new TestPackagingService
+                {
+                    GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
+                };
+            };
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, _, _, _, _, _, _) =>
+                {
+                    throw new InvalidOperationException("InstallTemplateAsync should not run when channel search fails.");
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToInstallTemplates, exitCode);
+        Assert.Contains(interactionService.DisplayedErrors, e => e.Contains("simulated network failure", StringComparison.Ordinal));
     }
 
     private sealed class FakeConfigurationServiceWithChannel(string channelValue) : IConfigurationService

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -5,10 +5,12 @@ using System.Text.Json.Nodes;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Scaffolding;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
 
@@ -16,6 +18,33 @@ namespace Aspire.Cli.Tests.Commands;
 
 public class InitCommandTests(ITestOutputHelper outputHelper)
 {
+    /// <summary>
+    /// Configures the test packaging service factory to return a single implicit channel
+    /// whose template package cache yields one Aspire.ProjectTemplates entry. Init's project-mode path needs this
+    /// to resolve a template version before invoking dotnet new install.
+    /// </summary>
+    private static void ConfigureImplicitTemplateChannel(CliServiceCollectionTestOptions options, string version = "13.3.0")
+    {
+        options.PackagingServiceFactory = _ =>
+        {
+            var fakeCache = new FakeNuGetPackageCache
+            {
+                GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                    Task.FromResult<IEnumerable<NuGetPackageCli>>(
+                        [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget.org", Version = version }])
+            };
+
+            var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache);
+
+            var packagingService = new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
+            };
+
+            return packagingService;
+        };
+    }
+
     [Theory]
     [InlineData("Test.csproj")]
     [InlineData("Test.fsproj")]
@@ -36,6 +65,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            ConfigureImplicitTemplateChannel(options);
             options.DotNetCliRunnerFactory = _ =>
             {
                 var runner = new TestDotNetCliRunner();
@@ -81,6 +111,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            ConfigureImplicitTemplateChannel(options);
             options.DotNetCliRunnerFactory = _ =>
             {
                 var runner = new TestDotNetCliRunner();
@@ -376,6 +407,274 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal(preExistingContent, await File.ReadAllTextAsync(appHostPath));
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenSolutionExistsAndChannelIsExplicit_PassesTemporaryNuGetConfigToTemplateInstall()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        FileInfo? capturedNuGetConfigFile = null;
+        string? capturedNuGetSource = null;
+        string? capturedTemplateNuGetConfigContents = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            // Match the bug repro: user has a global `channel` setting pointing at an explicit channel.
+            options.ConfigurationServiceFactory = _ => new FakeConfigurationServiceWithChannel("staging");
+
+            options.PackagingServiceFactory = _ =>
+            {
+                var fakeCache = new FakeNuGetPackageCache
+                {
+                    GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                        Task.FromResult<IEnumerable<NuGetPackageCli>>(
+                            [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "https://example.test/staging/v3/index.json", Version = "13.3.0" }])
+                };
+
+                var explicitChannel = PackageChannel.CreateExplicitChannel(
+                    "staging",
+                    PackageChannelQuality.Both,
+                    [new PackageMapping("Aspire*", "https://example.test/staging/v3/index.json")],
+                    fakeCache);
+
+                return new TestPackagingService
+                {
+                    GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([explicitChannel])
+                };
+            };
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, nugetConfigFile, nugetSource, _, _, _) =>
+                {
+                    capturedNuGetConfigFile = nugetConfigFile;
+                    capturedNuGetSource = nugetSource;
+                    if (nugetConfigFile is not null && File.Exists(nugetConfigFile.FullName))
+                    {
+                        capturedTemplateNuGetConfigContents = File.ReadAllText(nugetConfigFile.FullName);
+                    }
+                    return (0, version);
+                };
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.NotNull(capturedNuGetConfigFile);
+        Assert.Equal("https://example.test/staging/v3/index.json", capturedNuGetSource);
+        Assert.NotNull(capturedTemplateNuGetConfigContents);
+        Assert.Contains("https://example.test/staging/v3/index.json", capturedTemplateNuGetConfigContents);
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenSolutionExistsAndChannelIsImplicit_LeavesNuGetConfigNull()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        FileInfo? capturedNuGetConfigFile = new FileInfo("sentinel");
+        string? capturedNuGetSource = "sentinel";
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            ConfigureImplicitTemplateChannel(options);
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, nugetConfigFile, nugetSource, _, _, _) =>
+                {
+                    capturedNuGetConfigFile = nugetConfigFile;
+                    capturedNuGetSource = nugetSource;
+                    return (0, version);
+                };
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Null(capturedNuGetConfigFile);
+        // The implicit channel surfaces the package's Source field as the nugetSource even when no
+        // temporary config is generated, so nugetSource may be non-null. The contract this test guards
+        // is that nugetConfigFile stays null on the implicit channel.
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenSolutionExistsAndPrHivesPresent_DoesNotWidenToAllChannels()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        // Simulate a stale PR hive on disk so executionContext.GetPrHiveCount() returns > 0.
+        var hivesDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives"));
+        Directory.CreateDirectory(Path.Combine(hivesDir.FullName, "pr-12345", "packages"));
+
+        string? capturedTemplateVersion = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.PackagingServiceFactory = _ =>
+            {
+                // Implicit channel offers the expected stable version; PR hive channel offers a much
+                // newer version that should NOT be selected because init opts out of PR-hive widening.
+                var implicitCache = new FakeNuGetPackageCache
+                {
+                    GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                        Task.FromResult<IEnumerable<NuGetPackageCli>>(
+                            [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget.org", Version = "13.3.0" }])
+                };
+                var prHiveCache = new FakeNuGetPackageCache
+                {
+                    GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                        Task.FromResult<IEnumerable<NuGetPackageCli>>(
+                            [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "pr-hive", Version = "99.0.0-pr.12345" }])
+                };
+
+                var implicitChannel = PackageChannel.CreateImplicitChannel(implicitCache);
+                var prHiveChannel = PackageChannel.CreateExplicitChannel(
+                    "pr-12345",
+                    PackageChannelQuality.Both,
+                    [new PackageMapping("Aspire*", hivesDir.FullName + "/pr-12345/packages")],
+                    prHiveCache);
+
+                return new TestPackagingService
+                {
+                    GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel, prHiveChannel])
+                };
+            };
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) =>
+                {
+                    capturedTemplateVersion = version;
+                    return (0, version);
+                };
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal("13.3.0", capturedTemplateVersion);
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenChannelResolutionThrowsChannelNotFound_DisplaysFriendlyError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var interactionService = new TestInteractionService();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+
+            // Configure global channel = "missing-channel" so the resolver looks for a channel that doesn't exist.
+            options.ConfigurationServiceFactory = _ => new FakeConfigurationServiceWithChannel("missing-channel");
+
+            // Return only an implicit/default channel so the lookup fails to match "missing-channel".
+            options.PackagingServiceFactory = _ =>
+            {
+                var fakeCache = new FakeNuGetPackageCache
+                {
+                    GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                        Task.FromResult<IEnumerable<NuGetPackageCli>>(
+                            [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget.org", Version = "13.3.0" }])
+                };
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache);
+                return new TestPackagingService
+                {
+                    GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
+                };
+            };
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, _, _, _, _, _, _) =>
+                {
+                    throw new InvalidOperationException("InstallTemplateAsync should not run when channel resolution fails.");
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToInstallTemplates, exitCode);
+        Assert.Contains(interactionService.DisplayedErrors, e => e.Contains("missing-channel", StringComparison.Ordinal));
+    }
+
+    private sealed class FakeConfigurationServiceWithChannel(string channelValue) : IConfigurationService
+    {
+        public Task<string?> GetConfigurationAsync(string key, CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(string.Equals(key, "channel", StringComparison.Ordinal) ? channelValue : null);
+
+        public Task SetConfigurationAsync(string key, string value, bool isGlobal = false, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> DeleteConfigurationAsync(string key, bool isGlobal = false, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<Dictionary<string, string>> GetAllConfigurationAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new Dictionary<string, string>());
+
+        public Task<Dictionary<string, string>> GetLocalConfigurationAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new Dictionary<string, string>());
+
+        public Task<Dictionary<string, string>> GetGlobalConfigurationAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new Dictionary<string, string>());
+
+        public string GetSettingsFilePath(bool isGlobal) => string.Empty;
     }
 
     private sealed class TestScaffoldingService : IScaffoldingService

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -242,7 +242,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, invocationOptions, ct) =>
                 {
                     return (0, version);
                 };
@@ -318,7 +318,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, invocationOptions, ct) =>
                 {
                     selectedVersion = version;
                     return (0, version);
@@ -395,7 +395,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, invocationOptions, ct) =>
                 {
                     selectedVersion = version;
                     return (0, version);
@@ -535,7 +535,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             {
                 var runner = CreateTestRunnerWithStandardPackages();
 
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, options, cancellationToken) =>
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, options, cancellationToken) =>
                 {
                     return (0, version); // Success, return the template version
                 };
@@ -573,7 +573,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             {
                 var runner = CreateTestRunnerWithStandardPackages();
 
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, options, cancellationToken) =>
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, options, cancellationToken) =>
                 {
                     return (0, version); // Success, return the template version
                 };
@@ -1606,7 +1606,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = CreateTestRunnerWithStandardPackages();
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, invocationOptions, ct) =>
                 {
                     return (0, version);
                 };
@@ -1665,7 +1665,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = CreateTestRunnerWithStandardPackages();
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, invocationOptions, ct) =>
                 {
                     return (0, version);
                 };
@@ -1722,7 +1722,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = CreateTestRunnerWithStandardPackages();
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, invocationOptions, ct) =>
                 {
                     return (0, version);
                 };
@@ -1784,7 +1784,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 options.DotNetCliRunnerFactory = (sp) =>
                 {
                     var runner = CreateTestRunnerWithStandardPackages();
-                    runner.InstallTemplateAsyncCallback = (packageName, version, nugetSource, force, invocationOptions, ct) =>
+                    runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, invocationOptions, ct) =>
                     {
                         return (0, version);
                     };

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -355,19 +355,16 @@ public class DotNetTemplateFactoryTests
         var configurationService = new FakeConfigurationService();
         var telemetry = TestTelemetryHelper.CreateInitializedTelemetry();
         var hostEnvironment = new FakeCliHostEnvironment(nonInteractive);
-        var templateNuGetConfigService = new TemplateNuGetConfigService(interactionService, executionContext, packagingService, configurationService);
+        var templateNuGetConfigService = new TemplateNuGetConfigService(interactionService, executionContext, packagingService, configurationService, prompter, hostEnvironment);
 
         return new DotNetTemplateFactory(
             interactionService,
             runner,
             certificateService,
-            packagingService,
-            prompter,
             prompter,
             executionContext,
             sdkInstaller,
             features,
-            configurationService,
             telemetry,
             hostEnvironment,
             templateNuGetConfigService);

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -18,7 +18,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     public Func<FileInfo, ProcessInvocationOptions, CancellationToken, (int ExitCode, bool IsAspireHost, string? AspireHostingVersion)>? GetAppHostInformationAsyncCallback { get; set; }
     public Func<DirectoryInfo, ProcessInvocationOptions, CancellationToken, (int ExitCode, string[] ConfigPaths)>? GetNuGetConfigPathsAsyncCallback { get; set; }
     public Func<FileInfo, string[], string[], ProcessInvocationOptions, CancellationToken, (int ExitCode, JsonDocument? Output)>? GetProjectItemsAndPropertiesAsyncCallback { get; set; }
-    public Func<string, string, string?, bool, ProcessInvocationOptions, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
+    public Func<string, string, FileInfo?, string?, bool, ProcessInvocationOptions, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
     public Func<string, string, string, ProcessInvocationOptions, CancellationToken, int>? NewProjectAsyncCallback { get; set; }
     public Func<FileInfo, bool, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostCliBackchannel>?, ProcessInvocationOptions, CancellationToken, Task<int>>? RunAsyncCallback { get; set; }
     public Func<DirectoryInfo, string, bool, bool, int, int, FileInfo?, bool, ProcessInvocationOptions, CancellationToken, (int ExitCode, NuGetPackage[]? Packages)>? SearchPackagesAsyncCallback { get; set; }
@@ -88,7 +88,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     public Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, FileInfo? nugetConfigFile, string? nugetSource, bool force, ProcessInvocationOptions options, CancellationToken cancellationToken)
     {
         return InstallTemplateAsyncCallback != null
-            ? Task.FromResult(InstallTemplateAsyncCallback(packageName, version, nugetSource, force, options, cancellationToken))
+            ? Task.FromResult(InstallTemplateAsyncCallback(packageName, version, nugetConfigFile, nugetSource, force, options, cancellationToken))
             : Task.FromResult<(int, string?)>((0, version)); // If not overridden, just return success for the version specified.
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -114,6 +114,7 @@ internal static class CliTestHelper
         services.AddTransient(options.DotNetCliExecutionFactoryFactory);
         services.AddTransient(options.DotNetCliRunnerFactory);
         services.AddTransient(options.NuGetPackageCacheFactory);
+        services.AddSingleton<TemplateNuGetConfigService>();
         services.AddSingleton(options.TemplateProviderFactory);
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ITemplateFactory, DotNetTemplateFactory>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ITemplateFactory, CliTemplateFactory>());
@@ -527,8 +528,8 @@ internal sealed class CliServiceCollectionTestOptions
         var languageDiscovery = serviceProvider.GetRequiredService<ILanguageDiscovery>();
         var scaffoldingService = serviceProvider.GetRequiredService<IScaffoldingService>();
         var cliTemplateLogger = serviceProvider.GetRequiredService<ILogger<CliTemplateFactory>>();
-        var templateNuGetConfigService = new TemplateNuGetConfigService(interactionService, executionContext, packagingService, configurationService);
-        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, packagingService, prompter, templateVersionPrompter, executionContext, sdkInstaller, features, configurationService, telemetry, hostEnvironment, templateNuGetConfigService);
+        var templateNuGetConfigService = serviceProvider.GetRequiredService<TemplateNuGetConfigService>();
+        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService);
         var projectFactory = serviceProvider.GetRequiredService<IAppHostProjectFactory>();
         var cliFactory = new CliTemplateFactory(languageDiscovery, projectFactory, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, templateNuGetConfigService, cliTemplateLogger);
         return new TemplateProvider([dotNetFactory, cliFactory]);

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -145,7 +145,6 @@ internal static class CliTestHelper
         services.AddSingleton(options.AppHostServerSessionFactory);
         services.AddSingleton<ILanguageDiscovery, DefaultLanguageDiscovery>();
         services.AddSingleton(options.LanguageServiceFactory);
-        services.AddSingleton<TemplateNuGetConfigService>();
 
         // Bundle layout services - return null/no-op implementations to trigger SDK mode fallback
         // This ensures backward compatibility: no layout found = use legacy SDK mode


### PR DESCRIPTION
## Description

Forward-ports #16672 (the `release/13.3` fix) to `main`. Fixes #16654 — `aspire init` was failing with exit code 103 (`Aspire.ProjectTemplates::<version>+<sha> could not be installed, the package does not exist`) on any C# repo containing a `.sln`/`.slnx` file when the CLI was a non-stable build (staging/daily/PR).

The bug exists on `main` as well as `release/13.3`. #16672 is the parallel PR targeting the release branch (CI green, awaiting review).

### Root cause

`InitCommand.DropCSharpProjectSkeletonAsync` was running:

```
dotnet new install Aspire.ProjectTemplates@<cliVersion+sha> --force
```

…with `nugetConfigFile: null` and `nugetSource: null`, bypassing the channel feed wiring that `aspire new` uses. For non-stable builds, `Aspire.ProjectTemplates@<cliVersion+sha>` is published only to a per-commit darc feed (e.g. `darc-pub-microsoft-aspire-<sha8>`), which was never queried.

### Fix

Extracted the channel-aware template package resolution and install logic out of `DotNetTemplateFactory.ApplyTemplateAsync` and into `TemplateNuGetConfigService` (the existing "NuGet glue for templates" service). Two new methods:

- **`ResolveTemplatePackageAsync(TemplatePackageQuery, CancellationToken)`** — picks the right `(NuGetPackage, PackageChannel)` from `IPackagingService`. Verbatim move of the old private `GetProjectTemplatesVersionAsync` with one new opt-in flag (`IncludePrHives`).
- **`InstallTemplatePackageAsync(TemplatePackageSelection, IDotNetCliRunner, ...)`** — generates the `TemporaryNuGetConfig` from the channel mappings (when explicit) and runs `dotnet new install` with the right `--nuget-source` and `--configfile`. Verbatim move of the install block from `ApplyTemplateAsync`.

Both `DotNetTemplateFactory.ApplyTemplateAsync` and `InitCommand.DropCSharpProjectSkeletonAsync` now call these helpers.

### Behavior preservation for `aspire new`

- `extraArgsCallback` still runs **before** template install but **after** channel resolution (preserves prompt/error precedence).
- `IncludePrHives: true` keeps PR-hive widening on for `aspire new`.
- `KnownEmojis.Ice` status emoji retained for `aspire new`.
- All existing `DotNetTemplateFactory` and `NewCommand` tests pass unchanged.

### Behavior changes for `aspire init` (all intentional improvements)

- The version sent to `dotnet new install` is now the channel-resolved version (e.g. `13.4.0`) instead of `<cliVersion+sha>`.
- `aspire init` now honors the global `channel` configuration setting, matching `aspire new`.
- On install failure, captured stdout/stderr is displayed before the error header.
- `ChannelNotFoundException`/`EmptyChoicesException`/`NuGetPackageCacheException` produce friendly errors (returns `FailedToInstallTemplates`) instead of bubbling to the top-level "unexpected error" handler.
- `aspire init` does **NOT** include PR hives (`IncludePrHives: false`) so a developer with stale `~/.aspire/hives/*` doesn't get a different template than they would on a clean machine.

### Implementation notes

- `TemplateNuGetConfigService` is a singleton; `IDotNetCliRunner` is **transient**, so it's passed as a method parameter to `InstallTemplatePackageAsync` rather than injected (avoids the singleton-captures-transient lifetime trap).
- The extraction is mechanical — channel resolution and install logic are byte-for-byte equivalent except for the `IncludePrHives` opt-in flag, which is an additive change gated to `aspire init`.

### Forward-port notes

The two commits from #16672 cherry-picked cleanly onto `main` with one trivial conflict in `TemplateNuGetConfigService.cs`: `main` already gained `CreateOrUpdateNuGetConfigWithoutPromptAsync` from #16636 (single-file `aspire init` `nuget.config` drop). Resolved by keeping that method and appending the new `ResolveTemplatePackageAsync` / `InstallTemplatePackageAsync` methods alongside it. `InitCommand.cs`, `NewCommandTests.cs`, and `CliTestHelper.cs` auto-merged because the constructor field/registration changes from #16636 happened to be additive.

### Tests added

In `tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs`:

1. `InitCommand_WhenSolutionExistsAndChannelIsExplicit_PassesTemporaryNuGetConfigToTemplateInstall` — repros the bug scenario (global `channel = staging`) and asserts the temp NuGet config is generated with the channel's mappings and passed to `InstallTemplateAsync`.
2. `InitCommand_WhenSolutionExistsAndChannelIsImplicit_LeavesNuGetConfigNull` — asserts no temp NuGet config is generated for the implicit channel.
3. `InitCommand_WhenSolutionExistsAndPrHivesPresent_DoesNotWidenToAllChannels` — asserts that stale PR hive directories are ignored by init (covers blocking finding from rubber-duck review).
4. `InitCommand_WhenChannelResolutionThrowsChannelNotFound_DisplaysFriendlyError` — asserts a misconfigured channel surfaces a friendly error rather than an unexpected-error stack trace.
5. `InitCommand_WhenChannelTemplateSearchFails_DisplaysFriendlyError` — covers the `NuGetPackageCacheException` catch.

### Verification

Built the CLI from this branch and ran the targeted Aspire.Cli.Tests suite locally:

```
Aspire.Cli.Tests --filter-class *.InitCommandTests --filter-class *.NewCommandTests --filter-class *.DotNetTemplateFactoryTests
  total: 73, failed: 0, succeeded: 73, skipped: 0
```

@maddymontaquila will verify locally on the original `bitwarden/server` repro once CI is green.

## Checklist
- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No (only internal types — new records and methods on `TemplateNuGetConfigService`).
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
