### PR TITLE
Add docs PR tracking to milestone changelog workflow

### DIFF
--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fa74ca6093929f11ee1aaf8c22c1ec34db3867eff21fdab6f9ceff7b0b7d3554","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"42ff2508e396b4d8e762cf7982a8d702403d8e4d1e54aa092c0bdb38bf1ecc95","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -30,7 +30,9 @@
 #
 # Frontmatter env variables:
 #   - BATCH_SIZE: (main workflow)
+#   - DOCS_REPO: (main workflow)
 #   - MILESTONE: (main workflow)
+#   - MILESTONE_START: (main workflow)
 #   - PRODUCT: (main workflow)
 #   - REPO: (main workflow)
 #
@@ -79,7 +81,9 @@ run-name: "Milestone Changelog Generator"
 
 env:
   BATCH_SIZE: "20"
+  DOCS_REPO: microsoft/aspire.dev
   MILESTONE: "13.3"
+  MILESTONE_START: "2026-03-01"
   PRODUCT: Aspire
   REPO: microsoft/aspire
 
@@ -194,14 +198,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_1e70ebed00fa04b9_EOF'
+          cat << 'GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF'
           <system>
-          GH_AW_PROMPT_1e70ebed00fa04b9_EOF
+          GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1e70ebed00fa04b9_EOF'
+          cat << 'GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
@@ -233,12 +237,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_1e70ebed00fa04b9_EOF
+          GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1e70ebed00fa04b9_EOF'
+          cat << 'GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_1e70ebed00fa04b9_EOF
+          GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -426,9 +430,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_55500e9bb1cdc916_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2ef151aa002f7ef2_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_55500e9bb1cdc916_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2ef151aa002f7ef2_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -600,7 +604,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_3ed5b3e1a56a2e03_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_3f9fc849f1166d2a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -644,7 +648,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3ed5b3e1a56a2e03_EOF
+          GH_AW_MCP_CONFIG_3f9fc849f1166d2a_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1198,6 +1202,7 @@ jobs:
           MEMORY_REF="memory/milestone-changelog"
           MEMORY_DIR="$DATA_DIR/memory/$MILESTONE"
           PROCESSED_NUMBERS="[]"
+          PROCESSED_DOCS_NUMBERS="[]"
           FEEDBACK_FROM_MEMORY=""
           MEMORY_TMP=$(mktemp -d)
           CLONE_ERR=$(mktemp)
@@ -1232,6 +1237,17 @@ jobs:
                 PROCESSED_NUMBERS="$PRS_LISTING"
               fi
               echo "Extracted $(echo "$PROCESSED_NUMBERS" | jq length) processed PR numbers from filenames"
+            fi
+
+            DOCS_PRS_DIR="$MEMORY_DIR/prs-docs"
+            if [ -d "$DOCS_PRS_DIR" ]; then
+              DOCS_PRS_LISTING=$(ls "$DOCS_PRS_DIR" 2>/dev/null \
+                | sed -n 's/.*-\([0-9]*\)\.json$/\1/p' \
+                | jq -Rs '[split("\n") | .[] | select(. != "") | tonumber]')
+              if echo "$DOCS_PRS_LISTING" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+                PROCESSED_DOCS_NUMBERS="$DOCS_PRS_LISTING"
+              fi
+              echo "Extracted $(echo "$PROCESSED_DOCS_NUMBERS" | jq length) processed docs PR numbers from filenames"
             fi
 
             # Also grab the feedback issue number from memory
@@ -1272,10 +1288,37 @@ jobs:
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
 
-          # 3. Check if there is work to do (unprocessed PRs or updated feedback)
+          # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date
+          DOCS_REPO="${{ env.DOCS_REPO }}"
+          MILESTONE_START="${{ env.MILESTONE_START }}"
+          gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
+            --search "merged:>=${MILESTONE_START}" \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            | jq 'sort_by(.mergedAt)' \
+            > "$DATA_DIR/all-docs-prs.json"
+
+          DOCS_TOTAL=$(jq length "$DATA_DIR/all-docs-prs.json")
+          echo "Total docs PRs merged since $MILESTONE_START: $DOCS_TOTAL"
+
+          jq --argjson processed "$PROCESSED_DOCS_NUMBERS" \
+             --argjson batch_size "$BATCH_SIZE" \
+             '($processed | map({(tostring): true}) | add // {}) as $set | [.[] | select($set[.number | tostring] | not)] | .[0:$batch_size]' \
+             "$DATA_DIR/all-docs-prs.json" \
+             > "$DATA_DIR/batch-docs-prs.json"
+
+          DOCS_BATCH_COUNT=$(jq length "$DATA_DIR/batch-docs-prs.json")
+          DOCS_PROCESSED_COUNT=$(echo "$PROCESSED_DOCS_NUMBERS" | jq length)
+          echo "Docs PRs already processed: $DOCS_PROCESSED_COUNT"
+          echo "Docs PRs batch (oldest $BATCH_SIZE unprocessed): $DOCS_BATCH_COUNT"
+
+          # 3. Check if there is work to do (unprocessed PRs, unprocessed docs PRs, or updated feedback)
           HAS_WORK="false"
           if [ "$BATCH_COUNT" -gt 0 ]; then
             echo "Has $BATCH_COUNT unprocessed PRs"
+            HAS_WORK="true"
+          fi
+          if [ "$DOCS_BATCH_COUNT" -gt 0 ]; then
+            echo "Has $DOCS_BATCH_COUNT unprocessed docs PRs"
             HAS_WORK="true"
           fi
 

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"42ff2508e396b4d8e762cf7982a8d702403d8e4d1e54aa092c0bdb38bf1ecc95","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"05e62e2df2ae4f9fd49315c5842196374553a891771e402789b3f58dc4a28426","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -198,14 +198,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF'
+          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
           <system>
