### PR TITLE
Honor configured channel in 'aspire update'

### DIFF
--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -155,19 +155,39 @@ internal sealed class UpdateCommand : BaseCommand
             var project = _projectFactory.GetProject(projectFile);
             var isProjectReferenceMode = project.IsUsingProjectReferences(projectFile);
 
-            // Check if channel or quality option was provided (channel takes precedence)
+            // Resolve the channel using the documented precedence:
+            //   1. explicit --channel / hidden --quality
+            //   2. local app config "channel"
+            //   3. global config "channel"
+            //   4. interactive channel prompt when appropriate (PR hives present)
+            //   5. implicit/default channel as the documented fallback
+            // Local-vs-global precedence for steps 2 and 3 is honored implicitly:
+            // ConfigurationHelper.RegisterSettingsFiles loads the global settings file before the
+            // local one, so IConfiguration (and therefore GetConfigurationAsync) returns local first.
             var channelName = parseResult.GetValue(_channelOption) ?? parseResult.GetValue(_qualityOption);
+            var channelFromConfig = false;
+            if (string.IsNullOrWhiteSpace(channelName))
+            {
+                channelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
+                channelFromConfig = !string.IsNullOrWhiteSpace(channelName);
+            }
+
             PackageChannel channel;
 
             var allChannels = await InteractionService.ShowStatusAsync(
                 UpdateCommandStrings.CheckingForUpdates,
                 async () => await _packagingService.GetChannelsAsync(cancellationToken));
 
-            if (!string.IsNullOrEmpty(channelName))
+            if (!string.IsNullOrWhiteSpace(channelName))
             {
                 // Try to find a channel matching the provided channel/quality
                 channel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase))
                     ?? throw new ChannelNotFoundException($"No channel found matching '{channelName}'. Valid options are: {string.Join(", ", allChannels.Select(c => c.Name))}");
