### PR TITLE
[release/13.3] Normalize *.localhost dashboard URLs to localhost for CLI HTTP requests

### DIFF
--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -205,7 +205,8 @@ internal static class TelemetryCommandHelpers
             var loginToken = McpToolHelpers.ExtractLoginToken(dashboardUrl);
 
             // Normalize login URLs (e.g., http://localhost:18888/login?t=abc) to base URL
-            dashboardUrl = McpToolHelpers.NormalizeDashboardUrl(McpToolHelpers.StripLoginPath(dashboardUrl) ?? dashboardUrl);
+            var displayDashboardUrl = McpToolHelpers.StripLoginPath(dashboardUrl) ?? dashboardUrl;
+            dashboardUrl = McpToolHelpers.NormalizeDashboardUrl(displayDashboardUrl);
 
             if (!UrlHelper.IsHttpUrl(dashboardUrl))
             {
@@ -247,7 +248,7 @@ internal static class TelemetryCommandHelpers
             }
 
             var token = apiKey ?? string.Empty;
-            return new DashboardApiResult(true, null, dashboardUrl, token, dashboardUrl, 0);
+            return new DashboardApiResult(true, null, dashboardUrl, token, displayDashboardUrl, 0);
         }
 
         var result = await connectionResolver.ResolveConnectionAsync(

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -230,10 +230,10 @@ internal static class TelemetryCommandHelpers
                     var errorInfo = exchangeResult.FailureKind switch
                     {
                         TokenExchangeFailureKind.ConnectionError => new TelemetryErrorInfo(
-                            string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, dashboardUrl),
+                            string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, displayDashboardUrl),
                             TelemetryCommandStrings.DashboardConnectionFailedHint),
                         TokenExchangeFailureKind.ApiNotEnabled => new TelemetryErrorInfo(
-                            string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, dashboardUrl),
+                            string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, displayDashboardUrl),
                             TelemetryCommandStrings.DashboardApiNotEnabledHint),
                         _ => new TelemetryErrorInfo(
                             TelemetryCommandStrings.DashboardLoginTokenFailed,

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -205,7 +205,7 @@ internal static class TelemetryCommandHelpers
             var loginToken = McpToolHelpers.ExtractLoginToken(dashboardUrl);
 
             // Normalize login URLs (e.g., http://localhost:18888/login?t=abc) to base URL
-            dashboardUrl = McpToolHelpers.StripLoginPath(dashboardUrl) ?? dashboardUrl;
+            dashboardUrl = McpToolHelpers.NormalizeDashboardUrl(McpToolHelpers.StripLoginPath(dashboardUrl) ?? dashboardUrl);
 
             if (!UrlHelper.IsHttpUrl(dashboardUrl))
             {
@@ -282,10 +282,13 @@ internal static class TelemetryCommandHelpers
             return new DashboardApiResult(true, connection, null, null, null, 0);
         }
 
-        // Extract dashboard base URL (without /login path) for hyperlinks
+        var apiBaseUrl = McpToolHelpers.NormalizeDashboardUrl(dashboardInfo.ApiBaseUrl);
+
+        // Extract dashboard base URL (without /login path) for hyperlinks.
+        // Preserve the original hostname (e.g. *.dev.localhost) for display URLs.
         var extractedDashboardUrl = ExtractDashboardBaseUrl(dashboardInfo.DashboardUrls?.FirstOrDefault());
 
-        return new DashboardApiResult(true, connection, dashboardInfo.ApiBaseUrl, dashboardInfo.ApiToken, extractedDashboardUrl, 0);
+        return new DashboardApiResult(true, connection, apiBaseUrl, dashboardInfo.ApiToken, extractedDashboardUrl, 0);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Mcp/Tools/IDashboardInfoProvider.cs
+++ b/src/Aspire.Cli/Mcp/Tools/IDashboardInfoProvider.cs
@@ -49,6 +49,9 @@ internal sealed class StaticDashboardInfoProvider(string dashboardUrl, string? a
     {
         // For unsecured dashboards, apiToken is empty string (no X-API-Key header will be sent)
         var apiToken = apiKey ?? string.Empty;
-        return Task.FromResult((apiToken, dashboardUrl, (string?)dashboardUrl));
+        // Normalize the API base URL (e.g., rewrite *.localhost to localhost) for HTTP requests,
+        // but preserve the original URL as the dashboard display URL.
+        var apiBaseUrl = McpToolHelpers.NormalizeDashboardUrl(dashboardUrl);
+        return Task.FromResult((apiToken, apiBaseUrl, (string?)dashboardUrl));
     }
 }

--- a/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
+++ b/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Web;
 using Aspire.Cli.Backchannel;
 using Microsoft.Extensions.Logging;
@@ -26,9 +27,10 @@ internal static class McpToolHelpers
             throw new McpProtocolException(McpErrorMessages.DashboardNotAvailable, McpErrorCode.InternalError);
         }
 
+        var apiBaseUrl = NormalizeDashboardUrl(dashboardInfo.ApiBaseUrl);
         var dashboardBaseUrl = StripLoginPath(dashboardInfo.DashboardUrls.FirstOrDefault());
 
-        return (dashboardInfo.ApiToken, dashboardInfo.ApiBaseUrl, dashboardBaseUrl);
+        return (dashboardInfo.ApiToken, apiBaseUrl, dashboardBaseUrl);
     }
 
     /// <summary>
@@ -57,6 +59,26 @@ internal static class McpToolHelpers
         }
 
         return url;
