### PR TITLE
Honor explicit DCP config for polyglot apphosts

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -118,12 +118,12 @@ internal class ValidateDcpOptions : IValidateOptions<DcpOptions>
     {
         var builder = new ValidateOptionsResultBuilder();
 
-        if (string.IsNullOrEmpty(options.CliPath))
+        if (string.IsNullOrWhiteSpace(options.CliPath))
         {
             builder.AddError("The path to the DCP executable used for Aspire orchestration is required.", "CliPath");
         }
 
-        if (string.IsNullOrEmpty(options.DashboardPath))
+        if (string.IsNullOrWhiteSpace(options.DashboardPath))
         {
             builder.AddError("The path to the Aspire Dashboard binaries is missing.", "DashboardPath");
         }
@@ -152,7 +152,7 @@ internal class ConfigureDefaultDcpOptions(
         var configDcpPath = configuration[BundleDiscovery.DcpPathEnvVar];
         var configDashboardPath = configuration[BundleDiscovery.DashboardPathEnvVar];
 
-        if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.CliPath)]))
+        if (!string.IsNullOrWhiteSpace(dcpPublisherConfiguration[nameof(options.CliPath)]))
         {
             // If an explicit path to DCP was provided from configuration
             options.CliPath = dcpPublisherConfiguration[nameof(options.CliPath)];
@@ -161,7 +161,7 @@ internal class ConfigureDefaultDcpOptions(
                 options.ExtensionsPath = Path.Combine(dcpDir, "ext");
             }
         }
-        else if (!string.IsNullOrEmpty(configDcpPath))
+        else if (!string.IsNullOrWhiteSpace(configDcpPath))
         {
             // Configuration/environment variable override - set DCP paths from bundle
             options.CliPath = BundleDiscovery.GetDcpExecutablePath(configDcpPath);
@@ -174,12 +174,12 @@ internal class ConfigureDefaultDcpOptions(
             options.ExtensionsPath = GetMetadataValue(assemblyMetadata, DcpExtensionsPathMetadataKey);
         }
 
-        if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.DashboardPath)]))
+        if (!string.IsNullOrWhiteSpace(dcpPublisherConfiguration[nameof(options.DashboardPath)]))
         {
             // If an explicit path to Dashboard was provided from configuration
             options.DashboardPath = dcpPublisherConfiguration[nameof(options.DashboardPath)];
         }
-        else if (!string.IsNullOrEmpty(configDashboardPath))
+        else if (!string.IsNullOrWhiteSpace(configDashboardPath))
         {
             // Configuration/environment variable override - set Dashboard path from bundle
             options.DashboardPath = configDashboardPath;

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -147,18 +147,12 @@ internal class ConfigureDefaultDcpOptions(
         var dcpPublisherConfiguration = configuration.GetSection(DcpPublisher);
         var assemblyMetadata = appOptions.Assembly?.GetCustomAttributes<AssemblyMetadataAttribute>();
 
-        // Priority 1: Check configuration first (env vars are automatically bound via IConfiguration)
-        // BundleDiscovery env vars: ASPIRE_DCP_PATH, ASPIRE_DASHBOARD_PATH
+        // Priority 1: Check explicit DcpPublisher configuration first (env vars are automatically bound via IConfiguration)
+        // Priority 2: BundleDiscovery env vars: ASPIRE_DCP_PATH, ASPIRE_DASHBOARD_PATH
         var configDcpPath = configuration[BundleDiscovery.DcpPathEnvVar];
         var configDashboardPath = configuration[BundleDiscovery.DashboardPathEnvVar];
 
-        if (!string.IsNullOrEmpty(configDcpPath))
-        {
-            // Configuration/environment variable override - set DCP paths from bundle
-            options.CliPath = BundleDiscovery.GetDcpExecutablePath(configDcpPath);
-            options.ExtensionsPath = Path.Combine(configDcpPath, "ext");
-        }
-        else if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.CliPath)]))
+        if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.CliPath)]))
         {
             // If an explicit path to DCP was provided from configuration
             options.CliPath = dcpPublisherConfiguration[nameof(options.CliPath)];
@@ -167,6 +161,12 @@ internal class ConfigureDefaultDcpOptions(
                 options.ExtensionsPath = Path.Combine(dcpDir, "ext");
             }
         }
