### PR TITLE
Enable RestoreUseStaticGraphEvaluation for faster restore

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UsePublicApiAnalyzers>true</UsePublicApiAnalyzers>
-    <!-- Use NuGet's static graph evaluation for faster restore (~47% warm-restore reduction; M15a vs M02). Override with /p:RestoreUseStaticGraphEvaluation=false. -->
+    <!-- Use NuGet's static graph evaluation for faster restore (measured at about 47% faster for warm restores in this repo). Override with /p:RestoreUseStaticGraphEvaluation=false. -->
     <RestoreUseStaticGraphEvaluation Condition="'$(RestoreUseStaticGraphEvaluation)' == ''">true</RestoreUseStaticGraphEvaluation>
     <!-- Redirect test logs into a subfolder -->
     <TestResultsLogDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsLogDir)', 'TestLogs'))</TestResultsLogDir>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UsePublicApiAnalyzers>true</UsePublicApiAnalyzers>
+    <!-- Use NuGet's static graph evaluation for faster restore (~47% warm-restore reduction; M15a vs M02). Override with /p:RestoreUseStaticGraphEvaluation=false. -->
+    <RestoreUseStaticGraphEvaluation Condition="'$(RestoreUseStaticGraphEvaluation)' == ''">true</RestoreUseStaticGraphEvaluation>
     <!-- Redirect test logs into a subfolder -->
     <TestResultsLogDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsLogDir)', 'TestLogs'))</TestResultsLogDir>
     <!-- We don't want to use the workload for AppHost projects in this repo -->


### PR DESCRIPTION
## Summary

Enable NuGet's static graph evaluation for restore by setting `RestoreUseStaticGraphEvaluation=true` at the repo root. This is the second-biggest, lowest-risk repo-controllable build-perf win we measured.

## What changes

- `Directory.Build.props`: add a single property inside the existing top-level `<PropertyGroup>`:

  ```xml
  <RestoreUseStaticGraphEvaluation Condition="'$(RestoreUseStaticGraphEvaluation)' == ''">true</RestoreUseStaticGraphEvaluation>
  ```

  The condition preserves any explicit override from the SDK, Arcade, or downstream callers.

## Measurement evidence

| Measurement | Command | Wall-clock |
|---|---|---|
| **M02** (baseline) | `dotnet msbuild Aspire.slnx -t:Restore -m` | **32.97 s** |
| **M15a** (with `RestoreUseStaticGraphEvaluation=true`) | same command | **17.55 s** |

That is a **~46% reduction** in warm restore wall-clock on this repo (427 csproj, 6 NuGet feeds, 242 PackageVersions). The build that followed restore (M15) ran cleanly with no missing-asset errors.

Validation in this PR: `dotnet restore Aspire-Core.slnf` succeeds with the change applied (exit 0).

## Risk

**Low.** Static graph evaluation has been a NuGet feature since 5.0 and is widely used by large repos. Same restore output (`project.assets.json`) is expected. The conditional preserves any caller that already sets the property.

## Backward compatibility

Enabled for all consumers by default. Any developer or CI leg that needs the legacy evaluator can opt out for a single invocation:

```
dotnet restore /p:RestoreUseStaticGraphEvaluation=false
```

or by setting the property explicitly anywhere upstream of `Directory.Build.props`.