### PR TITLE
Parameterize milestone changelog prompt values

### DIFF
--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -54,7 +54,7 @@
 name: "13.3 Release Burndown Report"
 "on":
   schedule:
-  - cron: "34 8 * * *"
+  - cron: "42 9 * * *"
     # Friendly format: daily around 9am (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"19f591ac690b323fdd404921462ca68e563b6c34131b8a93c72375d23dbcc9d9","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fa74ca6093929f11ee1aaf8c22c1ec34db3867eff21fdab6f9ceff7b0b7d3554","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -194,14 +194,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_961c0dea0ec209b9_EOF'
+          cat << 'GH_AW_PROMPT_1e70ebed00fa04b9_EOF'
           <system>
-          GH_AW_PROMPT_961c0dea0ec209b9_EOF
+          GH_AW_PROMPT_1e70ebed00fa04b9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_961c0dea0ec209b9_EOF'
+          cat << 'GH_AW_PROMPT_1e70ebed00fa04b9_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
@@ -233,12 +233,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_961c0dea0ec209b9_EOF
+          GH_AW_PROMPT_1e70ebed00fa04b9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_961c0dea0ec209b9_EOF'
+          cat << 'GH_AW_PROMPT_1e70ebed00fa04b9_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_961c0dea0ec209b9_EOF
+          GH_AW_PROMPT_1e70ebed00fa04b9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -426,9 +426,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f213a4b7bd1f8807_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_55500e9bb1cdc916_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f213a4b7bd1f8807_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_55500e9bb1cdc916_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -600,7 +600,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_27034a2397aac366_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_3ed5b3e1a56a2e03_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -644,13 +644,38 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_27034a2397aac366_EOF
+          GH_AW_MCP_CONFIG_3ed5b3e1a56a2e03_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
+        # --allow-tool github
+        # --allow-tool safeoutputs
+        # --allow-tool shell(cat)
+        # --allow-tool shell(cd)
+        # --allow-tool shell(cp)
+        # --allow-tool shell(date)
+        # --allow-tool shell(echo)
+        # --allow-tool shell(gh:*)
+        # --allow-tool shell(grep)
+        # --allow-tool shell(head)
+        # --allow-tool shell(jq)
+        # --allow-tool shell(ls)
+        # --allow-tool shell(mkdir)
+        # --allow-tool shell(mv)
+        # --allow-tool shell(pwd)
+        # --allow-tool shell(python3)
+        # --allow-tool shell(rm)
+        # --allow-tool shell(sort)
+        # --allow-tool shell(tail)
+        # --allow-tool shell(uniq)
+        # --allow-tool shell(wc)
+        # --allow-tool shell(xargs)
+        # --allow-tool shell(xxd)
+        # --allow-tool shell(yq)
+        # --allow-tool write
         timeout-minutes: 30
         run: |
           set -o pipefail
