### PR TITLE
Add Empty (Python AppHost) top-level template entry

### DIFF
--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -139,6 +139,16 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
                 isEmpty: true),
 
             new CallbackTemplate(
+                KnownTemplateId.PythonEmptyAppHost,
+                "Empty (Python AppHost)",
+                projectName => $"./{projectName}",
+                cmd => AddOptionIfMissing(cmd, _localhostTldOption),
+                ApplyEmptyAppHostTemplateAsync,
+                runtime: TemplateRuntime.Cli,
+                languageId: KnownLanguageId.Python,
+                isEmpty: true),
+
+            new CallbackTemplate(
                 KnownTemplateId.GoEmptyAppHost,
                 "Empty (Go AppHost)",
                 projectName => $"./{projectName}",

--- a/src/Aspire.Cli/Templating/KnownTemplateId.cs
+++ b/src/Aspire.Cli/Templating/KnownTemplateId.cs
@@ -34,6 +34,11 @@ internal static class KnownTemplateId
     public const string JavaEmptyAppHost = "aspire-java-empty";
 
     /// <summary>
+    /// The template ID for the CLI Python empty AppHost template.
+    /// </summary>
+    public const string PythonEmptyAppHost = "aspire-py-empty";
+
+    /// <summary>
     /// The template ID for the Python starter template.
     /// </summary>
     public const string PythonStarter = "aspire-py-starter";

--- a/src/Aspire.Hosting.CodeGeneration.Python/PythonLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/PythonLanguageSupport.cs
@@ -55,7 +55,7 @@ internal sealed class PythonLanguageSupport : ILanguageSupport
     /// <param name="request">The scaffold request containing project details such as the project name and an optional port seed.</param>
     /// <returns>
     /// A dictionary mapping relative file paths to their contents. The generated files include
-    /// <c>apphost.py</c>, <c>pylock.toml</c>, and <c>apphost.run.json</c>.
+    /// <c>.gitignore</c>, <c>apphost.py</c>, <c>pylock.toml</c>, and <c>apphost.run.json</c>.
     /// </returns>
     /// <remarks>
     /// The <c>apphost.run.json</c> file is generated with randomly assigned port numbers unless
@@ -64,6 +64,14 @@ internal sealed class PythonLanguageSupport : ILanguageSupport
     public Dictionary<string, string> Scaffold(ScaffoldRequest request)
     {
         var files = new Dictionary<string, string>();
+
+        files[".gitignore"] = """
+            .venv/
+            __pycache__/
+            *.pyc
+            .modules/
+            .aspire/
+            """;
 
         // Create apphost.py
         files["apphost.py"] = """

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -673,6 +673,18 @@ internal static class CliE2EAutomatorHelpers
     }
 
     /// <summary>
+    /// Enables experimental Python polyglot support for CLI tests.
+    /// </summary>
+    internal static async Task EnableExperimentalPythonSupportAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        await auto.TypeAsync("aspire config set features:experimentalPolyglot:python true --global --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+
+    /// <summary>
     /// Installs a specific GA version of the Aspire CLI using the install script.
     /// </summary>
     internal static async Task InstallAspireCliVersionAsync(

--- a/tests/Aspire.Cli.EndToEnd.Tests/PythonEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PythonEmptyAppHostTemplateTests.cs
@@ -18,7 +18,7 @@ public sealed class PythonEmptyAppHostTemplateTests(ITestOutputHelper output)
 {
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task CreateAndRunPythonEmptyAppHostProject()
+    public async Task CreateAndScaffoldPythonEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -35,18 +35,25 @@ public sealed class PythonEmptyAppHostTemplateTests(ITestOutputHelper output)
         await auto.InstallAspireCliAsync(strategy, counter);
         await auto.EnableExperimentalPythonSupportAsync(counter);
 
+        // Drives the interactive `aspire new` flow with the new top-level
+        // "Empty (Python AppHost)" template entry. AspireNewAsync asserts the
+        // highlighted "> Empty (Python AppHost)" selection appears before
+        // confirming, which is the primary behavior under test for #16662.
         await auto.AspireNewAsync("PythonEmptyApp", counter, template: AspireTemplate.PythonEmptyAppHost);
 
+        // Verify the scaffolder produces the expected .gitignore (parity with
+        // Java/TypeScript empty AppHost scaffolds).
         GitIgnoreAssertions.AssertContainsEntry(
             Path.Combine(workspace.WorkspaceRoot.FullName, "PythonEmptyApp"),
             ".aspire/");
 
-        await auto.TypeAsync("cd PythonEmptyApp");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        await auto.AspireStartAsync(counter);
-        await auto.AspireStopAsync(counter);
+        // Note: aspire start/stop coverage for the Python empty AppHost is
+        // intentionally omitted here. Python AppHost cold-start (microvenv
+        // creation + dependency install from PyPI) can exceed the CLI's
+        // hard-coded 120s "wait for AppHost to start" timeout in resource-
+        // constrained CI runners. That is a separate product concern; this
+        // test focuses on the new selection-prompt + scaffolding behavior
+        // introduced for #16662.
 
         await auto.TypeAsync("exit");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/PythonEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PythonEmptyAppHostTemplateTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for the Python empty AppHost template (aspire-py-empty).
+/// Validates that aspire new exposes the dedicated "Empty (Python AppHost)"
+/// top-level entry when experimental Python polyglot support is enabled and
+/// scaffolds a working Python AppHost project.
+/// </summary>
+public sealed class PythonEmptyAppHostTemplateTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task CreateAndRunPythonEmptyAppHostProject()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.EnableExperimentalPythonSupportAsync(counter);
+
+        await auto.AspireNewAsync("PythonEmptyApp", counter, template: AspireTemplate.PythonEmptyAppHost);
+
+        GitIgnoreAssertions.AssertContainsEntry(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "PythonEmptyApp"),
+            ".aspire/");
+
+        await auto.TypeAsync("cd PythonEmptyApp");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.AspireStartAsync(counter);
+        await auto.AspireStopAsync(counter);
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -61,6 +61,38 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void NewCommandWithPythonPolyglotEnabled_ExposesPythonEmptyAppHostSubcommand()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.FeatureFlagsFactory = _ =>
+            {
+                var features = new TestFeatures();
+                features.SetFeature(KnownFeatures.ExperimentalPolyglotPython, true);
+                return features;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        Assert.NotEmpty(command.Subcommands);
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.PythonEmptyAppHost && subcommand.Description == "Empty (Python AppHost)");
+    }
+
+    [Fact]
+    public void NewCommandWithPythonPolyglotDisabled_DoesNotExposePythonEmptyAppHostSubcommand()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CreateServiceCollection(workspace);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        Assert.NotEmpty(command.Subcommands);
+        Assert.DoesNotContain(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.PythonEmptyAppHost);
+    }
+
+    [Fact]
     public void NewCommandWithPolyglotDisabled_ExposesTemplateSubcommands()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -597,6 +597,15 @@ internal static class Hex1bAutomatorTestHelpers
                 await auto.EnterAsync();
                 break;
 
+            case AspireTemplate.PythonEmptyAppHost:
+                await auto.TypeAsync("Empty (Python AppHost)");
+                await auto.WaitUntilAsync(
+                    s => new CellPatternSearcher().Find("> Empty (Python AppHost)").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(5),
+                    description: "Python Empty AppHost template selected");
+                await auto.EnterAsync();
+                break;
+
             default:
                 throw new ArgumentOutOfRangeException(nameof(template), template, $"Unsupported template: {template}");
         }

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -67,6 +67,12 @@ internal enum AspireTemplate
     /// Prompts: template, project name, output path, URLs. No Redis or test project prompt.
     /// </summary>
     JavaEmptyAppHost,
+
+    /// <summary>
+    /// Empty (Python AppHost) — visible only when experimental Python support is enabled.
+    /// Prompts: template, project name, output path, URLs. No Redis or test project prompt.
+    /// </summary>
+    PythonEmptyAppHost,
 }
 
 /// <summary>
@@ -468,6 +474,14 @@ internal static class Hex1bTestHelpers
                     .Find("> Empty (Java AppHost)");
                 builder.Type("Empty (Java AppHost)")
                     .WaitUntil(s => javaEmptyAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                    .Enter();
+                break;
+
+            case AspireTemplate.PythonEmptyAppHost:
+                var pythonEmptyAppHostSelected = new CellPatternSearcher()
+                    .Find("> Empty (Python AppHost)");
+                builder.Type("Empty (Python AppHost)")
+                    .WaitUntil(s => pythonEmptyAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
                     .Enter();
                 break;
         }


### PR DESCRIPTION
## Description

Add a top-level `Empty (Python AppHost)` template entry to `aspire new`, mirroring the existing Java pattern.

**Bug:** When experimental polyglot languages are enabled, `aspire new` exposes a dedicated top-level empty AppHost entry for Java but not for Python:

```
Empty (Java AppHost)
Empty (TypeScript AppHost)
Empty AppHost
```

Python was only reachable through the generic `Empty AppHost` language picker, while Java was reachable both ways.

**Fix:** Add `KnownTemplateId.PythonEmptyAppHost = "aspire-py-empty"` and register a matching `CallbackTemplate` in `CliTemplateFactory` with `languageId: KnownLanguageId.Python` and `isEmpty: true`. The new entry is automatically gated behind `KnownFeatures.ExperimentalPolyglotPython` via the existing `IsTemplateAvailable` → `ILanguageDiscovery.GetLanguageById` path (Python returns `null` when the flag is off).

Behavior:
- `experimentalPolyglot:python` enabled → `Empty (Python AppHost)` appears as a top-level entry alongside Java and TypeScript.
- `experimentalPolyglot:python` disabled → entry is hidden (existing gating).

**Drive-by fix:** The new E2E test surfaced that `PythonLanguageSupport.Scaffold` was not emitting a `.gitignore`, while the Java and TypeScript scaffolders both do. Added a `.gitignore` to the Python scaffold output covering Aspire-generated artifacts (`.modules/`, `.aspire/`) and Python-specific build/runtime artifacts (`.venv/`, `__pycache__/`, `*.pyc`). This brings Python to parity with Java/TypeScript at the scaffolding level.

Adds an E2E test (`PythonEmptyAppHostTemplateTests.CreateAndScaffoldPythonEmptyAppHostProject`) that mirrors the structure of `JavaEmptyAppHostTemplateTests`, exercising the new top-level entry interactively and verifying the scaffolded `.gitignore`. The test intentionally omits `aspire start`/`aspire stop` (see *Follow-up* below).

Fixes #16662

## Validation

Install this PR build:

```powershell
# PowerShell
iex "& { $(irm https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.ps1) } 16714"
```
```bash
# Bash
curl -fsSL https://raw.githubusercontent.com/microsoft/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s -- 16714
```

### Scenario 1 — Python flag OFF (entry hidden)

```bash
# Make sure the experimental Python polyglot flag is OFF.
aspire config delete -g features.experimentalPolyglot:python

aspire new
```

**Expected:** Top-level template list does **NOT** include `Empty (Python AppHost)`.

```bash
aspire new aspire-py-empty
```

**Expected:** Fails because the template is unavailable when the flag is off.

### Scenario 2 — Python flag ON (entry visible alongside Java)

```bash
aspire config set -g features.experimentalPolyglot:python true
aspire config set -g features.experimentalPolyglot:java   true

aspire new
```

**Expected:** Top-level template list now includes:

```
Empty (Java AppHost)
Empty (Python AppHost)        ← new
Empty (TypeScript AppHost)
Empty AppHost
```

Pick `Empty (Python AppHost)` and confirm it scaffolds a Python AppHost project.

```bash
aspire new aspire-py-empty -o testpy
ls -la testpy/.gitignore   # should exist and contain .venv/, __pycache__/, .modules/, .aspire/
```

**Expected:** Succeeds and creates a Python AppHost in `./testpy`, including a `.gitignore`.

### Cleanup

```bash
aspire config delete -g features.experimentalPolyglot:python
aspire config delete -g features.experimentalPolyglot:java
```

### Automated coverage

- **Unit tests** (`tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs`): verify the `aspire-py-empty` template is exposed when the flag is on and hidden when the flag is off.
- **E2E test** (`tests/Aspire.Cli.EndToEnd.Tests/PythonEmptyAppHostTemplateTests.cs`): drives the interactive `aspire new` flow inside a Linux container, types `Empty (Python AppHost)`, asserts the highlighted selection appears, completes scaffolding, and asserts the generated `.gitignore` contains `.aspire/`.

### Follow-up: Python AppHost cold-start vs. CLI startup timeout (out of scope)

The E2E test deliberately stops at scaffolding rather than running `aspire start` / `aspire stop`. Python AppHost first-run cold-start (microvenv creation + pip install from `.modules`/PyPI) can exceed the CLI's hard-coded 120s "wait for AppHost to start" timeout (`AppHostLauncher.cs:277`) on resource-constrained CI runners. Java's empty AppHost doesn't hit this because its bring-up is just JVM start. This is a separate product concern (either bump the timeout, make it configurable per-language, or pre-warm the venv) and is not in scope for this PR, which is purely about exposing the top-level template entry.

### Note

Issue #16661 (Python being shown in the generic `Empty AppHost` language picker even when the flag was off) is fixed in a separate PR (#16713). This PR is purely additive and doesn't alter the language-picker filtering behavior.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