+        else if (!string.IsNullOrEmpty(configDcpPath))
+        {
+            // Configuration/environment variable override - set DCP paths from bundle
+            options.CliPath = BundleDiscovery.GetDcpExecutablePath(configDcpPath);
+            options.ExtensionsPath = Path.Combine(configDcpPath, "ext");
+        }
         else
         {
             // Resolve via assembly metadata attributes (NuGet packages)
@@ -174,15 +174,15 @@ internal class ConfigureDefaultDcpOptions(
             options.ExtensionsPath = GetMetadataValue(assemblyMetadata, DcpExtensionsPathMetadataKey);
         }
 
-        if (!string.IsNullOrEmpty(configDashboardPath))
-        {
-            // Configuration/environment variable override - set Dashboard path from bundle
-            options.DashboardPath = configDashboardPath;
-        }
-        else if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.DashboardPath)]))
+        if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.DashboardPath)]))
         {
             // If an explicit path to Dashboard was provided from configuration
             options.DashboardPath = dcpPublisherConfiguration[nameof(options.DashboardPath)];
+        }
+        else if (!string.IsNullOrEmpty(configDashboardPath))
+        {
+            // Configuration/environment variable override - set Dashboard path from bundle
+            options.DashboardPath = configDashboardPath;
         }
         else
         {

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpCliArgsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpCliArgsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Dcp;
+using Aspire.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -58,5 +59,43 @@ public class DcpCliArgsTests
         Assert.Equal(42, dcpOptions.DependencyCheckTimeout);
         Assert.Equal("/not/a/valid/path", dcpOptions.CliPath);
         Assert.Equal("/not/a/valid/path", dcpOptions.DashboardPath);
+    }
+
+    [Fact]
+    public void ExplicitDcpPublisherConfigurationOverridesBundlePaths()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var explicitDcpPath = Path.Combine("explicit", "dcp");
+        var explicitDashboardPath = Path.Combine("explicit", "dashboard");
+
+        builder.Configuration[BundleDiscovery.DcpPathEnvVar] = Path.Combine("bundle", "dcp");
+        builder.Configuration[BundleDiscovery.DashboardPathEnvVar] = Path.Combine("bundle", "dashboard");
+        builder.Configuration["DcpPublisher:CliPath"] = explicitDcpPath;
+        builder.Configuration["DcpPublisher:DashboardPath"] = explicitDashboardPath;
+
+        using var app = builder.Build();
+        var dcpOptions = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value;
+
+        Assert.Equal(explicitDcpPath, dcpOptions.CliPath);
+        Assert.Equal(Path.Combine("explicit", "ext"), dcpOptions.ExtensionsPath);
+        Assert.Equal(explicitDashboardPath, dcpOptions.DashboardPath);
+    }
+
+    [Fact]
+    public void BundlePathsPopulateDcpOptionsWhenExplicitDcpPublisherConfigurationIsNotSet()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var bundleDcpPath = Path.Combine("bundle", "dcp");
+        var bundleDashboardPath = Path.Combine("bundle", "dashboard");
+
+        builder.Configuration[BundleDiscovery.DcpPathEnvVar] = bundleDcpPath;
+        builder.Configuration[BundleDiscovery.DashboardPathEnvVar] = bundleDashboardPath;
+
+        using var app = builder.Build();
+        var dcpOptions = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value;
+
+        Assert.Equal(BundleDiscovery.GetDcpExecutablePath(bundleDcpPath), dcpOptions.CliPath);
+        Assert.Equal(Path.Combine(bundleDcpPath, "ext"), dcpOptions.ExtensionsPath);
+        Assert.Equal(bundleDashboardPath, dcpOptions.DashboardPath);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpCliArgsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpCliArgsTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.Dcp;
 using Aspire.Shared;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -70,8 +71,7 @@ public class DcpCliArgsTests
 
         builder.Configuration[BundleDiscovery.DcpPathEnvVar] = Path.Combine("bundle", "dcp");
         builder.Configuration[BundleDiscovery.DashboardPathEnvVar] = Path.Combine("bundle", "dashboard");