-          GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF
+          GH_AW_PROMPT_4de97aeafbd5171b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF'
+          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
@@ -237,12 +237,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF
+          GH_AW_PROMPT_4de97aeafbd5171b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF'
+          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_ba28a8c0fe0e61fc_EOF
+          GH_AW_PROMPT_4de97aeafbd5171b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -430,9 +430,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2ef151aa002f7ef2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a6a28e7f728f79f0_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2ef151aa002f7ef2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a6a28e7f728f79f0_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -604,7 +604,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_3f9fc849f1166d2a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_0ce6f33cd1b55eda_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -648,7 +648,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3f9fc849f1166d2a_EOF
+          GH_AW_MCP_CONFIG_0ce6f33cd1b55eda_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1266,7 +1266,7 @@ jobs:
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
             --search "milestone:$MILESTONE" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-milestone-prs.json"
 
@@ -1288,12 +1288,29 @@ jobs:
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
 
+          # 2a. Enrich batch PRs with author_association (not available via gh pr list)
+          if [ "$BATCH_COUNT" -gt 0 ]; then
+            echo "Enriching batch PRs with author_association..."
+            # Build a JSON lookup object {"number": "association", ...} in one pass
+            ASSOC_JSON="{}"
+            for NUM in $(jq -r '.[].number' "$DATA_DIR/batch-prs.json"); do
+              ASSOC=$(gh api "repos/$REPO/pulls/$NUM" --jq '.author_association' 2>/dev/null || echo "UNKNOWN")
+              ASSOC_JSON=$(echo "$ASSOC_JSON" | jq --arg n "$NUM" --arg a "$ASSOC" '. + {($n): $a}')
+            done
+            # Merge all associations into batch-prs.json in a single rewrite
+            echo "$ASSOC_JSON" | jq --slurpfile prs "$DATA_DIR/batch-prs.json" \
+              '. as $lookup | $prs[0] | map(. + {authorAssociation: ($lookup[(.number | tostring)] // "UNKNOWN")})' \
+              > "$DATA_DIR/batch-prs-tmp.json" \
+              && mv "$DATA_DIR/batch-prs-tmp.json" "$DATA_DIR/batch-prs.json"
+            echo "Enriched $BATCH_COUNT batch PRs with author_association"
+          fi
+
           # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date
           DOCS_REPO="${{ env.DOCS_REPO }}"
           MILESTONE_START="${{ env.MILESTONE_START }}"
           gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
             --search "merged:>=${MILESTONE_START}" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-docs-prs.json"
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -970,7 +970,7 @@ Field definitions:
 - **mergedAt**: ISO 8601 UTC merge timestamp
 - **number**: Docs PR number (in `${DOCS_REPO}`)
 - **runDate**: ISO 8601 UTC timestamp of the workflow run that processed this docs PR
-- **status**: One of `"included"` (processed) or `"excluded"` (not relevant to the milestone)
+- **status**: One of `"included"` (matched to at least one changelog entry) or `"excluded"` (no match found, or not relevant to the milestone)
 - **title**: Original docs PR title
 
 After writing each file, **normalize formatting** by running:

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -778,10 +778,9 @@ If a docs PR is clearly unrelated to the milestone (e.g., it matched the date
 filter but documents an unrelated product or version), record it as
 `"excluded"` in the docs PR tracker (Step 6d) with a comment explaining why.
 
-For each remaining docs PR, determine whether it documents a changelog entry
-that has `docsRequired: true`. The batch data already contains each docs PR's
-`title`, `body`, and `files` (changed file paths) — no additional API calls
-are needed. Match by:
+For each remaining docs PR, determine whether it documents a changelog entry.
+The batch data already contains each docs PR's `title`, `body`, and `files`
+(changed file paths) — no additional API calls are needed. Match by:
 
 1. **Explicit product PR reference** — the docs PR body or title mentions a
    product PR number (e.g., "Documents #1234", links to
@@ -797,8 +796,7 @@ are needed. Match by:
    the docs PR to inspect its actual content. Use the diff to identify which
    product feature is being documented.
 4. **No match** — if the docs PR cannot be confidently matched to any
-   changelog entry with `docsRequired: true` (even after reading the diff),
-   record it as `"excluded"` in
+   changelog entry (even after reading the diff), record it as `"excluded"` in
    the docs PR tracker (Step 6d) with a comment explaining why (e.g.,
    "No matching changelog entry found").
 
@@ -1191,9 +1189,8 @@ if it exists) and check that:
 4. **Footer and metadata updates are expected** — changes to "PRs analyzed
    through", "PRs processed" counts, "Docs PRs" counts, "What's New" section,
    and Table of Contents summaries are normal and should not be flagged.