+    }
+
+    /// <summary>
+    /// Replaces AppHost-scoped <c>*.localhost</c> dashboard hostnames with <c>localhost</c>.
+    /// </summary>
+    internal static string NormalizeDashboardUrl(string url)
+    {
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && IsLocalhostTld(uri.Host))
+        {
+            var port = uri.IsDefaultPort ? string.Empty : ":" + uri.Port.ToString(CultureInfo.InvariantCulture);
+            var pathAndQuery = uri.PathAndQuery == "/" ? string.Empty : uri.PathAndQuery;
+            return $"{uri.Scheme}://localhost{port}{pathAndQuery}{uri.Fragment}";
+        }
+
+        return url;
+    }
+
+    private static bool IsLocalhostTld(string host)
+    {
+        return host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
+++ b/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
@@ -64,6 +64,11 @@ internal static class McpToolHelpers
     /// <summary>
     /// Replaces AppHost-scoped <c>*.localhost</c> dashboard hostnames with <c>localhost</c>.
     /// </summary>
+    /// <remarks>
+    /// DNS resolvers typically don't implement RFC 6761 for localhost subdomains, so hosts
+    /// like <c>dashboard.dev.localhost</c> fail to resolve when making HTTP requests.
+    /// Rewriting to <c>localhost</c> ensures the CLI can reach the dashboard API.
+    /// </remarks>
     internal static string NormalizeDashboardUrl(string url)
     {
         if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && IsLocalhostTld(uri.Host))

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentMcpLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentMcpLogsTests.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for the aspire agent mcp command with structured logs.
+/// Each test class runs as a separate CI job for parallelization.
+/// </summary>
+public sealed class AgentMcpLogsTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public Task AgentMcpListStructuredLogsReturnsLogsFromStarterApp()
+        => AgentMcpListStructuredLogsFromStarterAppCore(isolated: false, useDevLocalhost: false);
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public Task AgentMcpListStructuredLogsReturnsLogsFromStarterApp_Isolated()
+        => AgentMcpListStructuredLogsFromStarterAppCore(isolated: true, useDevLocalhost: false);
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public Task AgentMcpListStructuredLogsReturnsLogsFromStarterApp_DevLocalhost()
+        => AgentMcpListStructuredLogsFromStarterAppCore(isolated: false, useDevLocalhost: true);
+
+    private async Task AgentMcpListStructuredLogsFromStarterAppCore(bool isolated, bool useDevLocalhost)
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        using var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Create a new Starter project (includes an ASP.NET Core apiservice)
+        await auto.AspireNewAsync("AspireMcpLogsApp", counter, useDevLocalhost: useDevLocalhost);
+
+        // Navigate to the AppHost directory
+        await auto.TypeAsync("cd AspireMcpLogsApp/AspireMcpLogsApp.AppHost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Start the AppHost
+        await auto.AspireStartAsync(counter, isolated: isolated);
+
+        // Wait for the apiservice resource to be running before querying logs
+        await auto.TypeAsync("aspire wait apiservice --status up --timeout 300");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("is up (running).", timeout: TimeSpan.FromMinutes(6));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Send JSON-RPC messages to the MCP server via a compound command.
+        // The sleeps ensure proper protocol timing between initialize, initialized notification, and tool call.
+        await auto.TypeAsync(
+            "{ " +
+            "echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"e2e-test\",\"version\":\"0.1.0\"}}}'; " +
+            "sleep 3; " +
+            "echo '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}'; " +
+            "sleep 1; " +
+            "echo '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"list_structured_logs\",\"arguments\":{}}}'; " +
+            "sleep 15; " +
+            "} | aspire agent mcp > /tmp/mcp_out.txt 2>/tmp/mcp_err.txt || true");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+        // Verify the MCP output contains a successful tool call response with structured logs
+        await auto.TypeAsync("cat /tmp/mcp_out.txt | head -50");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Check that the response contains structured log data (the tool returns text with "STRUCTURED LOGS DATA")
+        await auto.TypeAsync(
+            "if grep -q 'STRUCTURED LOGS DATA' /tmp/mcp_out.txt; then echo 'MCP_LOGS_PRESENT'; " +
+            "elif grep -q 'list_structured_logs' /tmp/mcp_out.txt; then echo 'MCP_TOOL_FOUND_BUT_NO_LOGS'; " +
+            "else echo 'MCP_LOGS_MISSING'; fi");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("MCP_LOGS_PRESENT", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Also verify the initialize response was received (confirms MCP handshake worked)
+        await auto.TypeAsync(
+            "grep -q 'aspire-mcp-server' /tmp/mcp_out.txt && echo 'MCP_INIT_OK' || echo 'MCP_INIT_MISSING'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("MCP_INIT_OK", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Stop the AppHost
+        await auto.AspireStopAsync(counter);
+
+        // Exit the shell
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentMcpLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentMcpLogsTests.cs
@@ -63,40 +63,8 @@ public sealed class AgentMcpLogsTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync("is up (running).", timeout: TimeSpan.FromMinutes(6));
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Send JSON-RPC messages to the MCP server via a compound command.
-        // The sleeps ensure proper protocol timing between initialize, initialized notification, and tool call.
-        await auto.TypeAsync(
-            "{ " +
-            "echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"e2e-test\",\"version\":\"0.1.0\"}}}'; " +
-            "sleep 3; " +
-            "echo '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}'; " +
-            "sleep 1; " +
-            "echo '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"list_structured_logs\",\"arguments\":{}}}'; " +
-            "sleep 15; " +
-            "} | aspire agent mcp > /tmp/mcp_out.txt 2>/tmp/mcp_err.txt || true");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
-
-        // Verify the MCP output contains a successful tool call response with structured logs
-        await auto.TypeAsync("cat /tmp/mcp_out.txt | head -50");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Check that the response contains structured log data (the tool returns text with "STRUCTURED LOGS DATA")
-        await auto.TypeAsync(
-            "if grep -q 'STRUCTURED LOGS DATA' /tmp/mcp_out.txt; then echo 'MCP_LOGS_PRESENT'; " +
-            "elif grep -q 'list_structured_logs' /tmp/mcp_out.txt; then echo 'MCP_TOOL_FOUND_BUT_NO_LOGS'; " +
-            "else echo 'MCP_LOGS_MISSING'; fi");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("MCP_LOGS_PRESENT", timeout: TimeSpan.FromSeconds(10));
-        await auto.WaitForAnyPromptAsync(counter);
-
-        // Also verify the initialize response was received (confirms MCP handshake worked)
-        await auto.TypeAsync(
-            "grep -q 'aspire-mcp-server' /tmp/mcp_out.txt && echo 'MCP_INIT_OK' || echo 'MCP_INIT_MISSING'");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("MCP_INIT_OK", timeout: TimeSpan.FromSeconds(10));
-        await auto.WaitForAnyPromptAsync(counter);
+        // Call the MCP tool against the running AppHost
+        await auto.CallAgentMcpToolAsync(counter, "list_structured_logs", "STRUCTURED LOGS DATA");
 
         // Stop the AppHost
         await auto.AspireStopAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -18,6 +18,18 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
     [CaptureWorkspaceOnFailure]
     public async Task DashboardRunWithOtelTracesReturnsNoTraces()
     {
+        await DashboardRunWithOtelTracesReturnsNoTracesCore("http://localhost:18888");
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task DashboardRunWithOtelTracesReturnsNoTraces_DevLocalhost()
+    {
+        await DashboardRunWithOtelTracesReturnsNoTracesCore("http://dashboard.dev.localhost:18888");
+    }
+
+    private async Task DashboardRunWithOtelTracesReturnsNoTracesCore(string dashboardUrl)
+    {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
 
@@ -36,8 +48,8 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         // Store the dashboard log path inside the workspace so it gets captured on failure
         var dashboardLogPath = $"/workspace/{workspace.WorkspaceRoot.Name}/dashboard.log";
 
-        // Start the dashboard in the background with anonymous access and telemetry API enabled
-        await auto.TypeAsync($"aspire dashboard run --allow-anonymous --enable-api > {dashboardLogPath} 2>&1 &");
+        // Start the dashboard in the background
+        await auto.TypeAsync($"aspire dashboard run --dashboard-url {dashboardUrl} > {dashboardLogPath} 2>&1 &");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -68,7 +80,7 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Run aspire otel traces against the standalone dashboard
-        await auto.TypeAsync("aspire otel traces --dashboard-url http://localhost:18888");
+        await auto.TypeAsync($"aspire otel traces --dashboard-url {dashboardUrl}");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("No traces found", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -48,8 +48,8 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         // Store the dashboard log path inside the workspace so it gets captured on failure
         var dashboardLogPath = $"/workspace/{workspace.WorkspaceRoot.Name}/dashboard.log";
 
-        // Start the dashboard in the background with the specified frontend URL
-        await auto.TypeAsync($"aspire dashboard run --frontend-url {frontendUrl} > {dashboardLogPath} 2>&1 &");
+        // Start the dashboard in the background with anonymous access and the specified frontend URL
+        await auto.TypeAsync($"aspire dashboard run --frontend-url {frontendUrl} --allow-anonymous > {dashboardLogPath} 2>&1 &");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -73,9 +73,10 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Extract the dashboard URL (including login?t=xxx token) from the dashboard run output log.
-        // For the dev.localhost variant, the CLI must normalize the *.localhost host to localhost for HTTP requests.
-        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(grep -oE 'https?://[^ ]+login\\?t=[^ ]+' " + dashboardLogPath + " | head -1)");
+        // Extract the dashboard URL from the aspire dashboard run output.
+        // The output contains "Now listening on: http://..." when the dashboard is ready.
+        // For the dev.localhost variant, the CLI normalizes *.localhost to localhost for HTTP requests.
+        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(grep -m1 'Now listening on:' " + dashboardLogPath + " | grep -oE 'https?://[^ ]+')");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -48,8 +48,8 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         // Store the dashboard log path inside the workspace so it gets captured on failure
         var dashboardLogPath = $"/workspace/{workspace.WorkspaceRoot.Name}/dashboard.log";
 
-        // Start the dashboard in the background with anonymous access and the specified frontend URL
-        await auto.TypeAsync($"aspire dashboard run --frontend-url {frontendUrl} --allow-anonymous > {dashboardLogPath} 2>&1 &");
+        // Start the dashboard in the background with the specified frontend URL
+        await auto.TypeAsync($"aspire dashboard run --frontend-url {frontendUrl} > {dashboardLogPath} 2>&1 &");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -73,10 +73,10 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Extract the dashboard URL from the aspire dashboard run output.
-        // The output contains "Now listening on: http://..." when the dashboard is ready.
+        // Extract the dashboard login URL (with token) from the aspire dashboard run output.
+        // The dashboard outputs: "Login to the dashboard at http://host:port/login?t=xxx ."
         // For the dev.localhost variant, the CLI normalizes *.localhost to localhost for HTTP requests.
-        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(grep -m1 'Now listening on:' " + dashboardLogPath + " | grep -oE 'https?://[^ ]+')");
+        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(grep -oE 'https?://[^ ]+/login\\?t=[^ ]+' " + dashboardLogPath + " | head -1 | sed 's/ \\.$//')");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -80,6 +80,10 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
+        await auto.TypeAsync("echo \"OTEL_DASHBOARD_URL=$OTEL_DASHBOARD_URL\"");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
         await auto.TypeAsync("aspire otel traces --dashboard-url \"$OTEL_DASHBOARD_URL\"");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("No traces found", timeout: TimeSpan.FromSeconds(30));

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -18,17 +18,17 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
     [CaptureWorkspaceOnFailure]
     public async Task DashboardRunWithOtelTracesReturnsNoTraces()
     {
-        await DashboardRunWithOtelTracesReturnsNoTracesCore("http://localhost:18888");
+        await DashboardRunWithOtelTracesReturnsNoTracesCore("http://localhost:18888", "http://localhost:18888");
     }
 
     [Fact]
     [CaptureWorkspaceOnFailure]
     public async Task DashboardRunWithOtelTracesReturnsNoTraces_DevLocalhost()
     {
-        await DashboardRunWithOtelTracesReturnsNoTracesCore("http://dashboard.dev.localhost:18888");
+        await DashboardRunWithOtelTracesReturnsNoTracesCore("http://dashboard.dev.localhost:18888", "http://localhost:18888");
     }
 
-    private async Task DashboardRunWithOtelTracesReturnsNoTracesCore(string dashboardUrl)
+    private async Task DashboardRunWithOtelTracesReturnsNoTracesCore(string browserDashboardUrl, string localhostDashboardUrl)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -49,7 +49,7 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         var dashboardLogPath = $"/workspace/{workspace.WorkspaceRoot.Name}/dashboard.log";
 
         // Start the dashboard in the background
-        await auto.TypeAsync($"aspire dashboard run --dashboard-url {dashboardUrl} > {dashboardLogPath} 2>&1 &");
+        await auto.TypeAsync($"aspire dashboard run --dashboard-url {browserDashboardUrl} > {dashboardLogPath} 2>&1 &");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -58,8 +58,8 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Wait for the dashboard to become ready by polling the frontend URL
-        await auto.TypeAsync("for i in $(seq 1 30); do curl -ksSL -o /dev/null -w '%{http_code}' http://localhost:18888 2>/dev/null | grep -q 200 && break; sleep 1; done");
+        // Wait for the dashboard to become ready by polling the localhost URL
+        await auto.TypeAsync($"for i in $(seq 1 30); do curl -ksSL -o /dev/null -w '%{{http_code}}' {localhostDashboardUrl} 2>/dev/null | grep -q 200 && break; sleep 1; done");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
@@ -73,14 +73,17 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Verify the dashboard process is still running before querying traces
-        await auto.TypeAsync("kill -0 $DASHBOARD_PID 2>/dev/null && echo 'dashboard-running' || echo 'dashboard-stopped'");
+        // Get the dashboard URL from aspire ps and use it for otel traces
+        await auto.TypeAsync("aspire ps --format json > /tmp/ps_output.json");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("dashboard-running", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Run aspire otel traces against the standalone dashboard
-        await auto.TypeAsync($"aspire otel traces --dashboard-url {dashboardUrl}");
+        // Extract dashboardUrl from the JSON array and run otel traces with it
+        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(python3 -c \"import sys,json; data=json.load(open('/tmp/ps_output.json')); print(data[0]['dashboardUrl'])\")");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire otel traces --dashboard-url \"$OTEL_DASHBOARD_URL\"");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("No traces found", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -45,6 +45,16 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
 
+        // Use a known browser token so we can construct the dashboard URL directly,
+        // avoiding the need to parse it from logs (which contain Spectre Console OSC 8
+        // escape sequences that break grep-based URL extraction).
+        var browserToken = "testtoken1234567890abcdef12345678";
+
+        // Set the browser token env var before starting the dashboard
+        await auto.TypeAsync($"export DASHBOARD__FRONTEND__BROWSERTOKEN={browserToken}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
         // Store the dashboard log path inside the workspace so it gets captured on failure
         var dashboardLogPath = $"/workspace/{workspace.WorkspaceRoot.Name}/dashboard.log";
 
@@ -73,19 +83,10 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Extract the dashboard login URL (with token) from the aspire dashboard run output.
-        // The dashboard outputs: "Login to the dashboard at http://host:port/login?t=xxx ."
-        // Use [a-f0-9]+ for the token to avoid matching through Spectre Console link markup
-        // which concatenates the URL twice (link target + display text) with no separator.
-        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(grep -oE 'https?://[^ ]+/login\\?t=[a-f0-9]+' " + dashboardLogPath + " | head -1)");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+        // Construct the dashboard URL using the known token and localhost URL
+        var dashboardUrl = $"{localhostUrl}/login?t={browserToken}";
 
-        await auto.TypeAsync("echo \"OTEL_DASHBOARD_URL=$OTEL_DASHBOARD_URL\"");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        await auto.TypeAsync("aspire otel traces --dashboard-url \"$OTEL_DASHBOARD_URL\"");
+        await auto.TypeAsync($"aspire otel traces --dashboard-url \"{dashboardUrl}\"");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("No traces found", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -28,97 +28,6 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await DashboardRunWithOtelTracesReturnsNoTracesCore("http://dashboard.dev.localhost:18888", "http://localhost:18888");
     }
 
-    [Fact]
-    [CaptureWorkspaceOnFailure]
-    public Task AppHostOtelTracesReturnsTraces()
-        => AppHostOtelTracesReturnsTracesCore(useDevLocalhost: false);
-
-    [Fact]
-    [CaptureWorkspaceOnFailure]
-    public Task AppHostOtelTracesReturnsTraces_DevLocalhost()
-        => AppHostOtelTracesReturnsTracesCore(useDevLocalhost: true);
-
-    private async Task AppHostOtelTracesReturnsTracesCore(bool useDevLocalhost)
-    {
-        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
-        var strategy = CliInstallStrategy.Detect(output.WriteLine);
-
-        using var workspace = TemporaryWorkspace.Create(output);
-
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
-
-        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
-
-        var counter = new SequenceCounter();
-        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
-
-        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
-        await auto.InstallAspireCliAsync(strategy, counter);
-
-        // Create a new Starter project (includes an ASP.NET Core apiservice that generates traces)
-        await auto.AspireNewAsync("AspireOtelTracesApp", counter, useDevLocalhost: useDevLocalhost);
-
-        // Navigate to the AppHost directory
-        await auto.TypeAsync("cd AspireOtelTracesApp/AspireOtelTracesApp.AppHost");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Start the AppHost in the background
-        await auto.AspireStartAsync(counter);
-
-        // Wait for the apiservice resource to be running before querying traces
-        await auto.TypeAsync("aspire wait apiservice --status up --timeout 300");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("is up (running).", timeout: TimeSpan.FromMinutes(6));
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Generate some traces by hitting the apiservice endpoint via the dashboard's resource proxy
-        await auto.TypeAsync("curl -sSL http://localhost:$(aspire describe apiservice --format json | grep -oP '\"port\":\\s*\\K[0-9]+')/weatherforecast > /dev/null 2>&1 || true");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Brief pause so traces propagate to the dashboard
-        await auto.TypeAsync("for i in $(seq 1 5); do sleep 1; done");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(15));
-
-        // Run aspire otel traces and capture output to a file
-        await auto.TypeAsync("aspire otel traces > otel_traces.txt 2>&1");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Verify the output contains trace entries
-        await auto.TypeAsync("cat otel_traces.txt | head -20");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Check that traces are present (either from apiservice or webfrontend)
-        await auto.TypeAsync("if [ ! -r otel_traces.txt ]; then echo 'OTEL_TRACES_FILE_UNREADABLE'; elif [ -s otel_traces.txt ] && ! grep -q 'No traces found' otel_traces.txt; then echo 'TRACES_PRESENT'; else echo 'TRACES_MISSING'; fi");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("TRACES_PRESENT", timeout: TimeSpan.FromSeconds(10));
-        await auto.WaitForAnyPromptAsync(counter);
-
-        // Also verify JSON format works
-        await auto.TypeAsync("aspire otel traces --format json > otel_traces_json.txt 2>&1");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Verify JSON output contains trace data
-        await auto.TypeAsync("grep -q 'traceId' otel_traces_json.txt && echo 'JSON_TRACES_PRESENT' || echo 'JSON_TRACES_MISSING'");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("JSON_TRACES_PRESENT", timeout: TimeSpan.FromSeconds(10));
-        await auto.WaitForAnyPromptAsync(counter);
-
-        // Stop the AppHost
-        await auto.AspireStopAsync(counter);
-
-        // Exit the shell
-        await auto.TypeAsync("exit");
-        await auto.EnterAsync();
-
-        await pendingRun;
-    }
-
     private async Task DashboardRunWithOtelTracesReturnsNoTracesCore(string frontendUrl, string localhostUrl)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -166,8 +75,9 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
 
         // Extract the dashboard login URL (with token) from the aspire dashboard run output.
         // The dashboard outputs: "Login to the dashboard at http://host:port/login?t=xxx ."
-        // For the dev.localhost variant, the CLI normalizes *.localhost to localhost for HTTP requests.
-        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(grep -oE 'https?://[^ ]+/login\\?t=[^ ]+' " + dashboardLogPath + " | head -1 | sed 's/ \\.$//')");
+        // Use [a-f0-9]+ for the token to avoid matching through Spectre Console link markup
+        // which concatenates the URL twice (link target + display text) with no separator.
+        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(grep -oE 'https?://[^ ]+/login\\?t=[a-f0-9]+' " + dashboardLogPath + " | head -1)");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -83,8 +83,9 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Construct the dashboard URL using the known token and localhost URL
-        var dashboardUrl = $"{localhostUrl}/login?t={browserToken}";
+        // Construct the dashboard URL using the known token and the frontend URL.
+        // In the dev.localhost variant this exercises the CLI's NormalizeDashboardUrl path end-to-end.
+        var dashboardUrl = $"{frontendUrl}/login?t={browserToken}";
 
         await auto.TypeAsync($"aspire otel traces --dashboard-url \"{dashboardUrl}\"");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -28,7 +28,7 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await DashboardRunWithOtelTracesReturnsNoTracesCore("http://dashboard.dev.localhost:18888", "http://localhost:18888");
     }
 
-    private async Task DashboardRunWithOtelTracesReturnsNoTracesCore(string browserDashboardUrl, string localhostDashboardUrl)
+    private async Task DashboardRunWithOtelTracesReturnsNoTracesCore(string frontendUrl, string localhostUrl)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -48,8 +48,8 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         // Store the dashboard log path inside the workspace so it gets captured on failure
         var dashboardLogPath = $"/workspace/{workspace.WorkspaceRoot.Name}/dashboard.log";
 
-        // Start the dashboard in the background
-        await auto.TypeAsync($"aspire dashboard run --dashboard-url {browserDashboardUrl} > {dashboardLogPath} 2>&1 &");
+        // Start the dashboard in the background with the specified frontend URL
+        await auto.TypeAsync($"aspire dashboard run --frontend-url {frontendUrl} > {dashboardLogPath} 2>&1 &");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -59,7 +59,7 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Wait for the dashboard to become ready by polling the localhost URL
-        await auto.TypeAsync($"for i in $(seq 1 30); do curl -ksSL -o /dev/null -w '%{{http_code}}' {localhostDashboardUrl} 2>/dev/null | grep -q 200 && break; sleep 1; done");
+        await auto.TypeAsync($"for i in $(seq 1 30); do curl -ksSL -o /dev/null -w '%{{http_code}}' {localhostUrl} 2>/dev/null | grep -q 200 && break; sleep 1; done");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
@@ -73,13 +73,9 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Get the dashboard URL from aspire ps and use it for otel traces
-        await auto.TypeAsync("aspire ps --format json > /tmp/ps_output.json");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Extract dashboardUrl from the JSON array and run otel traces with it
-        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(python3 -c \"import sys,json; data=json.load(open('/tmp/ps_output.json')); print(data[0]['dashboardUrl'])\")");
+        // Extract the dashboard URL (including login?t=xxx token) from the dashboard run output log.
+        // For the dev.localhost variant, the CLI must normalize the *.localhost host to localhost for HTTP requests.
+        await auto.TypeAsync("OTEL_DASHBOARD_URL=$(grep -oE 'https?://[^ ]+login\\?t=[^ ]+' " + dashboardLogPath + " | head -1)");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardOtelTracesTests.cs
@@ -28,6 +28,97 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await DashboardRunWithOtelTracesReturnsNoTracesCore("http://dashboard.dev.localhost:18888", "http://localhost:18888");
     }
 
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public Task AppHostOtelTracesReturnsTraces()
+        => AppHostOtelTracesReturnsTracesCore(useDevLocalhost: false);
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public Task AppHostOtelTracesReturnsTraces_DevLocalhost()
+        => AppHostOtelTracesReturnsTracesCore(useDevLocalhost: true);
+
+    private async Task AppHostOtelTracesReturnsTracesCore(bool useDevLocalhost)
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        using var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Create a new Starter project (includes an ASP.NET Core apiservice that generates traces)
+        await auto.AspireNewAsync("AspireOtelTracesApp", counter, useDevLocalhost: useDevLocalhost);
+
+        // Navigate to the AppHost directory
+        await auto.TypeAsync("cd AspireOtelTracesApp/AspireOtelTracesApp.AppHost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Start the AppHost in the background
+        await auto.AspireStartAsync(counter);
+
+        // Wait for the apiservice resource to be running before querying traces
+        await auto.TypeAsync("aspire wait apiservice --status up --timeout 300");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("is up (running).", timeout: TimeSpan.FromMinutes(6));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Generate some traces by hitting the apiservice endpoint via the dashboard's resource proxy
+        await auto.TypeAsync("curl -sSL http://localhost:$(aspire describe apiservice --format json | grep -oP '\"port\":\\s*\\K[0-9]+')/weatherforecast > /dev/null 2>&1 || true");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Brief pause so traces propagate to the dashboard
+        await auto.TypeAsync("for i in $(seq 1 5); do sleep 1; done");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(15));
+
+        // Run aspire otel traces and capture output to a file
+        await auto.TypeAsync("aspire otel traces > otel_traces.txt 2>&1");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Verify the output contains trace entries
+        await auto.TypeAsync("cat otel_traces.txt | head -20");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Check that traces are present (either from apiservice or webfrontend)
+        await auto.TypeAsync("if [ ! -r otel_traces.txt ]; then echo 'OTEL_TRACES_FILE_UNREADABLE'; elif [ -s otel_traces.txt ] && ! grep -q 'No traces found' otel_traces.txt; then echo 'TRACES_PRESENT'; else echo 'TRACES_MISSING'; fi");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("TRACES_PRESENT", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Also verify JSON format works
+        await auto.TypeAsync("aspire otel traces --format json > otel_traces_json.txt 2>&1");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Verify JSON output contains trace data
+        await auto.TypeAsync("grep -q 'traceId' otel_traces_json.txt && echo 'JSON_TRACES_PRESENT' || echo 'JSON_TRACES_MISSING'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("JSON_TRACES_PRESENT", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Stop the AppHost
+        await auto.AspireStopAsync(counter);
+
+        // Exit the shell
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
     private async Task DashboardRunWithOtelTracesReturnsNoTracesCore(string frontendUrl, string localhostUrl)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/DashboardRunTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DashboardRunTests.cs
@@ -9,10 +9,10 @@ using Xunit;
 namespace Aspire.Cli.EndToEnd.Tests;
 
 /// <summary>
-/// End-to-end tests for the aspire dashboard run and aspire otel traces commands.
+/// End-to-end tests for the aspire dashboard run command combined with aspire otel and aspire agent mcp.
 /// Each test class runs as a separate CI job for parallelization.
 /// </summary>
-public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
+public sealed class DashboardRunTests(ITestOutputHelper output)
 {
     [Fact]
     [CaptureWorkspaceOnFailure]
@@ -91,6 +91,77 @@ public sealed class DashboardOtelTracesTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("No traces found", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitForSuccessPromptAsync(counter);
+
+        // Clean up: kill the background dashboard process
+        await auto.TypeAsync("kill -9 $DASHBOARD_PID 2>/dev/null; wait $DASHBOARD_PID 2>/dev/null; true");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Exit the shell
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public Task DashboardRunWithAgentMcpListTracesReturnsNoTraces()
+        => DashboardRunWithAgentMcpCore("http://localhost:18888", "http://localhost:18888", "list_traces", "TRACES DATA");
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public Task DashboardRunWithAgentMcpListTracesReturnsNoTraces_DevLocalhost()
+        => DashboardRunWithAgentMcpCore("http://dashboard.dev.localhost:18888", "http://localhost:18888", "list_traces", "TRACES DATA");
+
+    private async Task DashboardRunWithAgentMcpCore(string frontendUrl, string localhostUrl, string toolName, string expectedMarker)
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: false, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Use a known browser token so we can construct the dashboard URL directly
+        var browserToken = "testtoken1234567890abcdef12345678";
+
+        // Set the browser token env var before starting the dashboard
+        await auto.TypeAsync($"export DASHBOARD__FRONTEND__BROWSERTOKEN={browserToken}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Store the dashboard log path inside the workspace so it gets captured on failure
+        var dashboardLogPath = $"/workspace/{workspace.WorkspaceRoot.Name}/dashboard.log";
+
+        // Start the dashboard in the background with the specified frontend URL
+        await auto.TypeAsync($"aspire dashboard run --frontend-url {frontendUrl} > {dashboardLogPath} 2>&1 &");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Store the dashboard PID for cleanup
+        await auto.TypeAsync("DASHBOARD_PID=$!");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Wait for the dashboard to become ready by polling the localhost URL
+        await auto.TypeAsync($"for i in $(seq 1 30); do curl -ksSL -o /dev/null -w '%{{http_code}}' {localhostUrl} 2>/dev/null | grep -q 200 && break; sleep 1; done");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+        // Construct the dashboard URL using the known token and the frontend URL
+        var dashboardUrl = $"{frontendUrl}/login?t={browserToken}";
+
+        // Call the MCP tool against the standalone dashboard
+        await auto.CallAgentMcpToolAsync(counter, toolName, expectedMarker, $"--dashboard-url \"{dashboardUrl}\"");
 
         // Clean up: kill the background dashboard process
         await auto.TypeAsync("kill -9 $DASHBOARD_PID 2>/dev/null; wait $DASHBOARD_PID 2>/dev/null; true");

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -580,7 +580,7 @@ internal static class CliE2EAutomatorHelpers
 
         await auto.TypeAsync(
             $"DASHBOARD_URL=$(sed -n " +
-            "'s/.*\"dashboardUrl\"[[:space:]]*:[[:space:]]*\"\\(https\\?:\\/\\/localhost:[0-9]*\\).*/\\1/p' " +
+            "'s/.*\"dashboardUrl\"[[:space:]]*:[[:space:]]*\"\\(https\\?:\\/\\/[a-z.]*localhost:[0-9]*\\).*/\\1/p' " +
             $"\"{jsonFile}\" | head -1)");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -825,6 +825,59 @@ internal static class CliE2EAutomatorHelpers
         return null;
     }
 
+    /// <summary>
+    /// Sends a JSON-RPC initialize/initialized/tools-call sequence to <c>aspire agent mcp</c> and verifies the response.
+    /// </summary>
+    /// <param name="auto">The terminal automator.</param>
+    /// <param name="counter">The prompt sequence counter.</param>
+    /// <param name="toolName">The MCP tool name to invoke (e.g. <c>list_structured_logs</c>).</param>
+    /// <param name="expectedMarker">A string expected in the tool call output (e.g. <c>STRUCTURED LOGS DATA</c>).</param>
+    /// <param name="mcpArgs">Additional arguments to pass to <c>aspire agent mcp</c> (e.g. <c>--dashboard-url "..."</c>).</param>
+    internal static async Task CallAgentMcpToolAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string toolName,
+        string expectedMarker,
+        string? mcpArgs = null)
+    {
+        var argsFragment = mcpArgs is not null ? $" {mcpArgs}" : string.Empty;
+
+        // Send JSON-RPC messages to the MCP server via a compound command.
+        // The sleeps ensure proper protocol timing between initialize, initialized notification, and tool call.
+        await auto.TypeAsync(
+            "{ " +
+            "echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"e2e-test\",\"version\":\"0.1.0\"}}}'; " +
+            "sleep 3; " +
+            "echo '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}'; " +
+            "sleep 1; " +
+            $"echo '{{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{{\"name\":\"{toolName}\",\"arguments\":{{}}}}}}'; " +
+            "sleep 15; " +
+            $"}} | aspire agent mcp{argsFragment} > /tmp/mcp_out.txt 2>/tmp/mcp_err.txt || true");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+        // Dump output for debugging visibility in the recording
+        await auto.TypeAsync("cat /tmp/mcp_out.txt | head -50");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Check that the response contains the expected data marker
+        await auto.TypeAsync(
+            $"if grep -q '{expectedMarker}' /tmp/mcp_out.txt; then echo 'MCP_DATA_PRESENT'; " +
+            $"elif grep -q '{toolName}' /tmp/mcp_out.txt; then echo 'MCP_TOOL_FOUND_BUT_NO_DATA'; " +
+            "else echo 'MCP_DATA_MISSING'; fi");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("MCP_DATA_PRESENT", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Verify the initialize response was received (confirms MCP handshake worked)
+        await auto.TypeAsync(
+            "grep -q 'aspire-mcp-server' /tmp/mcp_out.txt && echo 'MCP_INIT_OK' || echo 'MCP_INIT_MISSING'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("MCP_INIT_OK", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+    }
+
     private static bool ShouldPreserveLocalWorkspace()
     {
         return TestContext.Current?.KeyValueStorage.TryGetValue("PreserveWorkspaceOnFailure", out var value) == true &&

--- a/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/OtelLogsTests.cs
@@ -17,14 +17,19 @@ public sealed class OtelLogsTests(ITestOutputHelper output)
     [Fact]
     [CaptureWorkspaceOnFailure]
     public Task OtelLogsReturnsStructuredLogsFromStarterApp()
-        => OtelLogsReturnsStructuredLogsFromStarterAppCore(isolated: false);
+        => OtelLogsReturnsStructuredLogsFromStarterAppCore(isolated: false, useDevLocalhost: false);
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public Task OtelLogsReturnsStructuredLogsFromStarterAppIsolated()
-        => OtelLogsReturnsStructuredLogsFromStarterAppCore(isolated: true);
+    public Task OtelLogsReturnsStructuredLogsFromStarterApp_Isolated()
+        => OtelLogsReturnsStructuredLogsFromStarterAppCore(isolated: true, useDevLocalhost: false);
 
-    private async Task OtelLogsReturnsStructuredLogsFromStarterAppCore(bool isolated)
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public Task OtelLogsReturnsStructuredLogsFromStarterApp_DevLocalhost()
+        => OtelLogsReturnsStructuredLogsFromStarterAppCore(isolated: false, useDevLocalhost: true);
+
+    private async Task OtelLogsReturnsStructuredLogsFromStarterAppCore(bool isolated, bool useDevLocalhost)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -42,14 +47,14 @@ public sealed class OtelLogsTests(ITestOutputHelper output)
         await auto.InstallAspireCliAsync(strategy, counter);
 
         // Create a new Starter project (includes an ASP.NET Core apiservice)
-        await auto.AspireNewAsync("AspireOtelLogsApp", counter);
+        await auto.AspireNewAsync("AspireOtelLogsApp", counter, useDevLocalhost: useDevLocalhost);
 
         // Navigate to the AppHost directory
         await auto.TypeAsync("cd AspireOtelLogsApp/AspireOtelLogsApp.AppHost");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Start the AppHost in the background
+        // Start the AppHost
         await auto.AspireStartAsync(counter, isolated: isolated);
 
         // Wait for the apiservice resource to be running before querying logs

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -4,6 +4,8 @@
 using System.Globalization;
 using System.Net;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
@@ -32,6 +34,118 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task TelemetryLogsCommand_WithDevLocalhostDashboardApiUrl_UsesLocalhost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var requestedHosts = new List<string>();
+        var resourcesJson = JsonSerializer.Serialize(
+            new ResourceInfoJson[] { new() { Name = "redis", InstanceId = null } },
+            OtlpJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        var resourceLogs = new OtlpResourceLogsJson[]
+        {
+            new()
+            {
+                Resource = TelemetryTestHelper.CreateOtlpResource("redis", null),
+                ScopeLogs =
+                [
+                    new OtlpScopeLogsJson
+                    {
+                        LogRecords =
+                        [
+                            new OtlpLogRecordJson
+                            {
+                                TimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime),
+                                SeverityNumber = 9,
+                                SeverityText = "Information",
+                                Body = new OtlpAnyValueJson { StringValue = "Ready to accept connections" },
+                                Attributes =
+                                [
+                                    new OtlpKeyValueJson { Key = "aspire.log_id", Value = new OtlpAnyValueJson { StringValue = "7" } }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var logsResponse = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceLogs = resourceLogs },
+            TotalCount = 1,
+            ReturnedCount = 1
+        };
+        var logsJson = JsonSerializer.Serialize(logsResponse, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
+                ProcessId = 1234
+            },
+            DashboardInfoResponse = new GetDashboardInfoResponse
+            {
+                ApiBaseUrl = "https://nextapp1.dev.localhost:64876",
+                ApiToken = "test-token",
+                DashboardUrls = ["https://nextapp1.dev.localhost:64876/login?t=test"],
+                IsHealthy = true
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri!.Host);
+
+            return request.RequestUri.AbsolutePath switch
+            {
+                "/api/telemetry/resources" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesJson, System.Text.Encoding.UTF8, "application/json")
+                },
+                "/api/telemetry/logs" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(logsJson, System.Text.Encoding.UTF8, "application/json")
+                },
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel logs --format json -n 5");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.All(requestedHosts, host => Assert.Equal("localhost", host));
+
+        var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
+        var items = JsonNode.Parse(jsonLine)!.AsArray();
+        Assert.Single(items);
+
+        var item = items[0]!;
+        Assert.Equal("Ready to accept connections", item["message"]!.GetValue<string>());
+        Assert.Equal("redis", item["resourceName"]!.GetValue<string>());
+
+        var dashboardUrl = item["dashboardUrl"]!.GetValue<string>();
+        Assert.Equal("https://nextapp1.dev.localhost:64876/structuredlogs?logEntryId=7", dashboardUrl);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -869,4 +869,36 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(expected, formattedJson, ignoreLineEndingDifferences: true);
     }
+
+    [Fact]
+    public async Task TelemetryLogsCommand_WithDevLocalhostUrl_ConnectionRefused_ErrorMessageShowsOriginalUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var testInteractionService = new TestInteractionService();
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            throw new HttpRequestException("Connection refused");
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel logs --dashboard-url http://dashboard.dev.localhost:18888/login?t=sometoken");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
+        // The error message should show the original *.dev.localhost URL the user typed,
+        // not the normalized localhost URL used for HTTP requests.
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, "http://dashboard.dev.localhost:18888"), errorMessage);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -148,6 +148,94 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("https://nextapp1.dev.localhost:64876/structuredlogs?logEntryId=7", dashboardUrl);
     }
 
+    [Fact]
+    public async Task TelemetryLogsCommand_WithDevLocalhostDashboardUrlArg_PreservesDisplayUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var requestedHosts = new List<string>();
+
+        var resourceLogs = new OtlpResourceLogsJson[]
+        {
+            new()
+            {
+                Resource = TelemetryTestHelper.CreateOtlpResource("redis", null),
+                ScopeLogs =
+                [
+                    new OtlpScopeLogsJson
+                    {
+                        LogRecords =
+                        [
+                            new OtlpLogRecordJson
+                            {
+                                TimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime),
+                                SeverityNumber = 9,
+                                SeverityText = "Information",
+                                Body = new OtlpAnyValueJson { StringValue = "Ready to accept connections" },
+                                Attributes =
+                                [
+                                    new OtlpKeyValueJson { Key = "aspire.log_id", Value = new OtlpAnyValueJson { StringValue = "7" } }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var logsResponse = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceLogs = resourceLogs },
+            TotalCount = 1,
+            ReturnedCount = 1
+        };
+        var logsJson = JsonSerializer.Serialize(logsResponse, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri!.Host);
+
+            return request.RequestUri.AbsolutePath switch
+            {
+                "/api/telemetry/resources" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                },
+                "/api/telemetry/logs" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(logsJson, System.Text.Encoding.UTF8, "application/json")
+                },
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel logs --format json -n 5 --dashboard-url http://dashboard.dev.localhost:18888");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // HTTP requests should be normalized to localhost
+        Assert.All(requestedHosts, host => Assert.Equal("localhost", host));
+
+        var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
+        var items = JsonNode.Parse(jsonLine)!.AsArray();
+        Assert.Single(items);
+
+        // The display URL in JSON output should preserve the original *.dev.localhost hostname
+        var dashboardUrl = items[0]!["dashboardUrl"]!.GetValue<string>();
+        Assert.Equal("http://dashboard.dev.localhost:18888/structuredlogs?logEntryId=7", dashboardUrl);
+    }
+
     [Theory]
     [InlineData(-1)]
     [InlineData(0)]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -144,6 +144,92 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("https://nextapp1.dev.localhost:64876/traces/detail/abc1234567890def", dashboardUrl);
     }
 
+    [Fact]
+    public async Task TelemetryTracesCommand_WithDevLocalhostDashboardUrlArg_PreservesDisplayUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var requestedHosts = new List<string>();
+
+        var resourceSpans = new OtlpResourceSpansJson[]
+        {
+            new()
+            {
+                Resource = TelemetryTestHelper.CreateOtlpResource("frontend", null),
+                ScopeSpans =
+                [
+                    new OtlpScopeSpansJson
+                    {
+                        Spans =
+                        [
+                            new OtlpSpanJson
+                            {
+                                TraceId = "abc1234567890def",
+                                SpanId = "span001",
+                                Name = "GET /home",
+                                StartTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime),
+                                EndTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime.AddMilliseconds(50)),
+                                Status = new OtlpSpanStatusJson { Code = 1 }
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var tracesResponse = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceSpans = resourceSpans },
+            TotalCount = 1,
+            ReturnedCount = 1
+        };
+        var tracesJson = JsonSerializer.Serialize(tracesResponse, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri!.Host);
+
+            return request.RequestUri.AbsolutePath switch
+            {
+                "/api/telemetry/resources" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                },
+                "/api/telemetry/traces" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(tracesJson, System.Text.Encoding.UTF8, "application/json")
+                },
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel traces --format json -n 5 --dashboard-url http://dashboard.dev.localhost:18888");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // HTTP requests should be normalized to localhost
+        Assert.All(requestedHosts, host => Assert.Equal("localhost", host));
+
+        var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
+        var items = JsonNode.Parse(jsonLine)!.AsArray();
+        Assert.Single(items);
+
+        // The display URL in JSON output should preserve the original *.dev.localhost hostname
+        var dashboardUrl = items[0]!["dashboardUrl"]!.GetValue<string>();
+        Assert.Equal("http://dashboard.dev.localhost:18888/traces/detail/abc1234567890def", dashboardUrl);
+    }
+
     [Theory]
     [InlineData(-1)]
     [InlineData(0)]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -3,6 +3,8 @@
 
 using System.Net;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
@@ -31,6 +33,115 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task TelemetryTracesCommand_WithDevLocalhostDashboardApiUrl_UsesLocalhost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var requestedHosts = new List<string>();
+        var resourcesJson = JsonSerializer.Serialize(
+            new ResourceInfoJson[] { new() { Name = "frontend", InstanceId = null } },
+            OtlpJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        var resourceSpans = new OtlpResourceSpansJson[]
+        {
+            new()
+            {
+                Resource = TelemetryTestHelper.CreateOtlpResource("frontend", null),
+                ScopeSpans =
+                [
+                    new OtlpScopeSpansJson
+                    {
+                        Spans =
+                        [
+                            new OtlpSpanJson
+                            {
+                                TraceId = "abc1234567890def",
+                                SpanId = "span001",
+                                Name = "GET /home",
+                                StartTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime),
+                                EndTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime.AddMilliseconds(50)),
+                                Status = new OtlpSpanStatusJson { Code = 1 }
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        var tracesResponse = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceSpans = resourceSpans },
+            TotalCount = 1,
+            ReturnedCount = 1
+        };
+        var tracesJson = JsonSerializer.Serialize(tracesResponse, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
+                ProcessId = 1234
+            },
+            DashboardInfoResponse = new GetDashboardInfoResponse
+            {
+                ApiBaseUrl = "https://nextapp1.dev.localhost:64876",
+                ApiToken = "test-token",
+                DashboardUrls = ["https://nextapp1.dev.localhost:64876/login?t=test"],
+                IsHealthy = true
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri!.Host);
+
+            return request.RequestUri.AbsolutePath switch
+            {
+                "/api/telemetry/resources" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesJson, System.Text.Encoding.UTF8, "application/json")
+                },
+                "/api/telemetry/traces" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(tracesJson, System.Text.Encoding.UTF8, "application/json")
+                },
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel traces --format json -n 5");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.All(requestedHosts, host => Assert.Equal("localhost", host));
+
+        var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
+        var items = JsonNode.Parse(jsonLine)!.AsArray();
+        Assert.Single(items);
+
+        var item = items[0]!;
+        Assert.Equal("abc1234567890def", item["traceId"]!.GetValue<string>());
+
+        var dashboardUrl = item["dashboardUrl"]!.GetValue<string>();
+        Assert.Equal("https://nextapp1.dev.localhost:64876/traces/detail/abc1234567890def", dashboardUrl);
     }
 
     [Theory]

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -502,7 +502,8 @@ internal static class Hex1bAutomatorTestHelpers
         string projectName,
         SequenceCounter counter,
         AspireTemplate template = AspireTemplate.Starter,
-        bool useRedisCache = true)
+        bool useRedisCache = true,
+        bool useDevLocalhost = false)
     {
         var templateTimeout = TimeSpan.FromSeconds(60);
 
@@ -607,7 +608,14 @@ internal static class Hex1bAutomatorTestHelpers
             s => new CellPatternSearcher().Find("Use *.dev.localhost URLs").Search(s).Count > 0,
             timeout: TimeSpan.FromSeconds(10),
             description: "URLs prompt");
-        await auto.EnterAsync(); // Accept default "No"
+        if (useDevLocalhost)
+        {
+            await auto.TypeAsync("y");
+        }
+        else
+        {
+            await auto.EnterAsync(); // Accept default "No"
+        }
 
         // Step 6: Redis prompt (only Starter, JsReact, PythonReact)
         if (template is AspireTemplate.Starter or AspireTemplate.JsReact or AspireTemplate.PythonReact)


### PR DESCRIPTION
Fixes https://github.com/microsoft/aspire/issues/15782

## Customer Impact

`aspire otel` and `aspire agent mcp` don't work with `*.dev.localhost` configured projects. Also impacts when `--dashboard-url` is specified.

Fix is to convert `*.dev.localhost` hosts to `localhost`.

## Testing

Unit and end to end tests.

## Risk

Low. The fix of changing the host name is simple, and this PR adds many unit tests and end to end tests in this area.

## Regression?

No

## Description

DNS resolvers typically don't implement RFC 6761 for localhost subdomains, so hosts like `myapp.dev.localhost` fail to resolve when the CLI makes HTTP requests to the dashboard API. This adds `NormalizeDashboardUrl` to `McpToolHelpers` which rewrites `*.localhost` API base URLs to `localhost` before making HTTP requests, while preserving the original hostname in dashboard display URLs (used in JSON output hyperlinks).

### Changes

- Add `NormalizeDashboardUrl` and `IsLocalhostTld` to `McpToolHelpers`
- Normalize API base URL in `TelemetryCommandHelpers` and `McpToolHelpers` (for HTTP requests)
- Preserve original `*.dev.localhost` hostname in dashboard display URLs (for JSON output)
- Add unit tests for logs/traces with `dev.localhost` backchannel URLs verifying both HTTP host normalization and dashboard URL preservation
- Add E2E test variant using `dev.localhost` dashboard URL

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No