### PR TITLE
Support backport PRs in milestone changelog workflow

### DIFF
--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"12d4ab82b11cac1db0607885a8acd8723cc08bffd97abd7f6a1d84663d7dbb62","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bc09c68f42616ff37665c366f69cf8321822db23c9b0b6fc0a345ee394f37031","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -190,14 +190,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f802b86e8a074264_EOF'
+          cat << 'GH_AW_PROMPT_5868524d72ca276e_EOF'
           <system>
-          GH_AW_PROMPT_f802b86e8a074264_EOF
+          GH_AW_PROMPT_5868524d72ca276e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f802b86e8a074264_EOF'
+          cat << 'GH_AW_PROMPT_5868524d72ca276e_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
@@ -229,12 +229,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_f802b86e8a074264_EOF
+          GH_AW_PROMPT_5868524d72ca276e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f802b86e8a074264_EOF'
+          cat << 'GH_AW_PROMPT_5868524d72ca276e_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_f802b86e8a074264_EOF
+          GH_AW_PROMPT_5868524d72ca276e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -422,9 +422,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9ca2488df69c598a_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_304aca6c9899de91_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_9ca2488df69c598a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_304aca6c9899de91_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -596,7 +596,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_969df59bed5c8848_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_3e03946cbe3bfb7c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -640,7 +640,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_969df59bed5c8848_EOF
+          GH_AW_MCP_CONFIG_3e03946cbe3bfb7c_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1221,7 +1221,7 @@ jobs:
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
             --search "milestone:$MILESTONE" \
-            --json number,title,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-milestone-prs.json"
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -125,7 +125,7 @@ jobs:
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
             --search "milestone:$MILESTONE" \
-            --json number,title,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-milestone-prs.json"
 
@@ -428,20 +428,23 @@ The pre-computation step (in the frontmatter) has already:
   file present)
 - Written the oldest ${BATCH_SIZE} unprocessed PRs to `/tmp/gh-aw/pr-data/batch-prs.json`
 
-Each entry in `batch-prs.json` contains: `number`, `title`, `author` (object with
-`login` and `is_bot`), `mergedAt`, `labels` (array of objects with `name`), `additions`,
-`deletions`, `changedFiles`.
+Each entry in `batch-prs.json` contains: `number`, `title`, `body`, `author` (object
+with `login` and `is_bot`), `mergedAt`, `labels` (array of objects with `name`),
+`additions`, `deletions`, `changedFiles`.
 
 ## Step 3: Process the batch PRs
 
 Read `/tmp/gh-aw/pr-data/batch-prs.json`. This is a JSON array of up to ${BATCH_SIZE}
 unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Each entry contains:
-`number`, `title`, `author` (object with `login` and `is_bot`), `mergedAt`, `labels`
-(array of objects with `name`), `additions`, `deletions`, `changedFiles`.
+`number`, `title`, `body`, `author` (object with `login` and `is_bot`), `mergedAt`,
+`labels` (array of objects with `name`), `additions`, `deletions`, `changedFiles`.
 
 1. **Exclude bot-authored PRs** — remove any PR whose `author.is_bot` is `true`,
-   **except** `app/copilot-swe-agent` which makes product changes on behalf of
-   developers and should be processed normally.
+   **except** these cases which should be processed normally:
+   - `app/copilot-swe-agent` — makes product changes on behalf of developers.
+   - **Backport PRs** — PRs whose body contains "Backport of #XXXX" (linking
+     to the original PR). These are created by backport bots and contain the
+     same meaningful changes as their source PRs, just targeting a release branch.
    Record each excluded bot PR as an individual tracker file in `prs/` with
    `status: "excluded"` in Step 6b so they are not re-processed on future runs.
 2. If the batch has fewer than ${BATCH_SIZE} PRs, this is the last batch — after
@@ -452,7 +455,32 @@ full body/description and changed file paths. Collect: number, title, author,
 `author_association`, body/description, labels, the list of changed files, and the
 total number of changed lines (additions + deletions).
 