+
+                if (channelFromConfig)
+                {
+                    _logger.LogDebug("Using channel '{ChannelName}' from configuration.", channel.Name);
+                }
             }
             else if (isProjectReferenceMode)
             {

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -157,18 +157,20 @@ internal sealed class UpdateCommand : BaseCommand
 
             // Resolve the channel using the documented precedence:
             //   1. explicit --channel / hidden --quality
-            //   2. local app config "channel"
+            //   2. local app config "channel" (relative to the resolved AppHost project, NOT cwd)
             //   3. global config "channel"
             //   4. interactive channel prompt when appropriate (PR hives present)
             //   5. implicit/default channel as the documented fallback
-            // Local-vs-global precedence for steps 2 and 3 is honored implicitly:
-            // ConfigurationHelper.RegisterSettingsFiles loads the global settings file before the
-            // local one, so IConfiguration (and therefore GetConfigurationAsync) returns local first.
+            // The directory-scoped lookup is critical: `aspire update --apphost <elsewhere>`
+            // must consult the project's directory tree, not the user's launch cwd. The
+            // process-wide IConfiguration is rooted at the launch cwd at startup, so using
+            // it here would silently read the wrong app's local config (issue #16650).
             var channelName = parseResult.GetValue(_channelOption) ?? parseResult.GetValue(_qualityOption);
             var channelFromConfig = false;
             if (string.IsNullOrWhiteSpace(channelName))
             {
-                channelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
+                var configLookupDirectory = projectFile.Directory ?? ExecutionContext.WorkingDirectory;
+                channelName = await _configurationService.GetConfigurationFromDirectoryAsync("channel", configLookupDirectory, cancellationToken);
                 channelFromConfig = !string.IsNullOrWhiteSpace(channelName);
             }
 

--- a/src/Aspire.Cli/Configuration/ConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/ConfigurationService.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -352,5 +355,92 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
         // Convert dot notation to colon notation for IConfiguration access
         var configKey = key.Replace('.', ':');
         return Task.FromResult(configuration[configKey]);
+    }
+
+    public Task<string?> GetConfigurationFromDirectoryAsync(string key, DirectoryInfo startDirectory, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(startDirectory);
+
+        var configKey = key.Replace('.', ':');
+
+        // 1. Project-relative local settings: walk up from startDirectory.
+        //    Intentionally bypasses the process-wide IConfiguration (which is rooted at the
+        //    CLI's launch cwd via ConfigurationHelper.RegisterSettingsFiles) so that commands
+        //    that operate on a path other than cwd (e.g. `aspire update --apphost <elsewhere>`)
+        //    consult the project's own aspire.config.json instead of the caller's cwd.
+        var localConfigPath = ConfigurationHelper.FindNearestConfigFilePath(startDirectory);
+        if (localConfigPath is not null)
+        {
+            var localConfig = LoadSettingsFileForReading(localConfigPath);
+            var localValue = localConfig[configKey];
+            if (!string.IsNullOrWhiteSpace(localValue))
+            {
+                return Task.FromResult<string?>(localValue);
+            }
+        }
+
+        // 2. Global settings file fallback (lower precedence).
+        if (File.Exists(globalSettingsFile.FullName))
+        {
+            var globalConfig = LoadSettingsFileForReading(globalSettingsFile.FullName);
+            var globalValue = globalConfig[configKey];
+            if (!string.IsNullOrWhiteSpace(globalValue))
+            {
+                return Task.FromResult<string?>(globalValue);
+            }
+        }
+
+        return Task.FromResult<string?>(null);
+    }
+
+    /// <summary>
+    /// Loads a single settings file into an isolated <see cref="IConfigurationRoot"/> for
+    /// directory-scoped lookups, mirroring <c>ConfigurationHelper.AddSettingsFile</c>'s
+    /// JSON-with-comments parsing and "throw on invalid JSON" behavior so directory-scoped
+    /// reads fail loudly the same way startup-time loads do.
+    /// </summary>
+    private static IConfigurationRoot LoadSettingsFileForReading(string filePath)
+    {
+        string content;
+        try
+        {
+            content = File.ReadAllText(filePath);
+        }
+        catch (IOException)
+        {
+            return new ConfigurationBuilder().Build();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new ConfigurationBuilder().Build();
+        }
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return new ConfigurationBuilder().Build();
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(content, documentOptions: ConfigurationHelper.ParseOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                string.Format(CultureInfo.CurrentCulture, ErrorStrings.InvalidJsonInConfigFile, filePath, ex.Message),
+                ex);
+        }
+
+        if (node is not JsonObject)
+        {
+            return new ConfigurationBuilder().Build();
+        }
+
+        var cleanJson = node.ToJsonString();
+        var bytes = System.Text.Encoding.UTF8.GetBytes(cleanJson);
+        return new ConfigurationBuilder()
+            .AddJsonStream(new MemoryStream(bytes))
+            .Build();
     }
 }

--- a/src/Aspire.Cli/Configuration/IConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/IConfigurationService.cs
@@ -11,5 +11,22 @@ internal interface IConfigurationService
     Task<Dictionary<string, string>> GetLocalConfigurationAsync(CancellationToken cancellationToken = default);
     Task<Dictionary<string, string>> GetGlobalConfigurationAsync(CancellationToken cancellationToken = default);
     Task<string?> GetConfigurationAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads a configuration value scoped to a specific directory rather than the
+    /// process-wide working directory. The lookup walks upward from
+    /// <paramref name="startDirectory"/> for the nearest <c>aspire.config.json</c>
+    /// (or legacy <c>.aspire/settings.json</c>); if the key is not present in that file,
+    /// falls back to the global settings file. The process-wide
+    /// <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> (which is rooted at
+    /// the working directory the CLI was launched from) is intentionally NOT consulted,
+    /// so commands like <c>aspire update --apphost &lt;path&gt;</c> can resolve config
+    /// from the project's directory tree instead of the caller's cwd.
+    /// </summary>
+    /// <remarks>
+    /// Throws <see cref="System.InvalidOperationException"/> if a settings file is found
+    /// but cannot be parsed as JSON, matching the behavior of startup-time settings load.
+    /// </remarks>
+    Task<string?> GetConfigurationFromDirectoryAsync(string key, DirectoryInfo startDirectory, CancellationToken cancellationToken = default);
     string GetSettingsFilePath(bool isGlobal);
 }

