### PR TITLE
Surface silent integration-assembly load failures (#16729)

### DIFF
--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -514,7 +514,13 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         {
             if (e.Data is not null)
             {
-                _logger.LogTrace("PrebuiltAppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
+                // Promoted from LogTrace to LogDebug so that apphost-server stdout reaches the
+                // CLI's on-disk log under the default file-logger filter (Debug). Previously
+                // these lines were dropped entirely, which made apphost-side warnings
+                // (for example, "LoaderExceptions" from the type-discovery path) invisible to
+                // anyone diagnosing a "no code generator found" / "no language support found"
+                // error. See https://github.com/microsoft/aspire/issues/16729.
+                _logger.LogDebug("PrebuiltAppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
                 outputCollector.AppendOutput(e.Data);
             }
         };
@@ -522,7 +528,11 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         {
             if (e.Data is not null)
             {
-                _logger.LogTrace("PrebuiltAppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
+                // Promoted from LogTrace to LogInformation so that apphost-server stderr is
+                // visible at the default console log level (Information). Stderr is reserved
+                // for genuine problems in well-behaved server processes, so surfacing it
+                // by default is appropriate. See https://github.com/microsoft/aspire/issues/16729.
+                _logger.LogInformation("PrebuiltAppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
                 outputCollector.AppendError(e.Data);
             }
         };

--- a/src/Aspire.Hosting.RemoteHost/AssemblyLoader.cs
+++ b/src/Aspire.Hosting.RemoteHost/AssemblyLoader.cs
@@ -111,6 +111,8 @@ internal sealed class AssemblyLoader
         string? integrationLibsPath,
         string applicationBasePath)
     {
+        WarnIfSharedAssemblyMismatch(integrationLibsPath, logger);
+
         var assemblyNames = GetAssemblyNamesToLoad(configuration, integrationLibsPath, applicationBasePath);
         var assemblies = new List<Assembly>();
 
@@ -131,6 +133,83 @@ internal sealed class AssemblyLoader
         }
 
         return assemblies;
+    }
+
+    /// <summary>
+    /// Warns when a shared assembly (one that <see cref="IntegrationLoadContext"/> intentionally
+    /// resolves through the default <see cref="AssemblyLoadContext"/>) exists in the integration
+    /// libs directory at a different identity than what the default context provides.
+    /// </summary>
+    /// <remarks>
+    /// This is a defense against a real failure mode: when the bundled <c>Aspire.TypeSystem</c>
+    /// (compiled into the apphost server's single-file executable) and the libs copy
+    /// (restored alongside <c>Aspire.Hosting.*.dll</c>) report different assembly versions or MVIDs,
+    /// integration assemblies that reference the libs copy will fail to bind their type
+    /// references through the default context. The resulting <see cref="ReflectionTypeLoadException"/>
+    /// would otherwise be swallowed silently and surface only as a downstream "no code generator
+    /// found" / "no language support found" error with no actionable diagnostic.
+    /// </remarks>
+    private static void WarnIfSharedAssemblyMismatch(string? integrationLibsPath, ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(integrationLibsPath) || !Directory.Exists(integrationLibsPath))
+        {
+            return;
+        }
+
+        foreach (var sharedName in IntegrationLoadContext.GetSharedAssemblyNames())
+        {
+            var libsPath = Path.Combine(integrationLibsPath, sharedName + ".dll");
+            if (!File.Exists(libsPath))
+            {
+                continue;
+            }
+
+            AssemblyName? probedName;
+            try
+            {
+                probedName = AssemblyName.GetAssemblyName(libsPath);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Could not read assembly identity from {Path}", libsPath);
+                continue;
+            }
+
+            Assembly? defaultAsm;
+            try
+            {
+                defaultAsm = AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(sharedName));
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Default context does not provide '{AssemblyName}'", sharedName);
+                continue;
+            }
+
+            var defaultName = defaultAsm.GetName();
+            var defaultMvid = defaultAsm.ManifestModule.ModuleVersionId;
+
+            if (defaultName.Version != probedName.Version)
+            {
+                logger.LogWarning(
+                    "Shared assembly '{AssemblyName}' version mismatch: bundled={BundledVersion}, libs={LibsVersion} ({LibsPath}). " +
+                    "Integration assemblies referencing this assembly from the libs directory will fail to bind their type " +
+                    "references through the default load context, which causes integrations to be silently skipped during type discovery. " +
+                    "This typically indicates the apphost server bundle and the restored integration packages were produced by " +
+                    "different build configurations.",
+                    sharedName,
+                    defaultName.Version,
+                    probedName.Version,
+                    libsPath);
+                continue;
+            }
+
+            // Same version, but different MVID (compiled from different sources) is also a binary-incompatibility risk.
+            // We can't read the probed MVID without loading the assembly, which we deliberately don't do here.
+            // Logging the bundled MVID at Debug helps correlate with any subsequent ReflectionTypeLoadException.
+            logger.LogDebug("Shared assembly '{AssemblyName}' identity matches: Version={Version}, BundledMvid={Mvid}",
+                sharedName, defaultName.Version, defaultMvid);
+        }
     }
 
     private static Assembly LoadAssembly(IntegrationLoadContext loadContext, string name)

--- a/src/Aspire.Hosting.RemoteHost/AssemblyLoader.cs
+++ b/src/Aspire.Hosting.RemoteHost/AssemblyLoader.cs
@@ -175,14 +175,11 @@ internal sealed class AssemblyLoader
                 continue;
             }
 
