### PR TITLE
Fix deployment test race condition in agent init prompt handling

### DIFF
--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -413,10 +413,11 @@ internal static class Hex1bAutomatorTestHelpers
             .Find("What version would you like to install?");
         var waitingForLegacyVersionSelection = new CellPatternSearcher()
             .Find("based on NuGet.config");
-        var addCompleted = new CellPatternSearcher()
-            .Find("added to your AppHost project");
-        var addFailed = new CellPatternSearcher()
-            .Find("already exists in the project");
+
+        // We intentionally do NOT check for completion text like "was added successfully"
+        // because it persists on the terminal from prior aspire-add runs and would match
+        // stale output when multiple aspire-add commands run in sequence. Instead we rely
+        // on the shell success/error prompt which uses a unique counter value.
 
         await auto.WaitUntilAsync(s =>
             {
@@ -426,9 +427,7 @@ internal static class Hex1bAutomatorTestHelpers
                     return true;
                 }
 
-                return addCompleted.Search(s).Count > 0
-                    || addFailed.Search(s).Count > 0
-                    || successPrompt.Search(s).Count > 0
+                return successPrompt.Search(s).Count > 0
                     || errorPrompt.Search(s).Count > 0;
             },
             timeout: effectiveTimeout,
@@ -459,7 +458,6 @@ internal static class Hex1bAutomatorTestHelpers
             .Find("configure AI agent environments");
 
         var agentInitFound = false;
-        var agentInitPromptRequiresEnter = false;
         var errorPromptFound = false;
 
         // Wait for either the agent init prompt (new CLI) or the success prompt (old CLI).
@@ -468,10 +466,6 @@ internal static class Hex1bAutomatorTestHelpers
             if (agentInitPrompt.Search(s).Count > 0)
             {
                 agentInitFound = true;
-                agentInitPromptRequiresEnter = new CellPatternSearcher()
-                    .Find("[Y/n]")
-                    .RightText(": ")
-                    .Search(s).Count > 0;
                 return true;
             }
             var successSearcher = new CellPatternSearcher()
@@ -502,10 +496,12 @@ internal static class Hex1bAutomatorTestHelpers
 
         await auto.WaitAsync(500);
         await auto.TypeAsync("n");
-        if (agentInitPromptRequiresEnter)
-        {
-            await auto.EnterAsync();
-        }
+
+        // Do not send Enter after typing "n" — the Spectre Console [Y/n] confirmation
+        // prompt accepts a single character. Sending Enter risks a race: if aspire init
+        // exits after reading "n" but before the Enter is delivered, bash receives the
+        // Enter and executes a phantom blank command, advancing CMDCOUNT and desyncing
+        // the test counter from the shell counter.
 
         await auto.WaitForSuccessPromptFailFastAsync(counter, effectiveTimeout);
     }


### PR DESCRIPTION
## Description

Fixes two race conditions in deployment E2E test infrastructure that caused flaky failures in tests with multiple `aspire add` calls (e.g., `AzureKeyVaultDeploymentTests`, `VnetStorageBlobInfraDeploymentTests`, `AksWithAzureResourcesDeploymentTests`, `TypeScriptVnetSqlServerInfraDeploymentTests`).

### Root cause

`DeclineAgentInitPromptAsync` was sending an Enter keypress after typing "n" to the `[Y/n]` agent init confirmation prompt. This created a race condition: if `aspire init` exited after reading "n" but before the Enter was delivered to the PTY, bash received the Enter and executed a phantom blank command, advancing `CMDCOUNT` by one. This desynced the test's `SequenceCounter` from bash's prompt counter, causing `WaitForAspireAddCompletionAsync` to match stale prompt text and return before `aspire add` finished. Subsequent commands (environment variable exports, additional `aspire add` calls) were then typed into the still-running `aspire add` process's stdin, meaning packages were never installed and deployments failed with CS1061 build errors.

### Changes

1. **`DeclineAgentInitPromptAsync`**: Remove Enter after typing "n". Spectre Console's `[Y/n]` confirmation prompt accepts single-character input — Enter is unnecessary and caused the phantom command race.

2. **`WaitForAspireAddCompletionAsync`**: Remove `addCompleted` ("added to your AppHost project") and `addFailed` ("already exists in the project") text-based matching. These patterns persist on the terminal from prior `aspire add` runs, causing false matches for subsequent calls in the same test. Now relies solely on version-selection prompts and shell counter-based prompt detection.

### Validation

Verified with a full deployment E2E test run: **37/37 tests passed** (previously 4 failures).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