--- a/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
@@ -934,6 +934,11 @@ public class TestConfigurationService : IConfigurationService
         return Task.FromResult<string?>(key);
     }
 
+    public Task<string?> GetConfigurationFromDirectoryAsync(string key, DirectoryInfo startDirectory, CancellationToken cancellationToken = default)
+    {
+        return GetConfigurationAsync(key, cancellationToken);
+    }
+
     public string GetSettingsFilePath(bool isGlobal)
     {
         return string.Empty;

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -710,6 +710,9 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         public Task<string?> GetConfigurationAsync(string key, CancellationToken cancellationToken = default)
             => Task.FromResult<string?>(string.Equals(key, "channel", StringComparison.Ordinal) ? channelValue : null);
 
+        public Task<string?> GetConfigurationFromDirectoryAsync(string key, DirectoryInfo startDirectory, CancellationToken cancellationToken = default)
+            => GetConfigurationAsync(key, cancellationToken);
+
         public Task SetConfigurationAsync(string key, string value, bool isGlobal = false, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1315,9 +1315,96 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.FailedToUpgradeProject, exitCode);
     }
 
-    private async Task<(int ExitCode, string UpdatedWithChannel, bool PromptInvoked)> RunUpdateAndCaptureChannelAsync(
+    [Fact]
+    public async Task UpdateCommand_ProjectInOtherDirectory_UsesProjectLocalConfiguredChannel()
+    {
+        // The CLI runs with `cwd == workspace.WorkspaceRoot` and we point --apphost at a project
+        // file living in a sibling directory inside the workspace. The configured channel must
+        // come from the project's directory tree, NOT from the cwd's. The cwd has no config.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var projectDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "elsewhere"));
+        var projectConfigPath = Path.Combine(projectDirectory.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(projectConfigPath, """{ "channel": "staging" }""");
+
+        var (exitCode, updatedWithChannel, promptInvoked) = await RunUpdateAndCaptureChannelAsync(
+            workspace,
+            updateArgs: $"update --apphost {Path.Combine(projectDirectory.FullName, "AppHost.csproj")}",
+            projectDirectory: projectDirectory);
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured locally to the project");
+        Assert.Equal("staging", updatedWithChannel);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_ProjectInOtherDirectory_PrefersProjectLocalConfigOverCwdConfig()
+    {
+        // Cwd has its own aspire.config.json with a different channel; the project's directory
+        // tree has the user's intended channel. The project-relative config must win, otherwise
+        // the user's stated intent (per --apphost) is silently overridden by an unrelated cwd.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        File.WriteAllText(
+            Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName),
+            """{ "channel": "daily" }""");
+
+        var projectDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "elsewhere"));
+        File.WriteAllText(
+            Path.Combine(projectDirectory.FullName, AspireConfigFile.FileName),
+            """{ "channel": "staging" }""");
+
+        var (exitCode, updatedWithChannel, promptInvoked) = await RunUpdateAndCaptureChannelAsync(
+            workspace,
+            updateArgs: $"update --apphost {Path.Combine(projectDirectory.FullName, "AppHost.csproj")}",
+            projectDirectory: projectDirectory);
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured locally to the project");
+        Assert.Equal("staging", updatedWithChannel);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_ProjectInOtherDirectory_ProjectLocalConfigWithoutChannel_FallsBackToGlobalConfig()
+    {
+        // The project-relative config exists but does not set a "channel" key. Channel resolution
+        // must fall back to the global settings file rather than the cwd-based process config.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        File.WriteAllText(
+            Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName),
+            """{ "channel": "daily" }""");
+
+        var globalDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire");
+        Directory.CreateDirectory(globalDir);
+        File.WriteAllText(Path.Combine(globalDir, "settings.global.json"), """{ "channel": "staging" }""");
+
+        var projectDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "elsewhere"));
+        File.WriteAllText(
+            Path.Combine(projectDirectory.FullName, AspireConfigFile.FileName),
+            """{ "language": "csharp" }""");
+
+        var (exitCode, updatedWithChannel, promptInvoked) = await RunUpdateAndCaptureChannelAsync(
+            workspace,
+            updateArgs: $"update --apphost {Path.Combine(projectDirectory.FullName, "AppHost.csproj")}",
+            projectDirectory: projectDirectory);
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured globally");
+        Assert.Equal("staging", updatedWithChannel);
+    }
+
+    private Task<(int ExitCode, string UpdatedWithChannel, bool PromptInvoked)> RunUpdateAndCaptureChannelAsync(
         TemporaryWorkspace workspace,
         string updateArgs)
