### PR TITLE
Improve CLI init output spacing

### DIFF
--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -112,6 +112,9 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             return new(previousResultExitCode, [], []);
         }
 
+        // Add a separating line between prompt and previous work in aspire new and aspire init.
+        interactionService.DisplayEmptyLine();
+
         var runAgentInit = await interactionService.PromptConfirmAsync(
             SharedCommandStrings.PromptRunAgentInit,
             binding: agentInitBinding,

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -157,6 +157,8 @@ internal sealed class InitCommand : BaseCommand
             }
         }
 
+        InteractionService.DisplayEmptyLine();
+
         // Step 4: Chain to aspire agent init for MCP server + skill configuration.
         // This prompt lets users choose which skills to install — including aspireify.
         var workspaceRoot = solutionFile?.Directory ?? workingDirectory;

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -157,8 +157,6 @@ internal sealed class InitCommand : BaseCommand
             }
         }
 
-        InteractionService.DisplayEmptyLine();
-
         // Step 4: Chain to aspire agent init for MCP server + skill configuration.
         // This prompt lets users choose which skills to install — including aspireify.
         var workspaceRoot = solutionFile?.Directory ?? workingDirectory;

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -413,6 +413,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         };
         var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
 
+        InteractionService.DisplayEmptyLine();
+
         var workspaceRoot = new DirectoryInfo(templateResult.OutputPath ?? ExecutionContext.WorkingDirectory.FullName);
         var agentInitBinding = PromptBinding.CreateInvertedBoolConfirm(parseResult, s_suppressAgentInitOption, defaultValue: true);
         var agentInitResult = await _agentInitCommand.PromptAndChainAsync(InteractionService, templateResult.ExitCode, workspaceRoot, agentInitBinding, cancellationToken);

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -170,6 +170,10 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             choice => choice.DisplayName.EscapeMarkup(),
             cancellationToken: cancellationToken);
 
+        // The prompt is cleared after selection.
+        // Write out the selected language again for context before proceeding.
+        InteractionService.DisplayPlainText($"Which language would you like to use? {selected.DisplayName}");
+
         return selected.LanguageId;
     }
 
@@ -412,8 +416,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             Language = selectedLanguageId
         };
         var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
-
-        InteractionService.DisplayEmptyLine();
 
         var workspaceRoot = new DirectoryInfo(templateResult.OutputPath ?? ExecutionContext.WorkingDirectory.FullName);
         var agentInitBinding = PromptBinding.CreateInvertedBoolConfirm(parseResult, s_suppressAgentInitOption, defaultValue: true);

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -391,7 +391,12 @@ internal class ConsoleInteractionService : IInteractionService
         {
             var renderable = MarkdownToSpectreConverter.ConvertToRenderable(markdown);
             target.Write(renderable);
-            target.WriteLine();
+
+            // A row automatically includes a newline, so we don't need to call WriteLine after writing the renderable.
+            if (renderable is not Rows)
+            {
+                target.WriteLine();
+            }
         }
         finally
         {

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -85,20 +85,23 @@ internal sealed class LanguageService : ILanguageService
             return (_projectFactory.GetProject(lang), lang);
         }
 
-        _interactionService.DisplayEmptyLine();
-        _interactionService.DisplayMarkdown("""
+        _interactionService.DisplayMarkdown(
+            """
             # Select AppHost Language
 
             Choose the programming language for your Aspire AppHost.
             This selection will be saved for future use.
             """);
-        _interactionService.DisplayEmptyLine();
 
         var selected = await _interactionService.PromptForSelectionAsync(
             "Which language would you like to use?",
             languages,
             lang => lang.DisplayName,
             cancellationToken: cancellationToken);
+
+        // The prompt is cleared after selection.
+        // Write out the selected template again for context before proceeding.
+        _interactionService.DisplayPlainText($"Which language would you like to use? {selected.DisplayName}");
 
         return (_projectFactory.GetProject(selected), selected);
     }

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -206,6 +206,56 @@ public class ConsoleInteractionServiceTests
         Assert.True(outputString.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length >= 3);
     }
 
+    [Theory]
+    [MemberData(nameof(DisplayMarkdown_BetweenPlainText_Data))]
+    public void DisplayMarkdown_BetweenPlainText_DoesNotInsertExtraEmptyLine(string markdown, string expectedOutput)
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+
+        var interactionService = CreateInteractionService(console);
+
+        interactionService.DisplayPlainText("before markdown");
+        interactionService.DisplayMarkdown(markdown);
+        interactionService.DisplayPlainText("after markdown");
+
+        Assert.Equal(expectedOutput, output.ToString(), ignoreLineEndingDifferences: true);
+    }
+
+    public static TheoryData<string, string> DisplayMarkdown_BetweenPlainText_Data => new()
+    {
+        {
+            """
+            # Heading
+
+            This is a paragraph.
+            """,
+            """
+            before markdown
+            Heading
+
+            This is a paragraph.
+
+            after markdown
+
+            """
+        },
+        {
+            "**bold**",
+            """
+            before markdown
+            bold
+            after markdown
+
+            """
+        },
+    };
+
     [Fact]
     public async Task ShowStatusAsync_InDebugMode_DisplaysSubtleMessageInsteadOfSpinner()
     {


### PR DESCRIPTION
## Description

Improves CLI output spacing in the init/new flows before chaining into agent init, avoids an extra trailing newline when markdown renders as Spectre rows, and restores the selected AppHost language prompt text after selection so users keep context as the cleared prompt advances.

<img width="1260" height="704" alt="aspire-init-spacing" src="https://github.com/user-attachments/assets/6956a6cc-e8cc-4f4f-b248-67f442cdacb4" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No