### PR TITLE
[release/13.3] Add Ubuntu apt mirror override for CLI E2E images

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -342,6 +342,8 @@ jobs:
           TEST_LOG_PATH: ${{ github.workspace }}/artifacts/log/test-logs
           TestsRunningOutsideOfRepo: true
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
+          # CLI E2E Dockerfiles consume this as a build arg to avoid overloaded default Ubuntu package servers.
+          ASPIRE_E2E_UBUNTU_APT_MIRROR: ${{ runner.os == 'Linux' && (runner.arch == 'ARM64' && 'http://azure.ports.ubuntu.com/ubuntu-ports/' || 'http://azure.archive.ubuntu.com/ubuntu/') || '' }}
           # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
@@ -428,6 +430,8 @@ jobs:
           NUGET_PACKAGES: ${{ github.workspace }}/.packages
           PLAYWRIGHT_INSTALLED: ${{ fromJson(inputs.properties).enablePlaywrightInstall != true && 'false' || 'true' }}
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
+          # CLI E2E Dockerfiles consume this as a build arg to avoid overloaded default Ubuntu package servers.
+          ASPIRE_E2E_UBUNTU_APT_MIRROR: ${{ runner.os == 'Linux' && (runner.arch == 'ARM64' && 'http://azure.ports.ubuntu.com/ubuntu-ports/' || 'http://azure.archive.ubuntu.com/ubuntu/') || '' }}
           # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -343,6 +343,7 @@ jobs:
           TestsRunningOutsideOfRepo: true
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
           # CLI E2E Dockerfiles consume this as a build arg to avoid overloaded default Ubuntu package servers.
+          # azure.archive.ubuntu.com does not serve HTTPS; HTTP is intentional and matches the GitHub-hosted Ubuntu runner fallback mirror.
           ASPIRE_E2E_UBUNTU_APT_MIRROR: ${{ runner.os == 'Linux' && (runner.arch == 'ARM64' && 'https://azure.ports.ubuntu.com/ubuntu-ports/' || 'http://azure.archive.ubuntu.com/ubuntu/') || '' }}
           # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
@@ -431,6 +432,7 @@ jobs:
           PLAYWRIGHT_INSTALLED: ${{ fromJson(inputs.properties).enablePlaywrightInstall != true && 'false' || 'true' }}
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
           # CLI E2E Dockerfiles consume this as a build arg to avoid overloaded default Ubuntu package servers.
+          # azure.archive.ubuntu.com does not serve HTTPS; HTTP is intentional and matches the GitHub-hosted Ubuntu runner fallback mirror.
           ASPIRE_E2E_UBUNTU_APT_MIRROR: ${{ runner.os == 'Linux' && (runner.arch == 'ARM64' && 'https://azure.ports.ubuntu.com/ubuntu-ports/' || 'http://azure.archive.ubuntu.com/ubuntu/') || '' }}
           # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -343,7 +343,7 @@ jobs:
           TestsRunningOutsideOfRepo: true
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
           # CLI E2E Dockerfiles consume this as a build arg to avoid overloaded default Ubuntu package servers.
-          ASPIRE_E2E_UBUNTU_APT_MIRROR: ${{ runner.os == 'Linux' && (runner.arch == 'ARM64' && 'http://azure.ports.ubuntu.com/ubuntu-ports/' || 'http://azure.archive.ubuntu.com/ubuntu/') || '' }}
+          ASPIRE_E2E_UBUNTU_APT_MIRROR: ${{ runner.os == 'Linux' && (runner.arch == 'ARM64' && 'https://azure.ports.ubuntu.com/ubuntu-ports/' || 'http://azure.archive.ubuntu.com/ubuntu/') || '' }}
           # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}
@@ -431,7 +431,7 @@ jobs:
           PLAYWRIGHT_INSTALLED: ${{ fromJson(inputs.properties).enablePlaywrightInstall != true && 'false' || 'true' }}
           TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: 'netaspireci.azurecr.io'
           # CLI E2E Dockerfiles consume this as a build arg to avoid overloaded default Ubuntu package servers.
