### PR TITLE
Use plain dotnet run for extension Run Without Debugging

### DIFF
--- a/playground/ProjectResourceExtensions/ProjectResourceExtensions.AppHost/AppHost.cs
+++ b/playground/ProjectResourceExtensions/ProjectResourceExtensions.AppHost/AppHost.cs
@@ -8,9 +8,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 var funcApp = builder.AddAzureFunctionsProject<Projects.AzureFunctionsService>("azure-functions-service")
     .WithExternalHttpEndpoints();
 
-// Bug #15606/#15647 repro: A standard project resource should always get
-// IDE execution when DEBUG_SESSION_PORT is set, even if the extension
-// advertises SupportedLaunchConfigurations that don't include "project".
+// Bug #15606/#15647 repro: A standard project resource should get
+// IDE execution when DEBUG_SESSION_PORT is set and the extension
+// advertises SupportedLaunchConfigurations that include "project"
+// (or omits the list entirely, e.g. Visual Studio).
 builder.AddProject<Projects.StandardService>("standard-service")
     .WithReference(funcApp)
     .WaitFor(funcApp);

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -51,7 +51,6 @@ internal sealed class ProcessInvocationOptions
 
     public bool NoLaunchProfile { get; set; }
     public bool StartDebugSession { get; set; }
-    public bool NoExtensionLaunch { get; set; }
     public bool Debug { get; set; }
 
     /// <summary>
