### PR TITLE
Filter Empty AppHost selectable languages by feature flag

### DIFF
--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -110,12 +110,13 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
-                supportsLanguageCallback: static languageId =>
-                    languageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.TypeScript, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.Python, StringComparison.OrdinalIgnoreCase),
-                selectableAppHostLanguages: [KnownLanguageId.CSharp, KnownLanguageId.TypeScript, KnownLanguageId.Python],
+                supportsLanguageCallback: languageId =>
+                    IsLanguageAvailable(languageId) &&
+                    (languageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase) ||
+                     languageId.Equals(KnownLanguageId.TypeScript, StringComparison.OrdinalIgnoreCase) ||
+                     languageId.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase) ||
+                     languageId.Equals(KnownLanguageId.Python, StringComparison.OrdinalIgnoreCase)),
+                selectableAppHostLanguages: FilterAvailableLanguages([KnownLanguageId.CSharp, KnownLanguageId.TypeScript, KnownLanguageId.Python]),
                 isEmpty: true),
 
             new CallbackTemplate(
@@ -182,6 +183,16 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
         }
 
         return _languageDiscovery.GetLanguageById(new LanguageId(template.LanguageId)) is not null;
+    }
+
+    private bool IsLanguageAvailable(string languageId)
+    {
+        return _languageDiscovery.GetLanguageById(new LanguageId(languageId)) is not null;
+    }
+
+    private string[] FilterAvailableLanguages(string[] languageIds)
+    {
+        return languageIds.Where(IsLanguageAvailable).ToArray();
     }
 
     private static string ApplyTokens(string content, string projectName, string projectNameLower, string aspireVersion, AppHostProfilePorts ports, string hostName = "localhost")

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -73,6 +73,66 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void EmptyAppHostTemplate_DoesNotOfferPythonLanguage_WhenPolyglotPythonDisabled()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace);
+        using var provider = services.BuildServiceProvider();
+
+        var templateProvider = provider.GetRequiredService<ITemplateProvider>();
+        var emptyTemplate = templateProvider.GetTemplates()
+            .Single(t => t.Name == KnownTemplateId.CSharpEmptyAppHost);
+
+        Assert.Contains(KnownLanguageId.CSharp, emptyTemplate.SelectableAppHostLanguages);
+        Assert.Contains(KnownLanguageId.TypeScript, emptyTemplate.SelectableAppHostLanguages);
+        Assert.DoesNotContain(KnownLanguageId.Python, emptyTemplate.SelectableAppHostLanguages);
+
+        Assert.True(emptyTemplate.SupportsLanguage(KnownLanguageId.CSharp));
+        Assert.True(emptyTemplate.SupportsLanguage(KnownLanguageId.TypeScript));
+        Assert.False(emptyTemplate.SupportsLanguage(KnownLanguageId.Python));
+    }
+
+    [Fact]
+    public void EmptyAppHostTemplate_OffersPythonLanguage_WhenPolyglotPythonEnabled()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.FeatureFlagsFactory = _ =>
+            {
+                var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotPython, true);
+                return features;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var templateProvider = provider.GetRequiredService<ITemplateProvider>();
+        var emptyTemplate = templateProvider.GetTemplates()
+            .Single(t => t.Name == KnownTemplateId.CSharpEmptyAppHost);
+
+        Assert.Contains(KnownLanguageId.CSharp, emptyTemplate.SelectableAppHostLanguages);
+        Assert.Contains(KnownLanguageId.TypeScript, emptyTemplate.SelectableAppHostLanguages);
+        Assert.Contains(KnownLanguageId.Python, emptyTemplate.SelectableAppHostLanguages);
+
+        Assert.True(emptyTemplate.SupportsLanguage(KnownLanguageId.Python));
+    }
+
+    [Fact]
+    public async Task NewCommandWithExplicitPythonOnEmptyTemplate_FailsWhenPolyglotPythonDisabled()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse($"new {KnownTemplateId.CSharpEmptyAppHost} --name TestApp --output . --language python");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
     public async Task NewCommandInteractiveFlowSmokeTest()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

Filter the `aspire-empty` template's selectable languages through the same feature-flag gating already used by `IsTemplateAvailable`, so disabled experimental polyglot languages no longer appear in the language picker.

**Bug:** `aspire new` showed Python as a selectable language for the generic **Empty AppHost** template even when `experimentalPolyglot:python` was disabled. Selecting Python then failed with `Unknown language: 'python'`.

**Root cause:** The `aspire-empty` `CallbackTemplate` in `CliTemplateFactory.GetTemplateDefinitions()` hardcoded `selectableAppHostLanguages` to `[csharp, typescript/nodejs, python]`, and `NewCommand.PromptForAppHostLanguageAsync` displayed that list directly. The same code path called `_languageDiscovery.GetLanguageById("python")` later, which returned `null` when the flag was off, producing the late `Unknown language` error.

**Fix:**
- Filter `selectableAppHostLanguages` through `_languageDiscovery.GetLanguageById` via two new helpers (`IsLanguageAvailable` / `FilterAvailableLanguages`).
- Tighten `supportsLanguageCallback` so explicit `--language python` is rejected up front when the flag is off (returns the standard `Template '...' does not support language 'python'.` error instead of the late `Unknown language` error).

The same gating now keeps any future experimental polyglot languages out of `selectableAppHostLanguages` lists if added without enabling their feature flag.

Fixes #16661

## Validation

Install this PR build (one-liner — replace the URL host once a release branch is involved):

```powershell
# PowerShell
iex "& { $(irm https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.ps1) } 16713"
```
```bash
# Bash
curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s -- 16713
```

### Scenario 1 — flag OFF (regression check)

```bash
# Make sure the experimental Python polyglot flag is OFF (it is by default).
# If you previously turned it on, clear it:
aspire config delete -g features.experimentalPolyglot:python

aspire new
# pick: "Empty AppHost"
```

**Expected:** Language picker shows only C# and TypeScript/JavaScript. **Python must NOT appear.**

Also try the explicit-language path:

```bash
aspire new aspire-empty --language python
```

**Expected:** Fails fast with `Template 'aspire-empty' does not support language 'python'.` (and **not** the old `Unknown language: 'python'`).

### Scenario 2 — flag ON (feature still works)

```bash
aspire config set -g features.experimentalPolyglot:python true

aspire new
# pick: "Empty AppHost"
```

**Expected:** Language picker now includes Python. Selecting Python successfully creates a Python AppHost.

```bash
aspire new aspire-empty --language python
```

**Expected:** Succeeds and scaffolds a Python AppHost.

### Cleanup

```bash
aspire config delete -g features.experimentalPolyglot:python
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
