### PR TITLE
Improve output path handling in 'new' command

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -446,7 +446,7 @@ internal interface INewCommandPrompter
 {
     Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken);
     Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken);
-    Task<string> PromptForOutputPath(string v, ParseResult parseResult, CancellationToken cancellationToken);
+    Task<string> PromptForOutputPath(string v, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default);
 }
 
 internal interface ITemplateVersionPrompter
@@ -559,10 +559,11 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
         return await topSelection.Action(cancellationToken);
     }
 
-    public virtual async Task<string> PromptForOutputPath(string path, ParseResult parseResult, CancellationToken cancellationToken)
+    public virtual async Task<string> PromptForOutputPath(string path, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
     {
         return await interactionService.PromptForFilePathAsync(
             NewCommandStrings.EnterTheOutputPath,
+            validator: validator,
             binding: PromptBinding.Create(parseResult, NewCommand.s_outputOption, path),
             directory: true,
             cancellationToken: cancellationToken

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -150,5 +150,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("NonInteractiveTemplateRequired", resourceCulture);
             }
         }
+
+        public static string OutputDirectoryNotEmpty {
+            get {
+                return ResourceManager.GetString("OutputDirectoryNotEmpty", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -156,5 +156,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("OutputDirectoryNotEmpty", resourceCulture);
             }
         }
+
+        public static string OutputPathContainsInvalidCharacters {
+            get {
+                return ResourceManager.GetString("OutputPathContainsInvalidCharacters", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -154,4 +154,7 @@
   <data name="NonInteractiveTemplateRequired" xml:space="preserve">
     <value>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</value>
   </data>
+  <data name="OutputDirectoryNotEmpty" xml:space="preserve">
+    <value>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -157,4 +157,7 @@
   <data name="OutputDirectoryNotEmpty" xml:space="preserve">
     <value>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</value>
   </data>
+  <data name="OutputPathContainsInvalidCharacters" xml:space="preserve">
+    <value>The output path '{0}' contains invalid characters.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Překládá se verze šablony...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">Výstupní cesta pro projekt</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Překládá se verze šablony...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Vorlagenversion wird ermittelt...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">Der Ausgabepfad für das Projekt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Vorlagenversion wird ermittelt...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Resolviendo versión de plantilla...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">La ruta de salida del proyecto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Resolviendo versión de plantilla...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Résolution en cours de la version du modèle…</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">Le chemin de sortie du projet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Résolution en cours de la version du modèle…</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Risoluzione della versione del modello in corso...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">Percorso di output per il progetto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Risoluzione della versione del modello in corso...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">テンプレートのバージョンを解決しています...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">プロジェクトの出力パス。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">テンプレートのバージョンを解決しています...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">프로젝트의 출력 경로입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">템플릿 버전을 확인하는 중...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">템플릿 버전을 확인하는 중...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">Ścieżka wyjściowa projektu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Trwa rozpoznawanie wersji szablonu...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Trwa rozpoznawanie wersji szablonu...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Resolvendo a versão do modelo...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">O caminho de saída para o projeto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Resolvendo a versão do modelo...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">Выходной путь для проекта.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Разрешение версии шаблона...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Разрешение версии шаблона...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Şablon sürümü çözümleniyor...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">Projenin çıkış yolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">Şablon sürümü çözümleniyor...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">项目的输出路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">正在解析模板版本...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">正在解析模板版本...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="needs-review-translation">專案的輸出路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmpty">
+        <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">正在解析範本版本...</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OutputPathContainsInvalidCharacters">
+        <source>The output path '{0}' contains invalid characters.</source>
+        <target state="new">The output path '{0}' contains invalid characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingTemplateVersion">
         <source>Resolving template version...</source>
         <target state="translated">正在解析範本版本...</target>

--- a/src/Aspire.Cli/Templating/CallbackTemplate.cs
+++ b/src/Aspire.Cli/Templating/CallbackTemplate.cs
@@ -8,7 +8,7 @@ namespace Aspire.Cli.Templating;
 internal class CallbackTemplate(
     string name,
     string description,
-    Func<string, string> pathDeriverCallback,
+    Func<CliExecutionContext, string, string> pathDeriverCallback,
     Action<Command> applyOptionsCallback,
     Func<CallbackTemplate, TemplateInputs, ParseResult, CancellationToken, Task<TemplateResult>> applyTemplateCallback,
     TemplateRuntime runtime = TemplateRuntime.DotNet,
@@ -28,7 +28,7 @@ internal class CallbackTemplate(
 
     public TemplateRuntime Runtime => runtime;
 
-    public Func<string, string> PathDeriver => pathDeriverCallback;
+    public Func<CliExecutionContext, string, string> PathDeriver => pathDeriverCallback;
 
     public string? LanguageId => languageId;
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -31,17 +31,15 @@ internal sealed partial class CliTemplateFactory
         var projectName = inputs.Name;
         if (string.IsNullOrWhiteSpace(projectName))
         {
-            var defaultName = _executionContext.WorkingDirectory.Name;
+            var defaultName = _.Name;
             projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
-        var outputPath = inputs.Output;
-        if (string.IsNullOrWhiteSpace(outputPath))
+        var outputPath = await ResolveOutputPathAsync(inputs, _.PathDeriver, projectName, parseResult, cancellationToken);
+        if (outputPath is null)
         {
-            var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
+            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
         }
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
         _logger.LogDebug("Applying empty AppHost template. LanguageId: {LanguageId}, Language: {LanguageDisplayName}, ProjectName: {ProjectName}, OutputPath: {OutputPath}.", languageId, language.DisplayName, projectName, outputPath);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -12,7 +12,7 @@ namespace Aspire.Cli.Templating;
 
 internal sealed partial class CliTemplateFactory
 {
-    private async Task<TemplateResult> ApplyEmptyAppHostTemplateAsync(CallbackTemplate _, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
+    private async Task<TemplateResult> ApplyEmptyAppHostTemplateAsync(CallbackTemplate template, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
         var languageId = inputs.Language;
         if (string.IsNullOrWhiteSpace(languageId))
@@ -31,11 +31,11 @@ internal sealed partial class CliTemplateFactory
         var projectName = inputs.Name;
         if (string.IsNullOrWhiteSpace(projectName))
         {
-            var defaultName = _.Name;
+            var defaultName = template.Name;
             projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
-        var outputPath = await ResolveOutputPathAsync(inputs, _.PathDeriver, projectName, parseResult, cancellationToken);
+        var outputPath = await ResolveOutputPathAsync(inputs, template.PathDeriver, projectName, parseResult, cancellationToken);
         if (outputPath is null)
         {
             return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.GoStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.GoStarterTemplate.cs
@@ -11,12 +11,12 @@ namespace Aspire.Cli.Templating;
 
 internal sealed partial class CliTemplateFactory
 {
-    private async Task<TemplateResult> ApplyGoStarterTemplateAsync(CallbackTemplate _, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
+    private async Task<TemplateResult> ApplyGoStarterTemplateAsync(CallbackTemplate template, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
         var projectName = inputs.Name;
         if (string.IsNullOrWhiteSpace(projectName))
         {
-            var defaultName = _.Name;
+            var defaultName = template.Name;
             projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
@@ -27,7 +27,7 @@ internal sealed partial class CliTemplateFactory
         }
 
         var aspireVersion = inputs.Version;
-        var outputPath = await ResolveOutputPathAsync(inputs, _.PathDeriver, projectName, parseResult, cancellationToken);
+        var outputPath = await ResolveOutputPathAsync(inputs, template.PathDeriver, projectName, parseResult, cancellationToken);
         if (outputPath is null)
         {
             return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.GoStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.GoStarterTemplate.cs
@@ -16,7 +16,7 @@ internal sealed partial class CliTemplateFactory
         var projectName = inputs.Name;
         if (string.IsNullOrWhiteSpace(projectName))
         {
-            var defaultName = _executionContext.WorkingDirectory.Name;
+            var defaultName = _.Name;
             projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
@@ -27,13 +27,11 @@ internal sealed partial class CliTemplateFactory
         }
 
         var aspireVersion = inputs.Version;
-        var outputPath = inputs.Output;
-        if (string.IsNullOrWhiteSpace(outputPath))
+        var outputPath = await ResolveOutputPathAsync(inputs, _.PathDeriver, projectName, parseResult, cancellationToken);
+        if (outputPath is null)
         {
-            var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
+            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
         }
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
         _logger.LogDebug("Applying Go starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -12,12 +12,12 @@ namespace Aspire.Cli.Templating;
 
 internal sealed partial class CliTemplateFactory
 {
-    private async Task<TemplateResult> ApplyPythonStarterTemplateAsync(CallbackTemplate _, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
+    private async Task<TemplateResult> ApplyPythonStarterTemplateAsync(CallbackTemplate template, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
         var projectName = inputs.Name;
         if (string.IsNullOrWhiteSpace(projectName))
         {
-            var defaultName = _.Name;
+            var defaultName = template.Name;
             projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
@@ -28,7 +28,7 @@ internal sealed partial class CliTemplateFactory
         }
 
         var aspireVersion = inputs.Version;
-        var outputPath = await ResolveOutputPathAsync(inputs, _.PathDeriver, projectName, parseResult, cancellationToken);
+        var outputPath = await ResolveOutputPathAsync(inputs, template.PathDeriver, projectName, parseResult, cancellationToken);
         if (outputPath is null)
         {
             return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -17,7 +17,7 @@ internal sealed partial class CliTemplateFactory
         var projectName = inputs.Name;
         if (string.IsNullOrWhiteSpace(projectName))
         {
-            var defaultName = _executionContext.WorkingDirectory.Name;
+            var defaultName = _.Name;
             projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
@@ -28,13 +28,11 @@ internal sealed partial class CliTemplateFactory
         }
 
         var aspireVersion = inputs.Version;
-        var outputPath = inputs.Output;
-        if (string.IsNullOrWhiteSpace(outputPath))
+        var outputPath = await ResolveOutputPathAsync(inputs, _.PathDeriver, projectName, parseResult, cancellationToken);
+        if (outputPath is null)
         {
-            var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
+            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
         }
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
         _logger.LogDebug("Applying Python starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -17,7 +17,7 @@ internal sealed partial class CliTemplateFactory
         var projectName = inputs.Name;
         if (string.IsNullOrWhiteSpace(projectName))
         {
-            var defaultName = _executionContext.WorkingDirectory.Name;
+            var defaultName = _.Name;
             projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
@@ -28,13 +28,11 @@ internal sealed partial class CliTemplateFactory
         }
 
         var aspireVersion = inputs.Version;
-        var outputPath = inputs.Output;
-        if (string.IsNullOrWhiteSpace(outputPath))
+        var outputPath = await ResolveOutputPathAsync(inputs, _.PathDeriver, projectName, parseResult, cancellationToken);
+        if (outputPath is null)
         {
-            var defaultOutputPath = $"./{projectName}";
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, cancellationToken);
+            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
         }
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
         _logger.LogDebug("Applying TypeScript starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -12,12 +12,12 @@ namespace Aspire.Cli.Templating;
 
 internal sealed partial class CliTemplateFactory
 {
-    private async Task<TemplateResult> ApplyTypeScriptStarterTemplateAsync(CallbackTemplate _, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
+    private async Task<TemplateResult> ApplyTypeScriptStarterTemplateAsync(CallbackTemplate template, TemplateInputs inputs, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
         var projectName = inputs.Name;
         if (string.IsNullOrWhiteSpace(projectName))
         {
-            var defaultName = _.Name;
+            var defaultName = template.Name;
             projectName = await _prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
@@ -28,7 +28,7 @@ internal sealed partial class CliTemplateFactory
         }
 
         var aspireVersion = inputs.Version;
-        var outputPath = await ResolveOutputPathAsync(inputs, _.PathDeriver, projectName, parseResult, cancellationToken);
+        var outputPath = await ResolveOutputPathAsync(inputs, template.PathDeriver, projectName, parseResult, cancellationToken);
         if (outputPath is null)
         {
             return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -231,25 +231,25 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
     {
         var outputPath = inputs.Output;
         var outputPathValidator = OutputPathHelper.CreateOutputPathValidator(_executionContext.WorkingDirectory.FullName);
-        var wasExplicitlyProvided = outputPath is not null;
+        var wasExplicitlyProvided = !string.IsNullOrWhiteSpace(outputPath);
         if (string.IsNullOrWhiteSpace(outputPath))
         {
             var defaultOutputPath = pathDeriver(_executionContext, projectName);
             outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, outputPathValidator, cancellationToken);
         }
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
-        // Validate the resolved output path when --output was explicitly provided.
-        // When the user interactively accepted the default, the prompt validator already ran.
+        // Validate before calling Path.GetFullPath to avoid exceptions from invalid characters.
         if (wasExplicitlyProvided)
         {
-            var validationError = OutputPathHelper.ValidateOutputPath(outputPath);
-            if (validationError is not null)
+            var earlyError = OutputPathHelper.ValidateOutputPath(outputPath, _executionContext.WorkingDirectory.FullName);
+            if (earlyError is not null)
             {
-                _interactionService.DisplayError(validationError);
+                _interactionService.DisplayError(earlyError);
                 return null;
             }
         }
+
+        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
         return outputPath;
     }

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -107,7 +107,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.TypeScriptStarter,
                 "Starter App (Express/React, TypeScript AppHost)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyTypeScriptStarterTemplateAsync,
                 runtime: TemplateRuntime.Cli,
@@ -116,7 +116,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.CSharpEmptyAppHost,
                 "Empty AppHost (Choose language...)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
@@ -127,7 +127,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.TypeScriptEmptyAppHost,
                 "Empty (TypeScript AppHost)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
@@ -138,7 +138,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.PythonEmptyAppHost,
                 "Empty (Python AppHost)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
@@ -149,7 +149,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.JavaEmptyAppHost,
                 "Empty (Java AppHost)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
@@ -160,7 +160,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.GoEmptyAppHost,
                 "Empty (Go AppHost)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
@@ -171,7 +171,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.RustEmptyAppHost,
                 "Empty (Rust AppHost)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
@@ -182,7 +182,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.PythonStarter,
                 "Starter App (FastAPI/React, TypeScript AppHost)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd =>
                 {
                     AddOptionIfMissing(cmd, _localhostTldOption);
@@ -195,7 +195,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             new CallbackTemplate(
                 KnownTemplateId.GoStarter,
                 "Starter App (Go API + Redis, Go AppHost)",
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyGoStarterTemplateAsync,
                 runtime: TemplateRuntime.Cli,
@@ -225,6 +225,33 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
         }
 
         return _languageDiscovery.GetLanguageById(new LanguageId(template.LanguageId)) is not null;
+    }
+
+    private async Task<string?> ResolveOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var outputPath = inputs.Output;
+        var outputPathValidator = OutputPathHelper.CreateOutputPathValidator(_executionContext.WorkingDirectory.FullName);
+        var wasExplicitlyProvided = outputPath is not null;
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            var defaultOutputPath = pathDeriver(_executionContext, projectName);
+            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, outputPathValidator, cancellationToken);
+        }
+        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
+
+        // Validate the resolved output path when --output was explicitly provided.
+        // When the user interactively accepted the default, the prompt validator already ran.
+        if (wasExplicitlyProvided)
+        {
+            var validationError = OutputPathHelper.ValidateOutputPath(outputPath);
+            if (validationError is not null)
+            {
+                _interactionService.DisplayError(validationError);
+                return null;
+            }
+        }
+
+        return outputPath;
     }
 
     private static string ApplyTokens(string content, string projectName, string projectNameLower, string aspireVersion, AppHostProfilePorts ports, string hostName = "localhost")

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -229,29 +229,16 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
 
     private async Task<string?> ResolveOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var outputPath = inputs.Output;
-        var outputPathValidator = OutputPathHelper.CreateOutputPathValidator(_executionContext.WorkingDirectory.FullName);
-        var wasExplicitlyProvided = !string.IsNullOrWhiteSpace(outputPath);
-        if (string.IsNullOrWhiteSpace(outputPath))
-        {
-            var defaultOutputPath = pathDeriver(_executionContext, projectName);
-            outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, outputPathValidator, cancellationToken);
-        }
-
-        // Validate before calling Path.GetFullPath to avoid exceptions from invalid characters.
-        if (wasExplicitlyProvided)
-        {
-            var earlyError = OutputPathHelper.ValidateOutputPath(outputPath, _executionContext.WorkingDirectory.FullName);
-            if (earlyError is not null)
+        return await OutputPathHelper.ResolveOutputPathAsync(
+            inputs.Output,
+            _executionContext.WorkingDirectory.FullName,
+            async () =>
             {
-                _interactionService.DisplayError(earlyError);
-                return null;
-            }
-        }
-
-        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
-
-        return outputPath;
+                var defaultOutputPath = pathDeriver(_executionContext, projectName);
+                var outputPathValidator = OutputPathHelper.CreateOutputPathValidator(_executionContext.WorkingDirectory.FullName);
+                return await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, outputPathValidator, cancellationToken);
+            },
+            _interactionService);
     }
 
     private static string ApplyTokens(string content, string projectName, string projectNameLower, string aspireVersion, AppHostProfilePorts ports, string hostName = "localhost")

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -130,7 +130,7 @@ internal class DotNetTemplateFactory(
         yield return new CallbackTemplate(
             "aspire-starter",
             TemplatingStrings.AspireStarter_Description,
-            projectName => $"./{projectName}",
+            (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             ApplyExtraAspireStarterOptions,
             (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireStarterOptionsAsync, ct),
             languageId: KnownLanguageId.CSharp
@@ -139,7 +139,7 @@ internal class DotNetTemplateFactory(
         yield return new CallbackTemplate(
             "aspire-ts-cs-starter",
             TemplatingStrings.AspireJsFrontendStarter_Description,
-            projectName => $"./{projectName}",
+            (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             ApplyExtraAspireJsFrontendStarterOptions,
             (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireJsFrontendStarterOptionsAsync, ct),
             languageId: KnownLanguageId.CSharp
@@ -150,7 +150,7 @@ internal class DotNetTemplateFactory(
             yield return new CallbackTemplate(
                 KnownTemplateId.DotNetEmptyAppHost,
                 TemplatingStrings.AspireEmptyDotNetTemplate_Description,
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 ApplyDevLocalhostTldOption,
                 ApplyTemplateWithNoExtraArgsAsync,
                 languageId: KnownLanguageId.CSharp,
@@ -160,7 +160,7 @@ internal class DotNetTemplateFactory(
             yield return new CallbackTemplate(
                 "aspire-apphost",
                 TemplatingStrings.AspireAppHost_Description,
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 ApplyDevLocalhostTldOption,
                 ApplyTemplateWithNoExtraArgsAsync,
                 languageId: KnownLanguageId.CSharp
@@ -169,7 +169,7 @@ internal class DotNetTemplateFactory(
             yield return new CallbackTemplate(
                 "aspire-servicedefaults",
                 TemplatingStrings.AspireServiceDefaults_Description,
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 _ => { },
                 ApplyTemplateWithNoExtraArgsAsync,
                 languageId: KnownLanguageId.CSharp
@@ -180,7 +180,7 @@ internal class DotNetTemplateFactory(
         var msTestTemplate = new CallbackTemplate(
             "aspire-mstest",
             TemplatingStrings.AspireMSTest_Description,
-            projectName => $"./{projectName}",
+            (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             _ => { },
             ApplyTemplateWithNoExtraArgsAsync,
             languageId: KnownLanguageId.CSharp
@@ -190,7 +190,7 @@ internal class DotNetTemplateFactory(
         var nunitTemplate = new CallbackTemplate(
             "aspire-nunit",
             TemplatingStrings.AspireNUnit_Description,
-            projectName => $"./{projectName}",
+            (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             _ => { },
             ApplyTemplateWithNoExtraArgsAsync,
             languageId: KnownLanguageId.CSharp
@@ -200,7 +200,7 @@ internal class DotNetTemplateFactory(
         var xunitTemplate = new CallbackTemplate(
             "aspire-xunit",
             TemplatingStrings.AspireXUnit_Description,
-            projectName => $"./{projectName}",
+            (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             _ => { },
             (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireXUnitOptionsAsync, ct),
             languageId: KnownLanguageId.CSharp
@@ -213,7 +213,7 @@ internal class DotNetTemplateFactory(
             yield return new CallbackTemplate(
                 "aspire-test",
                 TemplatingStrings.IntegrationTestsTemplate_Description,
-                projectName => $"./{projectName}",
+                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
                 _ => { },
                 async (template, inputs, parseResult, ct) =>
                 {
@@ -234,7 +234,7 @@ internal class DotNetTemplateFactory(
         return new CallbackTemplate(
             "aspire-apphost-singlefile",
             TemplatingStrings.AspireAppHostSingleFile_Description,
-            projectName => $"./{projectName}",
+            (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             ApplyDevLocalhostTldOption,
             (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspireSingleFileOptionsAsync, ct),
             languageId: KnownLanguageId.CSharp,
@@ -440,8 +440,13 @@ internal class DotNetTemplateFactory(
             return new TemplateResult(ExitCodeConstants.SdkNotInstalled);
         }
 
-        var name = await GetProjectNameAsync(inputs, parseResult, cancellationToken);
+        var name = await GetProjectNameAsync(inputs, template.Name, parseResult, cancellationToken);
         var outputPath = await GetOutputPathAsync(inputs, template.PathDeriver, name, parseResult, cancellationToken);
+
+        if (outputPath is null)
+        {
+            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+        }
 
         return await ApplyTemplateAsync(template, inputs, name, outputPath, parseResult, extraArgsCallback, cancellationToken);
     }
@@ -551,26 +556,29 @@ internal class DotNetTemplateFactory(
         }
     }
 
-    private async Task<string> GetProjectNameAsync(TemplateInputs inputs, ParseResult parseResult, CancellationToken cancellationToken)
+    private async Task<string> GetProjectNameAsync(TemplateInputs inputs, string templateName, ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (inputs.Name is not { } name || !ProjectNameValidator.IsProjectNameValid(name))
         {
-            var defaultName = executionContext.WorkingDirectory.Name;
+            var defaultName = templateName;
             name = await prompter.PromptForProjectNameAsync(defaultName, parseResult, cancellationToken);
         }
 
         return name;
     }
 
-    private async Task<string> GetOutputPathAsync(TemplateInputs inputs, Func<string, string> pathDeriver, string projectName, ParseResult parseResult, CancellationToken cancellationToken)
+    private async Task<string?> GetOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, ParseResult parseResult, CancellationToken cancellationToken)
     {
+        var validator = OutputPathHelper.CreateOutputPathValidator(executionContext.WorkingDirectory.FullName);
+        var wasExplicitlyProvided = inputs.Output is not null;
+
         if (inputs.Output is not { } outputPath)
         {
-            var defaultPath = pathDeriver(projectName);
-            outputPath = await prompter.PromptForOutputPath(defaultPath, parseResult, cancellationToken);
+            var defaultPath = pathDeriver(executionContext, projectName);
+            outputPath = await prompter.PromptForOutputPath(defaultPath, parseResult, validator, cancellationToken);
         }
 
-        outputPath = Path.GetFullPath(outputPath);
+        outputPath = Path.GetFullPath(outputPath, executionContext.WorkingDirectory.FullName);
 
         // When running in extension mode (VS Code), the folder picker returns the parent
         // directory the user selected. Append the project name as a subdirectory so the
@@ -588,6 +596,18 @@ internal class DotNetTemplateFactory(
             else
             {
                 outputPath = normalizedOutputPath;
+            }
+        }
+
+        // Validate the resolved output path when --output was explicitly provided.
+        // When the user interactively accepted the default, the prompt validator already ran.
+        if (wasExplicitlyProvided)
+        {
+            var validationError = OutputPathHelper.ValidateOutputPath(outputPath);
+            if (validationError is not null)
+            {
+                interactionService.DisplayError(validationError);
+                return null;
             }
         }
 

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -569,27 +569,21 @@ internal class DotNetTemplateFactory(
 
     private async Task<string?> GetOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var validator = OutputPathHelper.CreateOutputPathValidator(executionContext.WorkingDirectory.FullName);
-        var wasExplicitlyProvided = !string.IsNullOrWhiteSpace(inputs.Output);
-
-        if (inputs.Output is not { } outputPath)
-        {
-            var defaultPath = pathDeriver(executionContext, projectName);
-            outputPath = await prompter.PromptForOutputPath(defaultPath, parseResult, validator, cancellationToken);
-        }
-
-        // Validate before calling Path.GetFullPath to avoid exceptions from invalid characters.
-        if (wasExplicitlyProvided)
-        {
-            var earlyError = OutputPathHelper.ValidateOutputPath(outputPath, executionContext.WorkingDirectory.FullName);
-            if (earlyError is not null)
+        var outputPath = await OutputPathHelper.ResolveOutputPathAsync(
+            inputs.Output,
+            executionContext.WorkingDirectory.FullName,
+            async () =>
             {
-                interactionService.DisplayError(earlyError);
-                return null;
-            }
-        }
+                var defaultPath = pathDeriver(executionContext, projectName);
+                var validator = OutputPathHelper.CreateOutputPathValidator(executionContext.WorkingDirectory.FullName);
+                return await prompter.PromptForOutputPath(defaultPath, parseResult, validator, cancellationToken);
+            },
+            interactionService);
 
-        outputPath = Path.GetFullPath(outputPath, executionContext.WorkingDirectory.FullName);
+        if (outputPath is null)
+        {
+            return null;
+        }
 
         // When running in extension mode (VS Code), the folder picker returns the parent
         // directory the user selected. Append the project name as a subdirectory so the
@@ -608,14 +602,9 @@ internal class DotNetTemplateFactory(
             {
                 outputPath = normalizedOutputPath;
             }
-        }
 
-        // Validate the resolved output path when --output was explicitly provided.
-        // When the user interactively accepted the default, the prompt validator already ran.
-        // Note: invalid chars and non-empty directory are already checked before Path.GetFullPath above.
-        // After the VS Code extension path adjustment, re-check the final path for non-empty directory.
-        if (wasExplicitlyProvided)
-        {
+            // Re-validate the adjusted path for non-empty directory since appending the
+            // project name may target a different directory than the one already validated.
             var validationError = OutputPathHelper.ValidateResolvedOutputPath(outputPath);
             if (validationError is not null)
             {

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -570,12 +570,23 @@ internal class DotNetTemplateFactory(
     private async Task<string?> GetOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, ParseResult parseResult, CancellationToken cancellationToken)
     {
         var validator = OutputPathHelper.CreateOutputPathValidator(executionContext.WorkingDirectory.FullName);
-        var wasExplicitlyProvided = inputs.Output is not null;
+        var wasExplicitlyProvided = !string.IsNullOrWhiteSpace(inputs.Output);
 
         if (inputs.Output is not { } outputPath)
         {
             var defaultPath = pathDeriver(executionContext, projectName);
             outputPath = await prompter.PromptForOutputPath(defaultPath, parseResult, validator, cancellationToken);
+        }
+
+        // Validate before calling Path.GetFullPath to avoid exceptions from invalid characters.
+        if (wasExplicitlyProvided)
+        {
+            var earlyError = OutputPathHelper.ValidateOutputPath(outputPath, executionContext.WorkingDirectory.FullName);
+            if (earlyError is not null)
+            {
+                interactionService.DisplayError(earlyError);
+                return null;
+            }
         }
 
         outputPath = Path.GetFullPath(outputPath, executionContext.WorkingDirectory.FullName);
@@ -601,9 +612,11 @@ internal class DotNetTemplateFactory(
 
         // Validate the resolved output path when --output was explicitly provided.
         // When the user interactively accepted the default, the prompt validator already ran.
+        // Note: invalid chars and non-empty directory are already checked before Path.GetFullPath above.
+        // After the VS Code extension path adjustment, re-check the final path for non-empty directory.
         if (wasExplicitlyProvided)
         {
-            var validationError = OutputPathHelper.ValidateOutputPath(outputPath);
+            var validationError = OutputPathHelper.ValidateResolvedOutputPath(outputPath);
             if (validationError is not null)
             {
                 interactionService.DisplayError(validationError);

--- a/src/Aspire.Cli/Templating/ITemplate.cs
+++ b/src/Aspire.Cli/Templating/ITemplate.cs
@@ -36,9 +36,9 @@ internal interface ITemplate
     TemplateRuntime Runtime { get; }
 
     /// <summary>
-    /// Gets a function that derives the output path from a project name.
+    /// Gets a function that derives the default output path from an execution context and a project name.
     /// </summary>
-    Func<string, string> PathDeriver { get; }
+    Func<CliExecutionContext, string, string> PathDeriver { get; }
 
     /// <summary>
     /// Gets the AppHost language identifier associated with this template.

--- a/src/Aspire.Cli/Templating/OutputPathHelper.cs
+++ b/src/Aspire.Cli/Templating/OutputPathHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Spectre.Console;
 
@@ -9,6 +10,33 @@ namespace Aspire.Cli.Templating;
 
 internal static class OutputPathHelper
 {
+    /// <summary>
+    /// Resolves the output path by prompting if not provided, validating if explicit,
+    /// and converting to an absolute path.
+    /// </summary>
+    internal static async Task<string?> ResolveOutputPathAsync(
+        string? outputPath,
+        string workingDirectory,
+        Func<Task<string>> promptCallback,
+        IInteractionService interactionService)
+    {
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            outputPath = await promptCallback();
+        }
+        else
+        {
+            var earlyError = ValidateOutputPath(outputPath, workingDirectory);
+            if (earlyError is not null)
+            {
+                interactionService.DisplayError(earlyError);
+                return null;
+            }
+        }
+
+        return Path.GetFullPath(outputPath, workingDirectory);
+    }
+
     /// <summary>
     /// Returns a unique default output path based on the given base name.
     /// Invalid path characters are stripped from <paramref name="baseName"/>.
@@ -20,15 +48,15 @@ internal static class OutputPathHelper
     {
         baseName = SanitizeBaseName(baseName);
 
-        var candidate = $"./{baseName}";
-        if (!IsNonEmptyDirectory(candidate, workingDirectory))
+        var baseCandidate = $"./{baseName}";
+        if (!IsNonEmptyDirectory(baseCandidate, workingDirectory))
         {
-            return candidate;
+            return baseCandidate;
         }
 
         for (var i = 2; i < 1000; i++)
         {
-            candidate = $"./{baseName}-{i}";
+            var candidate = $"{baseCandidate}-{i}";
             if (!IsNonEmptyDirectory(candidate, workingDirectory))
             {
                 return candidate;
@@ -36,7 +64,7 @@ internal static class OutputPathHelper
         }
 
         // Fallback — extremely unlikely to reach here.
-        throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Unable to find a unique output directory name based on '{0}' after 999 attempts.", baseName));
+        return baseCandidate;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Templating/OutputPathHelper.cs
+++ b/src/Aspire.Cli/Templating/OutputPathHelper.cs
@@ -10,13 +10,13 @@ namespace Aspire.Cli.Templating;
 internal static class OutputPathHelper
 {
     /// <summary>
-    /// Returns a unique default output path based on the template name.
-    /// If <c>./{templateName}</c> already exists and is non-empty, appends
+    /// Returns a unique default output path based on the given base name.
+    /// If <c>./{baseName}</c> already exists and is non-empty, appends
     /// a numeric suffix (<c>-2</c>, <c>-3</c>, …) until an available name is found.
     /// </summary>
-    internal static string GetUniqueDefaultOutputPath(string templateName, string workingDirectory)
+    internal static string GetUniqueDefaultOutputPath(string baseName, string workingDirectory)
     {
-        var candidate = $"./{templateName}";
+        var candidate = $"./{baseName}";
         if (!IsNonEmptyDirectory(candidate, workingDirectory))
         {
             return candidate;
@@ -24,7 +24,7 @@ internal static class OutputPathHelper
 
         for (var i = 2; i < 1000; i++)
         {
-            candidate = $"./{templateName}-{i}";
+            candidate = $"./{baseName}-{i}";
             if (!IsNonEmptyDirectory(candidate, workingDirectory))
             {
                 return candidate;
@@ -32,16 +32,22 @@ internal static class OutputPathHelper
         }
 
         // Fallback — extremely unlikely to reach here.
-        return $"./{templateName}";
+        throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Unable to find a unique output directory name based on '{0}' after 999 attempts.", baseName));
     }
 
     /// <summary>
-    /// Creates a validator that checks whether the given output path refers to a non-empty existing directory.
+    /// Creates a validator that checks whether the given output path contains invalid characters
+    /// or refers to a non-empty existing directory.
     /// </summary>
     internal static Func<string, ValidationResult> CreateOutputPathValidator(string workingDirectory)
     {
         return path =>
         {
+            if (ContainsInvalidPathChars(path))
+            {
+                return ValidationResult.Error(string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, path));
+            }
+
             if (IsNonEmptyDirectory(path, workingDirectory))
             {
                 var fullPath = Path.GetFullPath(path, workingDirectory);
@@ -53,9 +59,30 @@ internal static class OutputPathHelper
     }
 
     /// <summary>
-    /// Validates the resolved (absolute) output path and returns an error message if it's a non-empty existing directory, or <see langword="null"/> if valid.
+    /// Validates a (possibly relative) output path before resolution. Returns an error message if the path
+    /// contains invalid characters or targets a non-empty existing directory, or <see langword="null"/> if valid.
     /// </summary>
-    internal static string? ValidateOutputPath(string absolutePath)
+    internal static string? ValidateOutputPath(string path, string workingDirectory)
+    {
+        if (ContainsInvalidPathChars(path))
+        {
+            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, path);
+        }
+
+        if (IsNonEmptyDirectory(path, workingDirectory))
+        {
+            var fullPath = Path.GetFullPath(path, workingDirectory);
+            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmpty, fullPath);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates the resolved (absolute) output path and returns an error message if it's
+    /// a non-empty existing directory, or <see langword="null"/> if valid.
+    /// </summary>
+    internal static string? ValidateResolvedOutputPath(string absolutePath)
     {
         if (Directory.Exists(absolutePath) && Directory.EnumerateFileSystemEntries(absolutePath).Any())
         {
@@ -63,6 +90,11 @@ internal static class OutputPathHelper
         }
 
         return null;
+    }
+
+    private static bool ContainsInvalidPathChars(string path)
+    {
+        return path.AsSpan().IndexOfAny(Path.GetInvalidPathChars()) >= 0;
     }
 
     private static bool IsNonEmptyDirectory(string relativePath, string workingDirectory)

--- a/src/Aspire.Cli/Templating/OutputPathHelper.cs
+++ b/src/Aspire.Cli/Templating/OutputPathHelper.cs
@@ -11,11 +11,15 @@ internal static class OutputPathHelper
 {
     /// <summary>
     /// Returns a unique default output path based on the given base name.
+    /// Invalid path characters are stripped from <paramref name="baseName"/>.
+    /// If all characters are invalid, <c>"output"</c> is used as the fallback name.
     /// If <c>./{baseName}</c> already exists and is non-empty, appends
     /// a numeric suffix (<c>-2</c>, <c>-3</c>, …) until an available name is found.
     /// </summary>
     internal static string GetUniqueDefaultOutputPath(string baseName, string workingDirectory)
     {
+        baseName = SanitizeBaseName(baseName);
+
         var candidate = $"./{baseName}";
         if (!IsNonEmptyDirectory(candidate, workingDirectory))
         {
@@ -90,6 +94,13 @@ internal static class OutputPathHelper
         }
 
         return null;
+    }
+
+    private static string SanitizeBaseName(string baseName)
+    {
+        var invalidChars = Path.GetInvalidPathChars();
+        var sanitized = string.Concat(baseName.Where(c => !invalidChars.Contains(c)));
+        return sanitized.Length > 0 ? sanitized : "output";
     }
 
     private static bool ContainsInvalidPathChars(string path)

--- a/src/Aspire.Cli/Templating/OutputPathHelper.cs
+++ b/src/Aspire.Cli/Templating/OutputPathHelper.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Cli.Resources;
+using Spectre.Console;
+
+namespace Aspire.Cli.Templating;
+
+internal static class OutputPathHelper
+{
+    /// <summary>
+    /// Returns a unique default output path based on the template name.
+    /// If <c>./{templateName}</c> already exists and is non-empty, appends
+    /// a numeric suffix (<c>-2</c>, <c>-3</c>, …) until an available name is found.
+    /// </summary>
+    internal static string GetUniqueDefaultOutputPath(string templateName, string workingDirectory)
+    {
+        var candidate = $"./{templateName}";
+        if (!IsNonEmptyDirectory(candidate, workingDirectory))
+        {
+            return candidate;
+        }
+
+        for (var i = 2; i < 1000; i++)
+        {
+            candidate = $"./{templateName}-{i}";
+            if (!IsNonEmptyDirectory(candidate, workingDirectory))
+            {
+                return candidate;
+            }
+        }
+
+        // Fallback — extremely unlikely to reach here.
+        return $"./{templateName}";
+    }
+
+    /// <summary>
+    /// Creates a validator that checks whether the given output path refers to a non-empty existing directory.
+    /// </summary>
+    internal static Func<string, ValidationResult> CreateOutputPathValidator(string workingDirectory)
+    {
+        return path =>
+        {
+            if (IsNonEmptyDirectory(path, workingDirectory))
+            {
+                var fullPath = Path.GetFullPath(path, workingDirectory);
+                return ValidationResult.Error(string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmpty, fullPath));
+            }
+
+            return ValidationResult.Success();
+        };
+    }
+
+    /// <summary>
+    /// Validates the resolved (absolute) output path and returns an error message if it's a non-empty existing directory, or <see langword="null"/> if valid.
+    /// </summary>
+    internal static string? ValidateOutputPath(string absolutePath)
+    {
+        if (Directory.Exists(absolutePath) && Directory.EnumerateFileSystemEntries(absolutePath).Any())
+        {
+            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmpty, absolutePath);
+        }
+
+        return null;
+    }
+
+    private static bool IsNonEmptyDirectory(string relativePath, string workingDirectory)
+    {
+        var fullPath = Path.GetFullPath(relativePath, workingDirectory);
+        return Directory.Exists(fullPath) && Directory.EnumerateFileSystemEntries(fullPath).Any();
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -94,9 +94,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
     [Fact]
     // Quarantined due to flakiness. See linked issue for details.
-    public async Task NewCommandDerivesOutputPathFromProjectNameForStarterTemplate()
+    public async Task NewCommandDerivesProjectNameFromTemplateNameForStarterTemplate()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedDefaultProjectName = null;
+        string? capturedDefaultOutputPath = null;
         var services = CreateServiceCollection(workspace, options =>
         {
             options.NewCommandPrompterFactory = (sp) =>
@@ -106,12 +108,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
                 prompter.PromptForProjectNameCallback = (defaultName) =>
                 {
+                    capturedDefaultProjectName = defaultName;
                     return "CustomName";
                 };
 
                 prompter.PromptForOutputPathCallback = (path) =>
                 {
-                    Assert.Equal("./CustomName", path);
+                    capturedDefaultOutputPath = path;
                     return path;
                 };
 
@@ -125,6 +128,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal("aspire-starter", capturedDefaultProjectName);
+        Assert.Equal("./CustomName", capturedDefaultOutputPath);
     }
 
     [Fact]
@@ -152,7 +157,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None");
+        var result = command.Parse("new aspire-starter --name MyApp --output ./output --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -451,7 +456,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None");
+        var result = command.Parse("new aspire-starter --name MyApp --output ./output --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -483,7 +488,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-starter --name MyApp --output . --use-redis-cache --test-framework None --version 9.2.0");
+        var result = command.Parse("new aspire-starter --name MyApp --output ./output --use-redis-cache --test-framework None --version 9.2.0");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -683,7 +688,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-starter --name TestApp --output .");
+        var result = command.Parse("new aspire-starter --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -708,7 +713,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         // This test validates that project names containing Spectre markup characters
         // (like '[' and ']') are properly escaped when displayed as default values in prompts.
         // This prevents crashes when the markup parser encounters malformed markup.
-        
+
         var projectNameWithMarkup = "[27;5;13~";  // Example of input that could crash the markup parser
         var capturedProjectNameDefault = string.Empty;
         var capturedOutputPathDefault = string.Empty;
@@ -735,8 +740,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 prompter.PromptForOutputPathCallback = (path) =>
                 {
                     capturedOutputPathDefault = path;
-                    // Return the path as-is - the escaping is handled internally by PromptForOutputPath
-                    return path;
+                    // Return a path with markup characters to verify it doesn't crash
+                    return projectNameWithMarkup;
                 };
 
                 return prompter;
@@ -746,14 +751,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
+        var result = command.Parse($"new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-        // Verify that the default output path was derived from the project name with markup characters
-        // The path parameter passed to the callback contains the unescaped markup characters
-        var expectedPath = $"./[27;5;13~";
+        // Verify that the default output path is derived from the project name (which contains markup characters)
+        var expectedPath = $"./{projectNameWithMarkup}";
         Assert.Equal(expectedPath, capturedOutputPathDefault);
     }
 
@@ -806,7 +810,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new --name TestApp --output .");
+        var result = command.Parse("new --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -816,8 +820,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain((KnownTemplateId.TypeScriptEmptyAppHost, "Empty (TypeScript AppHost)"), promptedTemplates);
         Assert.DoesNotContain((KnownTemplateId.JavaEmptyAppHost, "Empty (Java AppHost)"), promptedTemplates);
         Assert.Contains((KnownTemplateId.TypeScriptStarter, "Starter App (Express/React, TypeScript AppHost)"), promptedTemplates);
-        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
-        Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.ts")));
+        Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "aspire.config.json")));
     }
 
     [Fact]
@@ -876,7 +880,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new --name TestApp --output .");
+        var result = command.Parse("new --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -911,7 +915,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output .");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -972,7 +976,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output .");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -1035,7 +1039,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output .");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -1063,12 +1067,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output . --language typescript --localhost-tld false --suppress-agent-init");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output --language typescript --localhost-tld false --suppress-agent-init");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal(KnownLanguageId.TypeScript, scaffoldedLanguageId);
-        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.ts")));
     }
 
     [Fact]
@@ -1100,12 +1104,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-java-empty --name TestApp --output . --localhost-tld false");
+        var result = command.Parse("new aspire-java-empty --name TestApp --output ./output --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal(KnownLanguageId.Java, scaffoldedLanguageId);
-        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.java")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "AppHost.java")));
     }
 
     [Fact]
@@ -1136,12 +1140,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-py-empty --name TestApp --output . --localhost-tld false");
+        var result = command.Parse("new aspire-py-empty --name TestApp --output ./output --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal(KnownLanguageId.Python, scaffoldedLanguageId);
-        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.py")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.py")));
     }
 
     [Fact]
@@ -1153,11 +1157,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output . --localhost-tld false");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.cs")));
     }
 
     [Fact]
@@ -1197,13 +1201,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output .");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(localhostPrompted);
 
-        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", "aspire.config.json");
         Assert.True(File.Exists(runProfilePath));
         var runProfile = await File.ReadAllTextAsync(runProfilePath);
         Assert.Contains("testapp.dev.localhost", runProfile);
@@ -1229,7 +1233,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("new aspire-ts-empty --name TestApp --output . --localhost-tld false");
+        var result = command.Parse("new aspire-ts-empty --name TestApp --output ./output --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -1277,7 +1281,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("new aspire-ts-empty --name TestApp --output . --channel stable --localhost-tld false");
+        var result = command.Parse("new aspire-ts-empty --name TestApp --output ./output --channel stable --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
@@ -1298,7 +1302,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
                 var prompter = new TestNewCommandPrompter(interactionService);
 
-                // Accept the default "./TestApp" path from the prompt
+                // Accept the default path from the prompt
                 prompter.PromptForOutputPathCallback = (path) => path;
 
                 return prompter;
@@ -1317,7 +1321,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        // Do not pass --output so the default "./TestApp" path is used via the prompter
+        // Do not pass --output so the default project-name path is used via the prompter
         var result = command.Parse("new aspire-ts-empty --name TestApp --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
@@ -1396,14 +1400,14 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-ts-empty --name TestApp --output .");
+        var result = command.Parse("new aspire-ts-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(scaffoldingInvoked);
         Assert.True(localhostPrompted);
 
-        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", "aspire.config.json");
         var configContent = await File.ReadAllTextAsync(configPath);
         Assert.Contains("testapp.dev.localhost", configContent);
         Assert.DoesNotContain("://localhost", configContent);
@@ -1475,7 +1479,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("new aspire-ts-starter --name TestApp --output . --channel daily --localhost-tld false");
+        var result = command.Parse("new aspire-ts-starter --name TestApp --output ./output --channel daily --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -1483,7 +1487,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.True(buildAndGenerateCalled);
         Assert.Equal("daily", channelSeenByProject);
         Assert.Equal("9.2.0", sdkVersionSeenByProject);
-        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".modules", "aspire.ts")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", ".modules", "aspire.ts")));
     }
 
     [Fact]
@@ -1540,7 +1544,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("new aspire-ts-starter --name TestApp --output . --channel daily --localhost-tld false");
+        var result = command.Parse("new aspire-ts-starter --name TestApp --output ./output --channel daily --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -1566,7 +1570,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output .");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         // Before the fix, this would throw InvalidOperationException with
         // "Interactive input is not supported in this environment" because
@@ -1662,10 +1666,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        // The default project name is derived from the workspace directory name
-        Assert.Equal(workspace.WorkspaceRoot.Name, capturedProjectName);
-        // The default output path ends with the project name subdirectory
-        Assert.Equal(workspace.WorkspaceRoot.Name, Path.GetFileName(capturedOutputPath));
+        // The default project name is derived from the template name
+        Assert.Equal("aspire-starter", capturedProjectName);
+        // The default output path is derived from the template name
+        Assert.Equal(Path.Combine(workspace.WorkspaceRoot.FullName, "aspire-starter"), capturedOutputPath);
     }
 
     [Fact]
@@ -1742,14 +1746,15 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse($"new aspire-starter --name MyProject --output {workspace.WorkspaceRoot.FullName} --use-redis-cache --test-framework None --suppress-agent-init");
+        var outputDir = Path.Combine(workspace.WorkspaceRoot.FullName, "output");
+        var result = command.Parse($"new aspire-starter --name MyProject --output {outputDir} --use-redis-cache --test-framework None --suppress-agent-init");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
         // Agent init should not have run — no skill files should exist
-        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        var skillPath = Path.Combine(outputDir, ".agents", "skills", "aspire", "SKILL.md");
         Assert.False(File.Exists(skillPath));
     }
 
@@ -1828,7 +1833,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-ts-empty --name TestApp --output .");
+        var result = command.Parse("new aspire-ts-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -2096,14 +2101,14 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output . --suppress-agent-init");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output --suppress-agent-init");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
         // Agent init should not have run — no skill files should exist
-        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", ".agents", "skills", "aspire", "SKILL.md");
         Assert.False(File.Exists(skillPath));
     }
 
@@ -2122,14 +2127,14 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output . --suppress-agent-init=false");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output --suppress-agent-init=false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
         // Agent init should have run — default skill files should exist
-        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", ".agents", "skills", "aspire", "SKILL.md");
         Assert.True(File.Exists(skillPath));
     }
 
@@ -2148,14 +2153,99 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --name TestApp --output .");
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
         // Default is to run agent init
-        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
+        var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", ".agents", "skills", "aspire", "SKILL.md");
         Assert.True(File.Exists(skillPath));
+    }
+
+    [Fact]
+    public async Task NewCommandRejectsExplicitOutputToNonEmptyDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a non-empty directory at the output path
+        var existingDir = workspace.CreateDirectory("existing-output");
+        File.WriteAllText(Path.Combine(existingDir.FullName, "file.txt"), "content");
+
+        TestInteractionService? testInteractionService = null;
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.InteractionServiceFactory = (sp) =>
+            {
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse($"new aspire-starter --name TestApp --output {existingDir.FullName} --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+        Assert.NotNull(testInteractionService);
+        var expectedError = string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmpty, existingDir.FullName);
+        var e = Assert.Single(testInteractionService.DisplayedErrors);
+        Assert.Equal(expectedError, e);
+    }
+
+    [Fact]
+    public async Task NewCommandAllowsExplicitOutputToEmptyDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create an empty directory at the output path
+        var emptyDir = workspace.CreateDirectory("empty-output");
+
+        var services = CreateServiceCollection(workspace);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse($"new aspire-starter --name TestApp --output {emptyDir.FullName} --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task NewCommandDefaultOutputPathUsesUniqueProjectNameWhenDirectoryExists()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a non-empty directory matching the default project name (template name)
+        var existingDir = workspace.CreateDirectory("aspire-starter");
+        File.WriteAllText(Path.Combine(existingDir.FullName, "file.txt"), "content");
+
+        string? capturedDefaultPath = null;
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForOutputPathCallback = (path) =>
+                {
+                    capturedDefaultPath = path;
+                    return path;
+                };
+
+                return prompter;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal("./aspire-starter-2", capturedDefaultPath);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -2248,4 +2248,45 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Equal("./aspire-starter-2", capturedDefaultPath);
     }
+
+    [Fact]
+    public async Task NewCommandRejectsExplicitOutputWithInvalidPathCharacters()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        TestInteractionService? testInteractionService = null;
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.InteractionServiceFactory = (sp) =>
+            {
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var invalidPath = "output\0path";
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse($"new aspire-starter --name TestApp --output {invalidPath} --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+        Assert.NotNull(testInteractionService);
+        var expectedError = string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, invalidPath);
+        var e = Assert.Single(testInteractionService.DisplayedErrors);
+        Assert.Equal(expectedError, e);
+    }
+
+    [Fact]
+    public void OutputPathValidatorRejectsPathWithInvalidCharacters()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var validator = OutputPathHelper.CreateOutputPathValidator(workspace.WorkspaceRoot.FullName);
+
+        var invalidPath = "output\0path";
+        var validationResult = validator(invalidPath);
+
+        var expectedMessage = string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, invalidPath);
+        Assert.Equal(expectedMessage, validationResult.Message);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -2278,6 +2278,52 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandCreatesProjectInCurrentDirectoryWithOutputDot()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create an empty subdirectory to use as the CLI working directory.
+        // Keep options.WorkingDirectory as the workspace root so test infra
+        // (.aspire/logs, settings files) doesn't pollute the project dir.
+        var projectDir = workspace.CreateDirectory("my-project");
+        string? capturedOutputPath = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliExecutionContextFactory = _ =>
+            {
+                var root = workspace.WorkspaceRoot.FullName;
+                return new CliExecutionContext(
+                    projectDir,
+                    new DirectoryInfo(Path.Combine(root, ".aspire", "hives")),
+                    new DirectoryInfo(Path.Combine(root, ".aspire", "cache")),
+                    new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")),
+                    new DirectoryInfo(Path.Combine(root, ".aspire", "logs")),
+                    Path.Combine(root, ".aspire", "logs", "test.log"));
+            };
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = CreateTestRunnerWithStandardPackages();
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    capturedOutputPath = outputPath;
+                    return 0;
+                };
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-starter --name TestApp --output . --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(projectDir.FullName, capturedOutputPath);
+    }
+
+    [Fact]
     public void OutputPathValidatorRejectsPathWithInvalidCharacters()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -514,7 +514,7 @@ public class DotNetTemplateFactoryTests
         public Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<string> PromptForOutputPath(string defaultPath, ParseResult parseResult, CancellationToken cancellationToken)
+        public Task<string> PromptForOutputPath(string defaultPath, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public Task<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> PromptForTemplatesVersionAsync(IEnumerable<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> packages, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Templating/OutputPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/OutputPathHelperTests.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Templating;
+
+namespace Aspire.Cli.Tests.Templating;
+
+public class OutputPathHelperTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void GetUniqueDefaultOutputPath_ReturnsTemplateName_WhenDirectoryDoesNotExist()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+
+        var result = OutputPathHelper.GetUniqueDefaultOutputPath("aspire-starter", workspace.WorkspaceRoot.FullName);
+
+        Assert.Equal("./aspire-starter", result);
+    }
+
+    [Fact]
+    public void GetUniqueDefaultOutputPath_ReturnsTemplateName_WhenDirectoryExistsButIsEmpty()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+        workspace.CreateDirectory("aspire-starter");
+
+        var result = OutputPathHelper.GetUniqueDefaultOutputPath("aspire-starter", workspace.WorkspaceRoot.FullName);
+
+        Assert.Equal("./aspire-starter", result);
+    }
+
+    [Fact]
+    public void GetUniqueDefaultOutputPath_AppendsSuffix_WhenDirectoryExistsAndIsNonEmpty()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.CreateDirectory("aspire-starter");
+        File.WriteAllText(Path.Combine(dir.FullName, "file.txt"), "content");
+
+        var result = OutputPathHelper.GetUniqueDefaultOutputPath("aspire-starter", workspace.WorkspaceRoot.FullName);
+
+        Assert.Equal("./aspire-starter-2", result);
+    }
+
+    [Fact]
+    public void GetUniqueDefaultOutputPath_IncrementsUntilUnique()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+
+        // Create non-empty directories for aspire-starter and aspire-starter-2
+        foreach (var name in new[] { "aspire-starter", "aspire-starter-2" })
+        {
+            var dir = workspace.CreateDirectory(name);
+            File.WriteAllText(Path.Combine(dir.FullName, "file.txt"), "content");
+        }
+
+        var result = OutputPathHelper.GetUniqueDefaultOutputPath("aspire-starter", workspace.WorkspaceRoot.FullName);
+
+        Assert.Equal("./aspire-starter-3", result);
+    }
+
+    [Fact]
+    public void GetUniqueDefaultOutputPath_SkipsNonEmptyAndUsesEmptySlot()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+
+        // aspire-starter is non-empty, aspire-starter-2 is empty
+        var dir = workspace.CreateDirectory("aspire-starter");
+        File.WriteAllText(Path.Combine(dir.FullName, "file.txt"), "content");
+        workspace.CreateDirectory("aspire-starter-2");
+
+        var result = OutputPathHelper.GetUniqueDefaultOutputPath("aspire-starter", workspace.WorkspaceRoot.FullName);
+
+        Assert.Equal("./aspire-starter-2", result);
+    }
+
+    [Fact]
+    public void ValidateOutputPath_ReturnsNull_WhenDirectoryDoesNotExist()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+        var path = Path.Combine(workspace.WorkspaceRoot.FullName, "new-dir");
+
+        var result = OutputPathHelper.ValidateOutputPath(path);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ValidateOutputPath_ReturnsNull_WhenDirectoryExistsButIsEmpty()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.CreateDirectory("empty-dir");
+
+        var result = OutputPathHelper.ValidateOutputPath(dir.FullName);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ValidateOutputPath_ReturnsError_WhenDirectoryExistsAndIsNonEmpty()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.CreateDirectory("non-empty-dir");
+        File.WriteAllText(Path.Combine(dir.FullName, "file.txt"), "content");
+
+        var result = OutputPathHelper.ValidateOutputPath(dir.FullName);
+
+        Assert.NotNull(result);
+        Assert.Contains(dir.FullName, result);
+    }
+
+    [Fact]
+    public void CreateOutputPathValidator_ReturnsSuccess_WhenDirectoryDoesNotExist()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+        var validator = OutputPathHelper.CreateOutputPathValidator(workspace.WorkspaceRoot.FullName);
+
+        var result = validator("./new-dir");
+
+        Assert.True(result.Successful);
+    }
+
+    [Fact]
+    public void CreateOutputPathValidator_ReturnsSuccess_WhenDirectoryExistsButIsEmpty()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+        workspace.CreateDirectory("empty-dir");
+
+        var validator = OutputPathHelper.CreateOutputPathValidator(workspace.WorkspaceRoot.FullName);
+
+        var result = validator("./empty-dir");
+
+        Assert.True(result.Successful);
+    }
+
+    [Fact]
+    public void CreateOutputPathValidator_ReturnsError_WhenDirectoryExistsAndIsNonEmpty()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.CreateDirectory("non-empty-dir");
+        File.WriteAllText(Path.Combine(dir.FullName, "file.txt"), "content");
+
+        var validator = OutputPathHelper.CreateOutputPathValidator(workspace.WorkspaceRoot.FullName);
+
+        var result = validator("./non-empty-dir");
+
+        Assert.False(result.Successful);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Templating/OutputPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/OutputPathHelperTests.cs
@@ -73,6 +73,26 @@ public class OutputPathHelperTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void GetUniqueDefaultOutputPath_StripsInvalidPathCharacters()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+
+        var result = OutputPathHelper.GetUniqueDefaultOutputPath("my\0app", workspace.WorkspaceRoot.FullName);
+
+        Assert.Equal("./myapp", result);
+    }
+
+    [Fact]
+    public void GetUniqueDefaultOutputPath_FallsBackToOutput_WhenAllCharsInvalid()
+    {
+        using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
+
+        var result = OutputPathHelper.GetUniqueDefaultOutputPath("\0", workspace.WorkspaceRoot.FullName);
+
+        Assert.Equal("./output", result);
+    }
+
+    [Fact]
     public void ValidateOutputPath_ReturnsNull_WhenDirectoryDoesNotExist()
     {
         using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Templating/OutputPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/OutputPathHelperTests.cs
@@ -78,7 +78,7 @@ public class OutputPathHelperTests(ITestOutputHelper outputHelper)
         using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
         var path = Path.Combine(workspace.WorkspaceRoot.FullName, "new-dir");
 
-        var result = OutputPathHelper.ValidateOutputPath(path);
+        var result = OutputPathHelper.ValidateOutputPath(path, workspace.WorkspaceRoot.FullName);
 
         Assert.Null(result);
     }
@@ -89,7 +89,7 @@ public class OutputPathHelperTests(ITestOutputHelper outputHelper)
         using var workspace = Utils.TemporaryWorkspace.Create(outputHelper);
         var dir = workspace.CreateDirectory("empty-dir");
 
-        var result = OutputPathHelper.ValidateOutputPath(dir.FullName);
+        var result = OutputPathHelper.ValidateOutputPath(dir.FullName, workspace.WorkspaceRoot.FullName);
 
         Assert.Null(result);
     }
@@ -101,7 +101,7 @@ public class OutputPathHelperTests(ITestOutputHelper outputHelper)
         var dir = workspace.CreateDirectory("non-empty-dir");
         File.WriteAllText(Path.Combine(dir.FullName, "file.txt"), "content");
 
-        var result = OutputPathHelper.ValidateOutputPath(dir.FullName);
+        var result = OutputPathHelper.ValidateOutputPath(dir.FullName, workspace.WorkspaceRoot.FullName);
 
         Assert.NotNull(result);
         Assert.Contains(dir.FullName, result);

--- a/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Templating;
+using Spectre.Console;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.TestServices;
@@ -35,7 +36,7 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
         };
     }
 
-    public override Task<string> PromptForOutputPath(string path, ParseResult parseResult, CancellationToken cancellationToken)
+    public override Task<string> PromptForOutputPath(string path, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
     {
         return PromptForOutputPathCallback switch
         {


### PR DESCRIPTION
## Summary

Improves how the `new` command resolves and validates the output directory path.

## Changes

### Default output path uses template name
- The default output directory is now derived from the **template name** (e.g. `./aspire-starter`) instead of the working directory name.
- When the default path already exists and is non-empty, an auto-incrementing suffix is appended (`-2`, `-3`, …) to find a unique name.

### Output path validation
- Paths are validated for **invalid characters** (`Path.GetInvalidPathChars()`) before calling `Path.GetFullPath`, preventing `ArgumentException` crashes from characters like `\0`.
- The interactive output-path prompt now includes a **validator** that rejects invalid characters and non-empty directories inline.
- Explicitly provided `--output` paths that target a **non-empty existing directory** are rejected with a clear error message.
- Post-resolution validation re-checks the final path after VS Code extension path adjustment.

### New `OutputPathHelper` utility
- `GetUniqueDefaultOutputPath` — generates a unique `./name` path with numeric suffix fallback.
- `CreateOutputPathValidator` — returns a `Func<string, ValidationResult>` for Spectre.Console prompts.
- `ValidateOutputPath` / `ValidateResolvedOutputPath` — pre- and post-resolution validation helpers.
- `ContainsInvalidPathChars` — checks for invalid path characters.

### Other fixes
- `PathDeriver` signature updated from `Func<string, string>` to `Func<CliExecutionContext, string, string>` so templates can access the working directory.
- `wasExplicitlyProvided` now consistently uses `!string.IsNullOrWhiteSpace()` in both `DotNetTemplateFactory` and `CliTemplateFactory`.
- Default project name in `DotNetTemplateFactory.GetProjectNameAsync` changed from working directory name to template name.

## Tests

- `NewCommandRejectsExplicitOutputWithInvalidPathCharacters` — integration test verifying `--output` with invalid chars returns error exit code.
- `OutputPathValidatorRejectsPathWithInvalidCharacters` — unit test for `CreateOutputPathValidator` with invalid path characters.
- `OutputPathHelperTests` — unit tests for `GetUniqueDefaultOutputPath`, `ValidateOutputPath`, and `ValidateResolvedOutputPath`.
- Updated existing tests to match new `ValidateOutputPath` two-parameter signature.