@@ -119,7 +118,6 @@ internal sealed class DotNetCliRunner(
         {
             if (ExtensionHelper.IsExtensionHost(interactionService, out var extensionInteractionService, out var extensionBackchannel)
                 && projectFile is not null
-                && !options.NoExtensionLaunch
                 && await extensionBackchannel.HasCapabilityAsync(KnownCapabilities.Project, cancellationToken))
             {
                 await extensionInteractionService.LaunchAppHostAsync(

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -259,7 +259,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             throw;
         }
 
-        var watch = !isSingleFileAppHost && (_features.IsFeatureEnabled(KnownFeatures.DefaultWatchEnabled, defaultValue: false) || (isExtensionHost && !context.StartDebugSession));
+        var watch = !isSingleFileAppHost && _features.IsFeatureEnabled(KnownFeatures.DefaultWatchEnabled, defaultValue: false);
 
         try
         {
@@ -338,7 +338,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         // Start the apphost - the runner will signal the backchannel when ready
         try
         {
-            // noBuild: true if either watch mode is off (we already built above) or --no-build was passed
+            // noBuild: true if watch mode is off (we already built above). dotnet watch does not support --no-build.
             // noRestore: only relevant when noBuild is false (since --no-build implies --no-restore)
             var noBuild = !watch || context.NoBuild;
             return await _runner.RunAsync(

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -525,10 +525,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             StandardOutputCallback = runOutputCollector.AppendOutput,
             StandardErrorCallback = runOutputCollector.AppendError,
             NoLaunchProfile = true,
-            StartDebugSession = context.StartDebugSession,
-            // When not starting a debug session, prevent DotNetCliRunner from delegating the
-            // apphost launch to the extension — pipeline commands should run the apphost directly.
-            NoExtensionLaunch = !context.StartDebugSession,
+            StartDebugSession = context.StartDebugSession
         };
 
         if (isSingleFileAppHost)

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -338,7 +338,8 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         // Start the apphost - the runner will signal the backchannel when ready
         try
         {
-            // noBuild: true if watch mode is off (we already built above). dotnet watch does not support --no-build.
+            // noBuild: true if watch mode is off (we already built above), or if --no-build was explicitly requested.
+            // dotnet watch does not support --no-build, so watch + context.NoBuild is invalid and will fail in the runner.
             // noRestore: only relevant when noBuild is false (since --no-build implies --no-restore)
             var noBuild = !watch || context.NoBuild;
             return await _runner.RunAsync(

--- a/src/Aspire.Hosting/Utils/ExtensionUtils.cs
+++ b/src/Aspire.Hosting/Utils/ExtensionUtils.cs
@@ -24,10 +24,20 @@ internal static class ExtensionUtils
             return false;
         }
 
-        // Per DCP IDE execution spec, project launch configuration support is implicit.
-        // Custom launch types (for example, azure-functions) must be explicitly advertised.
-        return supportsDebuggingAnnotation.LaunchConfigurationType == "project"
-            || (supportedLaunchConfigurations is not null && supportedLaunchConfigurations.Contains(supportsDebuggingAnnotation.LaunchConfigurationType));
+        // When the IDE did not send DEBUG_SESSION_INFO (e.g. Visual Studio), fall back to the
+        // legacy rule that "project" launch configuration support is implicit. VS launches all
+        // project resources natively without advertising a capability list.
+        if (supportedLaunchConfigurations is null)
+        {
+            return supportsDebuggingAnnotation.LaunchConfigurationType == "project";
+        }
+
+        // The IDE advertised an explicit capability list — honor it for every type, including
+        // "project". An IDE that can launch project resources must include "project" in its list
+        // (the VS Code extension does this when the C# extension is installed). Treating "project"
+        // as implicitly supported here would route resources to an IDE that cannot launch them
+        // and leave them stuck.
+        return supportedLaunchConfigurations.Contains(supportsDebuggingAnnotation.LaunchConfigurationType);
     }
 
     private static string[]? GetSupportedLaunchConfigurations(IConfiguration configuration)

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -714,7 +714,6 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        // Pass --start-debug-session to avoid watch mode (which skips build)
         var result = command.Parse("run --start-debug-session");
 
         using var cts = new CancellationTokenSource();
@@ -728,6 +727,60 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(buildCalled, "Build should be called when extension has build-dotnet-using-cli capability.");
+    }
+
+    [Fact]
+    public async Task RunCommand_WhenExtensionNoDebugBuildFails_DoesNotRunAppHost()
+    {
+        var buildCalled = false;
+        var runCalled = false;
+
+        var extensionBackchannel = new TestExtensionBackchannel();
+        extensionBackchannel.HasCapabilityAsyncCallback = (capability, ct) => Task.FromResult(capability == KnownCapabilities.BuildDotnetUsingCli);
+
+        var extensionInteractionServiceFactory = (IServiceProvider sp) => new TestExtensionInteractionService(sp);
+
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) =>
+            {
+                buildCalled = true;
+                return 1;
+            };
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+            runner.RunAsyncCallback = (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
+            {
+                runCalled = true;
+                return Task.FromResult(0);
+            };
+            return runner;
+        };
+
+        var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = projectLocatorFactory;
+            options.DotNetCliRunnerFactory = runnerFactory;
+            options.ExtensionBackchannelFactory = _ => extensionBackchannel;
+            options.InteractionServiceFactory = extensionInteractionServiceFactory;
+            options.ConfigurationCallback += config =>
+            {
+                config["ASPIRE_EXTENSION_DEBUG_SESSION_ID"] = "test-session-id";
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
+        Assert.True(buildCalled, "Build should be called before launching the AppHost in extension no-debug mode.");
+        Assert.False(runCalled, "AppHost should not be launched when the pre-build fails.");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2193,11 +2193,13 @@ public class DcpExecutorTests
     }
 
     [Fact]
-    public async Task ProjectExecutable_DebugSessionInfoWithoutProjectStillDefaultsToProjectSupport()
+    public async Task ProjectExecutable_DebugSessionInfoWithoutProjectFallsBackToProcess()
     {
-        // Bug #15606/#15647: VS Code extension sends SupportedLaunchConfigurations=["azure-functions"]
-        // (not including "project"). Standard project resources should still get IDE execution because
-        // "project" launch support is implicit in DCP.
+        // When the IDE explicitly advertises a SupportedLaunchConfigurations list that does NOT
+        // include "project", honor it: the IDE cannot launch project resources, so we must run
+        // them as a Process from the AppHost. The VS Code extension behaves this way when the
+        // C# extension is not installed; routing project resources to the extension in that case
+        // would result in them never starting (the extension returns 400 UnsupportedLaunchConfiguration).
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
             AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
@@ -2228,11 +2230,7 @@ public class DcpExecutorTests
         await appExecutor.RunApplicationAsync();
 
         var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "ServiceA");
-        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
-
-        Assert.True(exe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
-        Assert.Single(launchConfigs);
-        Assert.Equal("project", launchConfigs[0].Type);
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
     }
 
     [Fact]
@@ -2440,10 +2438,11 @@ public class DcpExecutorTests
     [Fact]
     public async Task StandardAndCustomProjects_VSCodeScenario_BothRunInIde()
     {
-        // Combined VS Code scenario for bugs #15606/#15647 and class library projects:
-        // VS Code extension sends SupportedLaunchConfigurations=["azure-functions"] (not "project").
-        // A standard project (type "project") should still get IDE (implicit support).
-        // A project with "azure-functions" annotation should also get IDE (explicit match).
+        // Combined VS Code scenario for class library projects:
+        // VS Code extension sends SupportedLaunchConfigurations=["azure-functions"] (without "project").
+        // A standard project (type "project") falls to Process execution because the IDE explicitly
+        // did not advertise project support — the AppHost spawns dotnet itself.
+        // A project with "azure-functions" annotation gets IDE (explicit match).
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
             AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
@@ -2484,14 +2483,11 @@ public class DcpExecutorTests
         var dcpExes = kubernetesService.CreatedResources.OfType<Executable>().ToList();
         Assert.Equal(2, dcpExes.Count);
 
-        // Standard project: IDE via implicit "project" support (bug #15606/#15647 fix)
+        // Standard project: Process execution because the IDE did not advertise "project" support.
         var standardExe = Assert.Single(dcpExes, e => e.AppModelResourceName == "standard-project");
-        Assert.Equal(ExecutionType.IDE, standardExe.Spec.ExecutionType);
-        Assert.True(standardExe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var standardConfigs));
-        Assert.Single(standardConfigs);
-        Assert.Equal("project", standardConfigs[0].Type);
+        Assert.Equal(ExecutionType.Process, standardExe.Spec.ExecutionType);
 
-        // Azure Functions project: IDE via explicit "azure-functions" support
+        // Azure Functions project: IDE via explicit "azure-functions" support.
         var functionsExe = Assert.Single(dcpExes, e => e.AppModelResourceName == "functions-project");
         Assert.Equal(ExecutionType.IDE, functionsExe.Spec.ExecutionType);
     }


### PR DESCRIPTION
## Description

Three related fixes for VS Code extension + CLI AppHost launch.

### 1. Plain `dotnet run` for extension Run Without Debugging (`c0c98c0`)

The `watch` expression in `DotNetAppHostProject.RunAsync` disabled a build whenever the CLI was invoked from an extension host without `--start-debug-session`:

```csharp
var watch = !isSingleFileAppHost && (_features.IsFeatureEnabled(KnownFeatures.DefaultWatchEnabled, defaultValue: false) || (isExtensionHost && !context.StartDebugSession));
```

This is wrong as `Run without debugging` sessions should still be launched via VS Code when the C# extension is present, so a build must be run. For launches without the C# extension, we can rely on the existing fallback in `DotnetCliRunner` to run the apphost as a process.

### 2. Honor IDE-advertised `SupportedLaunchConfigurations` for project resources (`1252496`)

`ExtensionUtils.SupportsDebugging` treated `"project"` as implicitly supported by every IDE — even when the IDE explicitly advertised a `SupportedLaunchConfigurations` list that excluded it. In VS Code without the C# extension installed, project resources were routed to `ExecutionType.IDE`, the extension returned `UnsupportedLaunchConfiguration`, and resources never started (taking the dashboard down with them).

Now: when the IDE sends an explicit list, it's honored for every type including `"project"`. Implicit `"project"` support only applies when no list is sent (the Visual Studio scenario). Project resources whose launch type isn't advertised fall to `ExecutionType.Process` and the AppHost spawns them directly (without a debugger attached).

### 3. Remove `NoExtensionLaunch` flag (`4526960`)

`NoExtensionLaunch` was set on the publish path to prevent extension hand-off, but the upstream `IsExtensionHost` env-var check already prevents hand-off for plain `aspire publish` invocations, and the in-extension pipeline path uses `StartDebugSession=true` which goes through hand-off intentionally. The flag never actually gated anything. Removed since the field's naming is confusing and it is redundant.

-------

Verified using the `SimplePipelines` and `TestShop` apps.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