@@ -660,7 +685,7 @@ jobs:
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
           # shellcheck disable=SC1003
           sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --image-tag 0.25.28,squid=sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474,agent=sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a,api-proxy=sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb,cli-proxy=sha256:fdf310e4678ce58d248c466b89399e9680a3003038fd19322c388559016aaac7 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(cd)'\'' --allow-tool '\''shell(cp)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(gh:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(mkdir)'\'' --allow-tool '\''shell(mv)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(python3)'\'' --allow-tool '\''shell(rm)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(xargs)'\'' --allow-tool '\''shell(xxd)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bc09c68f42616ff37665c366f69cf8321822db23c9b0b6fc0a345ee394f37031","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"19f591ac690b323fdd404921462ca68e563b6c34131b8a93c72375d23dbcc9d9","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Generates and maintains a changelog for a configured Aspire milestone by
+# Generates and maintains a changelog for a configured milestone by
 # analyzing merged pull requests.
 # Creates or updates a wiki page named "<milestone>-Change-log" with a list
 # of new features, improvements, and notable bug fixes. A companion GitHub issue collects
@@ -31,6 +31,8 @@
 # Frontmatter env variables:
 #   - BATCH_SIZE: (main workflow)
 #   - MILESTONE: (main workflow)
+#   - PRODUCT: (main workflow)
+#   - REPO: (main workflow)
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -78,6 +80,8 @@ run-name: "Milestone Changelog Generator"
 env:
   BATCH_SIZE: "20"
   MILESTONE: "13.3"
+  PRODUCT: Aspire
+  REPO: microsoft/aspire
 
 jobs:
   activation:
@@ -190,14 +194,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_5868524d72ca276e_EOF'
+          cat << 'GH_AW_PROMPT_961c0dea0ec209b9_EOF'
           <system>
-          GH_AW_PROMPT_5868524d72ca276e_EOF
+          GH_AW_PROMPT_961c0dea0ec209b9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5868524d72ca276e_EOF'
+          cat << 'GH_AW_PROMPT_961c0dea0ec209b9_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
@@ -229,12 +233,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5868524d72ca276e_EOF
+          GH_AW_PROMPT_961c0dea0ec209b9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5868524d72ca276e_EOF'
+          cat << 'GH_AW_PROMPT_961c0dea0ec209b9_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_5868524d72ca276e_EOF
+          GH_AW_PROMPT_961c0dea0ec209b9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -422,9 +426,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_304aca6c9899de91_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f213a4b7bd1f8807_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_304aca6c9899de91_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f213a4b7bd1f8807_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -596,7 +600,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_3e03946cbe3bfb7c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_27034a2397aac366_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -640,7 +644,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3e03946cbe3bfb7c_EOF
+          GH_AW_MCP_CONFIG_27034a2397aac366_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1050,7 +1054,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           WORKFLOW_NAME: "Milestone Changelog Generator"
-          WORKFLOW_DESCRIPTION: "Generates and maintains a changelog for a configured Aspire milestone by\nanalyzing merged pull requests.\nCreates or updates a wiki page named \"<milestone>-Change-log\" with a list\nof new features, improvements, and notable bug fixes. A companion GitHub issue collects\neditorial feedback (e.g., exclude a change, rename an entry, merge entries)."
+          WORKFLOW_DESCRIPTION: "Generates and maintains a changelog for a configured milestone by\nanalyzing merged pull requests.\nCreates or updates a wiki page named \"<milestone>-Change-log\" with a list\nof new features, improvements, and notable bug fixes. A companion GitHub issue collects\neditorial feedback (e.g., exclude a change, rename an entry, merge entries)."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -370,9 +370,19 @@ previous entries. A companion feedback issue collects editorial comments.
 
 ## Important: available tools
 
-All shell commands are available via the `bash` tool. Prefer `cat` and `jq` for
-JSON processing (parsing, filtering, counting, transforming). Do **not** `cat`
-large JSON files in their entirety — use `jq` to extract only the fields you need.
+Only the commands in the `bash` allow list above are available — **not** all shell
+commands. Prefer `cat` and `jq` for JSON processing (parsing, filtering, counting,
+transforming). Do **not** `cat` large JSON files in their entirety — use `jq` to
+extract only the fields you need.
+
+**Shell syntax restriction:** The bash tool does **not** support shell builtins or
+syntax constructs like `for`, `while`, `if`, function definitions, or heredocs.
+These will be denied. To perform batch operations (e.g., writing multiple files),
+use one of these patterns:
+- Pipe data through `xargs` (e.g., `echo '...' | xargs -I{} sh -c '...'` is NOT
+  allowed — instead issue one `bash` call per file)
+- Use `python3 -c '...'` for complex batch logic
+- Issue separate `bash` tool calls for each file (preferred for clarity)
 
 ## Configuration
 
@@ -445,7 +455,7 @@ unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Each entry conta
 1. **Exclude bot-authored PRs** — remove any PR whose `author.is_bot` is `true`,
    **except** these cases which should be processed normally:
    - `app/copilot-swe-agent` — makes product changes on behalf of developers.
-   - **Backport PRs** — PRs whose body contains the word `backport` or `port`
+   - **Backport PRs** — PRs whose body contains the word `backport`
      and, upon inspection, appears to be a backport of another PR (e.g.,
      references an original PR number). These are created by backport bots
      and contain the same meaningful changes as their source PRs, just
@@ -463,16 +473,18 @@ total number of changed lines (additions + deletions).
 ### 3a. Processing backport PRs
 
 Backport PRs are identified by checking whether the PR body contains the word
-`backport` or `port` (case-insensitive). If either word is present, inspect the
-body text to determine whether the PR is actually a backport of another PR —
-look for references to an original PR number (e.g., "Backport of #1234",
-"port of #5678", a markdown link to another PR, etc.). Their body typically
+`backport` (case-insensitive). Do **not** match on the standalone word `port` —
+it appears too frequently in non-backport contexts (e.g., "containerPort",
+"port binding", "transport"). If `backport` is present, inspect the body text
+to determine whether the PR is actually a backport of another PR — look for
+references to an original PR number (e.g., "Backport of #1234", a markdown
+link to another PR, etc.). Their body typically
 contains only this backport reference plus a shiproom template that may be unfilled
 or partially filled. To process them:
 
 1. **Extract the original PR number** from the body by inspecting the text for
-   a reference to the source PR (e.g., "Backport of #1234", "#1234", or a
-   full URL like `https://github.com/${REPO}/pull/1234`).
+   a reference to the source PR (e.g., "Backport of #1234", or a full URL
+   like `https://github.com/${REPO}/pull/1234`).
 2. **Fetch the original PR** using `pull_request_read` to get its full title,
    body/description, labels, and changed file paths. Use the original PR's
    content as the primary source for generating the changelog entry.

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -1,6 +1,6 @@
 ---
 description: |
-  Generates and maintains a changelog for a configured Aspire milestone by
+  Generates and maintains a changelog for a configured milestone by
   analyzing merged pull requests.
   Creates or updates a wiki page named "<milestone>-Change-log" with a list
   of new features, improvements, and notable bug fixes. A companion GitHub issue collects
@@ -36,6 +36,8 @@ description: |
 # ──────────────────────────────────────────────────────────
 
 env:
+  PRODUCT: "Aspire"
+  REPO: "microsoft/aspire"
   MILESTONE: "13.3"
   BATCH_SIZE: "20"
 
@@ -357,12 +359,12 @@ steps:
 
 # Milestone Changelog Generator
 
-Generate and maintain a changelog for the **Aspire ${MILESTONE} milestone** as a wiki page.
+Generate and maintain a changelog for the **${PRODUCT} ${MILESTONE} milestone** as a wiki page.
 Each run appends newly merged changes to the existing content while preserving
 previous entries. A companion feedback issue collects editorial comments.
 
-> **Note:** `${MILESTONE}` and `${BATCH_SIZE}` refer to values set in the workflow's
-> `env` block (currently **`13.3`** and **`20`**). All file names, titles, and
+> **Note:** `${PRODUCT}`, `${REPO}`, `${MILESTONE}`, and `${BATCH_SIZE}` refer to values set in the workflow's
+> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`13.3`**, and **`20`**). All file names, titles, and
 > references below derive from those values.
 
 ## Important: available tools