-            Assembly? defaultAsm;
-            try
+            var defaultAsm = AssemblyLoadContext.Default.Assemblies.FirstOrDefault(
+                assembly => string.Equals(assembly.GetName().Name, sharedName, StringComparison.OrdinalIgnoreCase));
+            if (defaultAsm is null)
             {
-                defaultAsm = AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(sharedName));
-            }
-            catch (Exception ex)
-            {
-                logger.LogDebug(ex, "Default context does not provide '{AssemblyName}'", sharedName);
+                logger.LogDebug("Default context does not currently provide '{AssemblyName}'", sharedName);
                 continue;
             }
 

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
@@ -182,7 +182,7 @@ internal sealed class CodeGenerationService
             var generator = _resolver.GetCodeGenerator(language);
             if (generator == null)
             {
-                throw new ArgumentException($"No code generator found for language: {language}");
+                throw new ArgumentException(BuildNoCodeGeneratorMessage(language));
             }
 
             var context = _atsContextFactory.GetContext();
@@ -201,6 +201,26 @@ internal sealed class CodeGenerationService
             _logger.LogError(ex, "<< generateCode({Language}) failed", language);
             throw;
         }
+    }
+
+    private string BuildNoCodeGeneratorMessage(string language)
+    {
+        var available = _resolver.GetSupportedLanguages()
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (available.Length == 0)
+        {
+            // No generators discovered at all is almost always a binary-mismatch / type-load
+            // failure (see CodeGeneratorResolver warnings). Point the user at the apphost
+            // server log so they can see the underlying LoaderExceptions.
+            return $"No code generator found for language: {language}. " +
+                   "No code generators were discovered in any loaded assembly. " +
+                   "This usually indicates a binary mismatch between the bundled apphost server and the integration assemblies on disk; " +
+                   "check the apphost server log for 'LoaderExceptions' Warnings.";
+        }
+
+        return $"No code generator found for language: {language}. Available languages: {string.Join(", ", available)}.";
     }
 }
 

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
@@ -20,10 +20,20 @@ internal sealed class CodeGeneratorResolver
         IServiceProvider serviceProvider,
         AssemblyLoader assemblyLoader,
         ILogger<CodeGeneratorResolver> logger)
+        : this(serviceProvider, assemblyLoader.GetAssemblies, logger)
+    {
+    }
+
+    // Test-only seam: lets unit tests inject a synthetic assembly set without going through
+    // the AssemblyLoader (which is sealed and probes the file system).
+    internal CodeGeneratorResolver(
+        IServiceProvider serviceProvider,
+        Func<IReadOnlyList<Assembly>> assembliesProvider,
+        ILogger<CodeGeneratorResolver> logger)
     {
         _logger = logger;
         _generators = new Lazy<Dictionary<string, ICodeGenerator>>(
-            () => DiscoverGenerators(serviceProvider, assemblyLoader.GetAssemblies()));
+            () => DiscoverGenerators(serviceProvider, assembliesProvider()));
     }
 
     /// <summary>
@@ -37,6 +47,15 @@ internal sealed class CodeGeneratorResolver
         return generator;
     }
 