+    {
+        return RunUpdateAndCaptureChannelAsync(workspace, updateArgs, projectDirectory: workspace.WorkspaceRoot);
+    }
+
+    private async Task<(int ExitCode, string UpdatedWithChannel, bool PromptInvoked)> RunUpdateAndCaptureChannelAsync(
+        TemporaryWorkspace workspace,
+        string updateArgs,
+        DirectoryInfo projectDirectory)
     {
         var promptForSelectionInvoked = false;
         var updatedWithChannel = string.Empty;
@@ -1328,7 +1415,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             {
                 UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
                 {
-                    return Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")));
+                    return Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(projectDirectory.FullName, "AppHost.csproj")));
                 }
             };
 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Runtime.InteropServices;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
@@ -1161,6 +1162,216 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(promptForSelectionInvoked, "Channel selection prompt should not be shown when there are no hives");
         Assert.Equal("default", updatedWithChannel); // Implicit channel is named "default"
+    }
+
+    [Fact]
+    public async Task UpdateCommand_LocalConfiguredChannel_IsUsed()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Write a local aspire.config.json that selects the "staging" channel BEFORE the
+        // configuration is built so RegisterSettingsFiles picks it up.
+        var localConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(localConfigPath, """{ "channel": "staging" }""");
+
+        var (exitCode, updatedWithChannel, promptInvoked) = await RunUpdateAndCaptureChannelAsync(
+            workspace,
+            updateArgs: "update");
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured locally");
+        Assert.Equal("staging", updatedWithChannel);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_GlobalConfiguredChannel_IsUsed()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Write a global settings file that selects the "staging" channel. CliTestHelper points
+        // the global settings file at <workspace>/.aspire/settings.global.json.
+        var globalDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire");
+        Directory.CreateDirectory(globalDir);
+        var globalSettingsPath = Path.Combine(globalDir, "settings.global.json");
+        File.WriteAllText(globalSettingsPath, """{ "channel": "staging" }""");
+
+        var (exitCode, updatedWithChannel, promptInvoked) = await RunUpdateAndCaptureChannelAsync(
+            workspace,
+            updateArgs: "update");
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured globally");
+        Assert.Equal("staging", updatedWithChannel);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_ExplicitChannelOverridesConfiguredChannel()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Local config says staging, but command line specifies daily; daily must win.
+        var localConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(localConfigPath, """{ "channel": "staging" }""");
+
+        var (exitCode, updatedWithChannel, promptInvoked) = await RunUpdateAndCaptureChannelAsync(
+            workspace,
+            updateArgs: "update --channel daily");
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptInvoked, "Channel selection prompt should not be shown when --channel is specified");
+        Assert.Equal("daily", updatedWithChannel);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_LocalConfiguredChannel_OverridesGlobalConfiguredChannel()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Global says daily, local says staging — local should win.
+        var globalDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire");
+        Directory.CreateDirectory(globalDir);
+        File.WriteAllText(Path.Combine(globalDir, "settings.global.json"), """{ "channel": "daily" }""");
+
+        var localConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(localConfigPath, """{ "channel": "staging" }""");
+
+        var (exitCode, updatedWithChannel, promptInvoked) = await RunUpdateAndCaptureChannelAsync(
+            workspace,
+            updateArgs: "update");
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured");
+        Assert.Equal("staging", updatedWithChannel);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_WithoutHives_ConfiguredChannel_TakesPrecedenceOverImplicitFallback()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Without PR hives the legacy behavior was to silently pick the implicit "default"
+        // channel. With a configured channel present (here global), that configured channel
+        // must be used instead of the implicit fallback.
+        var globalDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire");
+        Directory.CreateDirectory(globalDir);
+        File.WriteAllText(Path.Combine(globalDir, "settings.global.json"), """{ "channel": "staging" }""");
+
+        var (exitCode, updatedWithChannel, promptInvoked) = await RunUpdateAndCaptureChannelAsync(
+            workspace,
+            updateArgs: "update");
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured");
+        Assert.NotEqual("default", updatedWithChannel);
+        Assert.Equal("staging", updatedWithChannel);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_ConfiguredChannelNotInChannelList_ThrowsChannelNotFound()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Configure a channel that doesn't exist in the channel list to ensure the
+        // configured value is actually consulted (and not silently ignored).
+        var localConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(localConfigPath, """{ "channel": "no-such-channel" }""");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator()
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
+                {
+                    return Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")));
+                }
+            };
+
+            options.InteractionServiceFactory = _ => new TestInteractionService();
+
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
+
+            options.ProjectUpdaterFactory = _ => new TestProjectUpdater();
+
+            options.PackagingServiceFactory = _ => new TestPackagingService()
+            {
+                GetChannelsAsyncCallback = (ct) =>
+                {
+                    var fakeCache = new FakeNuGetPackageCache();
+                    return Task.FromResult<IEnumerable<PackageChannel>>(new[]
+                    {
+                        PackageChannel.CreateImplicitChannel(fakeCache),
+                    });
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToUpgradeProject, exitCode);
+    }
+
+    private async Task<(int ExitCode, string UpdatedWithChannel, bool PromptInvoked)> RunUpdateAndCaptureChannelAsync(
+        TemporaryWorkspace workspace,
+        string updateArgs)
+    {
+        var promptForSelectionInvoked = false;
+        var updatedWithChannel = string.Empty;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator()
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
+                {
+                    return Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")));
+                }
+            };
+
+            options.InteractionServiceFactory = _ => new TestInteractionService()
+            {
+                PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
+                {
+                    promptForSelectionInvoked = true;
+                    return choices.Cast<object>().First();
+                }
+            };
+
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
+
+            options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
+            {
+                UpdateProjectAsyncCallback = (context, cancellationToken) =>
+                {
+                    updatedWithChannel = context.Channel.Name;
+                    return Task.FromResult(new ProjectUpdateResult { UpdatedApplied = false });
+                }
+            };
+
+            options.PackagingServiceFactory = _ => new TestPackagingService()
+            {
+                GetChannelsAsyncCallback = (ct) =>
+                {
+                    var fakeCache = new FakeNuGetPackageCache();
+                    var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache);
+                    var stagingChannel = PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Stable, mappings: null, fakeCache);
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, mappings: null, fakeCache);
+                    return Task.FromResult<IEnumerable<PackageChannel>>(new[] { implicitChannel, stagingChannel, dailyChannel });
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(updateArgs);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        return (exitCode, updatedWithChannel, promptForSelectionInvoked);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -1029,6 +1029,11 @@ builder.Build().Run();");
             return Task.FromResult<string?>(null);
         }
 