@@ -469,7 +471,7 @@ or partially filled. To process them:
 
 1. **Extract the original PR number** from the body by inspecting the text for
    a reference to the source PR (e.g., "Backport of #1234", "#1234", or a
-   full URL like `https://github.com/microsoft/aspire/pull/1234`).
+   full URL like `https://github.com/${REPO}/pull/1234`).
 2. **Fetch the original PR** using `pull_request_read` to get its full title,
    body/description, labels, and changed file paths. Use the original PR's
    content as the primary source for generating the changelog entry.
@@ -501,8 +503,7 @@ conditions are true:
 1. The PR title is vague or generic (e.g., "Fix", "Update", "Cleanup", "Address feedback",
    "Misc changes").
 2. The PR body/description is empty or contains only a template with no filled-in details.
-3. The changed file paths don't align with what the title/body describe (e.g., title says
-   "Dashboard fix" but files are in `src/Aspire.Cli/`).
+3. The changed file paths don't align with what the title/body describe.
 
 When reading the diff, **ignore generated files and playground app changes** — files matching these patterns:
 - `*/api/*.cs` (public API surface files)
@@ -549,7 +550,7 @@ bug fix in the Dashboard) should produce a separate entry for each. Every entry
 references the same PR number in its Changes line. Because the changelog is
 published to a **wiki page** (not an issue or PR), GitHub does not auto-link
 `#1234`-style shorthand references. Always use full markdown links:
-`[#1234](https://github.com/microsoft/aspire/pull/1234)`.
+`[#1234](https://github.com/${REPO}/pull/1234)`.
 
 ### 5a. Determine product area
 
@@ -587,7 +588,7 @@ Then determine whether either of these optional flags applies:
 | Flag | Emoji | When to set |
 |------|-------|-------------|
 | **Breaking change** | ⚠️ | Removed or renamed API, changed default behavior, migration required |
-| **Docs required** | 📝 | Change needs documentation on aspire.dev (new feature, changed behavior, new config options) |
+| **Docs required** | 📝 | Change needs documentation (new feature, changed behavior, new config options) |
 | **Community contribution** | 🌍 | PR author's `author_association` is not `MEMBER` or `OWNER`, **and** the PR's `author.is_bot` (from the batch data) is not `true` — i.e., the author is a human external community contributor. For **backport PRs** (Step 3a), use the original PR author's `author_association` and ignore the backport bot's `is_bot` flag. |
 
 > **Important — verifying `author_association`:** The `pull_request_read` MCP tool
@@ -596,7 +597,7 @@ Then determine whether either of these optional flags applies:
 > explicitly using the `bash` tool:
 >
 > ```bash
-> gh api "repos/microsoft/aspire/pulls/<NUMBER>" --jq '.author_association'
+> gh api "repos/${REPO}/pulls/<NUMBER>" --jq '.author_association'
 > ```
 >
 > **Never infer community-contributor status from fork origin, username, or any
@@ -607,7 +608,7 @@ A change can have zero or more flags. When present, show each flag on its own
 indented line below the Changes line:
 
 ```
-  Changes: [#1234](https://github.com/microsoft/aspire/pull/1234)  
+  Changes: [#1234](https://github.com/${REPO}/pull/1234)  
   ⚠️ **Breaking change**  
   📝 **Documentation required**  
   🌍 **Community contribution** by [@username](https://github.com/username)  
@@ -879,20 +880,20 @@ Use this exact format:
 
 - **🧭 Feature name**  
   Brief user-facing description  
-  Changes: [#1234](https://github.com/microsoft/aspire/pull/1234), [#1235](https://github.com/microsoft/aspire/pull/1235)  
+  Changes: [#1234](https://github.com/${REPO}/pull/1234), [#1235](https://github.com/${REPO}/pull/1235)  
   ⚠️ **Breaking change**  
   📝 **Documentation required**  
 
 - **🚀 Another feature**  
   What this means for users  
-  Changes: [#1236](https://github.com/microsoft/aspire/pull/1236)  
+  Changes: [#1236](https://github.com/${REPO}/pull/1236)  
   📝 **Documentation required**  
 
 #### Improvements
 
 - **⚡ Performance boost**  
   Faster startup for container resources  
-  Changes: [#1238](https://github.com/microsoft/aspire/pull/1238)  
+  Changes: [#1238](https://github.com/${REPO}/pull/1238)  
 
 ## 💻 CLI
 
@@ -902,13 +903,13 @@ Use this exact format:
 
 - **🆕 New CLI command**  
   Added a new command for scaffolding resources  
-  Changes: [#1240](https://github.com/microsoft/aspire/pull/1240)  
+  Changes: [#1240](https://github.com/${REPO}/pull/1240)  
 
 #### Bug fixes
 
 - **🐛 Fix crash on init**  
-  Resolved a crash when running aspire init in an empty directory  
-  Changes: [#1239](https://github.com/microsoft/aspire/pull/1239)  
+  Resolved a crash when running init in an empty directory  
+  Changes: [#1239](https://github.com/${REPO}/pull/1239)  
   ⚠️ **Breaking change**  
   🌍 **Community contribution** by [@contributor](https://github.com/contributor)  
 
@@ -920,7 +921,7 @@ Use this exact format:
 
 - **🎨 Dashboard improvement**  
   Description of the change  
-  Changes: [#1237](https://github.com/microsoft/aspire/pull/1237)  
+  Changes: [#1237](https://github.com/${REPO}/pull/1237)  
 
 ---
 
@@ -929,8 +930,8 @@ Use this exact format:
 (e.g., "Exclude PR #1234", "Rename: X → Y", "Merge PRs #1234 and #5678").*
 
 **PRs processed:** ✅ 6 included · ❌ 1 excluded · ⏳ 93 unprocessed · 100 total merged in milestone
-([View full PR tracker](https://github.com/microsoft/aspire/blob/memory/milestone-changelog/${MILESTONE}/prs/))
-**PRs analyzed through:** [#<number>](https://github.com/microsoft/aspire/pull/<number>) merged <merge date of the newest PR processed in this run, in UTC>
+([View full PR tracker](https://github.com/${REPO}/blob/memory/milestone-changelog/${MILESTONE}/prs/))
+**PRs analyzed through:** [#<number>](https://github.com/${REPO}/pull/<number>) merged <merge date of the newest PR processed in this run, in UTC>
 ```
 
 At the bottom of the page (after the footer), include a **PRs processed** summary
