### PR TITLE
Remove Aspire docs update section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,8 +27,3 @@ Fixes # (issue)
       - [ ] Yes
       - [ ] No
   - [ ] No
-- Does the change require an update in our Aspire docs?
-  - [ ] Yes
-    - Link to `aspire.dev` issue:
-      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
-  - [ ] No


### PR DESCRIPTION
Removed the section regarding updates to Aspire docs from the pull request template. We automate draft PRs already, no need to require someone to check a box.