### PR TITLE
Use Blazor assets blazor.web.js in .NET 10 and later

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -4,6 +4,8 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
+    <meta name="aspire-version" content="@VersionHelpers.DashboardDisplayVersion" />
+    <meta name="dotnet-runtime-version" content="@System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription" />
     <base href="/" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="stylesheet" href="_content/Microsoft.FluentUI.AspNetCore.Components/css/reboot.css" />
@@ -34,7 +36,14 @@
         But in .NET 10 and later the Blazor JS file is an asset. We can rely on Blazor JS always being available. Remove and use asset file in the future once .NET 10 is the minimum version.
         This file is copied from .NET 10 P4.
     *@
-    <script src="framework/blazor.web.js"></script>
+    @if (Environment.Version.Major >= 10)
+    {
+        <script src="_framework/blazor.web.js"></script>
+    }
+    else
+    {
+        <script src="framework/blazor.web.js"></script>
+    }
     <script src="js/app.js"></script>
     <script src="js/app-reconnect.js"></script>
 

--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -32,9 +32,10 @@
     <Routes @rendermode="@(new InteractiveServerRenderMode(prerender: false))" />
     <ReconnectModal />
     @*
-        Use Blazor JS shipped in dashboard's wwwroot. This is done because the dashboard is currently built for .NET 8, and in .NET 8 the Blazor JS is embedded in the components assembly.
-        But in .NET 10 and later the Blazor JS file is an asset. We can rely on Blazor JS always being available. Remove and use asset file in the future once .NET 10 is the minimum version.
-        This file is copied from .NET 10 P4.
+        The dashboard is built for .NET 8 but can run on newer runtimes via RollForward.
+        In .NET 8/9, Blazor JS is embedded in the components assembly and served from wwwroot/framework/.
+        In .NET 10+, Blazor JS is a static asset served via MapStaticAssets from the _framework/ path.
+        The wwwroot/framework/blazor.web.js copy is kept for pre-.NET 10 runtimes.
     *@
     @if (Environment.Version.Major >= 10)
     {

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -513,7 +513,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         // MapStaticAssets is available in .NET 10+. Use reflection because the dashboard targets .NET 8.
         // MapStaticAssets correctly serves Blazor's static assets from the _framework path.
-        TryMapStaticAssets(_app);
+        TryMapStaticAssets(_app, _logger);
 
         _app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
 
@@ -978,7 +978,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     /// This is used to correctly serve Blazor's static assets from the _framework path.
     /// It's required because blazor.web.js are loaded from assets in .NET 10 and later.
     /// </summary>
-    private static bool TryMapStaticAssets(WebApplication app)
+    private static bool TryMapStaticAssets(WebApplication app, ILogger logger)
     {
         if (Environment.Version.Major < 10)
         {
@@ -989,12 +989,14 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         var type = Type.GetType("Microsoft.AspNetCore.Builder.StaticAssetsEndpointRouteBuilderExtensions, Microsoft.AspNetCore.StaticAssets");
         if (type is null)
         {
+            logger.LogWarning("Could not find StaticAssetsEndpointRouteBuilderExtensions type. MapStaticAssets will not be called and the dashboard may fail to load.");
             return false;
         }
 
-        var method = type.GetMethod("MapStaticAssets", BindingFlags.Public | BindingFlags.Static);
+        var method = type.GetMethod("MapStaticAssets", BindingFlags.Public | BindingFlags.Static, [typeof(IEndpointRouteBuilder), typeof(string)]);
         if (method is null)
         {
+            logger.LogWarning("Could not find MapStaticAssets method on {Type}. MapStaticAssets will not be called and the dashboard may fail to load.", type.FullName);
             return false;
         }
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -262,9 +262,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
                 // Only loopback proxies are allowed by default. Clear that restriction because forwarders are
                 // being enabled by explicit configuration.
-#pragma warning disable ASPDEPR005 // Type or member is obsolete
                 options.KnownNetworks.Clear();
-#pragma warning restore ASPDEPR005 // Type or member is obsolete
                 options.KnownProxies.Clear();
             });
         }

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -976,7 +976,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     /// Calls MapStaticAssets via reflection. Available in .NET 10 and later.
     /// The dashboard targets .NET 8 so this API isn't directly available.
     /// This is used to correctly serve Blazor's static assets from the _framework path.