+    /// <summary>
+    /// Gets the languages of all discovered code generators.
+    /// </summary>
+    /// <returns>The set of supported language identifiers.</returns>
+    public IReadOnlyCollection<string> GetSupportedLanguages()
+    {
+        return _generators.Value.Keys.ToArray();
+    }
+
     private Dictionary<string, ICodeGenerator> DiscoverGenerators(
         IServiceProvider serviceProvider,
         IReadOnlyList<Assembly> assemblies)
@@ -46,17 +65,36 @@ internal sealed class CodeGeneratorResolver
         foreach (var assembly in assemblies)
         {
             Type[] types;
+            var assemblyName = assembly.GetName().Name;
+            var hadTypeLoadFailure = false;
             try
             {
                 types = assembly.GetTypes();
             }
             catch (ReflectionTypeLoadException ex)
             {
-                _logger.LogDebug(ex, "Some types in assembly '{AssemblyName}' could not be loaded", assembly.GetName().Name);
+                hadTypeLoadFailure = true;
+                // Surface loader binding failures at Warning level. These typically indicate
+                // a binary mismatch between the bundled runtime assemblies and the integration
+                // assemblies loaded from disk (for example, when Aspire.TypeSystem versions
+                // diverge). Including the LoaderExceptions in the log is essential for
+                // diagnosing these failures, which previously disappeared into Debug-level
+                // output that the apphost server never wrote to disk.
+                var loaderMessages = ex.LoaderExceptions is { Length: > 0 } loaders
+                    ? string.Join("; ", loaders.Where(e => e is not null).Select(e => e!.Message).Distinct())
+                    : "(no LoaderExceptions captured)";
+                _logger.LogWarning(
+                    ex,
+                    "Some types in assembly '{AssemblyName}' could not be loaded; {LoadedCount} of {TotalCount} types are available. LoaderExceptions: {LoaderExceptions}",
+                    assemblyName,
+                    ex.Types.Count(t => t is not null),
+                    ex.Types.Length,
+                    loaderMessages);
                 // Use the types that were successfully loaded
                 types = ex.Types.Where(t => t is not null).ToArray()!;
             }
 
+            var discoveredInAssembly = 0;
             foreach (var type in types)
             {
                 if (!type.IsAbstract &&
@@ -67,6 +105,7 @@ internal sealed class CodeGeneratorResolver
                     {
                         var generator = (ICodeGenerator)ActivatorUtilities.CreateInstance(serviceProvider, type);
                         generators[generator.Language] = generator;
+                        discoveredInAssembly++;
                         _logger.LogDebug("Discovered code generator: {TypeName} for language '{Language}'", type.Name, generator.Language);
                     }
                     catch (Exception ex)
@@ -75,8 +114,26 @@ internal sealed class CodeGeneratorResolver
                     }
                 }
             }
+
+            // If an assembly named like a code-generation contributor produced zero generators,
+            // that is almost certainly a silent type-load failure rather than an intentional
+            // design. Log a Warning so the user can see it.
+            if (discoveredInAssembly == 0 && LooksLikeCodeGeneratorAssembly(assemblyName))
+            {
+                _logger.LogWarning(
+                    "Assembly '{AssemblyName}' was loaded but did not contribute any {Interface} implementations. {Hint}",
+                    assemblyName,
+                    nameof(ICodeGenerator),
+                    hadTypeLoadFailure
+                        ? "This is likely caused by a binary mismatch between the bundled and probed assemblies (see preceding LoaderExceptions)."
+                        : "Verify the assembly contains a non-abstract type that implements " + typeof(ICodeGenerator).FullName + ".");
+            }
         }
 
         return generators;
     }