-5. **Docs PR links are expected additions** — new `Docs:` lines on entries whose
-   `docsRequired` is `true` are valid additions when corresponding docs PRs exist
-   in `/tmp/gh-aw/pr-data/batch-docs-prs.json`.
+5. **Docs PR links are expected additions** — new `Docs:` lines on entries when
+   corresponding docs PRs exist in `/tmp/gh-aw/pr-data/batch-docs-prs.json`.
 
 If any violation is found:
 - Log the specific violation (which entry was removed/modified, which PR number is

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -38,6 +38,8 @@ description: |
 env:
   PRODUCT: "Aspire"
   REPO: "microsoft/aspire"
+  DOCS_REPO: "microsoft/aspire.dev"
+  MILESTONE_START: "2026-03-01"
   MILESTONE: "13.3"
   BATCH_SIZE: "20"
 
@@ -75,6 +77,7 @@ jobs:
           MEMORY_REF="memory/milestone-changelog"
           MEMORY_DIR="$DATA_DIR/memory/$MILESTONE"
           PROCESSED_NUMBERS="[]"
+          PROCESSED_DOCS_NUMBERS="[]"
           FEEDBACK_FROM_MEMORY=""
           MEMORY_TMP=$(mktemp -d)
           CLONE_ERR=$(mktemp)
@@ -109,6 +112,17 @@ jobs:
                 PROCESSED_NUMBERS="$PRS_LISTING"
               fi
               echo "Extracted $(echo "$PROCESSED_NUMBERS" | jq length) processed PR numbers from filenames"
+            fi
+
+            DOCS_PRS_DIR="$MEMORY_DIR/prs-docs"
+            if [ -d "$DOCS_PRS_DIR" ]; then
+              DOCS_PRS_LISTING=$(ls "$DOCS_PRS_DIR" 2>/dev/null \
+                | sed -n 's/.*-\([0-9]*\)\.json$/\1/p' \
+                | jq -Rs '[split("\n") | .[] | select(. != "") | tonumber]')
+              if echo "$DOCS_PRS_LISTING" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+                PROCESSED_DOCS_NUMBERS="$DOCS_PRS_LISTING"
+              fi
+              echo "Extracted $(echo "$PROCESSED_DOCS_NUMBERS" | jq length) processed docs PR numbers from filenames"
             fi
 
             # Also grab the feedback issue number from memory
@@ -149,10 +163,37 @@ jobs:
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
 
-          # 3. Check if there is work to do (unprocessed PRs or updated feedback)
+          # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date
+          DOCS_REPO="${{ env.DOCS_REPO }}"
+          MILESTONE_START="${{ env.MILESTONE_START }}"
+          gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
+            --search "merged:>=${MILESTONE_START}" \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            | jq 'sort_by(.mergedAt)' \
+            > "$DATA_DIR/all-docs-prs.json"
+
+          DOCS_TOTAL=$(jq length "$DATA_DIR/all-docs-prs.json")
+          echo "Total docs PRs merged since $MILESTONE_START: $DOCS_TOTAL"
+
+          jq --argjson processed "$PROCESSED_DOCS_NUMBERS" \
+             --argjson batch_size "$BATCH_SIZE" \
+             '($processed | map({(tostring): true}) | add // {}) as $set | [.[] | select($set[.number | tostring] | not)] | .[0:$batch_size]' \
+             "$DATA_DIR/all-docs-prs.json" \
+             > "$DATA_DIR/batch-docs-prs.json"
+
+          DOCS_BATCH_COUNT=$(jq length "$DATA_DIR/batch-docs-prs.json")
+          DOCS_PROCESSED_COUNT=$(echo "$PROCESSED_DOCS_NUMBERS" | jq length)
+          echo "Docs PRs already processed: $DOCS_PROCESSED_COUNT"
+          echo "Docs PRs batch (oldest $BATCH_SIZE unprocessed): $DOCS_BATCH_COUNT"
+
+          # 3. Check if there is work to do (unprocessed PRs, unprocessed docs PRs, or updated feedback)
           HAS_WORK="false"
           if [ "$BATCH_COUNT" -gt 0 ]; then
             echo "Has $BATCH_COUNT unprocessed PRs"
+            HAS_WORK="true"
+          fi
+          if [ "$DOCS_BATCH_COUNT" -gt 0 ]; then
+            echo "Has $DOCS_BATCH_COUNT unprocessed docs PRs"
             HAS_WORK="true"
           fi
 
@@ -364,9 +405,9 @@ Generate and maintain a changelog for the **${PRODUCT} ${MILESTONE} milestone** 
 Each run appends newly merged changes to the existing content while preserving
 previous entries. A companion feedback issue collects editorial comments.
 
-> **Note:** `${PRODUCT}`, `${REPO}`, `${MILESTONE}`, and `${BATCH_SIZE}` refer to values set in the workflow's
-> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`13.3`**, and **`20`**). All file names, titles, and
-> references below derive from those values.
+> **Note:** `${PRODUCT}`, `${REPO}`, `${DOCS_REPO}`, `${MILESTONE_START}`, `${MILESTONE}`, and `${BATCH_SIZE}` refer to values set in the workflow's
+> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-03-01`**, **`13.3`**, and **`20`**). All file names,
+> titles, and references below derive from those values.
 
 ## Important: available tools
 
@@ -400,16 +441,26 @@ use one of these patterns:
 | Batch file | `/tmp/gh-aw/pr-data/batch-prs.json` (computed from all PRs minus processed) |
 | Existing body file | `/tmp/gh-aw/pr-data/existing-body.md` (fetched from wiki) |
 | PR tracker directory | `prs/` (under memory directories; one JSON file per PR) |
+| Docs repo | `${DOCS_REPO}` (repository containing documentation PRs) |
+| Docs milestone start | `${MILESTONE_START}` (fetch docs PRs merged on or after this date) |
+| Docs batch file | `/tmp/gh-aw/pr-data/batch-docs-prs.json` (unprocessed docs PRs) |
+| Docs PR tracker directory | `prs-docs/` (under memory directories; one JSON file per docs PR) |
 
 ## Step 1: Load existing changelog and feedback
 
-First, read `/tmp/gh-aw/pr-data/batch-prs.json` using the `bash` tool with `jq`
-to determine whether there are unprocessed PRs or only feedback to apply.
-If the batch is empty (zero unprocessed PRs), the feedback issue has new
-comments to apply (the `fetch-data` job already confirmed there is work).
-**Skip Steps 3 and 5** but continue through Steps 1, 2, 4, 6, 7, and 8 to
-apply editorial feedback, persist any feedback-modified change files, refresh
-the "What's New" section, and update the footer counts.
+First, read `/tmp/gh-aw/pr-data/batch-prs.json` and
+`/tmp/gh-aw/pr-data/batch-docs-prs.json` using the `bash` tool with `jq`
+to determine what work is available.
+
+- If `batch-prs.json` is **non-empty**, proceed through all steps (1–8).
+- If `batch-prs.json` is **empty** but `batch-docs-prs.json` is non-empty,
+  **skip Steps 3 and 5a–5e** (no product PRs to process) but continue through
+  Steps 1, 2, 4, 5f, 6, 7, and 8 to process docs PRs, apply editorial
+  feedback, and update the wiki.
+- If **both** batches are empty, the `fetch-data` job detected updated feedback.
+  **Skip Steps 3, 5a–5e, and 5f** but continue through Steps 1, 2, 4, 6, 7,
+  and 8 to apply editorial feedback, refresh the “What’s New” section, and
+  update the footer counts.
 
 1. Check if the file `/tmp/gh-aw/pr-data/existing-body.md` exists (fetched from the
    wiki page during the pre-computation step). If it does, read its contents as the
@@ -422,10 +473,14 @@ the "What's New" section, and update the footer counts.
    empty, no PRs have been processed yet.
 3. List the files in `/tmp/gh-aw/agent/memory/${MILESTONE}/changes/`.
    Each file is named `{first-pr-merge-date}-{slug}.json` and contains a changelog
-   entry (see Step 6 for the change file schema). Load these as the existing set of
+   entry (see Step 6a for the change file schema). Load these as the existing set of
    changelog entries. If the directory does not exist or is empty, there are no
    existing entries.
-4. Check if the file `/tmp/gh-aw/pr-data/feedback-issue.json` exists. If it
+4. List the files in `/tmp/gh-aw/agent/memory/${MILESTONE}/prs-docs/`.
+   Each file is named `{merge-date}-{number}.json` and contains a single docs
+   PR tracker entry (see Step 6d for the schema). If the directory does not
+   exist or is empty, no docs PRs have been processed yet.
+5. Check if the file `/tmp/gh-aw/pr-data/feedback-issue.json` exists. If it
    does, read the issue number and `updatedAt` timestamp from it and then read
    **all** comments on that issue into memory — these will be processed as
    editorial instructions in Step 4. If the file does not exist, there is no
@@ -444,6 +499,13 @@ The pre-computation step (in the frontmatter) has already:
 Each entry in `batch-prs.json` contains: `number`, `title`, `body`, `author` (object
 with `login` and `is_bot`), `mergedAt`, `labels` (array of objects with `name`),
 `additions`, `deletions`, `changedFiles`.
+
+The pre-computation step has also fetched merged PRs from `${DOCS_REPO}` that
+were merged on or after `${MILESTONE_START}`:
+- All matching docs PRs → `/tmp/gh-aw/pr-data/all-docs-prs.json`
+- Oldest ${BATCH_SIZE} unprocessed docs PRs → `/tmp/gh-aw/pr-data/batch-docs-prs.json`
+
+Each entry in `batch-docs-prs.json` has the same schema as `batch-prs.json`.
 
 ## Step 3: Process the batch PRs
 
@@ -634,6 +696,15 @@ This gives visibility and recognition to external contributors.
 
 Omit flag lines entirely when a flag does not apply.
 
+When documentation PRs have been matched to an entry (the `docsPrs` array is
+non-empty after Step 5f), add a `Docs:` line linking to the docs PRs:
+```
+  Docs: [${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)  
+```
+When multiple docs PRs are linked, separate them with commas. The `Docs:` line
+appears immediately after the `Changes:` line. Keep the
+`📝 **Documentation required**` flag line as well.
+
 ### 5c. Write name and description
 
 - **Emoji**: Choose a single emoji that represents the change. Pick something specific
@@ -671,6 +742,45 @@ rather than creating a new one:
 - When in doubt about whether a change is notable, include it — it can always be
   removed via a comment later.
 
+### 5f. Match documentation PRs
+
+Read `/tmp/gh-aw/pr-data/batch-docs-prs.json`. This is a JSON array of up to
+${BATCH_SIZE} unprocessed docs PRs from `${DOCS_REPO}`, sorted by `mergedAt`
+ascending. Each entry has the same schema as the product PR batch.
+
+Unlike product PRs (Step 3), **do not exclude bot-authored docs PRs** —
+automated docs PRs from bots often contain meaningful documentation updates.
+Process them the same as human-authored docs PRs.
+
+If a docs PR is clearly unrelated to the milestone (e.g., it matched the date
+filter but documents an unrelated product or version), record it as
+`"excluded"` in the docs PR tracker (Step 6d) with a comment explaining why.
+
+For each remaining docs PR, determine whether it documents a changelog entry
+that has `docsRequired: true`. Use the `pull_request_read` tool (specifying the
+`${DOCS_REPO}` repository) to fetch the full body, changed file paths, and
+any cross-references. Match by:
+
+1. **Explicit product PR reference** — the docs PR body or title mentions a
+   product PR number (e.g., "Documents #1234", links to
+   `https://github.com/${REPO}/pull/1234`). Match to the changelog entry
+   whose `prs` array contains that number.
+2. **Feature name or area match** — the docs PR title, body, or changed file paths
+   clearly correspond to a changelog entry’s name, area, or description
+   (e.g., a docs PR titled "Document Redis clustering" matches a changelog
+   entry named "Redis clustering support").
+3. **No match** — if the docs PR cannot be confidently matched to any
+   changelog entry with `docsRequired: true`, record it as `"included"` in
+   the docs PR tracker (Step 6d) with an empty `matchedChanges` array so it
+   is not re-processed.
+
+When a match is found:
+- Add the docs PR number to the matched change file’s `docsPrs` array.
+- Record the docs PR as `"included"` in the docs PR tracker (Step 6d).
+
+A single docs PR may match multiple changelog entries if it documents several
+features. Add its number to each matched entry’s `docsPrs` array.
+
 ## Step 6: Write state to disk
 
 The write directory `/tmp/gh-aw/agent/memory/${MILESTONE}/` is **pre-seeded**
@@ -684,7 +794,7 @@ after the wiki page is successfully published. The changelog body is **not**
 stored here — it is rendered from the change files in Step 7 and published to
 the wiki in Step 8.
 
-**Important:** All three sub-steps (6a, 6b, 6c) must be completed.
+**Important:** All four sub-steps (6a, 6b, 6c, 6d) must be completed.
 
 ### 6a. Write change files
 
@@ -713,6 +823,7 @@ Schema:
   "changeType": "New features",
   "communityContributors": ["@contributor"],
   "description": "Added a new command for scaffolding resources",
+  "docsPrs": [456],
   "docsRequired": true,
   "emoji": "🆕",
   "firstMergedAt": "2026-04-20T14:15:00Z",
@@ -731,6 +842,7 @@ Field definitions:
 - **communityContributors**: Array of GitHub usernames (prefixed with `@`) of
   external community contributors. Empty array if none.
 - **description**: User-facing description (one to two sentences)
+- **docsPrs**: Array of PR numbers from `${DOCS_REPO}` that document this change. Empty array if none.
 - **docsRequired**: `true` if documentation is needed, `false` otherwise
 - **emoji**: A single emoji representing the change
 - **firstMergedAt**: ISO 8601 UTC timestamp of the earliest PR's merge date
@@ -818,6 +930,55 @@ Copy `/tmp/gh-aw/pr-data/feedback-issue.json` to
 `/tmp/gh-aw/agent/memory/${MILESTONE}/feedback-issue.json` if the data file exists.
 This updates both the issue number and the `updatedAt` timestamp for the next run.
 
+### 6d. Update the docs PR tracker
+
+Write or update individual docs PR tracker files in:
+`/tmp/gh-aw/agent/memory/${MILESTONE}/prs-docs/`
+
+This directory tracks which docs PRs from `${DOCS_REPO}` have been processed.
+Each processed docs PR gets its own JSON file. Create the `prs-docs/` directory
+(via `mkdir -p`) if it does not exist.
+
+Filename format: `{merge-date-time}-{number}.json`
+
+Where:
+- `{merge-date-time}` is the docs PR’s merge date in `YYYYMMDDTHHmm` format
+- `{number}` is the docs PR number
+
+Example: `20260425T1000-456.json`
+
+Schema:
+
+```json
+{
+  "author": "username",
+  "comment": "Documents new CLI scaffolding command",
+  "matchedChanges": ["20260422T1830-new-cli-command.json"],
+  "mergedAt": "2026-04-25T10:00:00Z",
+  "number": 456,
+  "runDate": "2026-04-27T03:49:58Z",
+  "status": "included",
+  "title": "Document scaffolding command"
+}
+```
+
+Field definitions:
+- **author**: GitHub username of the docs PR author
+- **comment**: Brief explanation of why the docs PR was included or excluded
+- **matchedChanges**: Array of change file names (from `changes/`) that this docs PR
+  documents. Empty array if no changelog entries were matched.
+- **mergedAt**: ISO 8601 UTC merge timestamp
+- **number**: Docs PR number (in `${DOCS_REPO}`)
+- **runDate**: ISO 8601 UTC timestamp of the workflow run that processed this docs PR
+- **status**: One of `"included"` (processed) or `"excluded"` (not relevant to the milestone)
+- **title**: Original docs PR title
+
+After writing each file, **normalize formatting** by running:
+```bash
+jq --sort-keys '.' "<filepath>" > /tmp/docs-pr-fmt.json \
+  && mv /tmp/docs-pr-fmt.json "<filepath>"
+```
+
 ## Step 7: Build the wiki page body
 
 Build the wiki page body from **all change files** in
@@ -864,9 +1025,15 @@ Under each area heading, add a one-line **summary** counting the entries per cha
 type, e.g. `2 new features, 1 improvement` or `3 bug fixes`. Use singular form
 for counts of 1 (`1 new feature`, `1 bug fix`, `1 improvement`).
 
-**Every line** within a changelog entry (name, description, Changes, and each flag
+**Every line** within a changelog entry (name, description, Changes, Docs, and each flag
 line) must end with **two trailing spaces** (`  `) to produce a markdown line break.
 This includes the last line of each entry, even when there are no flags.
+
+When a changelog entry has a non-empty `docsPrs` array, add a **Docs:** line immediately
+after the `Changes:` line. Each docs PR is linked using the format
+`[${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)`. Separate multiple
+docs PRs with commas. The `📝 **Documentation required**` flag line is kept
+regardless of whether docs PRs are linked.
 
 Use this exact format:
 
@@ -900,6 +1067,7 @@ Use this exact format:
 1. **🚀 Another feature**  
   What this means for users  
   Changes: [#1236](https://github.com/${REPO}/pull/1236)  
+  Docs: [${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)  
   📝 **Documentation required**  
 
 #### Improvements
@@ -944,16 +1112,21 @@ Use this exact format:
 
 **PRs processed:** ✅ 6 included · ❌ 1 excluded · ⏳ 93 unprocessed · 100 total merged in milestone
 ([View full PR tracker](https://github.com/${REPO}/blob/memory/milestone-changelog/${MILESTONE}/prs/))
+**Docs PRs:** ✅ 3 included · ❌ 1 excluded · ⏳ 5 unprocessed · 9 total from [${DOCS_REPO}](https://github.com/${DOCS_REPO})
+([View docs PR tracker](https://github.com/${REPO}/blob/memory/milestone-changelog/${MILESTONE}/prs-docs/))
 **PRs analyzed through:** [#<number>](https://github.com/${REPO}/pull/<number>) merged <YYYY-MM-DD HH:mm> UTC
 ```
 
 At the bottom of the page (after the footer), include a **PRs processed** summary
-line, a link to the PR tracker directory on the memory branch, and a **PRs analyzed
-through** line showing the newest PR processed in this run:
+line, a link to the PR tracker directory on the memory branch, a **Docs PRs** summary
+line with a link to the docs PR tracker, and a **PRs analyzed through** line showing
+the newest PR processed in this run:
 
 ```
 **PRs processed:** ✅ <N> included · ❌ <N> excluded · ⏳ <N> unprocessed · <N> total merged in milestone
 ([View full PR tracker](https://github.com/${REPO}/blob/memory/milestone-changelog/${MILESTONE}/prs/))
+**Docs PRs:** ✅ <N> included · ❌ <N> excluded · ⏳ <N> unprocessed · <N> total from [${DOCS_REPO}](https://github.com/${DOCS_REPO})
+([View docs PR tracker](https://github.com/${REPO}/blob/memory/milestone-changelog/${MILESTONE}/prs-docs/))
 **PRs analyzed through:** [#<number>](https://github.com/${REPO}/pull/<number>) merged <YYYY-MM-DD HH:mm> UTC
 ```
 
@@ -962,6 +1135,12 @@ Compute the counts:
 - **excluded** = number of tracker files in `prs/` with `status: "excluded"`
 - **unprocessed** = total merged PRs in milestone (from `/tmp/gh-aw/pr-data/all-milestone-prs.json`) minus included minus excluded
 - **total** = total merged PRs in milestone
+
+Also compute docs PR counts for the footer:
+- **included** = number of tracker files in `prs-docs/` with `status: "included"`
+- **excluded** = number of tracker files in `prs-docs/` with `status: "excluded"`
+- **unprocessed** = total docs PRs (from `/tmp/gh-aw/pr-data/all-docs-prs.json`) minus included minus excluded
+- **total** = total docs PRs from `${DOCS_REPO}`
 
 Write the final markdown to `/tmp/gh-aw/agent/new-body.md`.
 
@@ -986,8 +1165,11 @@ if it exists) and check that:
    in `/tmp/gh-aw/pr-data/batch-prs.json`, unless the entry was added via editorial
    feedback from Step 4 (e.g., "Add entry" instructions).
 4. **Footer and metadata updates are expected** — changes to "PRs analyzed
-   through", "PRs processed" counts, "What's New" section, and Table of Contents
-   summaries are normal and should not be flagged.
+   through", "PRs processed" counts, "Docs PRs" counts, "What's New" section,
+   and Table of Contents summaries are normal and should not be flagged.
+5. **Docs PR links are expected additions** — new `Docs:` lines on entries whose
+   `docsRequired` is `true` are valid additions when corresponding docs PRs exist
+   in `/tmp/gh-aw/pr-data/batch-docs-prs.json`.
 
 If any violation is found:
 - Log the specific violation (which entry was removed/modified, which PR number is

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -141,7 +141,7 @@ jobs:
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
             --search "milestone:$MILESTONE" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-milestone-prs.json"
 
@@ -163,12 +163,29 @@ jobs:
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
 
+          # 2a. Enrich batch PRs with author_association (not available via gh pr list)
+          if [ "$BATCH_COUNT" -gt 0 ]; then
+            echo "Enriching batch PRs with author_association..."
+            # Build a JSON lookup object {"number": "association", ...} in one pass
+            ASSOC_JSON="{}"
+            for NUM in $(jq -r '.[].number' "$DATA_DIR/batch-prs.json"); do
+              ASSOC=$(gh api "repos/$REPO/pulls/$NUM" --jq '.author_association' 2>/dev/null || echo "UNKNOWN")
+              ASSOC_JSON=$(echo "$ASSOC_JSON" | jq --arg n "$NUM" --arg a "$ASSOC" '. + {($n): $a}')
+            done
+            # Merge all associations into batch-prs.json in a single rewrite
+            echo "$ASSOC_JSON" | jq --slurpfile prs "$DATA_DIR/batch-prs.json" \
+              '. as $lookup | $prs[0] | map(. + {authorAssociation: ($lookup[(.number | tostring)] // "UNKNOWN")})' \
+              > "$DATA_DIR/batch-prs-tmp.json" \
+              && mv "$DATA_DIR/batch-prs-tmp.json" "$DATA_DIR/batch-prs.json"
+            echo "Enriched $BATCH_COUNT batch PRs with author_association"
+          fi
+
           # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date
           DOCS_REPO="${{ env.DOCS_REPO }}"
           MILESTONE_START="${{ env.MILESTONE_START }}"
           gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
             --search "merged:>=${MILESTONE_START}" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-docs-prs.json"
 
@@ -497,8 +514,10 @@ The pre-computation step (in the frontmatter) has already:
 - Written the oldest ${BATCH_SIZE} unprocessed PRs to `/tmp/gh-aw/pr-data/batch-prs.json`
 
 Each entry in `batch-prs.json` contains: `number`, `title`, `body`, `author` (object
-with `login` and `is_bot`), `mergedAt`, `labels` (array of objects with `name`),
-`additions`, `deletions`, `changedFiles`.
+with `login` and `is_bot`), `authorAssociation` (string, e.g. `"MEMBER"`, `"OWNER"`,
+`"CONTRIBUTOR"`, `"NONE"`), `mergedAt`, `labels` (array of objects with `name`),
+`additions`, `deletions`, `changedFiles`, and `files` (array of objects with
+`path`, `additions`, `deletions`, `changeType`) listing the changed file paths.
 
 The pre-computation step has also fetched merged PRs from `${DOCS_REPO}` that
 were merged on or after `${MILESTONE_START}`:
@@ -512,7 +531,10 @@ Each entry in `batch-docs-prs.json` has the same schema as `batch-prs.json`.
 Read `/tmp/gh-aw/pr-data/batch-prs.json`. This is a JSON array of up to ${BATCH_SIZE}
 unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Each entry contains:
 `number`, `title`, `body`, `author` (object with `login` and `is_bot`), `mergedAt`,
-`labels` (array of objects with `name`), `additions`, `deletions`, `changedFiles`.
+`labels` (array of objects with `name`), `additions`, `deletions`, `changedFiles`,
+and `files` (array of objects with `path`, `additions`, `deletions`, `changeType`).
+The batch is also enriched with `authorAssociation` (fetched via REST API in the
+pre-computation step).
 
 1. **Exclude bot-authored PRs** — remove any PR whose `author.is_bot` is `true`,
    **except** these cases which should be processed normally:
@@ -527,10 +549,10 @@ unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Each entry conta
 2. If the batch has fewer than ${BATCH_SIZE} PRs, this is the last batch — after
    processing it, the backlog will be fully caught up.
 
-For each remaining (non-bot) PR, use the `pull_request_read` tool to fetch its
-full body/description and changed file paths. Collect: number, title, author,
-`author_association`, body/description, labels, the list of changed files, and the
-total number of changed lines (additions + deletions).
+For each remaining (non-bot) PR, collect all data from the batch: number, title,
+author, `authorAssociation`, body, labels, changed file paths (`files` array), and
+total changed lines (additions + deletions). No additional API calls are needed —
+the batch data contains everything required.
 
 ### 3a. Processing backport PRs
 
@@ -664,20 +686,19 @@ Then determine whether either of these optional flags applies:
 |------|-------|-------------|
 | **Breaking change** | ⚠️ | Removed or renamed API, changed default behavior, migration required |
 | **Docs required** | 📝 | Change needs documentation (new feature, changed behavior, new config options) |
-| **Community contribution** | 🌍 | PR author's `author_association` is not `MEMBER` or `OWNER`, **and** the PR's `author.is_bot` (from the batch data) is not `true` — i.e., the author is a human external community contributor. For **backport PRs** (Step 3a), use the original PR author's `author_association` and ignore the backport bot's `is_bot` flag. |
+| **Community contribution** | 🌍 | PR's `authorAssociation` (from the batch data) is not `MEMBER` or `OWNER`, **and** the PR's `author.is_bot` (from the batch data) is not `true` — i.e., the author is a human external community contributor. For **backport PRs** (Step 3a), use the original PR author's `authorAssociation` and ignore the backport bot's `is_bot` flag. |
 
-> **Important — verifying `author_association`:** The `pull_request_read` MCP tool
-> may omit the `author_association` field from its response. If the field is missing
-> or you cannot confirm its value from the tool response, you **must** fetch it
-> explicitly using the `bash` tool:
->
-> ```bash
-> gh api "repos/${REPO}/pulls/<NUMBER>" --jq '.author_association'
-> ```
->
+The `authorAssociation` field is pre-populated in the batch data by the fetch-data
+job. Use it directly — no additional API calls are needed. For **backport PRs**,
+the original PR's `author_association` is not in the batch; fetch it via:
+```bash
+gh api "repos/${REPO}/pulls/<ORIGINAL_NUMBER>" --jq '.author_association'
+```
+
 > **Never infer community-contributor status from fork origin, username, or any
-> other heuristic.** Only the `author_association` field from the GitHub API is
-> authoritative. Team members frequently submit PRs from personal forks.
+> other heuristic.** Only the `author_association` / `authorAssociation` field
+> from the GitHub API is authoritative. Team members frequently submit PRs from
+> personal forks.
 
 A change can have zero or more flags. When present, show each flag on its own
 indented line below the Changes line:
@@ -757,9 +778,9 @@ filter but documents an unrelated product or version), record it as
 `"excluded"` in the docs PR tracker (Step 6d) with a comment explaining why.
 
 For each remaining docs PR, determine whether it documents a changelog entry
-that has `docsRequired: true`. Use the `pull_request_read` tool (specifying the
-`${DOCS_REPO}` repository) to fetch the full body, changed file paths, and
-any cross-references. Match by:
+that has `docsRequired: true`. The batch data already contains each docs PR's
+`title`, `body`, and `files` (changed file paths) — no additional API calls
+are needed. Match by:
 
 1. **Explicit product PR reference** — the docs PR body or title mentions a
    product PR number (e.g., "Documents #1234", links to
@@ -910,8 +931,7 @@ To build/update:
 2. For each PR in the current batch, create or update its tracker file: set
    `status` to `"included"` or `"excluded"`, set `comment` to a brief
    explanation, and set `runDate` to the current ISO 8601 UTC timestamp.
-   For bot-excluded PRs (which skip the `pull_request_read` call in Step 3),
-   populate `author` from `author.login` and `title` from the batch data
+   Populate `author` from `author.login` and `title` from the batch data
    (`batch-prs.json`).
 
 Do **not** create tracker files for unprocessed PRs. PRs without a tracker file
@@ -967,7 +987,7 @@ Field definitions:
 - **mergedAt**: ISO 8601 UTC merge timestamp
 - **number**: Docs PR number (in `${DOCS_REPO}`)
 - **runDate**: ISO 8601 UTC timestamp of the workflow run that processed this docs PR
-- **status**: One of `"included"` (processed) or `"excluded"` (not relevant to the milestone)
+- **status**: One of `"included"` (matched to at least one changelog entry) or `"excluded"` (not relevant to the milestone)
 - **title**: Original docs PR title
 
 After writing each file, **normalize formatting** by running:

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -770,9 +770,9 @@ any cross-references. Match by:
    (e.g., a docs PR titled "Document Redis clustering" matches a changelog
    entry named "Redis clustering support").
 3. **No match** — if the docs PR cannot be confidently matched to any
-   changelog entry with `docsRequired: true`, record it as `"included"` in
-   the docs PR tracker (Step 6d) with an empty `matchedChanges` array so it
-   is not re-processed.
+   changelog entry with `docsRequired: true`, record it as `"excluded"` in
+   the docs PR tracker (Step 6d) with an empty `matchedChanges` array and a
+   comment explaining why (e.g., "No matching changelog entry found").
 
 When a match is found:
 - Add the docs PR number to the matched change file’s `docsPrs` array.

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -498,9 +498,8 @@ to determine what work is available.
    PR tracker entry (see Step 6d for the schema). If the directory does not
    exist or is empty, no docs PRs have been processed yet.
 5. Check if the file `/tmp/gh-aw/pr-data/feedback-issue.json` exists. If it
-   does, read the issue number and `updatedAt` timestamp from it and then read
-   **all** comments on that issue into memory — these will be processed as
-   editorial instructions in Step 4. If the file does not exist, there is no
+   does, read the issue number and `updatedAt` timestamp from it. The comments
+   on this issue will be read in Step 4 when processing editorial feedback. If the file does not exist, there is no
    feedback to process.
 
 ## Step 2: Review the pre-computed batch
@@ -524,7 +523,9 @@ were merged on or after `${MILESTONE_START}`:
 - All matching docs PRs → `/tmp/gh-aw/pr-data/all-docs-prs.json`
 - Oldest ${BATCH_SIZE} unprocessed docs PRs → `/tmp/gh-aw/pr-data/batch-docs-prs.json`
 
-Each entry in `batch-docs-prs.json` has the same schema as `batch-prs.json`.
+Each entry in `batch-docs-prs.json` has the same schema as `batch-prs.json`,
+except without the `authorAssociation` field (which is only enriched for
+product PRs).
 
 ## Step 3: Process the batch PRs
 
@@ -786,12 +787,18 @@ are needed. Match by:
    product PR number (e.g., "Documents #1234", links to
    `https://github.com/${REPO}/pull/1234`). Match to the changelog entry
    whose `prs` array contains that number.
-2. **Feature name or area match** — the docs PR title, body, or changed file paths
-   clearly correspond to a changelog entry’s name, area, or description
+2. **Feature name match** — the docs PR title, body, or changed file paths
+   clearly correspond to a changelog entry’s name or description
    (e.g., a docs PR titled "Document Redis clustering" matches a changelog
    entry named "Redis clustering support").
-3. **No match** — if the docs PR cannot be confidently matched to any
-   changelog entry with `docsRequired: true`, record it as `"excluded"` in
+3. **Read diff when uncertain** — if the docs PR appears related to the general
+   area of a changelog entry but the title, body, and file paths are not enough
+   to confidently confirm a match, use `pull_request_read` with `get_diff` on
+   the docs PR to inspect its actual content. Use the diff to identify which
+   product feature is being documented.
+4. **No match** — if the docs PR cannot be confidently matched to any
+   changelog entry with `docsRequired: true` (even after reading the diff),
+   record it as `"excluded"` in
    the docs PR tracker (Step 6d) with a comment explaining why (e.g.,
    "No matching changelog entry found").
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -771,8 +771,8 @@ any cross-references. Match by:
    entry named "Redis clustering support").
 3. **No match** — if the docs PR cannot be confidently matched to any
    changelog entry with `docsRequired: true`, record it as `"excluded"` in
-   the docs PR tracker (Step 6d) with an empty `matchedChanges` array and a
-   comment explaining why (e.g., "No matching changelog entry found").
+   the docs PR tracker (Step 6d) with a comment explaining why (e.g.,
+   "No matching changelog entry found").
 
 When a match is found:
 - Add the docs PR number to the matched change file’s `docsPrs` array.
@@ -953,7 +953,6 @@ Schema:
 {
   "author": "username",
   "comment": "Documents new CLI scaffolding command",
-  "matchedChanges": ["20260422T1830-new-cli-command.json"],
   "mergedAt": "2026-04-25T10:00:00Z",
   "number": 456,
   "runDate": "2026-04-27T03:49:58Z",
@@ -965,12 +964,10 @@ Schema:
 Field definitions:
 - **author**: GitHub username of the docs PR author
 - **comment**: Brief explanation of why the docs PR was included or excluded
-- **matchedChanges**: Array of change file names (from `changes/`) that this docs PR
-  documents. Empty array if no changelog entries were matched.
 - **mergedAt**: ISO 8601 UTC merge timestamp
 - **number**: Docs PR number (in `${DOCS_REPO}`)
 - **runDate**: ISO 8601 UTC timestamp of the workflow run that processed this docs PR
-- **status**: One of `"included"` (matched to at least one changelog entry) or `"excluded"` (no match found, or not relevant to the milestone)
+- **status**: One of `"included"` (processed) or `"excluded"` (not relevant to the milestone)
 - **title**: Original docs PR title
 
 After writing each file, **normalize formatting** by running:


### PR DESCRIPTION
## Summary

Adds documentation PR tracking to the milestone changelog workflow. The workflow now fetches merged PRs from the docs repo (\microsoft/aspire.dev\) and matches them to changelog entries, providing visibility into documentation coverage for milestone features.

## Changes

### fetch-data job
- Added \MILESTONE_START\ env var to control the date filter for docs PRs
- Fetch all merged PRs from \DOCS_REPO\ merged on or after \MILESTONE_START\
- Compute unprocessed docs PR batch (oldest \BATCH_SIZE\)
- Extract processed docs PR numbers from \prs-docs/\ tracker directory on memory branch
- Trigger workflow when unprocessed docs PRs exist

### Agent instructions
- **Step 1**: Load docs PR tracker files from \prs-docs/\ directory; added skip logic (skip Steps 3/5a-5e when only docs PRs need processing; skip 5f too when only feedback changed)
- **Step 2**: Document the docs PR batch schema
- **Step 5b**: Add \Docs:\ line format for linking docs PRs to changelog entries
- **Step 5f** (new): Match docs PRs to changelog entries by explicit PR reference, feature/area name match, or record as included with empty matchedChanges; bot-authored docs PRs are not excluded
- **Step 6a**: Added \docsPrs\ field to change file schema
- **Step 6d** (new): Docs PR tracker schema with \included\/\xcluded\ status (mirrors product PR tracker)
- **Step 7**: Docs PR footer with included/excluded/unprocessed counts and link to tracker directory
- **Step 8a**: Validate docs PR links as expected additions

### Configuration
- Added \DOCS_REPO\, \MILESTONE_START\, and docs-related paths to Configuration table