### PR TITLE
Improve AppHost debug console output for TS and C#

### DIFF
--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -602,9 +602,16 @@ export class AppHostParentOutputFilter {
   private _lastCategory: string | undefined;
 
   filter(output: string, category: string | undefined): AppHostParentOutput | undefined {
-    if (category === 'debug') {
+    // Per the DAP spec the `category` field is optional; clients should treat a
+    // missing category as `'console'`. Normalize once at the boundary so state
+    // tracking and per-line classification see a consistent value, and so
+    // category-less debug-adapter output gets the same suppression as `'console'`
+    // instead of being mirrored to the parent debug console as stdout.
+    const normalizedCategory = category ?? 'console';
+
+    if (normalizedCategory === 'debug') {
       this.resetState();
-      this._lastCategory = category;
+      this._lastCategory = normalizedCategory;
       return undefined;
     }
 
@@ -612,19 +619,19 @@ export class AppHostParentOutputFilter {
     // logical stream. When the DAP category changes (e.g. console -> stdout) we are
     // looking at a different stream and previous indented-continuation context no
     // longer applies.
-    if (category !== this._lastCategory) {
+    if (normalizedCategory !== this._lastCategory) {
       this.resetState();
     }
-    this._lastCategory = category;
+    this._lastCategory = normalizedCategory;
 
     const segments = output.match(/[^\r\n]*(?:\r\n|\r|\n|$)/g)?.filter(segment => segment.length > 0) ?? [];
     let filteredOutput = '';
     // If the DAP delivered this chunk on stderr, keep the whole emitted message on
     // stderr — the channel itself is authoritative regardless of per-line classification.
-    let hasErrorOutput = category === 'stderr';
+    let hasErrorOutput = normalizedCategory === 'stderr';
 
     for (const segment of segments) {
-      const outputCategory = this.getLineCategory(segment, category);
+      const outputCategory = this.getLineCategory(segment, normalizedCategory);
       if (outputCategory) {
         filteredOutput += segment;
         hasErrorOutput ||= outputCategory === 'stderr';
@@ -641,7 +648,7 @@ export class AppHostParentOutputFilter {
     };
   }
 
-  private getLineCategory(segment: string, category: string | undefined): 'stdout' | 'stderr' | undefined {
+  private getLineCategory(segment: string, category: string): 'stdout' | 'stderr' | undefined {
     const line = segment.replace(/(?:\r\n|\r|\n)$/, '');
     const trimmedLine = line.trim();
 
@@ -676,11 +683,11 @@ export class AppHostParentOutputFilter {
     return this.getCurrentCategory(category);
   }
 
-  private shouldMirrorConsoleOutput(category: string | undefined): boolean {
+  private shouldMirrorConsoleOutput(category: string): boolean {
     return category !== 'console' || this._continuingErrorBlock;
   }
 
-  private getCurrentCategory(category: string | undefined): 'stdout' | 'stderr' {
+  private getCurrentCategory(category: string): 'stdout' | 'stderr' {
     return category === 'stderr' || this._continuingErrorBlock ? 'stderr' : 'stdout';
   }
 

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -234,6 +234,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
   }
 
   private static readonly _nodeAppHostExtensions = ['.js', '.ts', '.mjs', '.mts', '.cjs', '.cts'];
+  private static readonly _csharpAppHostExtensions = ['.cs', '.csproj'];
 
   private _appHostRestartRequested = false;
 
@@ -241,6 +242,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     try {
       const fileExtension = path.extname(projectFile).toLowerCase();
       const isNodeAppHost = AspireDebugSession._nodeAppHostExtensions.includes(fileExtension);
+      const isCSharpAppHost = AspireDebugSession._csharpAppHostExtensions.includes(fileExtension);
 
       const debuggerExtension = isNodeAppHost ? nodeDebuggerExtension : projectDebuggerExtension;
 
@@ -248,6 +250,15 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       // When the user clicks "restart" on the app host child session,
       // we suppress VS Code's automatic child restart and restart the
       // entire Aspire debug session instead.
+      //
+      // The output filter is intentionally a positive opt-in for C# AppHosts only.
+      // The .NET debugger (`coreclr`) emits a lot of `console`-category chatter
+      // (module loads, exception-thrown notifications, the debugger banner, etc.)
+      // into the parent debug console, and structured `Microsoft.Extensions.Logging`
+      // lines need trce/dbug-level filtering. Other languages (Node, and future
+      // additions like Python/Go) use different debug adapters that don't produce
+      // that noise, so we pass their output through unmodified until/unless they
+      // explicitly opt in to filtering.
       this.createDebugAdapterTrackerCore(
         debuggerExtension.debugAdapter,
         (debugSessionId) => {
@@ -257,7 +268,9 @@ export class AspireDebugSession implements vscode.DebugAdapter {
           }
           return false;
         },
-        (output, category) => this.sendAppHostMessage(output, category)
+        isCSharpAppHost
+          ? (output, category) => this.sendAppHostMessage(output, category)
+          : (output, category) => this.sendMessage(output, false, category === 'stderr' ? 'stderr' : 'stdout')
       );
 
       let appHostArgs: string[];
@@ -557,15 +570,28 @@ export interface AppHostParentOutput {
 export class AppHostParentOutputFilter {
   private _continuingDroppedLog = false;
   private _continuingErrorBlock = false;
+  private _lastCategory: string | undefined;
 
   filter(output: string, category: string | undefined): AppHostParentOutput | undefined {
     if (category === 'debug') {
       this.resetState();
+      this._lastCategory = category;
       return undefined;
     }
 
+    // Continuation state (dropped log / error block) only makes sense within a single
+    // logical stream. When the DAP category changes (e.g. console -> stdout) we are
+    // looking at a different stream and previous indented-continuation context no
+    // longer applies.
+    if (category !== this._lastCategory) {
+      this.resetState();
+    }
+    this._lastCategory = category;
+
     const segments = output.match(/[^\r\n]*(?:\r\n|\r|\n|$)/g)?.filter(segment => segment.length > 0) ?? [];
     let filteredOutput = '';
+    // If the DAP delivered this chunk on stderr, keep the whole emitted message on
+    // stderr — the channel itself is authoritative regardless of per-line classification.
     let hasErrorOutput = category === 'stderr';
 
     for (const segment of segments) {
@@ -645,7 +671,12 @@ function getConsoleLogSeverity(line: string): 'low' | 'normal' | 'severe' | unde
         : 'normal';
   }
 
-  const simpleConsoleLogLevel = /^[^:]+:\s*(Trace|Debug|Information|Warning|Error|Critical):\s/.exec(line)?.[1];
+  // Microsoft.Extensions.Logging "simple" console formatter emits lines shaped like
+  // `<CategoryTypeName>[<EventId>]?: <Level>: <message>`. Real category names are
+  // namespaced .NET type names containing at least one dot (e.g.
+  // `Aspire.Hosting.Health.ResourceHealthCheckService`). Requiring a dot avoids
+  // matching arbitrary user stdout like `"Status: Error: connection refused"`.
+  const simpleConsoleLogLevel = /^[A-Za-z_]\w*(?:\.\w+)+(?:\[[^\]]+\])?:\s*(Trace|Debug|Information|Warning|Error|Critical):\s/.exec(line)?.[1];
   if (simpleConsoleLogLevel) {
     return simpleConsoleLogLevel === 'Trace' || simpleConsoleLogLevel === 'Debug'
       ? 'low'
@@ -662,7 +693,12 @@ function isIndentedContinuation(line: string): boolean {
 }
 
 function isSevereRuntimeOutputLine(line: string): boolean {
+  // Typed exception — `Namespace.Type.NameException: message` (also matches plain `System.Exception:`).
   return /(?:^|\s)(?:[A-Za-z_][\w`]*\.)+(?:[A-Za-z_][\w`]*Exception|Exception):/.test(line)
+    // JavaScript / Node.js error shapes — `Uncaught TypeError: ...`, `Error [CODE]: ...`.
     || /(?:^|\s)(?:Uncaught\s+)?(?:[A-Za-z_$][\w$]*Error|Error)(?:\s+\[[^\]]+\])?:/.test(line)
-    || /\b(?:fatal|fail(?:ed|ure)?|error|critical)\b/i.test(line);
+    // Anchored fatal-marker prefixes only — bare word matches like `\bfailed\b` produced
+    // false positives on user stdout (`"Failed payment retry queued"`, file paths
+    // containing "error", etc.).
+    || /^(?:fatal|critical|panic|aborted|segmentation\s+fault|unhandled\s+exception)\b/i.test(line);
 }

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -174,26 +174,59 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       ? Object.entries(configuredEnv).map(([name, value]) => ({ name, value: String(value) }))
       : undefined;
 
+    // Per-stream line buffers. CLI stdio chunks aren't guaranteed to arrive aligned to line
+    // boundaries; without buffering, partial lines (and split-point ANSI sequences) would be
+    // emitted as their own debug-console events, producing broken output like a bare emoji on
+    // one line followed by the rest of the message on the next.
+    let stdoutBuffer = '';
+    let stderrBuffer = '';
+
+    const flushBuffer = (buffer: string, category: 'stdout' | 'stderr') => {
+      const remainder = buffer.replace(/\r$/, '');
+      if (remainder.length > 0 && !isProgressEscapeSequence(remainder)) {
+        // Spectre's stderr is intentionally bare for non-error notifications (e.g. the version
+        // update banner). The DAP `'stderr'` category alone causes the debug console to render
+        // these lines in red; we don't add an extra `❌` because legitimate CLI errors are
+        // already emoji-prefixed by Spectre at the source.
+        this.sendMessage(remainder, true, category);
+      }
+    };
+
+    const handleChunk = (chunk: string, currentBuffer: string, category: 'stdout' | 'stderr'): string => {
+      const combined = currentBuffer + chunk;
+      const lines = combined.split('\n');
+      const partial = lines.pop() ?? '';
+      for (const line of lines) {
+        flushBuffer(line, category);
+      }
+      return partial;
+    };
+
     spawnCliProcess(
       this._terminalProvider,
       await this._terminalProvider.getAspireCliExecutablePath(),
       args,
       {
         stdoutCallback: (data) => {
-          for (const line of trimMessage(data)) {
-            this.sendMessage(line);
-          }
+          stdoutBuffer = handleChunk(data, stdoutBuffer, 'stdout');
         },
         stderrCallback: (data) => {
-          for (const line of trimMessage(data)) {
-            this.sendMessageWithEmoji("❌", line, false, 'stderr');
-          }
+          stderrBuffer = handleChunk(data, stderrBuffer, 'stderr');
         },
         errorCallback: (error) => {
           extensionLogOutputChannel.error(`Error spawning aspire process: ${error}`);
           vscode.window.showErrorMessage(processExceptionOccurred(error.message, commandLabel));
         },
         exitCallback: (code) => {
+          // Flush any partial line left in either buffer so trailing output isn't lost.
+          if (stdoutBuffer.length > 0) {
+            flushBuffer(stdoutBuffer, 'stdout');
+            stdoutBuffer = '';
+          }
+          if (stderrBuffer.length > 0) {
+            flushBuffer(stderrBuffer, 'stderr');
+            stderrBuffer = '';
+          }
           this.sendMessageWithEmoji("🔚", processExitedWithCode(code ?? '?'));
           // if the process failed, we want to stop the debug session
           this.dispose();
@@ -214,13 +247,9 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       }
     });
 
-    function trimMessage(message: string): string[] {
-      return message
-        .replace('\r\n', '\n')
-        .split('\n')
-        .map(line => line.trim())
-        // Filter empty lines and terminal progress bar escape sequences
-        .filter(line => line.length > 0 && !line.match(/^\u001b\]9;4;\d+\u001b\\$/));
+    function isProgressEscapeSequence(line: string): boolean {
+      // ConEmu/iTerm2 progress-reporting OSC sequence (`OSC 9;4;<state>;<value> ST`).
+      return /^\u001b\]9;4;\d+\u001b\\$/.test(line.trim());
     }
   }
 

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -25,6 +25,7 @@ export type DashboardBrowserType = 'openExternalBrowser' | 'integratedBrowser' |
 export class AspireDebugSession implements vscode.DebugAdapter {
   private readonly _onDidSendMessage = new EventEmitter<any>();
   private _messageSeq = 1;
+  private readonly _appHostParentOutputFilter = new AppHostParentOutputFilter();
 
   private readonly _session: vscode.DebugSession;
   private readonly _rpcServer: AspireRpcServer;
@@ -256,7 +257,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
           }
           return false;
         },
-        (output, category) => this.sendMessage(output, false, category)
+        (output, category) => this.sendAppHostMessage(output, category)
       );
 
       let appHostArgs: string[];
@@ -520,6 +521,13 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     this.sendMessage(`${emoji}  ${message}`, addNewLine, category);
   }
 
+  private sendAppHostMessage(message: string, category: string | undefined) {
+    const filteredMessage = this._appHostParentOutputFilter.filter(message, category);
+    if (filteredMessage) {
+      this.sendMessage(filteredMessage.output, false, filteredMessage.category);
+    }
+  }
+
   sendMessage(message: string, addNewLine: boolean = true, category: 'stdout' | 'stderr' = 'stdout') {
     this.sendEvent({
       type: 'event',
@@ -539,4 +547,122 @@ export class AspireDebugSession implements vscode.DebugAdapter {
 
 function isErrorWithStreamedDebugConsoleOutput(err: unknown): boolean {
   return err instanceof Error && (err as Error & { debugConsoleOutputAlreadyWritten?: boolean }).debugConsoleOutputAlreadyWritten === true;
+}
+
+export interface AppHostParentOutput {
+  output: string;
+  category: 'stdout' | 'stderr';
+}
+
+export class AppHostParentOutputFilter {
+  private _continuingDroppedLog = false;
+  private _continuingErrorBlock = false;
+
+  filter(output: string, category: string | undefined): AppHostParentOutput | undefined {
+    if (category === 'debug') {
+      this.resetState();
+      return undefined;
+    }
+
+    const segments = output.match(/[^\r\n]*(?:\r\n|\r|\n|$)/g)?.filter(segment => segment.length > 0) ?? [];
+    let filteredOutput = '';
+    let hasErrorOutput = category === 'stderr';
+
+    for (const segment of segments) {
+      const outputCategory = this.getLineCategory(segment, category);
+      if (outputCategory) {
+        filteredOutput += segment;
+        hasErrorOutput ||= outputCategory === 'stderr';
+      }
+    }
+
+    if (filteredOutput.length === 0) {
+      return undefined;
+    }
+
+    return {
+      output: filteredOutput,
+      category: hasErrorOutput ? 'stderr' : 'stdout'
+    };
+  }
+
+  private getLineCategory(segment: string, category: string | undefined): 'stdout' | 'stderr' | undefined {
+    const line = segment.replace(/(?:\r\n|\r|\n)$/, '');
+    const trimmedLine = line.trim();
+
+    if (trimmedLine.length === 0) {
+      return !this._continuingDroppedLog && this.shouldMirrorConsoleOutput(category) ? this.getCurrentCategory(category) : undefined;
+    }
+
+    if (this._continuingDroppedLog && isIndentedContinuation(line)) {
+      return undefined;
+    }
+
+    if (this._continuingErrorBlock && isIndentedContinuation(line)) {
+      return 'stderr';
+    }
+
+    const logSeverity = getConsoleLogSeverity(trimmedLine);
+    if (logSeverity) {
+      this._continuingDroppedLog = logSeverity === 'low';
+      this._continuingErrorBlock = logSeverity === 'severe';
+
+      return logSeverity === 'low' ? undefined : this.getCurrentCategory(category);
+    }
+
+    const isSevereOutput = isSevereRuntimeOutputLine(trimmedLine);
+    this._continuingDroppedLog = false;
+    this._continuingErrorBlock = isSevereOutput;
+
+    if (category === 'console' && !isSevereOutput) {
+      return undefined;
+    }
+
+    return this.getCurrentCategory(category);
+  }
+
+  private shouldMirrorConsoleOutput(category: string | undefined): boolean {
+    return category !== 'console' || this._continuingErrorBlock;
+  }
+
+  private getCurrentCategory(category: string | undefined): 'stdout' | 'stderr' {
+    return category === 'stderr' || this._continuingErrorBlock ? 'stderr' : 'stdout';
+  }
+
+  private resetState() {
+    this._continuingDroppedLog = false;
+    this._continuingErrorBlock = false;
+  }
+}
+
+function getConsoleLogSeverity(line: string): 'low' | 'normal' | 'severe' | undefined {
+  const defaultConsoleLogLevel = /^(trce|dbug|info|warn|fail|crit):\s/.exec(line)?.[1];
+  if (defaultConsoleLogLevel) {
+    return defaultConsoleLogLevel === 'trce' || defaultConsoleLogLevel === 'dbug'
+      ? 'low'
+      : defaultConsoleLogLevel === 'fail' || defaultConsoleLogLevel === 'crit'
+        ? 'severe'
+        : 'normal';
+  }
+
+  const simpleConsoleLogLevel = /^[^:]+:\s*(Trace|Debug|Information|Warning|Error|Critical):\s/.exec(line)?.[1];
+  if (simpleConsoleLogLevel) {
+    return simpleConsoleLogLevel === 'Trace' || simpleConsoleLogLevel === 'Debug'
+      ? 'low'
+      : simpleConsoleLogLevel === 'Error' || simpleConsoleLogLevel === 'Critical'
+        ? 'severe'
+        : 'normal';
+  }
+
+  return undefined;
+}
+
+function isIndentedContinuation(line: string): boolean {
+  return /^\s+\S/.test(line);
+}
+
+function isSevereRuntimeOutputLine(line: string): boolean {
+  return /(?:^|\s)(?:[A-Za-z_][\w`]*\.)+(?:[A-Za-z_][\w`]*Exception|Exception):/.test(line)
+    || /(?:^|\s)(?:Uncaught\s+)?(?:[A-Za-z_$][\w$]*Error|Error)(?:\s+\[[^\]]+\])?:/.test(line)
+    || /\b(?:fatal|fail(?:ed|ure)?|error|critical)\b/i.test(line);
 }

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -725,7 +725,7 @@ function isSevereRuntimeOutputLine(line: string): boolean {
   // Typed exception — `Namespace.Type.NameException: message` (also matches plain `System.Exception:`).
   return /(?:^|\s)(?:[A-Za-z_][\w`]*\.)+(?:[A-Za-z_][\w`]*Exception|Exception):/.test(line)
     // JavaScript / Node.js error shapes — `Uncaught TypeError: ...`, `Error [CODE]: ...`.
-    || /(?:^|\s)(?:Uncaught\s+)?(?:[A-Za-z_$][\w$]*Error|Error)(?:\s+\[[^\]]+\])?:/.test(line)
+    || /^(?:Uncaught\s+)?(?:[A-Za-z_$][\w$]*Error|Error)(?:\s+\[[^\]]+\])?:/.test(line)
     // Anchored fatal-marker prefixes only — bare word matches like `\bfailed\b` produced
     // false positives on user stdout (`"Failed payment retry queued"`, file paths
     // containing "error", etc.).

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -10,7 +10,7 @@ import { dcpServerNotInitialized } from '../loc/strings';
  * Return `true` to suppress VS Code's automatic child session restart.
  */
 export type AppHostRestartHandler = (debugSessionId: string) => boolean;
-export type AppHostOutputHandler = (output: string, category: 'stdout' | 'stderr') => void;
+export type AppHostOutputHandler = (output: string, category: string) => void;
 
 export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapter: string, onAppHostRestartRequested?: AppHostRestartHandler, onAppHostOutput?: AppHostOutputHandler): vscode.Disposable {
     return vscode.debug.registerDebugAdapterTrackerFactory(debugAdapter, {
@@ -46,7 +46,7 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                             const { category, output } = message.body;
                             if (typeof output === 'string' && category !== 'telemetry') {
                                 if (session.configuration.isApphost) {
-                                    onAppHostOutput?.(output, category === 'stderr' ? 'stderr' : 'stdout');
+                                    onAppHostOutput?.(output, category as string);
                                     return;
                                 }
 

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -10,7 +10,15 @@ import { dcpServerNotInitialized } from '../loc/strings';
  * Return `true` to suppress VS Code's automatic child session restart.
  */
 export type AppHostRestartHandler = (debugSessionId: string) => boolean;
-export type AppHostOutputHandler = (output: string, category: string) => void;
+
+/**
+ * DAP output event categories. Per the DAP spec the `category` field is optional;
+ * when missing, clients should treat it as `'console'`. This union keeps the known
+ * categories explicit while allowing adapter-specific values via the `(string & {})`
+ * trick, and includes `undefined` so callers can't accidentally rely on it being set.
+ */
+export type DapOutputCategory = 'console' | 'important' | 'stdout' | 'stderr' | 'debug' | 'telemetry' | (string & {}) | undefined;
+export type AppHostOutputHandler = (output: string, category: DapOutputCategory) => void;
 
 export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapter: string, onAppHostRestartRequested?: AppHostRestartHandler, onAppHostOutput?: AppHostOutputHandler): vscode.Disposable {
     return vscode.debug.registerDebugAdapterTrackerFactory(debugAdapter, {
@@ -46,7 +54,7 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                             const { category, output } = message.body;
                             if (typeof output === 'string' && category !== 'telemetry') {
                                 if (session.configuration.isApphost) {
-                                    onAppHostOutput?.(output, category as string);
+                                    onAppHostOutput?.(output, category);
                                     return;
                                 }
 

--- a/extension/src/debugger/languages/cli.ts
+++ b/extension/src/debugger/languages/cli.ts
@@ -33,6 +33,10 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
         shell: false
     });
 
+    // Set UTF-8 encoding so Node reassembles multi-byte characters across chunk boundaries instead of yielding broken bytes.
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
     if (options?.lineCallback) {
         const rl = readline.createInterface(child.stdout);
         rl.on('line', line => {
@@ -40,12 +44,12 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
         });
     }
 
-    child.stdout.on("data", (data) => {
-        options?.stdoutCallback?.(new String(data).toString());
+    child.stdout.on("data", (data: string) => {
+        options?.stdoutCallback?.(data);
     });
 
-    child.stderr.on("data", (data) => {
-        options?.stderrCallback?.(new String(data).toString());
+    child.stderr.on("data", (data: string) => {
+        options?.stderrCallback?.(data);
     });
 
     child.on('error', (error) => {

--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -78,14 +78,25 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
 
         for (const resource of resources) {
             // For pipeline steps the whole statement maps to a single Add*(...) call, so
-            // anchoring at the top of the chain reads naturally. For resources, however,
-            // a single fluent chain can declare several (e.g.
-            // `builder.AddPostgres("pg").AddDatabase("db")`) and collapsing them all to
-            // the chain's start line would stack two state/action lenses on the same
-            // line — the user can't tell which "Stopped" / which "Stop" belongs to which
-            // resource. Anchor each resource lens at its own call line instead.
-            const lensLine = resource.kind === 'pipelineStep'
-                ? (resource.statementStartLine ?? resource.range.start.line)
+            // anchoring at the top of the chain reads naturally.
+            //
+            // For resources, a single fluent chain can declare several (e.g.
+            // `builder.AddPostgres("pg").AddDatabase("db")`). If we collapsed all of those
+            // to the chain's start line their state/action lenses would stack on the same
+            // line and the user couldn't tell which "Stopped" / which "Stop" belongs to
+            // which resource. So when more than one resource shares a statement we anchor
+            // each at its own call line; when a chain declares just one resource we use
+            // the statement-start line so the lens sits above the whole declaration
+            // (e.g. above `const nodePlayer = await builder` rather than between that
+            // line and the `.addNodeApp(...)` call).
+            const statementStart = resource.statementStartLine ?? resource.range.start.line;
+            const sharedWithOthers = resource.kind === 'resource'
+                && resources.some(other =>
+                    other !== resource
+                    && other.kind === 'resource'
+                    && (other.statementStartLine ?? other.range.start.line) === statementStart);
+            const lensLine = (resource.kind === 'pipelineStep' || !sharedWithOthers)
+                ? statementStart
                 : resource.range.start.line;
             const lineRange = new vscode.Range(lensLine, 0, lensLine, 0);
 

--- a/extension/src/test/aspireCodeLensProvider.test.ts
+++ b/extension/src/test/aspireCodeLensProvider.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="mocha" />
+
 import * as assert from 'assert';
 import * as path from 'path';
 import * as sinon from 'sinon';
@@ -305,6 +307,96 @@ suite('AspireCodeLensProvider builder lens', () => {
         for (const lens of builderLenses) {
             assert.strictEqual(lens.range.start.line, 0);
         }
+        harness.dispose();
+    });
+});
+
+suite('AspireCodeLensProvider resource lens anchoring', () => {
+    let getConfigStub: sinon.SinonStub;
+
+    setup(() => {
+        getConfigStub = sinon.stub(vscode.workspace, 'getConfiguration').returns({
+            get: () => true,
+            has: () => true,
+            inspect: () => undefined,
+            update: () => Promise.resolve(),
+        } as any);
+    });
+
+    teardown(() => {
+        getConfigStub.restore();
+    });
+
+    function getResourceLenses(lenses: vscode.CodeLens[]): vscode.CodeLens[] {
+        return lenses.filter(l =>
+            l.command?.command !== 'aspire-vscode.codeLensOpenDashboard'
+            && l.command?.command !== 'aspire-vscode.codeLensViewAppHostLogs'
+            && l.command?.command !== 'aspire-vscode.codeLensDebugPipelineStep'
+        );
+    }
+
+    test('single-resource fluent chain anchors lens at the statement-start line, not the .add* call line', () => {
+        const docPath = p('repo', 'AppHost', 'apphost.ts');
+        const hostPath = p('repo', 'AppHost', 'apphost.ts');
+        // Multi-line chain: declaration starts at line 2 ("const nodePlayer = await builder")
+        // and the .addNodeApp(...) call is on line 3. Line 0 carries the createBuilder()
+        // entry point so the parser recognizes this as an AppHost file.
+        const content = [
+            'const builder = await createBuilder();',                               // line 0
+            '',                                                                     // line 1
+            '// Node Knight (Player 2)',                                            // line 2
+            'const nodePlayer = await builder',                                     // line 3
+            '    .addNodeApp("node-player", "./node-player", "src/server.ts")',     // line 4
+            '    .withRunScript("dev");',                                           // line 5
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [makeResource('node-player')],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const resourceLenses = getResourceLenses(lenses);
+
+        assert.ok(resourceLenses.length > 0, 'expected at least one resource lens for node-player');
+        for (const lens of resourceLenses) {
+            assert.strictEqual(
+                lens.range.start.line,
+                3,
+                `resource lens should anchor at statement-start line 3 (above 'const nodePlayer'), got ${lens.range.start.line}`
+            );
+        }
+        harness.dispose();
+    });
+
+    test('multi-resource fluent chain anchors each resource lens at its own .add* call line', () => {
+        const docPath = p('repo', 'AppHost', 'apphost.ts');
+        const hostPath = p('repo', 'AppHost', 'apphost.ts');
+        // Single fluent chain declaring two resources. Statement starts at line 2,
+        // pg call is on line 2, db call on line 3. We expect each resource's lens
+        // to anchor at its own .addX line so they don't stack.
+        const content = [
+            'const builder = await createBuilder();',         // line 0
+            '',                                                // line 1
+            'const db = builder.addPostgres("pg")',            // line 2 (statement-start AND pg call)
+            '    .addDatabase("db");',                          // line 3 (db call)
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [makeResource('pg'), makeResource('db')],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const resourceLenses = getResourceLenses(lenses);
+
+        const lines = new Set(resourceLenses.map(l => l.range.start.line));
+        assert.ok(
+            lines.has(2) && lines.has(3),
+            `expected resource lenses on both line 2 (pg) and line 3 (db) so they don't stack; got lines [${[...lines].join(', ')}]`
+        );
         harness.dispose();
     });
 });

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -5,7 +5,7 @@ import { createProjectDebuggerExtension, projectDebuggerExtension } from '../deb
 import { AspireResourceExtendedDebugConfiguration, ExecutableLaunchConfiguration, ProjectLaunchConfiguration } from '../dcp/types';
 import * as io from '../utils/io';
 import { ResourceDebuggerExtension } from '../debugger/debuggerExtensions';
-import { AspireDebugSession } from '../debugger/AspireDebugSession';
+import { AppHostParentOutputFilter, AspireDebugSession } from '../debugger/AspireDebugSession';
 
 class TestDotNetService {
     private _getDotNetTargetPathStub: sinon.SinonStub;
@@ -125,6 +125,47 @@ suite('Dotnet Debugger Extension Tests', () => {
             && message.body.output.includes(startError.message)), false);
 
         outputSubscription.dispose();
+    });
+
+    test('filters AppHost debugger noise from Aspire parent debug console', () => {
+        const filter = new AppHostParentOutputFilter();
+
+        assert.strictEqual(filter.filter("'TestShop.AppHost' (CoreCLR: clrhost): Loaded '/dotnet/System.Private.CoreLib.dll'. Skipped loading symbols.\n", 'console'), undefined);
+        assert.strictEqual(filter.filter("TestShop.AppHost.dll (29067): Loaded '/usr/local/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/System.Private.CoreLib.dll'. No se puede encontrar o abrir el archivo PDB.\n", 'console'), undefined);
+        assert.strictEqual(filter.filter("Loaded '/dotnet/System.Net.Http.dll'. Skipped loading symbols.\n", 'console'), undefined);
+        assert.strictEqual(filter.filter("Exception thrown: 'System.InvalidOperationException' in TestShop.AppHost.dll\n", 'console'), undefined);
+        assert.strictEqual(filter.filter('debug adapter details\n', 'debug'), undefined);
+        assert.strictEqual(filter.filter('-------------------------------------------------------------------------------\n', 'console'), undefined);
+        assert.strictEqual(filter.filter('You may only use the Microsoft Visual Studio .NET/C/C++ Debugger with Visual Studio Code.\n', 'console'), undefined);
+        assert.strictEqual(filter.filter('Usando la configuración de inicio de "/workspace/Properties/launchSettings.json" [perfil "https"]...\n', 'console'), undefined);
+        assert.strictEqual(filter.filter("dbug: Aspire.Hosting.Health.ResourceHealthCheckService[0]\n      Resource 'apigateway' is ready.\n", 'stdout'), undefined);
+        assert.strictEqual(filter.filter("Aspire.Hosting.Health.ResourceHealthCheckService: Debug: Resource 'apigateway' is ready.\n", 'stdout'), undefined);
+    });
+
+    test('keeps AppHost fatal output in Aspire parent debug console', () => {
+        const filter = new AppHostParentOutputFilter();
+        const criticalLog = "crit: TestShop.AppHost[0]\n      Host terminated unexpectedly.\n";
+        const unhandledException = 'Unhandled exception. System.InvalidOperationException: boom\n';
+        const unhandledBaseException = 'Unhandled exception. System.Exception: This code snippet is for illustrative purposes only.\n   at Program.<Main>$(String[] args) in /workspace/AppHost.cs:line 8\n';
+        const javascriptException = 'Uncaught TypeError: Cannot read properties of undefined\n    at file:///workspace/apphost.js:8:3\n';
+        const nodeModuleException = "Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@microsoft/aspire'\n    at packageResolve (node:internal/modules/esm/resolve:857:9)\n";
+        const consoleError = 'Fatal error: unable to bind port\n';
+
+        assert.deepStrictEqual(filter.filter(criticalLog, 'stdout'), { output: criticalLog, category: 'stderr' });
+        assert.deepStrictEqual(filter.filter(unhandledException, 'console'), { output: unhandledException, category: 'stderr' });
+        assert.deepStrictEqual(filter.filter(unhandledBaseException, 'console'), { output: unhandledBaseException, category: 'stderr' });
+        assert.deepStrictEqual(filter.filter(javascriptException, 'console'), { output: javascriptException, category: 'stderr' });
+        assert.deepStrictEqual(filter.filter(nodeModuleException, 'console'), { output: nodeModuleException, category: 'stderr' });
+        assert.deepStrictEqual(filter.filter(consoleError, 'console'), { output: consoleError, category: 'stderr' });
+    });
+
+    test('keeps AppHost warning and information output that is not debugger console chatter', () => {
+        const filter = new AppHostParentOutputFilter();
+        const warningLog = "warn: TestShop.AppHost[0]\n      Port is already allocated.\n";
+        const normalOutput = 'Now listening on: https://localhost:5001\n';
+
+        assert.deepStrictEqual(filter.filter(warningLog, 'stdout'), { output: warningLog, category: 'stdout' });
+        assert.deepStrictEqual(filter.filter(normalOutput, 'stdout'), { output: normalOutput, category: 'stdout' });
     });
 
     test('project is built when C# dev kit is installed and executable not found', async () => {

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -168,6 +168,39 @@ suite('Dotnet Debugger Extension Tests', () => {
         assert.deepStrictEqual(filter.filter(normalOutput, 'stdout'), { output: normalOutput, category: 'stdout' });
     });
 
+    test('does not promote benign AppHost stdout containing words like fail/error to stderr', () => {
+        const filter = new AppHostParentOutputFilter();
+        const benignFailMention = 'Failed payment retry queued for processing\n';
+        const benignErrorMention = 'Loaded handler from /src/error_handler/main.cs\n';
+        const benignFailureMention = 'Build complete with no failures detected\n';
+
+        assert.deepStrictEqual(filter.filter(benignFailMention, 'stdout'), { output: benignFailMention, category: 'stdout' });
+        assert.deepStrictEqual(filter.filter(benignErrorMention, 'stdout'), { output: benignErrorMention, category: 'stdout' });
+        assert.deepStrictEqual(filter.filter(benignFailureMention, 'stdout'), { output: benignFailureMention, category: 'stdout' });
+    });
+
+    test('does not classify arbitrary user stdout shaped like prefix:Level: as a structured log', () => {
+        const filter = new AppHostParentOutputFilter();
+        const userPrint = 'Status: Error: connection refused\n';
+        const userDebugPrint = 'Note: Debug: caller line 42\n';
+
+        assert.deepStrictEqual(filter.filter(userPrint, 'stdout'), { output: userPrint, category: 'stdout' });
+        assert.deepStrictEqual(filter.filter(userDebugPrint, 'stdout'), { output: userDebugPrint, category: 'stdout' });
+    });
+
+    test('continuation state is reset when DAP category changes between events', () => {
+        const filter = new AppHostParentOutputFilter();
+        // First event: a dropped trace log on stdout. Continuation state would say "drop indented lines".
+        assert.strictEqual(filter.filter('trce: Some.Category[0]\n', 'stdout'), undefined);
+        // A subsequent event on a different category (console) that happens to start with
+        // an indented line must NOT be silently dropped as a continuation of the trace log.
+        const indentedConsoleLine = '    Loaded module foo\n';
+        assert.strictEqual(filter.filter(indentedConsoleLine, 'console'), undefined); // dropped because console+non-severe, not because of continuation state
+        // And an indented stdout line afterwards is emitted normally instead of being dropped.
+        const indentedStdoutLine = '    plain user output line\n';
+        assert.deepStrictEqual(filter.filter(indentedStdoutLine, 'stdout'), { output: indentedStdoutLine, category: 'stdout' });
+    });
+
     test('project is built when C# dev kit is installed and executable not found', async () => {
         const outputPath = 'C:\\temp\\bin\\Debug\\net7.0\\TestProject.dll';
         const { extension, dotNetService } = createDebuggerExtension(outputPath, null, true, false);

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -201,6 +201,21 @@ suite('Dotnet Debugger Extension Tests', () => {
         assert.deepStrictEqual(filter.filter(indentedStdoutLine, 'stdout'), { output: indentedStdoutLine, category: 'stdout' });
     });
 
+    test('treats missing DAP category as console so debugger noise does not leak as stdout', () => {
+        const filter = new AppHostParentOutputFilter();
+        // Per the DAP spec a missing category should be treated as 'console'. The
+        // .NET debug adapter sometimes emits output events without a category, and
+        // this debugger chatter must be suppressed the same way as explicit
+        // 'console'-category lines instead of being mirrored as stdout.
+        const debuggerChatter = "'TestShop.AppHost' (CoreCLR: clrhost): Loaded '/dotnet/System.Private.CoreLib.dll'. Skipped loading symbols.\n";
+        assert.strictEqual(filter.filter(debuggerChatter, undefined), undefined);
+
+        // Severe runtime output without a category is still kept and promoted to stderr,
+        // matching the existing 'console'-category behavior.
+        const unhandledException = 'Unhandled exception. System.InvalidOperationException: boom\n';
+        assert.deepStrictEqual(filter.filter(unhandledException, undefined), { output: unhandledException, category: 'stderr' });
+    });
+
     test('project is built when C# dev kit is installed and executable not found', async () => {
         const outputPath = 'C:\\temp\\bin\\Debug\\net7.0\\TestProject.dll';
         const { extension, dotNetService } = createDebuggerExtension(outputPath, null, true, false);

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -334,32 +334,38 @@ export class AppHostDataRepository {
                     extensionLogOutputChannel.info(`aspire describe --follow exited with code ${code}`);
                     this._describeProcess = undefined;
 
-                    if (!this._disposed) {
-                        if (!this._describeReceivedData && code !== 0) {
-                            // The process exited with a non-zero code without ever producing valid data.
-                            // This is expected when no apphost is running. Don't set the error state
-                            // since that would show the "CLI not supported" banner; instead just show
-                            // the normal "no running apphost" welcome.
-                            extensionLogOutputChannel.warn('aspire describe --follow exited without producing data; no running apphost or CLI may not support this feature.');
-                            this._workspaceResources.clear();
-                            this._updateWorkspaceContext();
-                        } else {
-                            this._workspaceResources.clear();
-                            this._setError(undefined);
-                            this._updateWorkspaceContext();
-
-                            // Auto-restart with exponential backoff
-                            const delay = this._describeRestartDelay;
-                            this._describeRestartDelay = Math.min(this._describeRestartDelay * 2, this._getPollingIntervalMs());
-                            extensionLogOutputChannel.info(`Restarting describe --follow in ${delay}ms`);
-                            this._describeRestartTimer = setTimeout(() => {
-                                this._describeRestartTimer = undefined;
-                                if (!this._disposed && this._shouldWatchWorkspace) {
-                                    this._startDescribeWatch();
-                                }
-                            }, delay);
-                        }
+                    if (this._disposed) {
+                        return;
                     }
+
+                    // If this attempt never produced any data, there is no running apphost
+                    // to follow (or the CLI doesn't support --follow). Stop quietly: do not
+                    // set the error state (which would show the "CLI not supported" banner)
+                    // and do not auto-restart on a 5s loop forever — the panel will refresh
+                    // when the user explicitly retries or when activity resumes.
+                    if (!this._describeReceivedData) {
+                        extensionLogOutputChannel.warn(`aspire describe --follow exited (code ${code}) without producing data; not auto-restarting.`);
+                        this._workspaceResources.clear();
+                        this._updateWorkspaceContext();
+                        return;
+                    }
+
+                    // We had a working stream that ended (apphost shut down). Reset and try
+                    // once more with backoff in case the apphost is restarting; if that
+                    // attempt also produces no data we'll fall into the branch above.
+                    this._workspaceResources.clear();
+                    this._setError(undefined);
+                    this._updateWorkspaceContext();
+
+                    const delay = this._describeRestartDelay;
+                    this._describeRestartDelay = Math.min(this._describeRestartDelay * 2, this._getPollingIntervalMs());
+                    extensionLogOutputChannel.info(`Restarting describe --follow in ${delay}ms`);
+                    this._describeRestartTimer = setTimeout(() => {
+                        this._describeRestartTimer = undefined;
+                        if (!this._disposed && this._shouldWatchWorkspace) {
+                            this._startDescribeWatch();
+                        }
+                    }, delay);
                 },
                 errorCallback: (error) => {
                     if (this._describeProcess !== describeProcess) {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -515,11 +515,22 @@ internal sealed class RunCommand : BaseCommand
 
         grid.Columns[0].Width = longestLabelLength;
 
+        // In the extension's debug console, right-aligned labels and the surrounding padding
+        // render as visible left indentation, and the empty separator rows show up as blank
+        // lines that just push real content further down. Use a flush, single-spaced layout
+        // for the extension and keep the spaced-out look only for direct terminal output.
+        IRenderable LabelMarkup(string label)
+        {
+            var markup = new Markup($"[bold green]{label}[/]:");
+            return isExtensionHost ? markup : new Align(markup, HorizontalAlignment.Right);
+        }
+
         // AppHost row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{appHostLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(appHostRelativePath));
-        grid.AddRow(Text.Empty, Text.Empty);
+        grid.AddRow(LabelMarkup(appHostLabel), new Text(appHostRelativePath));
+        if (!isExtensionHost)
+        {
+            grid.AddRow(Text.Empty, Text.Empty);
+        }
 
         if (!isExtensionHost)
         {
@@ -527,7 +538,7 @@ internal sealed class RunCommand : BaseCommand
             if (!string.IsNullOrEmpty(dashboardUrl))
             {
                 grid.AddRow(
-                    new Align(new Markup($"[bold green]{dashboardLabel}[/]:"), HorizontalAlignment.Right),
+                    LabelMarkup(dashboardLabel),
                     new Markup($"[link={dashboardUrl}]{dashboardUrl}[/]"));
 
                 // Codespaces URL (if available)
@@ -539,28 +550,27 @@ internal sealed class RunCommand : BaseCommand
             else
             {
                 grid.AddRow(
-                    new Align(new Markup($"[bold green]{dashboardLabel}[/]:"), HorizontalAlignment.Right),
+                    LabelMarkup(dashboardLabel),
                     new Markup("[dim]N/A[/]"));
             }
             grid.AddRow(Text.Empty, Text.Empty);
         }
 
         // Logs row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(logFilePath));
+        grid.AddRow(LabelMarkup(logsLabel), new Text(logFilePath));
 
         // PID row (if provided)
         if (pid.HasValue)
         {
-            grid.AddRow(Text.Empty, Text.Empty);
-            grid.AddRow(
-                new Align(new Markup($"[bold green]{pidLabel}[/]:"), HorizontalAlignment.Right),
-                new Text(pid.Value.ToString(CultureInfo.InvariantCulture)));
+            if (!isExtensionHost)
+            {
+                grid.AddRow(Text.Empty, Text.Empty);
+            }
+            grid.AddRow(LabelMarkup(pidLabel), new Text(pid.Value.ToString(CultureInfo.InvariantCulture)));
         }
 
-        var padder = new Padder(grid, new Padding(3, 0));
-        console.DisplayRenderable(padder);
+        IRenderable summary = isExtensionHost ? grid : new Padder(grid, new Padding(3, 0));
+        console.DisplayRenderable(summary);
 
         return longestLabelLength;
     }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -339,16 +339,27 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayError(string errorMessage)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayErrorAsync(errorMessage.RemoveSpectreFormatting(), _cancellationToken));
+        // Serialize the local console write onto the same channel as the backchannel call so
+        // it stays ordered with prior queued operations (e.g. DisplayLines). Otherwise the
+        // synchronous Spectre write would land in the IDE debug console (via stdout/stderr
+        // capture) before earlier asynchronous DisplayLines RPCs had flushed, producing
+        // out-of-order output like an error message preceding the lines that explain it.
+        var result = _extensionTaskChannel.Writer.TryWrite(async () =>
+        {
+            await Backchannel.DisplayErrorAsync(errorMessage.RemoveSpectreFormatting(), _cancellationToken);
+            _consoleInteractionService.DisplayError(errorMessage);
+        });
         Debug.Assert(result);
-        _consoleInteractionService.DisplayError(errorMessage);
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayMessageAsync(emoji.Name, message.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(async () =>
+        {
+            await Backchannel.DisplayMessageAsync(emoji.Name, message.RemoveSpectreFormatting(), _cancellationToken);
+            _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup);
+        });
         Debug.Assert(result);
-        _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup);
     }
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
@@ -378,11 +389,20 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(lines.Select(line => new DisplayLineState(
+        // Materialize so we can iterate twice without re-enumerating a possibly lazy/one-shot source.
+        var materialized = lines as IReadOnlyCollection<(OutputLineStream Stream, string Line)> ?? lines.ToList();
+
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(materialized.Select(line => new DisplayLineState(
             line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
             line.Line.RemoveSpectreFormatting())), _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayLines(lines);
+
+        // Intentionally do NOT also write to the local console here. Unlike most Display* methods
+        // (whose backchannel sinks are distinct from the debug console — popups, status bar, log
+        // channel, etc.), the extension's `displayLines` RPC routes the lines into the active
+        // AppHost debug console. The CLI's stdout/stderr is also captured by the extension and
+        // forwarded into that same debug console, so calling _consoleInteractionService.DisplayLines
+        // here would surface every line twice.
     }
 
     public void DisplayCancellationMessage()

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -503,19 +503,19 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             var (guestExitCode, guestOutput) = await ExecuteGuestAppHostAsync(
                 appHostFile, directory, environmentVariables, enableHotReload, rpcClient, launcher, cancellationToken);
 
-            if (launcher is ExtensionGuestLauncher)
-            {
-                // Extension manages the guest app host lifecycle via VS Code debug session.
-                // Wait for the AppHost server to exit (Ctrl+C or extension termination).
-                await appHostServerProcess.WaitForExitAsync(cancellationToken);
-                return appHostServerProcess.ExitCode;
-            }
-
+            // A non-zero exit code at this point means the in-CLI portion of the guest run
+            // (typically a PreExecute step like `tsc --noEmit` for TypeScript) failed before
+            // the actual AppHost was launched. Surface the failure regardless of launcher
+            // type, otherwise the extension flow would silently hang in
+            // appHostServerProcess.WaitForExitAsync waiting for an apphost that was never started.
             if (guestExitCode != 0)
             {
                 _logger.LogError("{Language} apphost exited with code {ExitCode}", DisplayName, guestExitCode);
 
-                // Display the output (same pattern as DotNetCliRunner)
+                // Surface the captured output (e.g. tsc errors from a TypeScript PreExecute step)
+                // so the user can see why the apphost failed. In the extension flow,
+                // ExtensionInteractionService.DisplayLines routes these lines through the
+                // backchannel without also writing them to the CLI's captured stdout/stderr.
                 if (guestOutput is not null)
                 {
                     _interactionService.DisplayLines(guestOutput.GetLines());
@@ -539,6 +539,14 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 }
 
                 return guestExitCode;
+            }
+
+            if (launcher is ExtensionGuestLauncher)
+            {
+                // Extension manages the guest app host lifecycle via VS Code debug session.
+                // Wait for the AppHost server to exit (Ctrl+C or extension termination).
+                await appHostServerProcess.WaitForExitAsync(cancellationToken);
+                return appHostServerProcess.ExitCode;
             }
 
             // In watch mode, wait for server to exit (Ctrl+C or orphan detection)


### PR DESCRIPTION
## Description

Several related fixes for VS Code extension AppHost debug-console output and startup failure handling.

### 1. Filter debugger noise from the parent debug console

When a C# AppHost runs as a child debug session, the .NET debugger writes module-load messages, exception-thrown notifications, banner text, launch-profile messages, and other `console`/`debug` DAP output into the Aspire parent debug console.

This PR filters that noise while keeping real runtime output. Low-level AppHost logs (`trce`/`dbug`, `Trace`/`Debug`) are dropped, while severe output (`fail`/`crit`, `Error`/`Critical`, uncaught exceptions, fatal lines, and continuations) is preserved and shown on stderr.

<img width="1408" height="751" alt="image" src="https://github.com/user-attachments/assets/4b6e2d51-f463-4244-b422-c55aca8f88d7" />

### 2. Surface guest AppHost failures before launch

TypeScript/Node AppHosts can fail in a pre-launch step, such as `tsc --noEmit`, before the AppHost and backchannel are started. Previously the extension could stay stuck at `Connecting to AppHost...` without showing the compilation error.

Now the CLI checks that failure path before waiting for the extension launcher, displays the captured guest output, and completes the backchannel wait with an error so the run exits cleanly.

<img width="2506" height="678" alt="image" src="https://github.com/user-attachments/assets/de344f0a-10fa-4f10-bf56-124d07cd8858" />

### 3. Clean up AppHost debug-console output

CLI stdout/stderr from the extension host is now buffered by line and decoded as UTF-8, so output is not split mid-line or mid-emoji. Captured `DisplayLines` output is sent through the extension backchannel without also being written to captured stdout/stderr, which avoids duplicate lines and keeps failure details ordered before follow-up error/log messages.

Stderr is no longer blindly prefixed as an error by the extension; CLI/Spectre already adds the appropriate error prefix when output is actually an error.

<img width="1545" height="265" alt="image" src="https://github.com/user-attachments/assets/eeadb047-3a2a-4d1c-a435-450445f3adec" />

### 4. Fix smaller extension-host UX issues

This also stops `aspire describe --follow` from restarting forever when it exits before producing data, anchors CodeLens state/actions above single-resource fluent chains, and renders the AppHost/log summary without terminal-style indentation or blank separator rows in extension-host mode.

Verified with:

- `./dotnet.sh build src/Aspire.Cli/Aspire.Cli.csproj /p:SkipNativeBuild=true`
- `npm run compile-tests`
- `npm run unit-test | grep -A3 "AspireCodeLensProvider resource lens anchoring"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
