### PR TITLE
Update references to `Microsoft Learn` to `aspire.dev`

### DIFF
--- a/.github/instructions/client-readme.instructions.md
+++ b/.github/instructions/client-readme.instructions.md
@@ -447,7 +447,7 @@ Update client integration README.md files when:
 - Adding new extension methods
 - Updating configuration key paths
 - New features are added (health checks, metrics, etc.)
-- New Microsoft Learn or technology documentation becomes available
+- New aspire.dev or technology documentation becomes available
 
 ## Review Checklist
 

--- a/.github/instructions/hosting-readme.instructions.md
+++ b/.github/instructions/hosting-readme.instructions.md
@@ -226,7 +226,7 @@ Update hosting integration README.md files when:
 - Changing the primary usage pattern
 - Adding emulator support
 - Updating prerequisites or installation steps
-- New Microsoft Learn documentation becomes available
+- New aspire.dev documentation becomes available
 
 ## Review Checklist
 
@@ -237,7 +237,7 @@ When reviewing or creating a hosting integration README.md:
 - [ ] Installation section uses correct package name and `dotnetcli` code block
 - [ ] Usage example shows `Add{Technology}` method with `WithReference` pattern
 - [ ] Usage example uses appropriate variable names and resource names
-- [ ] "Additional documentation" section includes relevant Microsoft Learn links
+- [ ] "Additional documentation" section includes relevant aspire.dev links
 - [ ] "Feedback & contributing" section is present at the end
 - [ ] Trademark notices are included if applicable
 - [ ] No configuration details that belong in client integration READMEs

--- a/.github/instructions/xmldoc.instructions.md
+++ b/.github/instructions/xmldoc.instructions.md
@@ -13,7 +13,7 @@ This document provides comprehensive guidelines for writing high-quality XML doc
 XML documentation comments serve multiple purposes:
 
 - Generate IntelliSense tooltips in IDEs for developers using Aspire APIs
-- Create public API documentation published to Microsoft Learn
+- Create public API documentation published to aspire.dev
 - Improve code maintainability and understanding
 - Support automated documentation generation tools
 
@@ -26,7 +26,7 @@ XML documentation comments serve multiple purposes:
 - All public classes, interfaces, methods, properties, and events must be well-documented
 - Include detailed `<summary>`, `<remarks>`, `<example>`, and other appropriate tags
 - Focus on explaining purpose, usage patterns, and providing practical examples
-- This documentation will be published to Microsoft Learn and shown in IntelliSense
+- This documentation will be published to aspire.dev and shown in IntelliSense
 
 **Internal APIs require minimal documentation:**
 

--- a/docs/specs/appmodel.md
+++ b/docs/specs/appmodel.md
@@ -631,7 +631,7 @@ private static ReferenceExpression BuildConnectionString(
 
 ## Endpoint Primitives
 
-The [EndpointReference](https://learn.microsoft.com/en-us/dotnet/api/aspire.hosting.applicationmodel.endpointreference?view=dotnet-aspire-8.0) is the fundamental type used to interact with another resource's endpoint. It provides properties such as:
+The [EndpointReference](https://aspire.dev/reference/api/csharp/aspire.hosting/endpointreference/) is the fundamental type used to interact with another resource's endpoint. It provides properties such as:
 
 - Url
 - Host
@@ -737,7 +737,7 @@ builder.Build().Run();
   Error accessing Url: Endpoint has not been allocated.
   ```
 
-**NOTE: The overloads of [WithEnvironment](https://learn.microsoft.com/en-us/dotnet/api/aspire.hosting.resourcebuilderextensions.withenvironment) that take a callback run after endpoints have been allocated.** 
+**NOTE: The overloads of [WithEnvironment](https://aspire.dev/reference/api/csharp/aspire.hosting/resourcebuilderextensions/methods/#withenvironment-iresourcebuilder-t-action-environmentcallbackcontext) that take a callback run after endpoints have been allocated.** 
 
 ---
 

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -628,7 +628,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Go to Microsoft Learn documentation.
+        ///   Looks up a localized string similar to Go to aspire.dev documentation.
         /// </summary>
         public static string HelpDialogGetHelpLinkText {
             get {

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -164,7 +164,7 @@
     <value>Condition</value>
   </data>
   <data name="HelpDialogGetHelpLinkText" xml:space="preserve">
-    <value>Go to Microsoft Learn documentation</value>
+    <value>Go to aspire.dev documentation</value>
   </data>
   <data name="HelpDialogCategoryPanels" xml:space="preserve">
     <value>Panels</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Přejít na dokumentaci Microsoft Learn</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">Přejít na dokumentaci aspire.dev</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Zur Microsoft Learn-Dokumentation wechseln</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">Zur aspire.dev-Dokumentation wechseln</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Ir a la documentación de Microsoft Learn</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">Ir a la documentación de aspire.dev</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Accédez à la documentation Microsoft Learn</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">Accédez à la documentation aspire.dev</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Vai alla documentazione di Microsoft Learn</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">Vai alla documentazione di aspire.dev</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Microsoft Learn ドキュメントに移動</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">aspire.dev ドキュメントに移動</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Microsoft Learn 설명서로 이동</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">aspire.dev 설명서로 이동</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Przejdź do dokumentacji usługi Microsoft Learn</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">Przejdź do dokumentacji usługi aspire.dev</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Ir para a documentação do Microsoft Learn</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">Ir para a documentação do aspire.dev</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Перейти к документации Microsoft Learn</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">Перейти к документации aspire.dev</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">Microsoft Learn belgelerine git</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">aspire.dev belgelerine git</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">转到 Microsoft Learn 文档</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">转到 aspire.dev 文档</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -318,8 +318,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGetHelpLinkText">
-        <source>Go to Microsoft Learn documentation</source>
-        <target state="translated">前往 Microsoft Learn 文件</target>
+        <source>Go to aspire.dev documentation</source>
+        <target state="translated">前往 aspire.dev 文件</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogGoToConsoleLogs">


### PR DESCRIPTION
## Description

Update some references to `Microsoft Learn` to `aspire.dev`

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  Are you including unit tests for the changes and scenario tests if relevant?
  - [X] No
- Did you add public API?
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] No
