### PR TITLE
pr-docs-check: link drafted PR in source-PR comment and request SME as reviewer

### DIFF
--- a/.github/workflows/pr-docs-check.lock.yml
+++ b/.github/workflows/pr-docs-check.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"946623789bbe689cddf65c953f78bf102245cb9dd16ceef6ac5309cc43be84d3","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d39e10f915c4db4372356f6e189595fb60b956f363e9b3b92a76d00933bf07a8","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -206,19 +206,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9f9cd66f4aa5ac6e_EOF'
+          cat << 'GH_AW_PROMPT_f95800e0622c1b6e_EOF'
           <system>
-          GH_AW_PROMPT_9f9cd66f4aa5ac6e_EOF
+          GH_AW_PROMPT_f95800e0622c1b6e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9f9cd66f4aa5ac6e_EOF'
+          cat << 'GH_AW_PROMPT_f95800e0622c1b6e_EOF'
           <safe-output-tools>
-          Tools: add_comment, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_9f9cd66f4aa5ac6e_EOF
+          Tools: create_pull_request, missing_tool, missing_data, noop, notify_source_pr
+          GH_AW_PROMPT_f95800e0622c1b6e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_9f9cd66f4aa5ac6e_EOF'
+          cat << 'GH_AW_PROMPT_f95800e0622c1b6e_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -252,12 +252,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_9f9cd66f4aa5ac6e_EOF
+          GH_AW_PROMPT_f95800e0622c1b6e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9f9cd66f4aa5ac6e_EOF'
+          cat << 'GH_AW_PROMPT_f95800e0622c1b6e_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-docs-check.md}}
-          GH_AW_PROMPT_9f9cd66f4aa5ac6e_EOF
+          GH_AW_PROMPT_f95800e0622c1b6e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -500,44 +500,57 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_95f21b0d0ac6f882_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1,"target-repo":"microsoft/aspire"},"create_pull_request":{"allowed_base_branches":["main","release/*"],"base_branch":"main","draft":true,"fallback_as_issue":true,"labels":["docs-from-code"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/"],"reviewers":["${{ github.event.pull_request.user.login || '' }}"],"target-repo":"microsoft/aspire.dev","title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_95f21b0d0ac6f882_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1361dbd83912643a_EOF'
+          {"create_pull_request":{"allowed_base_branches":["main","release/*"],"base_branch":"main","draft":true,"fallback_as_issue":true,"labels":["docs-from-code"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/"],"target-repo":"microsoft/aspire.dev","title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"notify-source-pr":{"description":"Post the documentation analysis result as a comment on the source\nmicrosoft/aspire pull request and (when a draft documentation PR was\nopened on microsoft/aspire.dev) request a review from the SME\nidentified from the source PR.\n\nEmit exactly one `notify_source_pr` item per run, after you've finished\nany `create_pull_request` or no-docs-needed reasoning. Use `result:\n\"drafted\"` when you just emitted a `create_pull_request`; use `result:\n\"skipped\"` when no docs PR is needed. DO NOT try to embed the drafted\nPR's URL or number in the `summary` text — the workflow knows them\nfrom the safe-outputs handler and will substitute the real values.\n","inputs":{"result":{"default":null,"description":"'drafted' if a docs PR was opened on microsoft/aspire.dev, or 'skipped' if no docs PR was needed.","required":true,"type":"string"},"sme_login":{"default":null,"description":"GitHub login of the SME from the source PR (preferred reviewer for the drafted docs PR). Empty string if no SME was identified.","required":false,"type":"string"},"source_pr_number":{"default":null,"description":"PR number on microsoft/aspire that triggered this run.","required":true,"type":"number"},"summary":{"default":null,"description":"Short markdown summary of the documentation changes (when drafted) or rationale (when skipped). 1-3 sentences plus optional bullet list. DO NOT include the drafted PR URL or number — the workflow injects those automatically.","required":true,"type":"string"},"target_branch":{"default":null,"description":"Effective target branch on microsoft/aspire.dev (only meaningful when result is 'drafted').","required":false,"type":"string"}}},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_1361dbd83912643a_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Comments will be added in repository \"microsoft/aspire\". Supports reply_to_id for discussion threading.",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[docs] \". Labels [\"docs-from-code\"] will be automatically added. PRs will be created as drafts. Reviewers [\"${{ github.event.pull_request.user.login || '' }}\"] will be assigned."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[docs] \". Labels [\"docs-from-code\"] will be automatically added. PRs will be created as drafts."
               },
               "repo_params": {},
-              "dynamic_tools": []
+              "dynamic_tools": [
+                {
+                  "description": "Post the documentation analysis result as a comment on the source\nmicrosoft/aspire pull request and (when a draft documentation PR was\nopened on microsoft/aspire.dev) request a review from the SME\nidentified from the source PR.\n\nEmit exactly one `notify_source_pr` item per run, after you've finished\nany `create_pull_request` or no-docs-needed reasoning. Use `result:\n\"drafted\"` when you just emitted a `create_pull_request`; use `result:\n\"skipped\"` when no docs PR is needed. DO NOT try to embed the drafted\nPR's URL or number in the `summary` text — the workflow knows them\nfrom the safe-outputs handler and will substitute the real values.\n",
+                  "inputSchema": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "result": {
+                        "description": "'drafted' if a docs PR was opened on microsoft/aspire.dev, or 'skipped' if no docs PR was needed.",
+                        "type": "string"
+                      },
+                      "sme_login": {
+                        "description": "GitHub login of the SME from the source PR (preferred reviewer for the drafted docs PR). Empty string if no SME was identified.",
+                        "type": "string"
+                      },
+                      "source_pr_number": {
+                        "description": "PR number on microsoft/aspire that triggered this run.",
+                        "type": "number"
+                      },
+                      "summary": {
+                        "description": "Short markdown summary of the documentation changes (when drafted) or rationale (when skipped). 1-3 sentences plus optional bullet list. DO NOT include the drafted PR URL or number — the workflow injects those automatically.",
+                        "type": "string"
+                      },
+                      "target_branch": {
+                        "description": "Effective target branch on microsoft/aspire.dev (only meaningful when result is 'drafted').",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "result",
+                      "source_pr_number",
+                      "summary"
+                    ],
+                    "type": "object"
+                  },
+                  "name": "notify_source_pr"
+                }
+              ]
             }
           GH_AW_VALIDATION_JSON: |
             {
-              "add_comment": {
-                "defaultMax": 1,
-                "fields": {
-                  "body": {
-                    "required": true,
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 65000
-                  },
-                  "item_number": {
-                    "issueOrPRNumber": true
-                  },
-                  "reply_to_id": {
-                    "type": "string",
-                    "maxLength": 256
-                  },
-                  "repo": {
-                    "type": "string",
-                    "maxLength": 256
-                  }
-                }
-              },
               "create_pull_request": {
                 "defaultMax": 1,
                 "fields": {
@@ -730,7 +743,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_17676f1593ceb03e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_0a4b064baf6a37ea_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -776,7 +789,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_17676f1593ceb03e_EOF
+          GH_AW_MCP_CONFIG_0a4b064baf6a37ea_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1011,6 +1024,7 @@ jobs:
       - activation
       - agent
       - detection
+      - notify_source_pr
       - safe_outputs
     if: >
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
@@ -1339,6 +1353,224 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
             await main();
 
+  notify_source_pr:
+    name: Notify source PR
+    needs:
+      - agent
+      - detection
+      - safe_outputs
+    if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'notify_source_pr')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download agent output artifact
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agent
+          path: ${{ runner.temp }}/gh-aw/safe-jobs/
+      - name: Configure Safe Outputs Job Environment Variables
+        id: setup-safe-job-env
+        run: |
+          find "${RUNNER_TEMP}/gh-aw/safe-jobs/" -type f -print
+          echo "GH_AW_AGENT_OUTPUT=${RUNNER_TEMP}/gh-aw/safe-jobs/agent_output.json" >> "$GITHUB_OUTPUT"
+      - name: Mint aspire-bot token (microsoft/aspire)
+        id: aspire-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        env:
+          GH_AW_AGENT_OUTPUT: ${{ steps.setup-safe-job-env.outputs.GH_AW_AGENT_OUTPUT }}
+        with:
+          app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
+          owner: microsoft
+          private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
+          repositories: aspire
+      - name: Mint aspire-bot token (microsoft/aspire.dev)
+        id: aspire-dev-token
+        if: needs.safe_outputs.outputs.created_pr_url != ''
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        env:
+          GH_AW_AGENT_OUTPUT: ${{ steps.setup-safe-job-env.outputs.GH_AW_AGENT_OUTPUT }}
+        with:
+          app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
+          owner: microsoft
+          private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
+          repositories: aspire.dev
+      - name: Post status comment on source PR
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          DRAFT_PR_NUMBER: ${{ needs.safe_outputs.outputs.created_pr_number }}
+          DRAFT_PR_URL: ${{ needs.safe_outputs.outputs.created_pr_url }}
+          GH_AW_AGENT_OUTPUT: ${{ steps.setup-safe-job-env.outputs.GH_AW_AGENT_OUTPUT }}
+        with:
+          github-token: ${{ steps.aspire-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- pr-docs-check:notify-source-pr -->';
+            const SUMMARY_MAX = 2000;
+
+            const outputPath = process.env.GH_AW_AGENT_OUTPUT;
+            if (!outputPath || !fs.existsSync(outputPath)) {
+              core.warning(`Agent output file not found at ${outputPath}; skipping comment.`);
+              return;
+            }
+
+            let payload;
+            try {
+              payload = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+            } catch (e) {
+              core.warning(`Failed to parse agent output: ${e.message}`);
+              return;
+            }
+            const items = (payload && Array.isArray(payload.items)) ? payload.items : [];
+            const item = items.find(i => i && i.type === 'notify_source_pr');
+            if (!item) {
+              core.info('No notify_source_pr item in agent output; nothing to post.');
+              return;
+            }
+
+            // Source PR number is supplied by the agent. Validate it as a
+            // positive integer with a sane upper bound; the safe-jobs framework
+            // does not pass workflow-context expressions through env: cleanly,
+            // and threat detection has already gated this output.
+            const agentNumber = parseInt(String(item.source_pr_number), 10);
+            if (!Number.isInteger(agentNumber) || agentNumber <= 0 || agentNumber > 10_000_000) {
+              core.warning(`Invalid source_pr_number from agent: ${item.source_pr_number}; skipping comment.`);
+              return;
+            }
+            const sourcePrNumber = agentNumber;
+
+            const result = (item.result || '').toString().trim().toLowerCase();
+            const targetBranch = (item.target_branch || '').toString().trim();
+            const draftUrl = (process.env.DRAFT_PR_URL || '').trim();
+            const draftNumber = (process.env.DRAFT_PR_NUMBER || '').trim();
+
+            // Bound the agent-supplied summary so a malformed item can't blow up the comment.
+            let summary = (item.summary || '').toString().trim();
+            if (summary.length > SUMMARY_MAX) {
+              summary = summary.slice(0, SUMMARY_MAX) + '\n\n_(summary truncated)_';
+            }
+
+            let body;
+            if (result === 'drafted' && draftUrl) {
+              const branchSuffix = targetBranch ? ` targeting \`${targetBranch}\`` : '';
+              const numberDisplay = draftNumber || '?';
+              body = [
+                MARKER,
+                `📝 Documentation has been drafted in [microsoft/aspire.dev#${numberDisplay}](${draftUrl})${branchSuffix}.`,
+                '',
+                summary,
+                '',
+                '> [!NOTE]',
+                '> This draft PR needs human review before merging.'
+              ].join('\n');
+            } else if (result === 'drafted') {
+              // Agent intended to draft a PR but the safe-outputs handler did not produce
+              // a created_pr_url. Surface this as a failure rather than a "skipped" result.
+              body = [
+                MARKER,
+                '⚠️ Documentation drafting was attempted but the draft PR could not be confirmed.',
+                '',
+                `See the workflow run for details: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+                '',
+                summary
+              ].join('\n');
+            } else {
+              body = [
+                MARKER,
+                '✅ No documentation update needed.',
+                '',
+                summary
+              ].join('\n');
+            }
+
+            // Best-effort hide-older-comments: minimize prior comments on this PR that
+            // carry our marker. Mirrors the framework's hide-older-comments behavior
+            // for re-runs of the same workflow on the same PR.
+            try {
+              const existing = await github.paginate(github.rest.issues.listComments, {
+                owner: 'microsoft',
+                repo: 'aspire',
+                issue_number: sourcePrNumber,
+                per_page: 100,
+              });
+              for (const c of existing) {
+                if (c.body && c.body.includes(MARKER)) {
+                  try {
+                    await github.graphql(
+                      `mutation($id: ID!) { minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) { minimizedComment { isMinimized } } }`,
+                      { id: c.node_id }
+                    );
+                  } catch (e) {
+                    core.warning(`Failed to minimize comment ${c.id}: ${e.message}`);
+                  }
+                }
+              }
+            } catch (e) {
+              core.warning(`Failed to enumerate prior comments: ${e.message}`);
+            }
+
+            await github.rest.issues.createComment({
+              owner: 'microsoft',
+              repo: 'aspire',
+              issue_number: sourcePrNumber,
+              body,
+            });
+            core.info(`Posted ${result || 'unknown'} comment on microsoft/aspire#${sourcePrNumber}`);
+      - name: Request SME review on draft PR
+        if: needs.safe_outputs.outputs.created_pr_url != ''
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          DRAFT_PR_NUMBER: ${{ needs.safe_outputs.outputs.created_pr_number }}
+          GH_AW_AGENT_OUTPUT: ${{ steps.setup-safe-job-env.outputs.GH_AW_AGENT_OUTPUT }}
+        with:
+          github-token: ${{ steps.aspire-dev-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+
+            const outputPath = process.env.GH_AW_AGENT_OUTPUT;
+            if (!outputPath || !fs.existsSync(outputPath)) {
+              core.info('Agent output file not found; skipping reviewer request.');
+              return;
+            }
+            let payload;
+            try {
+              payload = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+            } catch (e) {
+              core.warning(`Failed to parse agent output: ${e.message}`);
+              return;
+            }
+            const items = (payload && Array.isArray(payload.items)) ? payload.items : [];
+            const item = items.find(i => i && i.type === 'notify_source_pr');
+            if (!item) {
+              core.info('No notify_source_pr item; skipping reviewer request.');
+              return;
+            }
+            const sme = (item.sme_login || '').toString().trim().replace(/^@/, '');
+            if (!sme) {
+              core.info('No SME login provided; leaving draft PR without an explicit reviewer.');
+              return;
+            }
+
+            const draftNumber = parseInt(String(process.env.DRAFT_PR_NUMBER || ''), 10);
+            if (!Number.isInteger(draftNumber) || draftNumber <= 0) {
+              core.warning(`Invalid draft PR number: ${process.env.DRAFT_PR_NUMBER}`);
+              return;
+            }
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: 'microsoft',
+                repo: 'aspire.dev',
+                pull_number: draftNumber,
+                reviewers: [sme],
+              });
+              core.info(`Requested @${sme} as reviewer on microsoft/aspire.dev#${draftNumber}`);
+            } catch (e) {
+              // Best-effort: an SME may not be assignable on aspire.dev (no write access,
+              // outside collaborator, etc.). Don't fail the job over this.
+              core.warning(`Failed to request reviewer @${sme} on microsoft/aspire.dev#${draftNumber}: ${e.message}`);
+            }
+
   pre_activation:
     if: >
       ((github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch') && github.repository_owner == 'microsoft') &&
@@ -1394,8 +1626,6 @@ jobs:
       app_token_minting_failed: ${{ steps.safe-outputs-app-token.outcome == 'failure' }}
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
-      comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
-      comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
       created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
@@ -1508,7 +1738,8 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target-repo\":\"microsoft/aspire\"},\"create_pull_request\":{\"allowed_base_branches\":[\"main\",\"release/*\"],\"base_branch\":\"main\",\"draft\":true,\"fallback_as_issue\":true,\"labels\":[\"docs-from-code\"],\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"protected_path_prefixes\":[\".github/\",\".agents/\",\".githooks/\",\".husky/\"],\"reviewers\":[\"${{ github.event.pull_request.user.login || '' }}\"],\"target-repo\":\"microsoft/aspire.dev\",\"title_prefix\":\"[docs] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUT_JOBS: "{\"notify_source_pr\":\"\"}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"allowed_base_branches\":[\"main\",\"release/*\"],\"base_branch\":\"main\",\"draft\":true,\"fallback_as_issue\":true,\"labels\":[\"docs-from-code\"],\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"protected_path_prefixes\":[\".github/\",\".agents/\",\".githooks/\",\".husky/\"],\"target-repo\":\"microsoft/aspire.dev\",\"title_prefix\":\"[docs] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ steps.safe-outputs-app-token.outputs.token }}
         with:

--- a/.github/workflows/pr-docs-check.md
+++ b/.github/workflows/pr-docs-check.md
@@ -116,10 +116,10 @@ safe-outputs:
   create-pull-request:
     title-prefix: "[docs] "
     labels: [docs-from-code]
-    # On pull_request-triggered runs, request the original aspire PR author as
-    # reviewer for the generated aspire.dev draft PR. On workflow_dispatch runs
-    # this expression resolves to empty and no reviewer is auto-requested.
-    reviewers: "${{ github.event.pull_request.user.login || '' }}"
+    # NOTE: do NOT set a static `reviewers:` here. The drafted PR's reviewer is
+    # the SME identified from the source aspire PR's reviews at runtime, and
+    # that decision can't live in static frontmatter. The `notify-source-pr`
+    # safe-output job below requests the SME on the drafted PR after creation.
     draft: true
     # Default to aspire.dev main, but allow the agent to override the PR base
     # per run using the milestone/linked-issue/source-base reasoning in the
@@ -134,13 +134,236 @@ safe-outputs:
     # and repository security config unless this policy is intentionally relaxed.
     protected-files: blocked
     fallback-as-issue: true
-  add-comment:
-    target-repo: "microsoft/aspire"
-    # This workflow only comments on pull requests, so opt out of discussion
-    # support to avoid requesting the invalid GitHub App discussions scope.
-    # Tracked: https://github.com/github/gh-aw/issues/25467
-    discussions: false
-    hide-older-comments: true
+  jobs:
+    notify-source-pr:
+      name: "Notify source PR"
+      description: |
+        Post the documentation analysis result as a comment on the source
+        microsoft/aspire pull request and (when a draft documentation PR was
+        opened on microsoft/aspire.dev) request a review from the SME
+        identified from the source PR.
+
+        Emit exactly one `notify_source_pr` item per run, after you've finished
+        any `create_pull_request` or no-docs-needed reasoning. Use `result:
+        "drafted"` when you just emitted a `create_pull_request`; use `result:
+        "skipped"` when no docs PR is needed. DO NOT try to embed the drafted
+        PR's URL or number in the `summary` text — the workflow knows them
+        from the safe-outputs handler and will substitute the real values.
+      runs-on: ubuntu-latest
+      needs: [safe_outputs]
+      permissions:
+        contents: read
+      inputs:
+        source_pr_number:
+          description: "PR number on microsoft/aspire that triggered this run."
+          required: true
+          type: number
+        result:
+          description: "'drafted' if a docs PR was opened on microsoft/aspire.dev, or 'skipped' if no docs PR was needed."
+          required: true
+          type: string
+        sme_login:
+          description: "GitHub login of the SME from the source PR (preferred reviewer for the drafted docs PR). Empty string if no SME was identified."
+          required: false
+          type: string
+        target_branch:
+          description: "Effective target branch on microsoft/aspire.dev (only meaningful when result is 'drafted')."
+          required: false
+          type: string
+        summary:
+          description: "Short markdown summary of the documentation changes (when drafted) or rationale (when skipped). 1-3 sentences plus optional bullet list. DO NOT include the drafted PR URL or number — the workflow injects those automatically."
+          required: true
+          type: string
+      steps:
+        - name: Mint aspire-bot token (microsoft/aspire)
+          id: aspire-token
+          uses: actions/create-github-app-token@v3.1.1
+          with:
+            app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
+            private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
+            owner: microsoft
+            repositories: aspire
+        - name: Mint aspire-bot token (microsoft/aspire.dev)
+          id: aspire-dev-token
+          if: needs.safe_outputs.outputs.created_pr_url != ''
+          uses: actions/create-github-app-token@v3.1.1
+          with:
+            app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
+            private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
+            owner: microsoft
+            repositories: aspire.dev
+        - name: Post status comment on source PR
+          uses: actions/github-script@v9
+          env:
+            DRAFT_PR_URL: ${{ needs.safe_outputs.outputs.created_pr_url }}
+            DRAFT_PR_NUMBER: ${{ needs.safe_outputs.outputs.created_pr_number }}
+          with:
+            github-token: ${{ steps.aspire-token.outputs.token }}
+            script: |
+              const fs = require('fs');
+              const MARKER = '<!-- pr-docs-check:notify-source-pr -->';
+              const SUMMARY_MAX = 2000;
+
+              const outputPath = process.env.GH_AW_AGENT_OUTPUT;
+              if (!outputPath || !fs.existsSync(outputPath)) {
+                core.warning(`Agent output file not found at ${outputPath}; skipping comment.`);
+                return;
+              }
+
+              let payload;
+              try {
+                payload = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+              } catch (e) {
+                core.warning(`Failed to parse agent output: ${e.message}`);
+                return;
+              }
+              const items = (payload && Array.isArray(payload.items)) ? payload.items : [];
+              const item = items.find(i => i && i.type === 'notify_source_pr');
+              if (!item) {
+                core.info('No notify_source_pr item in agent output; nothing to post.');
+                return;
+              }
+
+              // Source PR number is supplied by the agent. Validate it as a
+              // positive integer with a sane upper bound; the safe-jobs framework
+              // does not pass workflow-context expressions through env: cleanly,
+              // and threat detection has already gated this output.
+              const agentNumber = parseInt(String(item.source_pr_number), 10);
+              if (!Number.isInteger(agentNumber) || agentNumber <= 0 || agentNumber > 10_000_000) {
+                core.warning(`Invalid source_pr_number from agent: ${item.source_pr_number}; skipping comment.`);
+                return;
+              }
+              const sourcePrNumber = agentNumber;
+
+              const result = (item.result || '').toString().trim().toLowerCase();
+              const targetBranch = (item.target_branch || '').toString().trim();
+              const draftUrl = (process.env.DRAFT_PR_URL || '').trim();
+              const draftNumber = (process.env.DRAFT_PR_NUMBER || '').trim();
+
+              // Bound the agent-supplied summary so a malformed item can't blow up the comment.
+              let summary = (item.summary || '').toString().trim();
+              if (summary.length > SUMMARY_MAX) {
+                summary = summary.slice(0, SUMMARY_MAX) + '\n\n_(summary truncated)_';
+              }
+
+              let body;
+              if (result === 'drafted' && draftUrl) {
+                const branchSuffix = targetBranch ? ` targeting \`${targetBranch}\`` : '';
+                const numberDisplay = draftNumber || '?';
+                body = [
+                  MARKER,
+                  `📝 Documentation has been drafted in [microsoft/aspire.dev#${numberDisplay}](${draftUrl})${branchSuffix}.`,
+                  '',
+                  summary,
+                  '',
+                  '> [!NOTE]',
+                  '> This draft PR needs human review before merging.'
+                ].join('\n');
+              } else if (result === 'drafted') {
+                // Agent intended to draft a PR but the safe-outputs handler did not produce
+                // a created_pr_url. Surface this as a failure rather than a "skipped" result.
+                body = [
+                  MARKER,
+                  '⚠️ Documentation drafting was attempted but the draft PR could not be confirmed.',
+                  '',
+                  `See the workflow run for details: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+                  '',
+                  summary
+                ].join('\n');
+              } else {
+                body = [
+                  MARKER,
+                  '✅ No documentation update needed.',
+                  '',
+                  summary
+                ].join('\n');
+              }
+
+              // Best-effort hide-older-comments: minimize prior comments on this PR that
+              // carry our marker. Mirrors the framework's hide-older-comments behavior
+              // for re-runs of the same workflow on the same PR.
+              try {
+                const existing = await github.paginate(github.rest.issues.listComments, {
+                  owner: 'microsoft',
+                  repo: 'aspire',
+                  issue_number: sourcePrNumber,
+                  per_page: 100,
+                });
+                for (const c of existing) {
+                  if (c.body && c.body.includes(MARKER)) {
+                    try {
+                      await github.graphql(
+                        `mutation($id: ID!) { minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) { minimizedComment { isMinimized } } }`,
+                        { id: c.node_id }
+                      );
+                    } catch (e) {
+                      core.warning(`Failed to minimize comment ${c.id}: ${e.message}`);
+                    }
+                  }
+                }
+              } catch (e) {
+                core.warning(`Failed to enumerate prior comments: ${e.message}`);
+              }
+
+              await github.rest.issues.createComment({
+                owner: 'microsoft',
+                repo: 'aspire',
+                issue_number: sourcePrNumber,
+                body,
+              });
+              core.info(`Posted ${result || 'unknown'} comment on microsoft/aspire#${sourcePrNumber}`);
+        - name: Request SME review on draft PR
+          if: needs.safe_outputs.outputs.created_pr_url != ''
+          uses: actions/github-script@v9
+          env:
+            DRAFT_PR_NUMBER: ${{ needs.safe_outputs.outputs.created_pr_number }}
+          with:
+            github-token: ${{ steps.aspire-dev-token.outputs.token }}
+            script: |
+              const fs = require('fs');
+
+              const outputPath = process.env.GH_AW_AGENT_OUTPUT;
+              if (!outputPath || !fs.existsSync(outputPath)) {
+                core.info('Agent output file not found; skipping reviewer request.');
+                return;
+              }
+              let payload;
+              try {
+                payload = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+              } catch (e) {
+                core.warning(`Failed to parse agent output: ${e.message}`);
+                return;
+              }
+              const items = (payload && Array.isArray(payload.items)) ? payload.items : [];
+              const item = items.find(i => i && i.type === 'notify_source_pr');
+              if (!item) {
+                core.info('No notify_source_pr item; skipping reviewer request.');
+                return;
+              }
+              const sme = (item.sme_login || '').toString().trim().replace(/^@/, '');
+              if (!sme) {
+                core.info('No SME login provided; leaving draft PR without an explicit reviewer.');
+                return;
+              }
+
+              const draftNumber = parseInt(String(process.env.DRAFT_PR_NUMBER || ''), 10);
+              if (!Number.isInteger(draftNumber) || draftNumber <= 0) {
+                core.warning(`Invalid draft PR number: ${process.env.DRAFT_PR_NUMBER}`);
+                return;
+              }
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner: 'microsoft',
+                  repo: 'aspire.dev',
+                  pull_number: draftNumber,
+                  reviewers: [sme],
+                });
+                core.info(`Requested @${sme} as reviewer on microsoft/aspire.dev#${draftNumber}`);
+              } catch (e) {
+                // Best-effort: an SME may not be assignable on aspire.dev (no write access,
+                // outside collaborator, etc.). Don't fail the job over this.
+                core.warning(`Failed to request reviewer @${sme} on microsoft/aspire.dev#${draftNumber}: ${e.message}`);
+              }
 
 timeout-minutes: 20
 ---
@@ -195,7 +418,32 @@ the significance is unclear from filenames alone.
 If this was triggered via `workflow_dispatch`, use the `pr_number` input to look up
 the PR details.
 
-## Step 2: Determine Target Branch on `microsoft/aspire.dev`
+## Step 2: Identify the Subject-Matter Expert (SME)
+
+Determine which human is the best fit to review the drafted documentation PR. The
+SME is the person who reviewed/approved the source `microsoft/aspire` PR — not the
+PR author. Use the GitHub tools to list pull request reviews for the source PR
+(`GET /repos/microsoft/aspire/pulls/{N}/reviews`) and apply the following logic:
+
+1. **Collapse reviews by reviewer.** For each unique reviewer login, keep only their
+   *most recent* review event (the latest `submitted_at`).
+2. **Exclude** the source PR author and any bot account (login ending in `[bot]`,
+   or matching `dependabot`, `github-actions`, `aspire-bot`, `copilot`, etc.).
+3. **Prefer** reviewers whose latest collapsed state is `APPROVED`. Among those,
+   pick the one with the most recent `submitted_at`.
+4. **Fallback A**: if no `APPROVED` reviewer exists, pick the reviewer with any
+   non-`COMMENTED`-only state (for example, `CHANGES_REQUESTED`) whose latest
+   `submitted_at` is most recent.
+5. **Fallback B**: if no reviews exist at all, look at CODEOWNERS for the changed
+   files in `microsoft/aspire` and use the first individual login (skip team
+   handles). Treat this as a hint, not a strong signal.
+6. **Final fallback**: leave `SME_LOGIN` empty (the workflow will draft the PR
+   without an explicit reviewer rather than guess).
+
+Capture the chosen login as `SME_LOGIN`. Do NOT include the `@` prefix. You will pass
+this to the `notify_source_pr` safe output later.
+
+## Step 3: Determine Target Branch on `microsoft/aspire.dev`
 
 All draft docs PRs must be based on the `microsoft/aspire.dev` branch that
 corresponds to the release represented by the source PR. Resolve the target
@@ -220,7 +468,7 @@ Normalize milestone titles with the regex `^v?(\d+)\.(\d+)(?:\.(\d+))?`:
 The result of this step is a single **target branch** string, either `main` or
 `release/X.Y[.Z]`.
 
-## Step 3: Use an Existing Target Branch, Otherwise Fall Back to `main`
+## Step 4: Use an Existing Target Branch, Otherwise Fall Back to `main`
 
 Use the local `microsoft/aspire.dev` workspace for this step.
 
@@ -237,7 +485,7 @@ Do **not** create or push new branches in this step. This step only chooses an
 existing `microsoft/aspire.dev` branch to use for documentation edits and for
 the draft PR base.
 
-## Step 4: Detect Significant Changes and Decide Whether a Docs PR Is Required
+## Step 5: Detect Significant Changes and Decide Whether a Docs PR Is Required
 
 Review the PR metadata and candidate diffs for **significant user-facing changes**.
 
@@ -276,18 +524,21 @@ Do not create a docs PR for minor or already-understood changes just because the
 docs-adjacent area. If the change is small, internal, or already covered by existing docs,
 treat it as **no docs PR required**.
 
-## Step 5: If No Docs PR Is Required
+## Step 6: If No Docs PR Is Required
 
 If you determine that no docs PR is required because the change is not significant or the
 existing docs already cover it sufficiently:
 
-1. **Comment on the PR** in `microsoft/aspire` (PR number from Step 1) with:
-    - A brief message confirming no documentation PR is required
-    - A short explanation of why (for example: "internal refactoring only",
-      "test/build changes only", or "existing docs already cover this behavior")
-2. **Stop here** — do not proceed to the remaining steps.
+1. Emit a single `notify_source_pr` safe output with:
+   - `source_pr_number`: the source PR number from Step 1.
+   - `result`: `"skipped"`.
+   - `sme_login`: `SME_LOGIN` from Step 2 (or an empty string if none was found).
+   - `summary`: a short markdown rationale (1–3 sentences). For example:
+     `"Test/build changes only — existing docs already cover this behavior."`.
+2. **Stop here** — do not proceed to the remaining steps. Do **not** emit
+   `create_pull_request` or any other safe output for the no-docs path.
 
-## Step 6: Read the doc-writer Skill
+## Step 7: Read the doc-writer Skill
 
 Read the file `.github/skills/doc-writer/SKILL.md` from the checked-out
 `microsoft/aspire.dev` workspace. This skill contains comprehensive guidelines for
@@ -300,17 +551,17 @@ writing documentation on the Aspire docs site, including:
 
 **You must follow all guidelines in the doc-writer skill when writing documentation.**
 
-## Step 7: Browse Existing Documentation
+## Step 8: Browse Existing Documentation
 
 Explore the existing documentation in `src/frontend/src/content/docs/` to:
 
 - Identify pages that cover the affected feature area
-- Confirm the documentation gap you identified in Step 4
+- Confirm the documentation gap you identified in Step 5
 - Determine whether existing pages need updates or new pages should be created
 - Understand the current documentation structure, naming conventions, and patterns
 - Find related pages that should be cross-referenced
 
-## Step 8: Write Documentation Changes
+## Step 9: Write Documentation Changes
 
 Based on your analysis, make the actual file changes in the workspace:
 
@@ -321,20 +572,20 @@ Based on your analysis, make the actual file changes in the workspace:
 Keep the changes focused on the significant user-facing change that triggered this
 workflow. Prefer updating the smallest correct set of pages over broad speculative edits.
 
-Ensure all changes follow the doc-writer skill guidelines from Step 6. Include:
+Ensure all changes follow the doc-writer skill guidelines from Step 7. Include:
 - Proper frontmatter (`title`, `description`)
 - Required Starlight component imports
 - Code examples where appropriate
 - Cross-references to related documentation pages
 - Correct use of Aside, Steps, Tabs, and other components
 
-## Step 9: Create Draft PR
+## Step 10: Create Draft PR
 
 Create a draft pull request on `microsoft/aspire.dev` with:
 
-**Base branch**: the effective target branch chosen in Step 3. When emitting
+**Base branch**: the effective target branch chosen in Step 4. When emitting
 the `create_pull_request` safe output, set its `base` field to that branch
-(for example, `release/13.3`, `release/13.2.1`, or `main`). If Step 3 fell
+(for example, `release/13.3`, `release/13.2.1`, or `main`). If Step 4 fell
 back to `main` because the resolved release branch does not exist on
 `microsoft/aspire.dev`, use `main` here and say so in the PR description.
 
@@ -352,14 +603,28 @@ back to `main` because the resolved release branch does not exist on
 - A list of files modified or created
 - Whether pages were updated or newly created
 
-## Step 10: Comment on Source PR
+Do **not** include `reviewers` in the `create_pull_request` emission. The SME
+identified in Step 2 is requested as a reviewer by the `notify_source_pr`
+safe-output job, not by `create_pull_request`.
 
-After the draft PR is created, **comment on the original PR** in `microsoft/aspire`
-(PR number from Step 1) with:
+## Step 11: Notify Source PR
 
-- A message indicating documentation updates have been drafted
-- A link to the newly created draft PR on `microsoft/aspire.dev`
-- The target branch the draft PR was opened against (for example,
-  `release/13.3`)
-- A brief summary of what documentation changes were made
-- A note that the draft PR needs human review before merging
+After emitting `create_pull_request`, emit a single `notify_source_pr` safe output
+with:
+
+- `source_pr_number`: the source PR number from Step 1.
+- `result`: `"drafted"`.
+- `sme_login`: `SME_LOGIN` from Step 2 (or an empty string if none was found).
+- `target_branch`: the effective target branch from Step 4 (for example,
+  `release/13.3` or `main`).
+- `summary`: a short markdown summary (1–3 sentences plus optional bullet list)
+  of the documentation changes made. List the files modified or created. Do **not**
+  describe links here — the workflow injects the drafted PR's URL automatically.
+
+> [!IMPORTANT]
+> Do **not** try to compose the drafted PR's URL or PR number yourself in the
+> `summary` text. The `notify_source_pr` safe-output job knows the real values
+> from the safe-outputs handler and will substitute them when posting the
+> comment. Likewise, do **not** call `add_comment` for either the "drafted" or
+> "skipped" path — `notify_source_pr` is the only commenting path used by this
+> workflow.


### PR DESCRIPTION
## Description

Updates the `pr-docs-check` `gh aw` workflow so the comment posted on a merged `microsoft/aspire` PR includes a working link to the drafted documentation PR on `microsoft/aspire.dev`, and so the drafted PR's reviewer is the SME who reviewed/approved the source PR (not the source PR author).

### Why

Today the workflow uses `safe-outputs.add-comment` and `create-pull-request` with a static `reviewers` field expanded from `github.event.pull_request.user.login`:

1. The comment never reliably contains the drafted PR's URL. The framework's temporary-id substitution (`#aw_xxx`) requires camelCase `number` + `repo` fields on the safe-output item, but `create_pull_request` returns `pull_request_number` and is therefore never registered in the temp-id map. The agent had no way to compose a real link in advance.
2. The reviewer is wrong in almost every case. The PR author rarely needs to also review the docs change; the human who approved the change should review the docs that describe it.

### What changed

- **Removed** `safe-outputs.add-comment` and the static `reviewers:` field from `safe-outputs.create-pull-request`.
- **Added** a custom `safe-outputs.jobs.notify-source-pr` job declaring `needs: [safe_outputs]`. The compiler appends this to the auto-built `[agent, detection]`, giving the job access to `needs.safe_outputs.outputs.created_pr_url` and `created_pr_number`. The job:
  - Mints two `aspire-bot` tokens (one scoped to `microsoft/aspire`, one scoped to `microsoft/aspire.dev`).
  - Posts a status comment on the source PR with the **real** drafted PR URL. Three states are handled:
    - `drafted` + URL → success message linking the docs PR.
    - `drafted` but no URL → ⚠️ failure surface (links to the workflow run).
    - `skipped` → ✅ no docs needed.
  - Older comments carrying the marker `<!-- pr-docs-check:notify-source-pr -->` are minimized via GraphQL `minimizeComment` for clean re-runs.
  - Best-effort calls `pulls.requestReviewers` on the drafted PR with the agent-discovered SME login. Wrapped in `try/catch` so an outside-collaborator 422 does not break the comment step.
- **Added** a new agent prompt step (Step 2: *Identify the SME*) that walks PR reviews, collapses by reviewer, prefers the most recent `APPROVED` reviewer, with fallbacks to a `CHANGES_REQUESTED` reviewer and CODEOWNERS as a hint. The agent emits a single `notify_source_pr` safe-output item carrying `source_pr_number`, `result`, `sme_login`, `target_branch`, and a length-bounded `summary`. The agent is explicitly forbidden from composing the drafted PR URL itself or calling `add_comment`.

### Validation

- `gh aw compile pr-docs-check --strict --validate` passes with 0 errors / 0 warnings.
- Inspected the regenerated `pr-docs-check.lock.yml`:
  - `notify_source_pr` job has `needs: [agent, detection, safe_outputs]`.
  - The job `if:` is `contains(needs.agent.outputs.output_types, 'notify_source_pr')` so it skips cleanly when the agent emits no notification (and when `safe_outputs` itself fails).
  - Tools list registered for the agent includes `notify_source_pr` and no longer includes `add_comment`.
  - `secrets.ASPIRE_BOT_APP_ID` / `ASPIRE_BOT_PRIVATE_KEY` are referenced directly inside the action `with:` blocks (avoiding the safe-jobs `env:` echo into `GITHUB_OUTPUT` pattern).
- `actions-lock.json` was regenerated by the compiler (added pins for `actions/create-github-app-token@v3.1.1`, `actions/download-artifact@v8.0.1`, `actions/setup-node@v6.4.0`, `actions/upload-artifact@v7.0.1`).

Fixes nothing user-visible; this is workflow-automation hygiene.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