-          ASPIRE_E2E_UBUNTU_APT_MIRROR: ${{ runner.os == 'Linux' && (runner.arch == 'ARM64' && 'http://azure.ports.ubuntu.com/ubuntu-ports/' || 'http://azure.archive.ubuntu.com/ubuntu/') || '' }}
+          ASPIRE_E2E_UBUNTU_APT_MIRROR: ${{ runner.os == 'Linux' && (runner.arch == 'ARM64' && 'https://azure.ports.ubuntu.com/ubuntu-ports/' || 'http://azure.archive.ubuntu.com/ubuntu/') || '' }}
           # PR metadata for CLI E2E tests that download artifacts from a PR
           GITHUB_PR_NUMBER: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ fromJson(inputs.properties).requiresCliArchive == true && github.event.pull_request.head.sha || '' }}

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -311,6 +311,7 @@ internal static class CliE2ETestHelpers
             startInfo.ArgumentList.Add("--quiet");
             startInfo.ArgumentList.Add("--build-arg");
             startInfo.ArgumentList.Add("SKIP_SOURCE_BUILD=true");
+            AddUbuntuAptMirrorBuildArg(startInfo);
             startInfo.ArgumentList.Add("-f");
             startInfo.ArgumentList.Add(dockerfilePath);
             startInfo.ArgumentList.Add("-t");
@@ -360,6 +361,7 @@ internal static class CliE2ETestHelpers
 
             startInfo.ArgumentList.Add("build");
             startInfo.ArgumentList.Add("--quiet");
+            AddUbuntuAptMirrorBuildArg(startInfo);
             startInfo.ArgumentList.Add("-f");
             startInfo.ArgumentList.Add(dockerfilePath);
             startInfo.ArgumentList.Add("-t");
@@ -444,6 +446,18 @@ internal static class CliE2ETestHelpers
     private static string GenerateDockerContainerName()
     {
         return $"hex1b-test-{Guid.NewGuid():N}".Substring(0, 32);
+    }
+
+    private static void AddUbuntuAptMirrorBuildArg(ProcessStartInfo startInfo)
+    {
+        var buildArgs = new Dictionary<string, string>();
+        CliInstallStrategy.ConfigureUbuntuAptMirrorBuildArg(buildArgs);
+
+        foreach (var (name, value) in buildArgs)
+        {
+            startInfo.ArgumentList.Add("--build-arg");
+            startInfo.ArgumentList.Add($"{name}={value}");
+        }
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliInstallStrategyTests.cs
@@ -159,6 +159,34 @@ public class CliInstallStrategyTests
     }
 
     [Fact]