+
+    private static bool LooksLikeCodeGeneratorAssembly(string? assemblyName)
+        => assemblyName is not null
+           && assemblyName.StartsWith("Aspire.Hosting.CodeGeneration.", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Aspire.Hosting.RemoteHost/IntegrationLoadContext.cs
+++ b/src/Aspire.Hosting.RemoteHost/IntegrationLoadContext.cs
@@ -16,6 +16,12 @@ internal sealed class IntegrationLoadContext : AssemblyLoadContext
 {
     private const string SharedAssemblyName = "Aspire.TypeSystem";
 
+    /// <summary>
+    /// Gets the assembly names that this load context shares with the default
+    /// <see cref="AssemblyLoadContext"/> (i.e., resolution always defers to the default ALC).
+    /// </summary>
+    internal static IReadOnlyList<string> GetSharedAssemblyNames() => [SharedAssemblyName];
+
     private readonly string[] _probeDirectories;
     private readonly ILogger _logger;
 

--- a/src/Aspire.Hosting.RemoteHost/Language/LanguageService.cs
+++ b/src/Aspire.Hosting.RemoteHost/Language/LanguageService.cs
@@ -46,7 +46,7 @@ internal sealed class LanguageService
             var languageSupport = _resolver.GetLanguageSupport(language);
             if (languageSupport == null)
             {
-                throw new ArgumentException($"No language support found for: {language}");
+                throw new ArgumentException(BuildNoLanguageSupportMessage(language));
             }
 
             var request = new ScaffoldRequest
@@ -118,7 +118,7 @@ internal sealed class LanguageService
             var languageSupport = _resolver.GetLanguageSupport(language);
             if (languageSupport == null)
             {
-                throw new ArgumentException($"No language support found for: {language}");
+                throw new ArgumentException(BuildNoLanguageSupportMessage(language));
             }
 
             var spec = languageSupport.GetRuntimeSpec();
@@ -131,5 +131,26 @@ internal sealed class LanguageService
             _logger.LogError(ex, "<< getRuntimeSpec({Language}) failed", language);
             throw;
         }
+    }
+
+    private string BuildNoLanguageSupportMessage(string language)
+    {
+        var available = _resolver.GetAllLanguages()
+            .Select(l => l.Language)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (available.Length == 0)
+        {
+            // No language support discovered at all is almost always a binary-mismatch /
+            // type-load failure (see LanguageSupportResolver warnings). Point the user at
+            // the apphost server log and the GitHub issue tracker.
+            return $"No language support found for: {language}. " +
+                   "No language support implementations were discovered in any loaded assembly. " +
+                   "This usually indicates a binary mismatch between the bundled apphost server and the integration assemblies on disk; " +
+                   "check the apphost server log for 'LoaderExceptions' Warnings.";
+        }
+
+        return $"No language support found for: {language}. Available languages: {string.Join(", ", available)}.";
     }
 }

--- a/src/Aspire.Hosting.RemoteHost/Language/LanguageSupportResolver.cs
+++ b/src/Aspire.Hosting.RemoteHost/Language/LanguageSupportResolver.cs
@@ -20,10 +20,20 @@ internal sealed class LanguageSupportResolver
         IServiceProvider serviceProvider,
         AssemblyLoader assemblyLoader,
         ILogger<LanguageSupportResolver> logger)
+        : this(serviceProvider, assemblyLoader.GetAssemblies, logger)
+    {
+    }
+
+    // Test-only seam: lets unit tests inject a synthetic assembly set without going through
+    // the AssemblyLoader (which is sealed and probes the file system).
+    internal LanguageSupportResolver(
+        IServiceProvider serviceProvider,
+        Func<IReadOnlyList<Assembly>> assembliesProvider,
+        ILogger<LanguageSupportResolver> logger)
     {
         _logger = logger;
         _languages = new Lazy<Dictionary<string, ILanguageSupport>>(
-            () => DiscoverLanguages(serviceProvider, assemblyLoader.GetAssemblies()));
+            () => DiscoverLanguages(serviceProvider, assembliesProvider()));
     }
 
     /// <summary>