@@ -939,8 +940,8 @@ through** line showing the newest PR processed in this run:
 
 ```
 **PRs processed:** ✅ <N> included · ❌ <N> excluded · ⏳ <N> unprocessed · <N> total merged in milestone
-([View full PR tracker](https://github.com/microsoft/aspire/blob/memory/milestone-changelog/${MILESTONE}/prs/))
-**PRs analyzed through:** [#<number>](https://github.com/microsoft/aspire/pull/<number>) merged <date>
+([View full PR tracker](https://github.com/${REPO}/blob/memory/milestone-changelog/${MILESTONE}/prs/))
+**PRs analyzed through:** [#<number>](https://github.com/${REPO}/pull/<number>) merged <date>
 ```
 
 Compute the counts:

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -228,7 +228,8 @@ permissions:
 network: defaults
 
 tools:
-  bash: [":*"]
+  # Default safe commands + commands observed in actual workflow runs
+  bash: ["cat", "cd", "cp", "date", "echo", "gh", "grep", "head", "jq", "ls", "mkdir", "mv", "python3", "pwd", "rm", "sort", "tail", "uniq", "wc", "xargs", "xxd"]
   github:
     toolsets: [repos, issues, pull_requests, search]
     # Allow reading PR data from external contributors. These PRs have already

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -853,8 +853,8 @@ After the Table of Contents, add a **What's New** section that lists the
 of their most recent PR.
 Each item is a link to the area heading, using the format:
 `- [<date> — <change-emoji> <Name>](#<area-slug>)`
-where `<date>` is the merge date of the last PR in `YYYY-M-D HH:mm` format
-(no leading zeroes on month/day, 24-hour UTC time), `<change-emoji>` is the
+where `<date>` is the merge date of the last PR in `YYYY-MM-DD HH:mm` format
+(zero-padded month/day, 24-hour UTC time), `<change-emoji>` is the
 entry's individual emoji, `<Name>` is the changelog entry name, and
 `<area-slug>` is the GitHub-generated slug for that area's `##` heading
 (e.g., `-apphost`, `-cli`, `-dashboard`). The `#` before the slug is mandatory
@@ -881,9 +881,9 @@ Use this exact format:
 
 ## What's New
 
