### PR TITLE
Fix aspire run failing when DisableDashboard is true

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -293,9 +293,7 @@ internal sealed class RunCommand : BaseCommand
 
             if (dashboardUrls.DashboardHealthy is false)
             {
-                runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "dashboard_failed");
-                InteractionService.DisplayError(RunCommandStrings.DashboardFailedToStart);
-                return ExitCodeConstants.DashboardFailure;
+                InteractionService.DisplayMessage(KnownEmojis.Warning, RunCommandStrings.DashboardFailedToStart);
             }
 
             // Display the UX

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -383,7 +383,11 @@ internal sealed class RunCommand : BaseCommand
 
             if (ExtensionHelper.IsExtensionHost(InteractionService, out var extInteractionService, out _))
             {
-                extInteractionService.DisplayDashboardUrls(dashboardUrls);
+                if (dashboardUrls.DashboardHealthy is true)
+                {
+                    extInteractionService.DisplayDashboardUrls(dashboardUrls);
+                }
+
                 extInteractionService.NotifyAppHostStartupCompleted();
             }
 

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -182,7 +182,7 @@
     <value>Connecting to AppHost...</value>
   </data>
   <data name="DashboardFailedToStart" xml:space="preserve">
-    <value>Aspire Dashboard failed to start.</value>
+    <value>Aspire Dashboard failed to start or is disabled.</value>
   </data>
   <data name="AppHost" xml:space="preserve">
     <value>AppHost</value>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Řídicí panel Aspire se nepovedlo spustit.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Řídicí panel Aspire se nepovedlo spustit.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Fehler beim Starten des Aspire-Dashboards.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Fehler beim Starten des Aspire-Dashboards.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">No se pudo iniciar el panel de Aspire.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">No se pudo iniciar el panel de Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Nous n’avons pas pu lancer le tableau de bord Aspire.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Nous n’avons pas pu lancer le tableau de bord Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Avvio del dashboard di Aspire non riuscito.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Avvio del dashboard di Aspire non riuscito.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Aspire ダッシュボードの起動に失敗しました。</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Aspire ダッシュボードの起動に失敗しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Azure 대시보드를 시작하지 못했습니다.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Azure 대시보드를 시작하지 못했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Nie udało się uruchomić pulpitu nawigacyjnego Aspire.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Nie udało się uruchomić pulpitu nawigacyjnego Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Falha ao iniciar o Painel do Aspire.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Falha ao iniciar o Painel do Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Не удалось запустить панель управления Aspire.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Не удалось запустить панель управления Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Aspire Pano başlatılamadı.</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Aspire Pano başlatılamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Aspire 仪表板启动失败。</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Aspire 仪表板启动失败。</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DashboardFailedToStart">
-        <source>Aspire Dashboard failed to start.</source>
-        <target state="translated">Aspire 儀表板啟動失敗。</target>
+        <source>Aspire Dashboard failed to start or is disabled.</source>
+        <target state="needs-review-translation">Aspire 儀表板啟動失敗。</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -156,8 +156,8 @@ internal class AppHostRpcTarget(
     {
         if (!options.DashboardEnabled)
         {
-            logger.LogError("Dashboard URL requested but dashboard is disabled.");
-            throw new InvalidOperationException("Dashboard URL requested but dashboard is disabled.");
+            logger.LogDebug("Dashboard URL requested but dashboard is disabled.");
+            return new DashboardUrlsState { DashboardHealthy = false };
         }
 
         return await DashboardUrlsHelper.GetDashboardUrlsAsync(serviceProvider, logger, cancellationToken).ConfigureAwait(false);

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
@@ -470,6 +471,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         };
 
         var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
+        var testInteractionService = new TestInteractionService();
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -477,7 +479,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.ProjectLocatorFactory = projectLocatorFactory;
             options.AppHostBackchannelFactory = backchannelFactory;
             options.DotNetCliRunnerFactory = runnerFactory;
-            options.InteractionServiceFactory = (sp) => new TestInteractionService();
+            options.InteractionServiceFactory = (sp) => testInteractionService;
         });
 
         using var provider = services.BuildServiceProvider();
@@ -494,6 +496,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         // The command should succeed even when the dashboard is unhealthy
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Verify a warning was displayed (not an error)
+        var m = Assert.Single(testInteractionService.DisplayedMessages);
+        Assert.Equal(KnownEmojis.Warning, m.Emoji);
+        Assert.Equal(RunCommandStrings.DashboardFailedToStart, m.Message);
+        Assert.Empty(testInteractionService.DisplayedErrors);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -425,13 +425,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task RunCommand_WhenDashboardFailsToStart_ReturnsNonZeroExitCodeWithClearErrorMessage()
+    public async Task RunCommand_WhenDashboardFailsToStart_ContinuesWithWarning()
     {
 
         var backchannelFactory = (IServiceProvider sp) =>
         {
             var backchannel = new TestAppHostBackchannel();
-            // Configure the backchannel to throw DashboardStartupException when GetDashboardUrlsAsync is called
+            // Configure the backchannel to return unhealthy dashboard state
             backchannel.GetDashboardUrlsAsyncCallback = (ct) =>
             {
                 return Task.FromResult(new DashboardUrlsState
@@ -484,10 +484,16 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
-        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
 
-        // Assert that the command returns the expected failure exit code
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        // Simulate CTRL-C - the command should continue past the unhealthy dashboard
+        cts.Cancel();
+
+        var exitCode = await pendingRun.DefaultTimeout(TestConstants.LongTimeoutDuration);
+
+        // The command should succeed even when the dashboard is unhealthy
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

When `DisableDashboard = true` is set in an app host, `aspire run` would fail with a `DashboardFailure` exit code while `aspire start` succeeded. This PR fixes the inconsistency so both commands work when the dashboard is disabled.

Two changes:

1. **AppHostRpcTarget** (`src/Aspire.Hosting`): Return `DashboardUrlsState` with `DashboardHealthy = false` instead of throwing `InvalidOperationException` when the dashboard is disabled. Also downgraded the log level from `Error` to `Debug` since this is an expected configuration.
2. **RunCommand** (`src/Aspire.Cli`): Treat an unhealthy dashboard as a warning instead of a fatal error, allowing the app host to continue running without the dashboard. The dashboard URL shows as "N/A" in the summary output.

Fixes #16619

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