@@ -55,17 +65,36 @@ internal sealed class LanguageSupportResolver
         foreach (var assembly in assemblies)
         {
             Type[] types;
+            var assemblyName = assembly.GetName().Name;
+            var hadTypeLoadFailure = false;
             try
             {
                 types = assembly.GetTypes();
             }
             catch (ReflectionTypeLoadException ex)
             {
-                _logger.LogDebug(ex, "Some types in assembly '{AssemblyName}' could not be loaded", assembly.GetName().Name);
+                hadTypeLoadFailure = true;
+                // Surface loader binding failures at Warning level. These typically indicate
+                // a binary mismatch between the bundled runtime assemblies and the integration
+                // assemblies loaded from disk (for example, when Aspire.TypeSystem versions
+                // diverge). Including the LoaderExceptions in the log is essential for
+                // diagnosing these failures, which previously disappeared into Debug-level
+                // output that the apphost server never wrote to disk.
+                var loaderMessages = ex.LoaderExceptions is { Length: > 0 } loaders
+                    ? string.Join("; ", loaders.Where(e => e is not null).Select(e => e!.Message).Distinct())
+                    : "(no LoaderExceptions captured)";
+                _logger.LogWarning(
+                    ex,
+                    "Some types in assembly '{AssemblyName}' could not be loaded; {LoadedCount} of {TotalCount} types are available. LoaderExceptions: {LoaderExceptions}",
+                    assemblyName,
+                    ex.Types.Count(t => t is not null),
+                    ex.Types.Length,
+                    loaderMessages);
                 // Use the types that were successfully loaded
                 types = ex.Types.Where(t => t is not null).ToArray()!;
             }
 
+            var discoveredInAssembly = 0;
             foreach (var type in types)
             {
                 if (!type.IsAbstract &&
@@ -76,6 +105,7 @@ internal sealed class LanguageSupportResolver
                     {
                         var language = (ILanguageSupport)ActivatorUtilities.CreateInstance(serviceProvider, type);
                         languages[language.Language] = language;
+                        discoveredInAssembly++;
                         _logger.LogDebug("Discovered language support: {TypeName} for language '{Language}'", type.Name, language.Language);
                     }
                     catch (Exception ex)
@@ -84,8 +114,26 @@ internal sealed class LanguageSupportResolver
                     }
                 }
             }
+
+            // If an assembly named like a code-generation/language-support contributor produced
+            // zero implementations, that is almost certainly a silent type-load failure rather
+            // than an intentional design. Log a Warning so the user can see it.
+            if (discoveredInAssembly == 0 && LooksLikeLanguageSupportAssembly(assemblyName))
+            {
+                _logger.LogWarning(
+                    "Assembly '{AssemblyName}' was loaded but did not contribute any {Interface} implementations. {Hint}",
+                    assemblyName,
+                    nameof(ILanguageSupport),
+                    hadTypeLoadFailure
+                        ? "This is likely caused by a binary mismatch between the bundled and probed assemblies (see preceding LoaderExceptions)."
+                        : "Verify the assembly contains a non-abstract type that implements " + typeof(ILanguageSupport).FullName + ".");
+            }
         }
 
         return languages;
     }