-- [2026-4-22 22:48 — 🧭 Feature name](#-apphost)
-- [2026-4-21 07:30 — 🆕 New CLI command](#-cli)
-- [2026-4-20 23:05 — 🚀 Another feature](#-apphost)
+- [2026-04-22 22:48 — 🧭 Feature name](#-apphost)
+- [2026-04-21 07:30 — 🆕 New CLI command](#-cli)
+- [2026-04-20 23:05 — 🚀 Another feature](#-apphost)
 
 ## 🏠 AppHost
 
@@ -891,20 +891,20 @@ Use this exact format:
 
 #### New features
 
-- **🧭 Feature name**  
+1. **🧭 Feature name**  
   Brief user-facing description  
   Changes: [#1234](https://github.com/${REPO}/pull/1234), [#1235](https://github.com/${REPO}/pull/1235)  
   ⚠️ **Breaking change**  
   📝 **Documentation required**  
 
-- **🚀 Another feature**  
+1. **🚀 Another feature**  
   What this means for users  
   Changes: [#1236](https://github.com/${REPO}/pull/1236)  
   📝 **Documentation required**  
 
 #### Improvements
 
-- **⚡ Performance boost**  
+1. **⚡ Performance boost**  
   Faster startup for container resources  
   Changes: [#1238](https://github.com/${REPO}/pull/1238)  
 
@@ -914,13 +914,13 @@ Use this exact format:
 
 #### New features
 
-- **🆕 New CLI command**  
+1. **🆕 New CLI command**  
   Added a new command for scaffolding resources  
   Changes: [#1240](https://github.com/${REPO}/pull/1240)  
 
 #### Bug fixes
 
-- **🐛 Fix crash on init**  
+1. **🐛 Fix crash on init**  
   Resolved a crash when running init in an empty directory  
   Changes: [#1239](https://github.com/${REPO}/pull/1239)  
   ⚠️ **Breaking change**  
@@ -932,7 +932,7 @@ Use this exact format:
 
 #### Improvements
 
-- **🎨 Dashboard improvement**  
+1. **🎨 Dashboard improvement**  
   Description of the change  
   Changes: [#1237](https://github.com/${REPO}/pull/1237)  
 
@@ -944,7 +944,7 @@ Use this exact format:
 
 **PRs processed:** ✅ 6 included · ❌ 1 excluded · ⏳ 93 unprocessed · 100 total merged in milestone
 ([View full PR tracker](https://github.com/${REPO}/blob/memory/milestone-changelog/${MILESTONE}/prs/))
-**PRs analyzed through:** [#<number>](https://github.com/${REPO}/pull/<number>) merged <merge date of the newest PR processed in this run, in UTC>
+**PRs analyzed through:** [#<number>](https://github.com/${REPO}/pull/<number>) merged <YYYY-MM-DD HH:mm> UTC
 ```
 
 At the bottom of the page (after the footer), include a **PRs processed** summary
@@ -954,7 +954,7 @@ through** line showing the newest PR processed in this run:
 ```
 **PRs processed:** ✅ <N> included · ❌ <N> excluded · ⏳ <N> unprocessed · <N> total merged in milestone
 ([View full PR tracker](https://github.com/${REPO}/blob/memory/milestone-changelog/${MILESTONE}/prs/))
-**PRs analyzed through:** [#<number>](https://github.com/${REPO}/pull/<number>) merged <date>
+**PRs analyzed through:** [#<number>](https://github.com/${REPO}/pull/<number>) merged <YYYY-MM-DD HH:mm> UTC
 ```
 
 Compute the counts:


### PR DESCRIPTION
## Description

Parameterizes the milestone changelog agent workflow so the prompt is less hard-coded to the current Aspire repository.

This change:
- Adds `PRODUCT` and `REPO` environment variables to `.github/workflows/milestone-changelog.md`.
- Uses `${PRODUCT}` in the generated changelog title instead of hard-coding `Aspire`.
- Uses `${REPO}` in PR, tracker, and GitHub API examples instead of hard-coding `microsoft/aspire`.
- Generalizes a few prompt examples and documentation wording that were Aspire-specific.
- Regenerates `.github/workflows/milestone-changelog.lock.yml` with `gh aw compile` so the runnable workflow includes the new env vars.

Validation: ran `gh aw compile` successfully. It completed with 0 errors and 2 existing schedule warnings.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