-        builder.Configuration["DcpPublisher:CliPath"] = explicitDcpPath;
-        builder.Configuration["DcpPublisher:DashboardPath"] = explicitDashboardPath;
+        AddDcpPublisherPathConfigurationOverride(builder.Configuration, explicitDcpPath, explicitDashboardPath);
 
         using var app = builder.Build();
         var dcpOptions = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value;
@@ -90,6 +90,7 @@ public class DcpCliArgsTests
 
         builder.Configuration[BundleDiscovery.DcpPathEnvVar] = bundleDcpPath;
         builder.Configuration[BundleDiscovery.DashboardPathEnvVar] = bundleDashboardPath;
+        AddDcpPublisherPathConfigurationOverride(builder.Configuration, string.Empty, string.Empty);
 
         using var app = builder.Build();
         var dcpOptions = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value;
@@ -97,5 +98,48 @@ public class DcpCliArgsTests
         Assert.Equal(BundleDiscovery.GetDcpExecutablePath(bundleDcpPath), dcpOptions.CliPath);
         Assert.Equal(Path.Combine(bundleDcpPath, "ext"), dcpOptions.ExtensionsPath);
         Assert.Equal(bundleDashboardPath, dcpOptions.DashboardPath);
+    }
+
+    [Fact]
+    public void WhitespaceDcpPublisherPathConfigurationFallsBackToBundlePaths()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var bundleDcpPath = Path.Combine("bundle", "dcp");
+        var bundleDashboardPath = Path.Combine("bundle", "dashboard");
+
+        builder.Configuration[BundleDiscovery.DcpPathEnvVar] = bundleDcpPath;
+        builder.Configuration[BundleDiscovery.DashboardPathEnvVar] = bundleDashboardPath;
+        AddDcpPublisherPathConfigurationOverride(builder.Configuration, " ", "\t");
+
+        using var app = builder.Build();
+        var dcpOptions = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value;
+
+        Assert.Equal(BundleDiscovery.GetDcpExecutablePath(bundleDcpPath), dcpOptions.CliPath);
+        Assert.Equal(Path.Combine(bundleDcpPath, "ext"), dcpOptions.ExtensionsPath);
+        Assert.Equal(bundleDashboardPath, dcpOptions.DashboardPath);
+    }
+
+    [Fact]
+    public void DcpOptionsValidationFailsForWhitespacePaths()
+    {
+        var validator = new ValidateDcpOptions();
+        var result = validator.Validate(null, new DcpOptions
+        {
+            CliPath = " ",
+            DashboardPath = "\t",
+        });
+
+        Assert.True(result.Failed);
+        Assert.Contains("The path to the DCP executable used for Aspire orchestration is required.", result.FailureMessage);
+        Assert.Contains("The path to the Aspire Dashboard binaries is missing.", result.FailureMessage);
+    }
+
+    private static void AddDcpPublisherPathConfigurationOverride(ConfigurationManager configuration, string cliPath, string dashboardPath)
+    {
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["DcpPublisher:CliPath"] = cliPath,
+            ["DcpPublisher:DashboardPath"] = dashboardPath,
+        });
     }
 }


### PR DESCRIPTION
## Description

TypeScript and other polyglot apphosts launched through the CLI get bundle discovery settings such as `ASPIRE_DCP_PATH` from the temporary AppHost server process. Those bundle defaults previously took precedence over explicit `DcpPublisher` configuration, so a command like `DcpPublisher__CliPath=/path/to/dcp aspire run` could still use the bundled DCP executable.

This changes DCP option resolution so explicit `DcpPublisher:CliPath` and `DcpPublisher:DashboardPath` settings win over bundle discovery paths, while keeping `ASPIRE_DCP_PATH` and `ASPIRE_DASHBOARD_PATH` as fallbacks when no explicit DCP publisher setting exists.

Fixes: #16443

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