+
+    private static bool LooksLikeLanguageSupportAssembly(string? assemblyName)
+        => assemblyName is not null
+           && assemblyName.StartsWith("Aspire.Hosting.CodeGeneration.", StringComparison.OrdinalIgnoreCase);
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/RecordingLogger.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/RecordingLogger.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+/// <summary>
+/// Minimal in-memory logger used by tests that need to inspect emitted log entries.
+/// Thread-safe; entries are appended in the order Log is called.
+/// </summary>
+internal sealed class RecordingLogger<T> : ILogger<T>
+{
+    public ConcurrentQueue<LogEntry> Entries { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Enqueue(new LogEntry(logLevel, eventId, formatter(state, exception), exception));
+    }
+
+    internal sealed record LogEntry(LogLevel Level, EventId EventId, string Message, Exception? Exception);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Aspire.Hosting.RemoteHost.CodeGeneration;
+using Aspire.Hosting.RemoteHost.Language;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+/// <summary>
+/// Coverage for the diagnostics surfaced by the discovery resolvers when type loading fails or
+/// when a "code generation" assembly is loaded but contributes no implementations. These tests
+/// guard the user-facing fix for https://github.com/microsoft/aspire/issues/16729 — a previously
+/// silent ReflectionTypeLoadException that produced a downstream "no code generator found" /
+/// "no language support found" error with no actionable diagnostic.
+/// </summary>
+public class ResolverDiagnosticsTests
+{
+    [Fact]
+    public void CodeGeneratorResolver_LogsWarning_WhenAssemblyTypeLoadFails()
+    {
+        var logger = new RecordingLogger<CodeGeneratorResolver>();
+        var stub = new TypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var resolver = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[stub], logger);
+
+        Assert.Null(resolver.GetCodeGenerator("anything"));
+
+        var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning && e.Message.Contains("could not be loaded"));
+        Assert.NotNull(warning);
+        Assert.Contains("LoaderExceptions", warning!.Message);
+        Assert.Contains(stub.GetName().Name!, warning.Message);
+        Assert.Contains("synthetic loader exception", warning.Message);
+    }
+
+    [Fact]
+    public void LanguageSupportResolver_LogsWarning_WhenAssemblyTypeLoadFails()
+    {
+        var logger = new RecordingLogger<LanguageSupportResolver>();
+        var stub = new TypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var resolver = new LanguageSupportResolver(services, () => (IReadOnlyList<Assembly>)[stub], logger);
+
+        Assert.Null(resolver.GetLanguageSupport("anything"));
+
+        var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning && e.Message.Contains("could not be loaded"));
+        Assert.NotNull(warning);
+        Assert.Contains("LoaderExceptions", warning!.Message);
+        Assert.Contains(stub.GetName().Name!, warning.Message);
+        Assert.Contains("synthetic loader exception", warning.Message);
+    }
+
+    [Fact]
+    public void CodeGeneratorResolver_LogsWarning_WhenCodeGenerationAssemblyContributesNothing()
+    {
+        var logger = new RecordingLogger<CodeGeneratorResolver>();
+        // The marker name is what triggers the "did not contribute any" diagnostic.
+        var empty = new EmptyNamedAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var resolver = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[empty], logger);
+
+        Assert.Null(resolver.GetCodeGenerator("anything"));
+
+        var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning && e.Message.Contains("did not contribute"));
+        Assert.NotNull(warning);
+        Assert.Contains("ICodeGenerator", warning!.Message);
+    }
+
+    [Fact]
+    public void CodeGeneratorResolver_DoesNotLogContributionWarning_ForArbitraryAssembly()
+    {
+        var logger = new RecordingLogger<CodeGeneratorResolver>();
+        var arbitrary = new EmptyNamedAssembly("My.Custom.Integration");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        _ = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[arbitrary], logger).GetCodeGenerator("anything");
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("did not contribute"));
+    }
+
+    private sealed class TypeLoadFailingAssembly : Assembly
+    {
+        private readonly AssemblyName _name;
+
+        public TypeLoadFailingAssembly(string name) => _name = new AssemblyName(name);
+
+        public override AssemblyName GetName() => _name;
+
+        public override Type[] GetTypes()
+            => throw new ReflectionTypeLoadException(
+                [null, typeof(string)],
+                [new FileLoadException("synthetic loader exception: simulated Aspire.TypeSystem mismatch")]);
+    }
+
+    private sealed class EmptyNamedAssembly : Assembly
+    {
+        private readonly AssemblyName _name;
+
+        public EmptyNamedAssembly(string name) => _name = new AssemblyName(name);
+
+        public override AssemblyName GetName() => _name;
+
+        public override Type[] GetTypes() => [typeof(string)];
+    }
+}

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Aspire.Hosting.RemoteHost.CodeGeneration;
+using Aspire.Hosting.RemoteHost.Language;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+/// <summary>
+/// Verifies the user-facing error messages on the RPC-exposed services include actionable
+/// information instead of just "No language support found for: X". See
+/// https://github.com/microsoft/aspire/issues/16729 for the background.
+/// </summary>
+public class ServiceErrorMessageTests
+{
+    [Fact]
+    public void ScaffoldAppHost_UnknownLanguage_ListsAvailableLanguages()
+    {
+        var (langService, _) = CreateServices();
+
+        var ex = Assert.Throws<ArgumentException>(() => langService.ScaffoldAppHost("klingon", "/tmp/whatever"));
+
+        Assert.Contains("No language support found for: klingon", ex.Message);
+        Assert.Contains("Available languages:", ex.Message);
+        Assert.Contains("typescript/nodejs", ex.Message);
+    }
+
+    [Fact]
+    public void GenerateCode_UnknownLanguage_ListsAvailableLanguages()
+    {
+        var (_, codeService) = CreateServices();
+
+        var ex = Assert.Throws<ArgumentException>(() => codeService.GenerateCode("klingon"));
+
+        Assert.Contains("No code generator found for language: klingon", ex.Message);
+        Assert.Contains("Available languages:", ex.Message);
+        Assert.Contains("TypeScript", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ScaffoldAppHost_NoLanguagesDiscovered_PointsAtBundleMismatch()
+    {
+        var langService = CreateLanguageServiceWithEmptyResolver();
+
+        var ex = Assert.Throws<ArgumentException>(() => langService.ScaffoldAppHost("typescript/nodejs", "/tmp/whatever"));
+
+        Assert.Contains("No language support found for: typescript/nodejs", ex.Message);
+        Assert.Contains("LoaderExceptions", ex.Message);
+        Assert.Contains("binary mismatch", ex.Message);
+    }
+
+    [Fact]
+    public void GenerateCode_NoGeneratorsDiscovered_PointsAtBundleMismatch()
+    {
+        var codeService = CreateCodeGenerationServiceWithEmptyResolver();
+
+        var ex = Assert.Throws<ArgumentException>(() => codeService.GenerateCode("TypeScript"));
+
+        Assert.Contains("No code generator found for language: TypeScript", ex.Message);
+        Assert.Contains("LoaderExceptions", ex.Message);
+        Assert.Contains("binary mismatch", ex.Message);
+    }
+
+    private static (LanguageService Lang, CodeGenerationService Code) CreateServices()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AtsAssemblies:0"] = "Aspire.Hosting.CodeGeneration.Go",
+                ["AtsAssemblies:1"] = "Aspire.Hosting.CodeGeneration.Java",
+                ["AtsAssemblies:2"] = "Aspire.Hosting.CodeGeneration.Python",
+                ["AtsAssemblies:3"] = "Aspire.Hosting.CodeGeneration.Rust",
+                ["AtsAssemblies:4"] = "Aspire.Hosting.CodeGeneration.TypeScript"
+            })
+            .Build();
+
+        var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance);
+        // Note: do NOT dispose the ServiceProvider here. The resolvers lazily instantiate
+        // language-support / code-generator types via ActivatorUtilities, which would fail
+        // if the provider had already been disposed.
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        var langResolver = new LanguageSupportResolver(services, loader, NullLogger<LanguageSupportResolver>.Instance);
+        var codeResolver = new CodeGeneratorResolver(services, loader, NullLogger<CodeGeneratorResolver>.Instance);
+
+        var auth = CreateAuthenticatedState();
+
+        var atsContextFactory = new AtsContextFactory(loader, NullLogger<AtsContextFactory>.Instance);
+
+        var lang = new LanguageService(auth, langResolver, NullLogger<LanguageService>.Instance);
+        var code = new CodeGenerationService(auth, atsContextFactory, codeResolver, NullLogger<CodeGenerationService>.Instance);
+        return (lang, code);
+    }
+
+    private static LanguageService CreateLanguageServiceWithEmptyResolver()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        // Use the test-only seam to inject an empty assembly list so the resolver hits the
+        // "no implementations discovered" branch deterministically, regardless of what
+        // AssemblyLoader probing finds in the test runtime directory.
+        var langResolver = new LanguageSupportResolver(
+            services,
+            Array.Empty<Assembly>,
+            NullLogger<LanguageSupportResolver>.Instance);
+
+        var auth = CreateAuthenticatedState();
+        return new LanguageService(auth, langResolver, NullLogger<LanguageService>.Instance);
+    }
+
+    private static CodeGenerationService CreateCodeGenerationServiceWithEmptyResolver()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance);
+        var services = new ServiceCollection().BuildServiceProvider();
+        var codeResolver = new CodeGeneratorResolver(
+            services,
+            Array.Empty<Assembly>,
+            NullLogger<CodeGeneratorResolver>.Instance);
+
+        var auth = CreateAuthenticatedState();
+        var atsContextFactory = new AtsContextFactory(loader, NullLogger<AtsContextFactory>.Instance);
+        return new CodeGenerationService(auth, atsContextFactory, codeResolver, NullLogger<CodeGenerationService>.Instance);
+    }
+
+    // The default state is "authenticated" when no JsonRpcAuthToken is present in configuration.
+    private static JsonRpcAuthenticationState CreateAuthenticatedState()
+        => new(new ConfigurationBuilder().Build());
+}

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
@@ -105,7 +105,7 @@ public class ServiceErrorMessageTests
         // AssemblyLoader probing finds in the test runtime directory.
         var langResolver = new LanguageSupportResolver(
             services,
-            Array.Empty<Assembly>,
+            () => Array.Empty<Assembly>(),
             NullLogger<LanguageSupportResolver>.Instance);
 
         var auth = CreateAuthenticatedState();