+    public void ConfigureContainer_AddsUbuntuAptMirrorBuildArgWhenEnvironmentVariableIsSet()
+    {
+        using var environment = new EnvironmentVariableScope(
+            (CliInstallStrategy.UbuntuAptMirrorEnvironmentVariableName, "http://azure.archive.ubuntu.com/ubuntu/"));
+
+        var strategy = CliInstallStrategy.LatestGa();
+        var options = new DockerContainerOptions();
+
+        strategy.ConfigureContainer(options);
+
+        Assert.Equal("http://azure.archive.ubuntu.com/ubuntu/", options.BuildArgs[CliInstallStrategy.UbuntuAptMirrorBuildArgName]);
+    }
+
+    [Fact]
+    public void ConfigureContainer_DoesNotAddUbuntuAptMirrorBuildArgWhenEnvironmentVariableIsEmpty()
+    {
+        using var environment = new EnvironmentVariableScope(
+            (CliInstallStrategy.UbuntuAptMirrorEnvironmentVariableName, null));
+
+        var strategy = CliInstallStrategy.LatestGa();
+        var options = new DockerContainerOptions();
+
+        strategy.ConfigureContainer(options);
+
+        Assert.DoesNotContain(CliInstallStrategy.UbuntuAptMirrorBuildArgName, options.BuildArgs.Keys);
+    }
+
+    [Fact]
     public void Detect_DotnetTool_WhenEnvironmentVariableIsSet()
     {
         using var environment = new EnvironmentVariableScope(

--- a/tests/Shared/CliInstallStrategy.cs
+++ b/tests/Shared/CliInstallStrategy.cs
@@ -209,6 +209,8 @@ internal enum CliInstallQuality
 internal sealed class CliInstallStrategy
 {
     internal const string CliArchiveDirEnvironmentVariableName = "ASPIRE_E2E_CLI_ARCHIVE_DIR";
+    internal const string UbuntuAptMirrorBuildArgName = "UBUNTU_APT_MIRROR";
+    internal const string UbuntuAptMirrorEnvironmentVariableName = "ASPIRE_E2E_UBUNTU_APT_MIRROR";
 
     private const string PreinstalledEnvironmentVariableName = "ASPIRE_E2E_PREINSTALLED";
     /// <summary>
@@ -513,6 +515,7 @@ internal sealed class CliInstallStrategy
     public void ConfigureContainer(DockerContainerOptions config)
     {
         config.BuildArgs["SKIP_SOURCE_BUILD"] = "true";
+        ConfigureUbuntuAptMirrorBuildArg(config.BuildArgs);
 
         switch (Mode)
         {
@@ -556,6 +559,15 @@ internal sealed class CliInstallStrategy
 
             default:
                 throw new InvalidOperationException($"Unknown install mode: {Mode}");
+        }
+    }
+
+    internal static void ConfigureUbuntuAptMirrorBuildArg(IDictionary<string, string> buildArgs)
+    {
+        var ubuntuAptMirror = Environment.GetEnvironmentVariable(UbuntuAptMirrorEnvironmentVariableName);
+        if (!string.IsNullOrWhiteSpace(ubuntuAptMirror))
+        {
+            buildArgs[UbuntuAptMirrorBuildArgName] = ubuntuAptMirror;
         }
     }
 

--- a/tests/Shared/Docker/Dockerfile.e2e
+++ b/tests/Shared/Docker/Dockerfile.e2e
@@ -24,8 +24,8 @@ ARG UBUNTU_APT_MIRROR=
 
 # Install native AOT build toolchain.
 COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
-RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
-    if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
+RUN if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
+      sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
       apt-get update -qq && \
       apt-get install -y --no-install-recommends clang zlib1g-dev && \
       rm -rf /var/lib/apt/lists/*; \

--- a/tests/Shared/Docker/Dockerfile.e2e
+++ b/tests/Shared/Docker/Dockerfile.e2e
@@ -20,9 +20,12 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 ARG SKIP_SOURCE_BUILD=false
+ARG UBUNTU_APT_MIRROR=
 
 # Install native AOT build toolchain.
-RUN if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
+COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
+    if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
       apt-get update -qq && \
       apt-get install -y --no-install-recommends clang zlib1g-dev && \
       rm -rf /var/lib/apt/lists/*; \
@@ -47,11 +50,15 @@ RUN if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
 # ============================================================
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS runtime
 
+ARG UBUNTU_APT_MIRROR=
+
 # --- Common tooling (shared between dotnet and polyglot variants) ---
 
 # Install gh CLI (needed by get-aspire-cli-pr.sh to download PR artifacts).
 # Install Docker CLI plus the buildx/compose plugins used by publish and deploy flows.
-RUN apt-get update -qq && \
+COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
+    apt-get update -qq && \
     apt-get install -y --no-install-recommends gpg docker.io docker-buildx docker-compose-v2 unzip && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/tests/Shared/Docker/Dockerfile.e2e
+++ b/tests/Shared/Docker/Dockerfile.e2e
@@ -24,8 +24,8 @@ ARG UBUNTU_APT_MIRROR=
 
 # Install native AOT build toolchain.
 COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR"
 RUN if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
-      sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
       apt-get update -qq && \
       apt-get install -y --no-install-recommends clang zlib1g-dev && \
       rm -rf /var/lib/apt/lists/*; \
@@ -57,8 +57,8 @@ ARG UBUNTU_APT_MIRROR=
 # Install gh CLI (needed by get-aspire-cli-pr.sh to download PR artifacts).
 # Install Docker CLI plus the buildx/compose plugins used by publish and deploy flows.
 COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
-RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
-    apt-get update -qq && \
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR"
+RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends gpg docker.io docker-buildx docker-compose-v2 unzip && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/tests/Shared/Docker/Dockerfile.e2e-podman
+++ b/tests/Shared/Docker/Dockerfile.e2e-podman
@@ -4,7 +4,11 @@
 # deploy flows can be tested without depending on host Podman state.
 FROM mcr.microsoft.com/dotnet/sdk:10.0
 
-RUN apt-get update -qq && \
+ARG UBUNTU_APT_MIRROR=
+
+COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
+    apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \

--- a/tests/Shared/Docker/Dockerfile.e2e-podman
+++ b/tests/Shared/Docker/Dockerfile.e2e-podman
@@ -7,8 +7,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0
 ARG UBUNTU_APT_MIRROR=
 
 COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
-RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
-    apt-get update -qq && \
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR"
+RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \

--- a/tests/Shared/Docker/Dockerfile.e2e-polyglot-base
+++ b/tests/Shared/Docker/Dockerfile.e2e-polyglot-base
@@ -25,8 +25,8 @@ ARG UBUNTU_APT_MIRROR=
 
 # Install native AOT build toolchain.
 COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
-RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
-    if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR"
+RUN if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
       apt-get update -qq && \
       apt-get install -y --no-install-recommends clang zlib1g-dev && \
       rm -rf /var/lib/apt/lists/*; \
@@ -55,8 +55,8 @@ ARG UBUNTU_APT_MIRROR=
 
 # Install base tools and Docker CLI.
 COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
-RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
-    apt-get update -qq && \
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR"
+RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
       ca-certificates curl gpg docker.io git libicu-dev unzip && \
     rm -rf /var/lib/apt/lists/*

--- a/tests/Shared/Docker/Dockerfile.e2e-polyglot-base
+++ b/tests/Shared/Docker/Dockerfile.e2e-polyglot-base
@@ -21,9 +21,12 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 ARG SKIP_SOURCE_BUILD=false
+ARG UBUNTU_APT_MIRROR=
 
 # Install native AOT build toolchain.
-RUN if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
+COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
+    if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
       apt-get update -qq && \
       apt-get install -y --no-install-recommends clang zlib1g-dev && \
       rm -rf /var/lib/apt/lists/*; \
@@ -48,8 +51,12 @@ RUN if [ "$SKIP_SOURCE_BUILD" != "true" ]; then \
 # ============================================================
 FROM ubuntu:24.04 AS runtime
 
+ARG UBUNTU_APT_MIRROR=
+
 # Install base tools and Docker CLI.
-RUN apt-get update -qq && \
+COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
+    apt-get update -qq && \
     apt-get install -y --no-install-recommends \
       ca-certificates curl gpg docker.io git libicu-dev unzip && \
     rm -rf /var/lib/apt/lists/*

--- a/tests/Shared/Docker/Dockerfile.e2e-polyglot-java
+++ b/tests/Shared/Docker/Dockerfile.e2e-polyglot-java
@@ -6,7 +6,7 @@ FROM aspire-e2e-polyglot-base
 ARG UBUNTU_APT_MIRROR=
 
 COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
-RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
-    apt-get update -qq && \
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR"
+RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends openjdk-25-jdk && \
     rm -rf /var/lib/apt/lists/*

--- a/tests/Shared/Docker/Dockerfile.e2e-polyglot-java
+++ b/tests/Shared/Docker/Dockerfile.e2e-polyglot-java
@@ -3,6 +3,10 @@
 
 FROM aspire-e2e-polyglot-base
 
-RUN apt-get update -qq && \
+ARG UBUNTU_APT_MIRROR=
+
+COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
+RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR" && \
+    apt-get update -qq && \
     apt-get install -y --no-install-recommends openjdk-25-jdk && \
     rm -rf /var/lib/apt/lists/*

--- a/tests/Shared/Docker/configure-ubuntu-apt-mirror.sh
+++ b/tests/Shared/Docker/configure-ubuntu-apt-mirror.sh
@@ -7,6 +7,18 @@ if [ -z "$ubuntu_apt_mirror" ]; then
     exit 0
 fi
 
+if [ ! -f /etc/os-release ]; then
+    echo "Skipping UBUNTU_APT_MIRROR because /etc/os-release was not found." >&2
+    exit 0
+fi
+
+. /etc/os-release
+
+if [ "${ID:-}" != "ubuntu" ]; then
+    echo "Skipping UBUNTU_APT_MIRROR because current image ID is '${ID:-unknown}', not 'ubuntu'." >&2
+    exit 0
+fi
+
 case "$ubuntu_apt_mirror" in
     *://*) ;;
     *)
@@ -14,13 +26,6 @@ case "$ubuntu_apt_mirror" in
         exit 1
         ;;
 esac
-
-. /etc/os-release
-
-if [ "${ID:-}" != "ubuntu" ]; then
-    echo "UBUNTU_APT_MIRROR can only be used with Ubuntu images. Current image ID is '${ID:-unknown}'." >&2
-    exit 1
-fi
 
 if [ -z "${VERSION_CODENAME:-}" ]; then
     echo "Could not determine the Ubuntu version codename from /etc/os-release." >&2

--- a/tests/Shared/Docker/configure-ubuntu-apt-mirror.sh
+++ b/tests/Shared/Docker/configure-ubuntu-apt-mirror.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+ubuntu_apt_mirror="${1:-}"
+
+if [ -z "$ubuntu_apt_mirror" ]; then
+    exit 0
+fi
+
+case "$ubuntu_apt_mirror" in
+    *://*) ;;
+    *)
+        echo "UBUNTU_APT_MIRROR must be an absolute URI, got '$ubuntu_apt_mirror'." >&2
+        exit 1
+        ;;
+esac
+
+. /etc/os-release
+
+if [ "${ID:-}" != "ubuntu" ]; then
+    echo "UBUNTU_APT_MIRROR can only be used with Ubuntu images. Current image ID is '${ID:-unknown}'." >&2
+    exit 1
+fi
+
+if [ -z "${VERSION_CODENAME:-}" ]; then
+    echo "Could not determine the Ubuntu version codename from /etc/os-release." >&2
+    exit 1
+fi
+
+ubuntu_apt_mirror="${ubuntu_apt_mirror%/}"
+ubuntu_apt_components="${UBUNTU_APT_COMPONENTS:-main restricted universe multiverse}"
+ubuntu_sources_file="/etc/apt/sources.list.d/ubuntu.sources"
+
+mkdir -p "$(dirname "$ubuntu_sources_file")"
+
+cat > "$ubuntu_sources_file" <<EOF
+Types: deb
+URIs: $ubuntu_apt_mirror
+Suites: $VERSION_CODENAME $VERSION_CODENAME-updates $VERSION_CODENAME-backports $VERSION_CODENAME-security
+Components: $ubuntu_apt_components
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+if [ -f /etc/apt/sources.list ]; then
+    printf '# Ubuntu sources configured in %s\n' "$ubuntu_sources_file" > /etc/apt/sources.list
+fi


### PR DESCRIPTION
Backport of #16753 to release/13.3

/cc @danegsta

## Description

Manual backport of #16753 after the automated backport failed on a three-way merge conflict in `tests/Shared/Docker/Dockerfile.e2e`.

Adds a declarative Ubuntu APT mirror override for the CLI E2E test Dockerfiles. The Dockerfiles now accept `UBUNTU_APT_MIRROR` and use a shared helper to write a deb822 `ubuntu.sources` file, rather than patching existing apt configuration with `sed`.

This also wires `ASPIRE_E2E_UBUNTU_APT_MIRROR` through the CLI E2E Docker build configuration, including the shared polyglot and Podman base image builds. Linux CI test jobs default to Azure-hosted Ubuntu mirrors, using `azure.archive.ubuntu.com` for x64 and `azure.ports.ubuntu.com` for arm64, to reduce failures when the default Ubuntu package servers are overloaded.

Validation:
- `./restore.sh`
- `git --no-pager diff --check upstream/release/13.3...HEAD`
- `sh -n tests/Shared/Docker/configure-ubuntu-apt-mirror.sh`
- `dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj --no-launch-profile -- --filter-class "*.CliInstallStrategyTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `docker run --rm -v "$PWD/tests/Shared/Docker/configure-ubuntu-apt-mirror.sh:/tmp/configure-ubuntu-apt-mirror.sh:ro" ubuntu:24.04 sh -c 'sh /tmp/configure-ubuntu-apt-mirror.sh http://azure.archive.ubuntu.com/ubuntu/ && grep -F "URIs: http://azure.archive.ubuntu.com/ubuntu" /etc/apt/sources.list.d/ubuntu.sources && grep -F "noble-security" /etc/apt/sources.list.d/ubuntu.sources'`

Fixes # (issue)

## Customer Impact

Release-branch CLI E2E validation can fail when the default Ubuntu package servers are overloaded, which can delay validation of servicing fixes.

## Testing

Restore, focused CLI install strategy tests, shell syntax validation, diff whitespace checks, and an Ubuntu container smoke test for the mirror configuration helper.

## Risk

Low. The change is scoped to CLI E2E test Docker image setup and CI build arguments, with no public API or shipped runtime behavior changes.

## Regression?

Unknown - the source PR does not identify a product regression; this is a CI reliability mitigation.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