-### 3a. Read the PR diff when needed
+### 3a. Processing backport PRs
+
+Backport PRs are identified by their body containing "Backport of #XXXX"
+(a link to the original source PR). Their body typically contains only this
+backport reference plus a shiproom template that may be unfilled or partially
+filled. To process them:
+
+1. **Extract the original PR number** from the body (parse "Backport of #XXXX").
+2. **Fetch the original PR** using `pull_request_read` to get its full title,
+   body/description, labels, and changed file paths. Use the original PR's
+   content as the primary source for generating the changelog entry.
+3. **Use the backport PR's title** (stripping any branch prefix, such as
+   `[release/...]`, if present) as the display name if the original PR's title
+   is identical. Otherwise prefer the clearer of the two.
+4. **Use the backport PR's number** (not the original) in the `Changes:` line
+   and in `prs` arrays, since the backport is the PR that was merged into the
+   milestone.
+5. **Use the original PR author's `author_association`** for the community
+   contribution flag (Step 5b), since the backport bot is not a meaningful author.
+   Set the `author` field in the PR tracker to the original PR's author, not the
+   bot.
+
+If the original PR number cannot be parsed from the body, fall back to processing
+the backport PR using its own title, labels, and changed files (same as a normal PR).
+
+### 3b. Read the PR diff when needed
 
 For PRs with **5,000 or fewer** total changed lines, read the diff if **any** of these
 conditions are true:
@@ -653,6 +681,7 @@ Schema:
 {
   "area": "CLI",
   "areaEmoji": "💻",
+  "backport": false,
   "breaking": false,
   "changeType": "New features",
   "communityContributors": ["@contributor"],
@@ -669,6 +698,7 @@ Schema:
 Field definitions:
 - **area**: Product area name (see Step 5a area table)
 - **areaEmoji**: Emoji for the product area (see Step 5a area table)
+- **backport**: `true` if this entry was generated from a backport PR (Step 3a), `false` otherwise
 - **breaking**: `true` if this is a breaking change, `false` otherwise
 - **changeType**: One of `"New features"`, `"Improvements"`, or `"Bug fixes"`
 - **communityContributors**: Array of GitHub usernames (prefixed with `@`) of

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -442,9 +442,11 @@ unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Each entry conta
 1. **Exclude bot-authored PRs** — remove any PR whose `author.is_bot` is `true`,
    **except** these cases which should be processed normally:
    - `app/copilot-swe-agent` — makes product changes on behalf of developers.
-   - **Backport PRs** — PRs whose body contains "Backport of #XXXX" (linking
-     to the original PR). These are created by backport bots and contain the
-     same meaningful changes as their source PRs, just targeting a release branch.
+   - **Backport PRs** — PRs whose body contains the word `backport` or `port`
+     and, upon inspection, appears to be a backport of another PR (e.g.,
+     references an original PR number). These are created by backport bots
+     and contain the same meaningful changes as their source PRs, just
+     targeting a release branch.
    Record each excluded bot PR as an individual tracker file in `prs/` with
    `status: "excluded"` in Step 6b so they are not re-processed on future runs.
 2. If the batch has fewer than ${BATCH_SIZE} PRs, this is the last batch — after
@@ -457,12 +459,17 @@ total number of changed lines (additions + deletions).
 
 ### 3a. Processing backport PRs
 
-Backport PRs are identified by their body containing "Backport of #XXXX"
-(a link to the original source PR). Their body typically contains only this
-backport reference plus a shiproom template that may be unfilled or partially
-filled. To process them:
+Backport PRs are identified by checking whether the PR body contains the word
+`backport` or `port` (case-insensitive). If either word is present, inspect the
+body text to determine whether the PR is actually a backport of another PR —
+look for references to an original PR number (e.g., "Backport of #1234",
+"port of #5678", a markdown link to another PR, etc.). Their body typically
+contains only this backport reference plus a shiproom template that may be unfilled
+or partially filled. To process them:
 
-1. **Extract the original PR number** from the body (parse "Backport of #XXXX").
+1. **Extract the original PR number** from the body by inspecting the text for
+   a reference to the source PR (e.g., "Backport of #1234", "#1234", or a
+   full URL like `https://github.com/microsoft/aspire/pull/1234`).
 2. **Fetch the original PR** using `pull_request_read` to get its full title,
    body/description, labels, and changed file paths. Use the original PR's
    content as the primary source for generating the changelog entry.
@@ -475,7 +482,13 @@ filled. To process them:
 5. **Use the original PR author's `author_association`** for the community
    contribution flag (Step 5b), since the backport bot is not a meaningful author.
    Set the `author` field in the PR tracker to the original PR's author, not the
-   bot.
+   bot. When evaluating Step 5b's "Community contribution" flag for a backport PR,
+   use the **original author's** `author_association` and treat `author.is_bot` as
+   `false` (since the original author — not the backport bot — is the meaningful
+   contributor).
+6. **Set `backport: true`** in the change file for this entry (see Step 6a schema).
+   If the backport PR is grouped with an existing entry that was not a backport,
+   keep `backport: false` (the entry is not purely backport-derived).
 
 If the original PR number cannot be parsed from the body, fall back to processing
 the backport PR using its own title, labels, and changed files (same as a normal PR).
@@ -575,7 +588,7 @@ Then determine whether either of these optional flags applies:
 |------|-------|-------------|
 | **Breaking change** | ⚠️ | Removed or renamed API, changed default behavior, migration required |
 | **Docs required** | 📝 | Change needs documentation on aspire.dev (new feature, changed behavior, new config options) |
-| **Community contribution** | 🌍 | PR author's `author_association` is not `MEMBER` or `OWNER`, **and** the PR's `author.is_bot` (from the batch data) is not `true` — i.e., the author is a human external community contributor |
+| **Community contribution** | 🌍 | PR author's `author_association` is not `MEMBER` or `OWNER`, **and** the PR's `author.is_bot` (from the batch data) is not `true` — i.e., the author is a human external community contributor. For **backport PRs** (Step 3a), use the original PR author's `author_association` and ignore the backport bot's `is_bot` flag. |
 
 > **Important — verifying `author_association`:** The `pull_request_read` MCP tool
 > may omit the `author_association` field from its response. If the field is missing
@@ -698,7 +711,7 @@ Schema:
 Field definitions:
 - **area**: Product area name (see Step 5a area table)
 - **areaEmoji**: Emoji for the product area (see Step 5a area table)
-- **backport**: `true` if this entry was generated from a backport PR (Step 3a), `false` otherwise
+- **backport**: `true` if this entry was generated from a backport PR (Step 3a item 6), `false` otherwise. When grouping: if a backport PR is grouped with an existing non-backport entry, keep `false`
 - **breaking**: `true` if this is a breaking change, `false` otherwise
 - **changeType**: One of `"New features"`, `"Improvements"`, or `"Bug fixes"`
 - **communityContributors**: Array of GitHub usernames (prefixed with `@`) of


### PR DESCRIPTION
## Summary

Updates the milestone changelog workflow to correctly process backport PRs instead of silently excluding them as bot-authored PRs.

## Changes

- **Include `body` in batch data** — Added `body` to the `gh pr list --json` fields so the PR body is available in `batch-prs.json` without requiring an extra API call.
- **Updated bot exclusion rule** — Backport PRs (detected by body containing "Backport of #XXXX") are now exempted from bot exclusion, even though they're typically authored by bots.
- **Added Step 3a (Processing backport PRs)** — New section with explicit instructions for how the agent should handle backport PRs: extract the original PR number, fetch the original for context, use the backport's PR number in the changelog, and attribute authorship to the original author.
- **Added `backport` flag to change file schema** — Boolean field to track whether a changelog entry originated from a backport PR.
- **Renumbered Step 3a → 3b** — The existing "Read the PR diff when needed" section is now 3b.

## Motivation

Backport PRs (e.g., #16678) are created by bots like `aspire-repo-bot` and were being excluded by the bot filter. These PRs contain real product changes that should appear in the changelog for the release milestone they target.