@@ -122,7 +122,7 @@ public class ServiceErrorMessageTests
         var services = new ServiceCollection().BuildServiceProvider();
         var codeResolver = new CodeGeneratorResolver(
             services,
-            Array.Empty<Assembly>,
+            () => Array.Empty<Assembly>(),
             NullLogger<CodeGeneratorResolver>.Instance);
 
         var auth = CreateAuthenticatedState();


### PR DESCRIPTION
## Description

This PR hardens the diagnostic chain so that when the integration-assembly load path *does* fail — for any reason: build-pipeline version skew, stale local NuGet cache, transitive dependency mismatch, partially populated probe directory, etc. — the failure is **loud and self-explanatory** instead of surfacing only as:

```text
No code generator found for language: TypeScript
No language support found for: typescript/nodejs
```

The original report (#16729) was a cryptic CLI failure on `aspire new` with TypeScript templates. After investigation, that specific symptom traced to a stale local NuGet cache anomaly on the reporter''s machine (a mix of package contents from switching between PR / staging / stable `13.3.0` builds) and is **not reproducible** after clearing `~/.nuget` and `~/.aspire`. So this PR no longer attempts a runtime binding fix — it is **diagnostic hardening only**, which is the part that has lasting value regardless of which upstream condition produced the resolver miss.

## Changes

- `CodeGeneratorResolver` / `LanguageSupportResolver` now log `ReflectionTypeLoadException` at **Warning** level and include the `LoaderExceptions` text in the message (was previously `LogDebug`, which is below the file logger''s default Information threshold and never reached the user log).
- When an assembly named like `Aspire.Hosting.CodeGeneration.*` is loaded but contributes **zero** `ICodeGenerator` / `ILanguageSupport` types, log a Warning so the silent-failure case is visible.
- `AssemblyLoader.LoadAssemblies` performs an `Aspire.TypeSystem` version sanity check at startup against the libs directory and warns when the bundled and probed versions diverge — surfacing this lets us catch build-pipeline regressions early even if the runtime tolerates the skew.
- `LanguageService` / `CodeGenerationService` error messages now list the available languages, or point at the apphost-server log + binary mismatch when zero are discovered.
- `PrebuiltAppHostServer` promotes spawned-process stdout/stderr capture from `Trace` to `Debug`/`Information`, so warnings emitted by the apphost server actually reach the default file log.

### Internal-only API additions

- `CodeGeneratorResolver.GetSupportedLanguages()` so the service can list available languages in error messages.
- An internal test-only constructor on both resolvers that takes a `Func<IReadOnlyList<Assembly>>`, used by the new tests.
- `IntegrationLoadContext.GetSharedAssemblyNames()` so the assembly loader''s version sanity check stays in sync with the actual load context policy.

## Tests

New coverage in `tests/Aspire.Hosting.RemoteHost.Tests/`:

- `ResolverDiagnosticsTests` (4) — proves the resolvers log Warnings on zero-contributor assemblies and on `ReflectionTypeLoadException`.
- `ServiceErrorMessageTests` (4) — proves the user-visible error messages list available languages or point at the binary-mismatch scenario.

All `Aspire.Hosting.RemoteHost.Tests` pass locally.

## Notes

- Re-targeted from `release/13.3` to `main`. The branch was reset to `upstream/main` and the diagnostic commit was cherry-picked clean.
- An earlier revision of this PR also contained an `IntegrationLoadContext.Load` change that resolved `Aspire.TypeSystem` by simple name from the default ALC, intended to tolerate `42.42.42.42` ↔ `13.3.0.0` version skew. That change has been **dropped** along with its regression test, since the originally-reported failure turned out to be a local cache anomaly rather than a build-pipeline skew, and shipping a binding-policy change without a confirmed root cause to defend against would be premature. The hardening here keeps that scenario visible if it ever does occur.

Closes #16729

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes — `ResolverDiagnosticsTests` (4) and `ServiceErrorMessageTests` (4) covering the new diagnostic paths.
- Did you add public API?
  - [x] No — `CodeGeneratorResolver.GetSupportedLanguages()`, the additional resolver constructors, and `IntegrationLoadContext.GetSharedAssemblyNames()` are all `internal`; the resolvers themselves are `internal sealed`.
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No