-    /// It's required because blazor.web.js are loaded from assets in .NET 10 and later.
+    /// It's required because blazor.web.js is loaded from assets in .NET 10 and later.
     /// </summary>
     private static bool TryMapStaticAssets(WebApplication app, ILogger logger)
     {
@@ -1001,7 +1001,15 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
 
         // MapStaticAssets(IEndpointRouteBuilder endpoints, string? staticAssetsManifestPath = null)
-        method.Invoke(null, [app, null]);
-        return true;
+        try
+        {
+            method.Invoke(null, [app, null]);
+            return true;
+        }
+        catch (TargetInvocationException ex)
+        {
+            logger.LogWarning(ex, "MapStaticAssets invocation failed. The dashboard may fail to load.");
+            return false;
+        }
     }
 }

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -262,7 +262,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
                 // Only loopback proxies are allowed by default. Clear that restriction because forwarders are
                 // being enabled by explicit configuration.
+#pragma warning disable ASPDEPR005 // Type or member is obsolete
                 options.KnownNetworks.Clear();
+#pragma warning restore ASPDEPR005 // Type or member is obsolete
                 options.KnownProxies.Clear();
             });
         }
@@ -510,6 +512,10 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         _app.UseMiddleware<BrowserSecurityHeadersMiddleware>();
         _app.UseAntiforgery();
+
+        // MapStaticAssets is available in .NET 10+. Use reflection because the dashboard targets .NET 8.
+        // MapStaticAssets correctly serves Blazor's static assets from the _framework path.
+        TryMapStaticAssets(_app);
 
         _app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
 
@@ -967,4 +973,35 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     }
 
     private static bool IsHttpsOrNull(BindingAddress? address) => address == null || string.Equals(address.Scheme, "https", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Calls MapStaticAssets via reflection. Available in .NET 10 and later.
+    /// The dashboard targets .NET 8 so this API isn't directly available.
+    /// This is used to correctly serve Blazor's static assets from the _framework path.
+    /// It's required because blazor.web.js are loaded from assets in .NET 10 and later.
+    /// </summary>
+    private static bool TryMapStaticAssets(WebApplication app)
+    {
+        if (Environment.Version.Major < 10)
+        {
+            return false;
+        }
+
+        // MapStaticAssets is an extension method on StaticAssetsEndpointRouteBuilderExtensions.
+        var type = Type.GetType("Microsoft.AspNetCore.Builder.StaticAssetsEndpointRouteBuilderExtensions, Microsoft.AspNetCore.StaticAssets");
+        if (type is null)
+        {
+            return false;
+        }
+
+        var method = type.GetMethod("MapStaticAssets", BindingFlags.Public | BindingFlags.Static);
+        if (method is null)
+        {
+            return false;
+        }
+
+        // MapStaticAssets(IEndpointRouteBuilder endpoints, string? staticAssetsManifestPath = null)
+        method.Invoke(null, [app, null]);
+        return true;
+    }
 }


### PR DESCRIPTION
## Description

Background: In .NET 9 or 10, the Blazor team removed the blazor.web.js file as an embedded resource and made it a static asset. Unfortunatly Aspire dashboard targets .NET 8 so doesn't have access to `MapStaticAssets` method. The fix last year was to include blazor.web.js file in the dashboard's wwwroot directory and serve it ourselves.

In .NET 11 there have been changes to blazor.web.js file. We have two choices:
1. Have a .NET 10 and .NET 11 versions of the file that the dashboard serves. There will be ongoing problems with the file as it changes.
2. Try to use `MapStaticAssets` so we use the version included in Blazor

This PR is the second approach. It uses reflection to call `MapStaticAssets` in .NET 10 or later.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