+        public Task<string?> GetConfigurationFromDirectoryAsync(string key, DirectoryInfo startDirectory, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
         public string GetSettingsFilePath(bool isGlobal)
         {
             return isGlobal

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -402,6 +402,11 @@ public class DotNetTemplateFactoryTests
             return Task.FromResult<string?>(null);
         }
 
+        public Task<string?> GetConfigurationFromDirectoryAsync(string key, DirectoryInfo startDirectory, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
         public string GetSettingsFilePath(bool isGlobal)
         {
             return "/tmp/settings.json";

--- a/tests/Aspire.Cli.Tests/TestServices/TestConfigurationService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConfigurationService.cs
@@ -47,6 +47,18 @@ public sealed class TestConfigurationService : IConfigurationService
         return Task.FromResult(result);
     }
 
+    public Task<string?> GetConfigurationFromDirectoryAsync(string key, DirectoryInfo startDirectory, CancellationToken cancellationToken = default)
+    {
+        // Tests that don't care about directory-scoped lookups can reuse OnGetConfiguration.
+        // Tests that DO care should set OnGetConfigurationFromDirectory directly.
+        var result = OnGetConfigurationFromDirectory is not null
+            ? OnGetConfigurationFromDirectory.Invoke(key, startDirectory)
+            : OnGetConfiguration?.Invoke(key);
+        return Task.FromResult(result);
+    }
+
+    public Func<string, DirectoryInfo, string?>? OnGetConfigurationFromDirectory { get; set; }
+
     public string SettingsFilePath { get; set; } = string.Empty;
 
     public string GetSettingsFilePath(bool isGlobal)


### PR DESCRIPTION
## Description

Fixes #16650.

`aspire update` previously only consulted `--channel`/`--quality` from the command line. When neither was supplied it dropped straight through to the implicit/default channel (whatever `NuGet.config` happened to point at), even when the user had explicitly set `aspire config set channel staging` either locally or globally. The CLI silently used a different channel than the user''s stated intent.

This PR centralizes channel resolution in `UpdateCommand.ExecuteAsync` to use the documented precedence:

1. explicit `--channel` / hidden `--quality` (CLI)
2. local app-config `channel` (`aspire.config.json` in the project tree)
3. global config `channel` (e.g. `%APPDATA%\.aspire\settings.json`)
4. interactive channel prompt when appropriate (PR hives present)
5. implicit/default channel as the documented fallback

Local-vs-global precedence for steps 2 and 3 is preserved through the existing `IConfiguration` registration order: `ConfigurationHelper.RegisterSettingsFiles` loads the global settings file before the local one, so `IConfigurationService.GetConfigurationAsync("channel", ...)` returns the local value when both are set.

`aspire update --self` retains its existing prompt-and-persist behavior; project updates will now pick up the persisted channel on subsequent runs (closing the inconsistency called out in the issue).

This is a 💥 **blocking-release** fix targeting `main` first; a backport PR to `release/13.3` will follow.

## Validation

To verify locally, install the CLI from this PR:

```bash
# Linux/macOS
./eng/scripts/get-aspire-cli-pr.sh 16716

# Windows PowerShell
.\eng\scripts\get-aspire-cli-pr.ps1 16716
```

Then in any Aspire app:

```bash
# 1. Set a configured channel (local OR global)
aspire config set channel staging
# or:  aspire config set channel staging --global

# 2. Run update WITHOUT --channel
aspire update
```

Expected: the CLI uses `staging`. Previously it would silently fall through to the implicit/default channel. With `--channel` passed explicitly, behavior is unchanged (CLI still wins). Clearing `channel` from config and running `aspire update` again should pick the implicit/default channel.

## Automated coverage

`tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs` adds regressions covering local config, global config, explicit-CLI-wins, and the no-config fallback paths.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
