### PR TITLE
[release/13.3] Fix notification action closure over scoped services

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/NotificationEntryComponent.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/NotificationEntryComponent.razor.cs
@@ -16,6 +16,9 @@ public partial class NotificationEntryComponent : ComponentBase
     [Parameter]
     public EventCallback OnDismiss { get; set; }
 
+    [Inject]
+    public required IServiceProvider Services { get; init; }
+
     private string IntentClass => Entry.Intent switch
     {
         MessageIntent.Success => "intent-success",
@@ -49,7 +52,7 @@ public partial class NotificationEntryComponent : ComponentBase
     {
         if (Entry.PrimaryAction is { } primaryAction)
         {
-            await primaryAction.OnClick();
+            await primaryAction.OnClick(Services);
         }
     }
 }

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -165,7 +165,7 @@ public sealed class DashboardCommandExecutor(
             if (response.Result is not null)
             {
                 toastParameters.PrimaryAction = loc[nameof(Dashboard.Resources.Resources.ResourceCommandViewResponse)];
-                toastParameters.OnPrimaryAction = EventCallback.Factory.Create<ToastResult>(this, () => OpenViewResponseDialogAsync(command, response));
+                toastParameters.OnPrimaryAction = EventCallback.Factory.Create<ToastResult>(this, () => OpenViewResponseDialogAsync(dialogService, command, response));
             }
 
             notificationService.ReplaceNotification(progressNotificationId, new NotificationEntry
@@ -173,12 +173,12 @@ public sealed class DashboardCommandExecutor(
                 Title = successTitle,
                 Body = response.Message,
                 Intent = MessageIntent.Success,
-                PrimaryAction = response.Result is not null ? CreateViewResponseNotificationAction(command, response) : null
+                PrimaryAction = response.Result is not null ? CreateViewResponseNotificationAction(loc, command, response) : null
             });
 
             if (response.Result?.DisplayImmediately == true)
             {
-                await OpenViewResponseDialogAsync(command, response).ConfigureAwait(false);
+                await OpenViewResponseDialogAsync(dialogService, command, response).ConfigureAwait(false);
             }
         }
         else if (response.Kind == ResourceCommandResponseKind.Cancelled)
@@ -206,7 +206,7 @@ public sealed class DashboardCommandExecutor(
             if (response.Result is not null)
             {
                 toastParameters.SecondaryAction = loc[nameof(Dashboard.Resources.Resources.ResourceCommandViewResponse)];
-                toastParameters.OnSecondaryAction = EventCallback.Factory.Create<ToastResult>(this, () => OpenViewResponseDialogAsync(command, response));
+                toastParameters.OnSecondaryAction = EventCallback.Factory.Create<ToastResult>(this, () => OpenViewResponseDialogAsync(dialogService, command, response));
             }
 
             notificationService.ReplaceNotification(progressNotificationId, new NotificationEntry
@@ -214,12 +214,12 @@ public sealed class DashboardCommandExecutor(
                 Title = failedTitle,
                 Body = response.Message,
                 Intent = MessageIntent.Error,
-                PrimaryAction = response.Result is not null ? CreateViewResponseNotificationAction(command, response) : null
+                PrimaryAction = response.Result is not null ? CreateViewResponseNotificationAction(loc, command, response) : null
             });
 
             if (response.Result?.DisplayImmediately == true)
             {
-                await OpenViewResponseDialogAsync(command, response).ConfigureAwait(false);
+                await OpenViewResponseDialogAsync(dialogService, command, response).ConfigureAwait(false);
             }
         }
 
@@ -261,16 +261,22 @@ public sealed class DashboardCommandExecutor(
         };
     }
 
-    private NotificationAction CreateViewResponseNotificationAction(CommandViewModel command, ResourceCommandResponseViewModel response)
+    private static NotificationAction CreateViewResponseNotificationAction(IStringLocalizer<Dashboard.Resources.Resources> loc, CommandViewModel command, ResourceCommandResponseViewModel response)
     {
         return new NotificationAction
         {
             Text = loc[nameof(Dashboard.Resources.Resources.ResourceCommandViewResponse)],
-            OnClick = () => OpenViewResponseDialogAsync(command, response)
+            OnClick = (services) =>
+            {
+                // Get dialog service from passed in services since this data is long lived.
+                // Using the dialog service from executor could cause closure over scoped services.
+                var dialogService = services.GetRequiredService<DashboardDialogService>();
+                return OpenViewResponseDialogAsync(dialogService, command, response);
+            }
         };
     }
 
-    private async Task OpenViewResponseDialogAsync(CommandViewModel command, ResourceCommandResponseViewModel response)
+    private static async Task OpenViewResponseDialogAsync(DashboardDialogService dialogService, CommandViewModel command, ResourceCommandResponseViewModel response)
     {
         var fixedFormat = response.Result!.Format switch
         {

--- a/src/Aspire.Dashboard/Model/INotificationService.cs
+++ b/src/Aspire.Dashboard/Model/INotificationService.cs
@@ -72,7 +72,7 @@ public sealed class NotificationEntry
 public sealed class NotificationAction
 {
     public required string Text { get; init; }
-    public required Func<Task> OnClick { get; init; }
+    public required Func<IServiceProvider, Task> OnClick { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
Fixes https://github.com/microsoft/aspire/issues/16594

## Summary

Fix `NotificationAction.OnClick` capturing scoped services via closure in `DashboardCommandExecutor`. Notifications are long-lived and can outlive the scope that created them, leading to disposed service errors when the action is invoked later.

## Changes

- Changed `NotificationAction.OnClick` signature from `Func<Task>` to `Func<IServiceProvider, Task>` so the caller provides a current `IServiceProvider`.
- `NotificationEntryComponent` injects `IServiceProvider` and passes it when invoking the action.
- `DashboardCommandExecutor.CreateViewResponseNotificationAction` is now static and resolves `DashboardDialogService` from the passed-in service provider at invocation time.
- `OpenViewResponseDialogAsync` is now static and receives `DashboardDialogService` as a parameter.