### PR TITLE
Fix Foundry hosted agent endpoint resolution

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -348,6 +348,7 @@ public class AzureContainerAppEnvironmentResource :
         var endpoint = endpointReference.EndpointAnnotation;
         var scheme = PreserveHttpEndpoints ? endpoint.UriScheme : "https";
         var port = string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) ? 80 : 443;
+        var tlsEnabled = string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) || endpoint.TlsEnabled;
         var host = GetHostAddressExpression(endpointReference);
 
         return property switch
@@ -360,7 +361,7 @@ public class AzureContainerAppEnvironmentResource :
                 : ReferenceExpression.Create($"{new ContainerPortReference(endpointReference.Resource)}"),
             EndpointProperty.Scheme => ReferenceExpression.Create($"{scheme}"),
             EndpointProperty.HostAndPort => ReferenceExpression.Create($"{host}:{port.ToString(CultureInfo.InvariantCulture)}"),
-            EndpointProperty.TlsEnabled => ReferenceExpression.Create($"{(endpoint.TlsEnabled ? bool.TrueString : bool.FalseString)}"),
+            EndpointProperty.TlsEnabled => ReferenceExpression.Create($"{(tlsEnabled ? bool.TrueString : bool.FalseString)}"),
             _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{endpoint.Name}'.")
         };
     }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -6,6 +6,7 @@
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
 using Azure.Provisioning;
@@ -334,6 +335,34 @@ public class AzureContainerAppEnvironmentResource :
         builder.Append($".{ContainerAppDomain}");
 
         return builder.Build();
+    }
+
+    /// <inheritdoc/>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public ReferenceExpression GetEndpointPropertyExpression(EndpointReferenceExpression endpointReferenceExpression)
+    {
+        ArgumentNullException.ThrowIfNull(endpointReferenceExpression);
+
+        var endpointReference = endpointReferenceExpression.Endpoint;
+        var property = endpointReferenceExpression.Property;
+        var endpoint = endpointReference.EndpointAnnotation;
+        var scheme = PreserveHttpEndpoints ? endpoint.UriScheme : "https";
+        var port = string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) ? 80 : 443;
+        var host = GetHostAddressExpression(endpointReference);
+
+        return property switch
+        {
+            EndpointProperty.Url => ReferenceExpression.Create($"{scheme}://{host}"),
+            EndpointProperty.Host or EndpointProperty.IPV4Host => host,
+            EndpointProperty.Port => ReferenceExpression.Create($"{port.ToString(CultureInfo.InvariantCulture)}"),
+            EndpointProperty.TargetPort => endpoint.TargetPort is int targetPort
+                ? ReferenceExpression.Create($"{targetPort.ToString(CultureInfo.InvariantCulture)}")
+                : ReferenceExpression.Create($"{new ContainerPortReference(endpointReference.Resource)}"),
+            EndpointProperty.Scheme => ReferenceExpression.Create($"{scheme}"),
+            EndpointProperty.HostAndPort => ReferenceExpression.Create($"{host}:{port.ToString(CultureInfo.InvariantCulture)}"),
+            EndpointProperty.TlsEnabled => ReferenceExpression.Create($"{(endpoint.TlsEnabled ? bool.TrueString : bool.FalseString)}"),
+            _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{endpoint.Name}'.")
+        };
     }
 
     internal BicepOutputReference GetVolumeStorage(IResource resource, ContainerMountAnnotation volume, int volumeIndex)

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIREAZURE001
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppService;
@@ -481,6 +482,34 @@ public class AzureAppServiceEnvironmentResource :
     {
         var resource = endpointReference.Resource;
         return ReferenceExpression.Create($"{resource.Name.ToLowerInvariant()}-{WebSiteSuffix}.azurewebsites.net");
+    }
+
+    /// <inheritdoc/>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public ReferenceExpression GetEndpointPropertyExpression(EndpointReferenceExpression endpointReferenceExpression)
+    {
+        ArgumentNullException.ThrowIfNull(endpointReferenceExpression);
+
+        var endpointReference = endpointReferenceExpression.Endpoint;
+        var property = endpointReferenceExpression.Property;
+        var endpoint = endpointReference.EndpointAnnotation;
+        var scheme = PreserveHttpEndpoints ? endpoint.UriScheme : "https";
+        var port = string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) ? 80 : 443;
+        var host = GetHostAddressExpression(endpointReference);
+
+        return property switch
+        {
+            EndpointProperty.Url => ReferenceExpression.Create($"{scheme}://{host}"),
+            EndpointProperty.Host or EndpointProperty.IPV4Host => host,
+            EndpointProperty.Port => ReferenceExpression.Create($"{port.ToString(CultureInfo.InvariantCulture)}"),
+            EndpointProperty.TargetPort => endpoint.TargetPort is int targetPort
+                ? ReferenceExpression.Create($"{targetPort.ToString(CultureInfo.InvariantCulture)}")
+                : ReferenceExpression.Create($"{new ContainerPortReference(endpointReference.Resource)}"),
+            EndpointProperty.Scheme => ReferenceExpression.Create($"{scheme}"),
+            EndpointProperty.HostAndPort => host,
+            EndpointProperty.TlsEnabled => ReferenceExpression.Create($"{(endpoint.TlsEnabled ? bool.TrueString : bool.FalseString)}"),
+            _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{endpoint.Name}'.")
+        };
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -495,6 +495,7 @@ public class AzureAppServiceEnvironmentResource :
         var endpoint = endpointReference.EndpointAnnotation;
         var scheme = PreserveHttpEndpoints ? endpoint.UriScheme : "https";
         var port = string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) ? 80 : 443;
+        var tlsEnabled = string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) || endpoint.TlsEnabled;
         var host = GetHostAddressExpression(endpointReference);
 
         return property switch
@@ -507,7 +508,7 @@ public class AzureAppServiceEnvironmentResource :
                 : ReferenceExpression.Create($"{new ContainerPortReference(endpointReference.Resource)}"),
             EndpointProperty.Scheme => ReferenceExpression.Create($"{scheme}"),
             EndpointProperty.HostAndPort => host,
-            EndpointProperty.TlsEnabled => ReferenceExpression.Create($"{(endpoint.TlsEnabled ? bool.TrueString : bool.FalseString)}"),
+            EndpointProperty.TlsEnabled => ReferenceExpression.Create($"{(tlsEnabled ? bool.TrueString : bool.FalseString)}"),
             _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{endpoint.Name}'.")
         };
     }

--- a/src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj
+++ b/src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\AzureRoleAssignmentUtils.cs" />
     <Compile Include="$(RepoRoot)src\Shared\ContainerRegistryInfrastructure.cs" />
+    <Compile Include="$(RepoRoot)src\Aspire.Hosting\Utils\FormattingHelpers.cs" Link="Utils\FormattingHelpers.cs" />
     <Compile Remove="tools\**\*.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -6,6 +6,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 using Azure.AI.Projects;
 using Azure.AI.Projects.Agents;
 using Azure.Identity;
@@ -266,7 +267,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
 
             if (expression.StringFormats[i] is string stringFormat && args[i] is string value)
             {
-                args[i] = FormatValue(value, stringFormat);
+                args[i] = FormattingHelpers.FormatValue(value, stringFormat);
             }
         }
 
@@ -292,7 +293,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
         var deploymentTarget = endpointReference.Resource.GetDeploymentTargetAnnotation();
         if (deploymentTarget?.ComputeEnvironment is not { } computeEnvironment)
         {
-            var reason = $"Resource '{endpointReference.Resource.Name}' does not have an ComputeEnvironment deployment target.";
+            var reason = $"Resource '{endpointReference.Resource.Name}' does not have a compute environment deployment target.";
             throw CreateEndpointResolutionException(hostedAgent, resource, environmentVariableName, endpointReference, reason);
         }
 
@@ -321,14 +322,6 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
             $"Endpoint '{endpointReference.EndpointName}' on resource '{endpointReference.Resource.Name}' cannot be used. {reason}");
     }
 
-    private static string FormatValue(string value, string format)
-    {
-        return format.ToLowerInvariant() switch
-        {
-            "uri" => Uri.EscapeDataString(value),
-            _ => throw new NotSupportedException($"The format '{format}' is not supported. Supported formats are 'uri' (encodes a URI)")
-        };
-    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Pipelines;
@@ -91,7 +92,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
     /// <summary>
     /// Convert all dynamic values into concrete values for deployment.
     /// </summary>
-    public async Task<HostedAgentConfiguration> ToHostedAgentConfigurationAsync(PipelineStepContext context)
+    private async Task<HostedAgentConfiguration> ToHostedAgentConfigurationAsync(PipelineStepContext context)
     {
         var imageName = await ((IValueProvider)Image).GetValueAsync(context.CancellationToken).ConfigureAwait(false);
         if (string.IsNullOrEmpty(imageName))
@@ -102,7 +103,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
         var def = new HostedAgentConfiguration(imageName)
         {
             // ProcessEnvironmentVariableValuesAsync does not resolve values properly in the deploy context
-            EnvironmentVariables = await GetResolvedEnvironmentVariablesAsync(context.ExecutionContext, Target, context.Logger, context.CancellationToken).ConfigureAwait(false),
+            EnvironmentVariables = await GetResolvedEnvironmentVariablesAsync(context.ExecutionContext, this, Target, context.Logger, context.CancellationToken).ConfigureAwait(false),
         };
         if (Configure is not null)
         {
@@ -114,7 +115,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
     /// <summary>
     /// Publishes the hosted agent during the manifest publishing phase.
     /// </summary>
-    public async Task PublishAsync(ManifestPublishingContext ctx)
+    private async Task PublishAsync(ManifestPublishingContext ctx)
     {
         // Write agent manifest
         ctx.Writer.WriteString("type", "azure.ai.agent.v0");
@@ -128,7 +129,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
     /// <summary>
     /// Deploys the specified agent to the given Microsoft Foundry project.
     /// </summary>
-    public async Task<ProjectsAgentVersion> DeployAsync(PipelineStepContext context, AzureCognitiveServicesProjectResource project)
+    private async Task<ProjectsAgentVersion> DeployAsync(PipelineStepContext context, AzureCognitiveServicesProjectResource project)
     {
         ArgumentNullException.ThrowIfNull(project);
 
@@ -149,6 +150,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
 
     internal static async Task<Dictionary<string, string>> GetResolvedEnvironmentVariablesAsync(
         DistributedApplicationExecutionContext context,
+        AzureHostedAgentResource hostedAgent,
         IResource resource,
         ILogger logger,
         CancellationToken cancellationToken)
@@ -183,10 +185,10 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
                     resolvedEnvVars[key] = s;
                     break;
                 case IValueProvider provider:
-                    resolvedEnvVars[key] = await provider.GetValueAsync(cancellationToken).ConfigureAwait(false) ?? string.Empty;
+                    resolvedEnvVars[key] = await ResolveValueProviderAsync(provider, context, hostedAgent, resource, key, cancellationToken).ConfigureAwait(false) ?? string.Empty;
                     break;
                 case IFormattable f:
-                    resolvedEnvVars[key] = f.ToString(null, System.Globalization.CultureInfo.InvariantCulture);
+                    resolvedEnvVars[key] = f.ToString(null, CultureInfo.InvariantCulture);
                     break;
                 default:
                     logger.LogWarning("Environment variable '{Key}' for resource '{Name}' has unknown value of type '{type}' and will be skipped.", key, resource.Name, value.GetType().FullName);
@@ -194,6 +196,138 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
             }
         }
         return resolvedEnvVars;
+    }
+
+    private static async ValueTask<string?> ResolveValueProviderAsync(
+        IValueProvider provider,
+        DistributedApplicationExecutionContext context,
+        AzureHostedAgentResource hostedAgent,
+        IResource resource,
+        string environmentVariableName,
+        CancellationToken cancellationToken)
+    {
+        if (context.IsPublishMode)
+        {
+            switch (provider)
+            {
+                case EndpointReference endpointReference:
+                    return await ResolvePublishedEndpointAsync(endpointReference.Property(EndpointProperty.Url), context, hostedAgent, resource, environmentVariableName, cancellationToken).ConfigureAwait(false);
+                case EndpointReferenceExpression endpointReferenceExpression:
+                    return await ResolvePublishedEndpointAsync(endpointReferenceExpression, context, hostedAgent, resource, environmentVariableName, cancellationToken).ConfigureAwait(false);
+                case ReferenceExpression referenceExpression:
+                    return await ResolveReferenceExpressionAsync(referenceExpression, context, hostedAgent, resource, environmentVariableName, cancellationToken).ConfigureAwait(false);
+                case ConnectionStringReference connectionStringReference:
+                    var connectionString = await ResolveReferenceExpressionAsync(connectionStringReference.Resource.ConnectionStringExpression, context, hostedAgent, resource, environmentVariableName, cancellationToken).ConfigureAwait(false);
+                    if (string.IsNullOrEmpty(connectionString) && !connectionStringReference.Optional)
+                    {
+                        throw new DistributedApplicationException($"The connection string for the resource '{connectionStringReference.Resource.Name}' is not available.");
+                    }
+
+                    return connectionString;
+                case IResourceWithConnectionString connectionStringResource and not ParameterResource:
+                    return await ResolveReferenceExpressionAsync(connectionStringResource.ConnectionStringExpression, context, hostedAgent, resource, environmentVariableName, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return await provider.GetValueAsync(
+            new ValueProviderContext
+            {
+                ExecutionContext = context,
+                Caller = resource
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<string?> ResolveReferenceExpressionAsync(
+        ReferenceExpression expression,
+        DistributedApplicationExecutionContext context,
+        AzureHostedAgentResource hostedAgent,
+        IResource resource,
+        string environmentVariableName,
+        CancellationToken cancellationToken)
+    {
+        if (expression.IsConditional)
+        {
+            var conditionValue = await ResolveValueProviderAsync(expression.Condition!, context, hostedAgent, resource, environmentVariableName, cancellationToken).ConfigureAwait(false);
+            var branch = string.Equals(conditionValue, expression.MatchValue, StringComparison.OrdinalIgnoreCase) ? expression.WhenTrue! : expression.WhenFalse!;
+
+            return await ResolveReferenceExpressionAsync(branch, context, hostedAgent, resource, environmentVariableName, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (expression.Format.Length == 0)
+        {
+            return null;
+        }
+
+        var args = new object?[expression.ValueProviders.Count];
+        for (var i = 0; i < expression.ValueProviders.Count; i++)
+        {
+            args[i] = await ResolveValueProviderAsync(expression.ValueProviders[i], context, hostedAgent, resource, environmentVariableName, cancellationToken).ConfigureAwait(false);
+
+            if (expression.StringFormats[i] is string stringFormat && args[i] is string value)
+            {
+                args[i] = FormatValue(value, stringFormat);
+            }
+        }
+
+        return string.Format(CultureInfo.InvariantCulture, expression.Format, args);
+    }
+
+    private static async ValueTask<string?> ResolvePublishedEndpointAsync(
+        EndpointReferenceExpression endpointReferenceExpression,
+        DistributedApplicationExecutionContext context,
+        AzureHostedAgentResource hostedAgent,
+        IResource resource,
+        string environmentVariableName,
+        CancellationToken cancellationToken)
+    {
+        var endpointReference = endpointReferenceExpression.Endpoint;
+        var endpoint = endpointReference.EndpointAnnotation;
+
+        if (endpointReference.Resource != hostedAgent.Target && !endpoint.IsExternal)
+        {
+            throw CreateEndpointResolutionException(hostedAgent, resource, environmentVariableName, endpointReference, $"Endpoint '{endpoint.Name}' is internal. Foundry hosted agents can only reference externally exposed endpoints during publish.");
+        }
+
+        var deploymentTarget = endpointReference.Resource.GetDeploymentTargetAnnotation();
+        if (deploymentTarget?.ComputeEnvironment is not { } computeEnvironment)
+        {
+            var reason = $"Resource '{endpointReference.Resource.Name}' does not have an ComputeEnvironment deployment target.";
+            throw CreateEndpointResolutionException(hostedAgent, resource, environmentVariableName, endpointReference, reason);
+        }
+
+#pragma warning disable ASPIRECOMPUTE002
+        var expression = computeEnvironment.GetEndpointPropertyExpression(endpointReferenceExpression);
+#pragma warning restore ASPIRECOMPUTE002
+
+        return await expression.GetValueAsync(
+            new ValueProviderContext
+            {
+                ExecutionContext = context,
+                Caller = resource
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static InvalidOperationException CreateEndpointResolutionException(
+        AzureHostedAgentResource hostedAgent,
+        IResource resource,
+        string environmentVariableName,
+        EndpointReference endpointReference,
+        string reason)
+    {
+        return new InvalidOperationException(
+            $"Unable to resolve environment variable '{environmentVariableName}' for Foundry hosted agent '{hostedAgent.Name}' from target resource '{resource.Name}'. " +
+            $"Endpoint '{endpointReference.EndpointName}' on resource '{endpointReference.Resource.Name}' cannot be used. {reason}");
+    }
+
+    private static string FormatValue(string value, string format)
+    {
+        return format.ToLowerInvariant() switch
+        {
+            "uri" => Uri.EscapeDataString(value),
+            _ => throw new NotSupportedException($"The format '{format}' is not supported. Supported formats are 'uri' (encodes a URI)")
+        };
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
@@ -27,6 +27,13 @@ public interface IComputeEnvironmentResource : IResource
     /// </summary>
     /// <param name="endpointReferenceExpression">The endpoint reference expression for which to retrieve a deployed endpoint property.</param>
     /// <returns>A <see cref="ReferenceExpression"/> representing the deployed endpoint property.</returns>
+    /// <remarks>
+    /// This method is used by deployment publishers to resolve endpoint properties from deployed compute infrastructure without
+    /// requiring a local endpoint allocation. The default implementation composes values from <see cref="GetHostAddressExpression(EndpointReference)"/>,
+    /// the endpoint scheme, and endpoint ports. HTTP and HTTPS endpoints use ports 80 and 443 respectively when no explicit port is configured.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpointReferenceExpression"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the requested endpoint property is unsupported, or when a non-HTTP/HTTPS endpoint does not specify a port.</exception>
     [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     ReferenceExpression GetEndpointPropertyExpression(EndpointReferenceExpression endpointReferenceExpression)
     {

--- a/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -20,4 +21,59 @@ public interface IComputeEnvironmentResource : IResource
     /// </remarks>
     [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) => throw new NotImplementedException();
+
+    /// <summary>
+    /// Gets a <see cref="ReferenceExpression"/> representing a deployed endpoint property for the specified <see cref="EndpointReferenceExpression"/>.
+    /// </summary>
+    /// <param name="endpointReferenceExpression">The endpoint reference expression for which to retrieve a deployed endpoint property.</param>
+    /// <returns>A <see cref="ReferenceExpression"/> representing the deployed endpoint property.</returns>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    ReferenceExpression GetEndpointPropertyExpression(EndpointReferenceExpression endpointReferenceExpression)
+    {
+        ArgumentNullException.ThrowIfNull(endpointReferenceExpression);
+
+        var endpointReference = endpointReferenceExpression.Endpoint;
+        var property = endpointReferenceExpression.Property;
+        var endpoint = endpointReference.EndpointAnnotation;
+        var scheme = endpoint.UriScheme;
+        var port = endpoint.Port ?? GetDefaultPort(scheme, endpoint);
+        var host = new Lazy<ReferenceExpression>(() => GetHostAddressExpression(endpointReference));
+
+        return property switch
+        {
+            EndpointProperty.Url => IsDefaultPort(scheme, port)
+                ? ReferenceExpression.Create($"{scheme}://{host.Value}")
+                : ReferenceExpression.Create($"{scheme}://{host.Value}:{port.ToString(CultureInfo.InvariantCulture)}"),
+            EndpointProperty.Host or EndpointProperty.IPV4Host => host.Value,
+            EndpointProperty.Port => ReferenceExpression.Create($"{port.ToString(CultureInfo.InvariantCulture)}"),
+            EndpointProperty.TargetPort => endpoint.TargetPort is int targetPort
+                ? ReferenceExpression.Create($"{targetPort.ToString(CultureInfo.InvariantCulture)}")
+                : ReferenceExpression.Create($"{new ContainerPortReference(endpointReference.Resource)}"),
+            EndpointProperty.Scheme => ReferenceExpression.Create($"{scheme}"),
+            EndpointProperty.HostAndPort => ReferenceExpression.Create($"{host.Value}:{port.ToString(CultureInfo.InvariantCulture)}"),
+            EndpointProperty.TlsEnabled => ReferenceExpression.Create($"{(endpoint.TlsEnabled ? bool.TrueString : bool.FalseString)}"),
+            _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{endpoint.Name}'.")
+        };
+    }
+
+    private static int GetDefaultPort(string scheme, EndpointAnnotation endpoint)
+    {
+        if (string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase))
+        {
+            return 80;
+        }
+
+        if (string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase))
+        {
+            return 443;
+        }
+
+        throw new InvalidOperationException($"Endpoint '{endpoint.Name}' must specify a port for scheme '{scheme}'.");
+    }
+
+    private static bool IsDefaultPort(string scheme, int port)
+    {
+        return string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) && port == 80 ||
+            string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) && port == 443;
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
@@ -28,9 +28,11 @@ public interface IComputeEnvironmentResource : IResource
     /// <param name="endpointReferenceExpression">The endpoint reference expression for which to retrieve a deployed endpoint property.</param>
     /// <returns>A <see cref="ReferenceExpression"/> representing the deployed endpoint property.</returns>
     /// <remarks>
-    /// This method is used by deployment publishers to resolve endpoint properties from deployed compute infrastructure without
-    /// requiring a local endpoint allocation. The default implementation composes values from <see cref="GetHostAddressExpression(EndpointReference)"/>,
-    /// the endpoint scheme, and endpoint ports. HTTP and HTTPS endpoints use ports 80 and 443 respectively when no explicit port is configured.
+    /// Use this method when an endpoint property should be represented as a compute-environment-specific
+    /// <see cref="ReferenceExpression"/> instead of being resolved from a local endpoint allocation.
+    /// The default implementation composes values from <see cref="GetHostAddressExpression(EndpointReference)"/>,
+    /// the endpoint scheme, and endpoint ports. HTTP and HTTPS endpoints use ports 80 and 443 respectively
+    /// when no explicit port is configured.
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpointReferenceExpression"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the requested endpoint property is unsupported, or when a non-HTTP/HTTPS endpoint does not specify a port.</exception>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -804,6 +804,34 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("webSiteSuffix", output.Name);
     }
 
+    [Theory]
+    [InlineData(EndpointProperty.Url, "https://project1-website123.azurewebsites.net")]
+    [InlineData(EndpointProperty.Host, "project1-website123.azurewebsites.net")]
+    [InlineData(EndpointProperty.IPV4Host, "project1-website123.azurewebsites.net")]
+    [InlineData(EndpointProperty.Port, "443")]
+    [InlineData(EndpointProperty.TargetPort, "5000")]
+    [InlineData(EndpointProperty.Scheme, "https")]
+    [InlineData(EndpointProperty.HostAndPort, "project1-website123.azurewebsites.net")]
+    [InlineData(EndpointProperty.TlsEnabled, "False")]
+    public async Task GetEndpointPropertyExpression_ReturnsAppServiceEndpointPropertyExpression(EndpointProperty property, string expected)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureAppServiceEnvironment("env");
+        env.Resource.Outputs["webSiteSuffix"] = "website123";
+        env.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        var project = builder
+            .AddProject<Project>("project1", launchProfileName: null)
+            .WithEndpoint(port: 8080, targetPort: 5000, scheme: "http", name: "http", isExternal: true);
+
+#pragma warning disable ASPIRECOMPUTE002
+        var expression = env.Resource.GetEndpointPropertyExpression(project.GetEndpoint("http").Property(property));
+#pragma warning restore ASPIRECOMPUTE002
+
+        Assert.Equal(expected, await expression.GetValueAsync(default));
+    }
+
     [Fact]
     public async Task AddAppServiceWithApplicationInsightsLocation()
     {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -812,7 +812,7 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
     [InlineData(EndpointProperty.TargetPort, "5000")]
     [InlineData(EndpointProperty.Scheme, "https")]
     [InlineData(EndpointProperty.HostAndPort, "project1-website123.azurewebsites.net")]
-    [InlineData(EndpointProperty.TlsEnabled, "False")]
+    [InlineData(EndpointProperty.TlsEnabled, "True")]
     public async Task GetEndpointPropertyExpression_ReturnsAppServiceEndpointPropertyExpression(EndpointProperty property, string expected)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2230,7 +2230,7 @@ public class AzureContainerAppsTests
     [InlineData(EndpointProperty.TargetPort, "5000")]
     [InlineData(EndpointProperty.Scheme, "https")]
     [InlineData(EndpointProperty.HostAndPort, "project1.example.azurecontainerapps.io:443")]
-    [InlineData(EndpointProperty.TlsEnabled, "False")]
+    [InlineData(EndpointProperty.TlsEnabled, "True")]
     public async Task GetEndpointPropertyExpression_ReturnsContainerAppEndpointPropertyExpression(EndpointProperty property, string expected)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2222,6 +2222,34 @@ public class AzureContainerAppsTests
         Assert.Equal("AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN", output.Name);
     }
 
+    [Theory]
+    [InlineData(EndpointProperty.Url, "https://project1.example.azurecontainerapps.io")]
+    [InlineData(EndpointProperty.Host, "project1.example.azurecontainerapps.io")]
+    [InlineData(EndpointProperty.IPV4Host, "project1.example.azurecontainerapps.io")]
+    [InlineData(EndpointProperty.Port, "443")]
+    [InlineData(EndpointProperty.TargetPort, "5000")]
+    [InlineData(EndpointProperty.Scheme, "https")]
+    [InlineData(EndpointProperty.HostAndPort, "project1.example.azurecontainerapps.io:443")]
+    [InlineData(EndpointProperty.TlsEnabled, "False")]
+    public async Task GetEndpointPropertyExpression_ReturnsContainerAppEndpointPropertyExpression(EndpointProperty property, string expected)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("env");
+        env.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = "example.azurecontainerapps.io";
+        env.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        var project = builder
+            .AddProject<Project>("project1", launchProfileName: null)
+            .WithEndpoint(port: 8080, targetPort: 5000, scheme: "http", name: "http", isExternal: true);
+
+#pragma warning disable ASPIRECOMPUTE002
+        var expression = env.Resource.GetEndpointPropertyExpression(project.GetEndpoint("http").Property(property));
+#pragma warning restore ASPIRECOMPUTE002
+
+        Assert.Equal(expected, await expression.GetValueAsync(default));
+    }
+
     [Fact]
     public async Task ContainerAppProvisionDependsOnTargetPushStep()
     {

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.AppContainers;
 using Aspire.Hosting.Foundry;
 using Aspire.Hosting.Utils;
 using Microsoft.AI.Foundry.Local;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -261,6 +263,167 @@ public class FoundryExtensionsTests
 
         // Assert - Both calls should return the same resource instance, not duplicates
         Assert.Same(firstResult, secondResult);
+    }
+
+    [Fact]
+    public async Task PublishAsHostedAgent_ResolvesExternalContainerAppReference()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("env");
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        var weatherAgent = builder.AddProject<Project>("weather-agent", launchProfileName: null)
+            .WithEndpoint(targetPort: 9000, scheme: "http", name: "http", isExternal: true)
+            .WithComputeEnvironment(env);
+
+        var advisorAgent = builder.AddProject<Project>("advisor-agent", launchProfileName: null)
+            .WithReference(weatherAgent)
+            .WaitFor(weatherAgent)
+            .PublishAsHostedAgent(project);
+
+        using var app = builder.Build();
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var hostedAgent = Assert.Single(model.Resources.OfType<AzureHostedAgentResource>());
+        var environment = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
+        environment.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = "example.azurecontainerapps.io";
+        environment.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var environmentVariables = await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
+            builder.ExecutionContext,
+            hostedAgent,
+            advisorAgent.Resource,
+            NullLogger<FoundryExtensionsTests>.Instance,
+            cts.Token);
+
+        Assert.Equal("https://weather-agent.example.azurecontainerapps.io", environmentVariables["services__weather-agent__http__0"]);
+    }
+
+    [Fact]
+    public async Task PublishAsHostedAgent_ResolvesReferenceExpressionEnvironmentVariable()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("env");
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        var weatherAgent = builder.AddProject<Project>("weather-agent", launchProfileName: null)
+            .WithEndpoint(targetPort: 9000, scheme: "http", name: "http", isExternal: true)
+            .WithComputeEnvironment(env);
+
+        var advisorAgent = builder.AddProject<Project>("advisor-agent", launchProfileName: null)
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables["WEATHER_HEALTH_URL"] = ReferenceExpression.Create($"{weatherAgent.GetEndpoint("http")}/health");
+            })
+            .PublishAsHostedAgent(project);
+
+        using var app = builder.Build();
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var hostedAgent = Assert.Single(model.Resources.OfType<AzureHostedAgentResource>());
+        var environment = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
+        environment.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = "example.azurecontainerapps.io";
+        environment.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var environmentVariables = await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
+            builder.ExecutionContext,
+            hostedAgent,
+            advisorAgent.Resource,
+            NullLogger<FoundryExtensionsTests>.Instance,
+            cts.Token);
+
+        Assert.Equal("https://weather-agent.example.azurecontainerapps.io/health", environmentVariables["WEATHER_HEALTH_URL"]);
+    }
+
+    [Fact]
+    public async Task PublishAsHostedAgent_ResolvesEndpointReferenceExpressionEnvironmentVariable()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("env");
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        var weatherAgent = builder.AddProject<Project>("weather-agent", launchProfileName: null)
+            .WithEndpoint(targetPort: 9000, scheme: "http", name: "http", isExternal: true)
+            .WithComputeEnvironment(env);
+
+        var advisorAgent = builder.AddProject<Project>("advisor-agent", launchProfileName: null)
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables["WEATHER_HOST_AND_PORT"] = weatherAgent.GetEndpoint("http").Property(EndpointProperty.HostAndPort);
+            })
+            .PublishAsHostedAgent(project);
+
+        using var app = builder.Build();
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var hostedAgent = Assert.Single(model.Resources.OfType<AzureHostedAgentResource>());
+        var environment = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
+        environment.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = "example.azurecontainerapps.io";
+        environment.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var environmentVariables = await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
+            builder.ExecutionContext,
+            hostedAgent,
+            advisorAgent.Resource,
+            NullLogger<FoundryExtensionsTests>.Instance,
+            cts.Token);
+
+        Assert.Equal("weather-agent.example.azurecontainerapps.io:443", environmentVariables["WEATHER_HOST_AND_PORT"]);
+    }
+
+    [Fact]
+    public async Task PublishAsHostedAgent_ThrowsForInternalContainerAppReference()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("env");
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        var weatherAgent = builder.AddProject<Project>("weather-agent", launchProfileName: null)
+            .WithHttpEndpoint(targetPort: 9000)
+            .WithComputeEnvironment(env);
+
+        var advisorAgent = builder.AddProject<Project>("advisor-agent", launchProfileName: null)
+            .WithReference(weatherAgent)
+            .WaitFor(weatherAgent);
+
+        advisorAgent.PublishAsHostedAgent(project);
+
+        using var app = builder.Build();
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var hostedAgent = Assert.Single(model.Resources.OfType<AzureHostedAgentResource>());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
+                builder.ExecutionContext,
+                hostedAgent,
+                advisorAgent.Resource,
+                NullLogger<FoundryExtensionsTests>.Instance,
+                default));
+
+        Assert.Contains("Foundry hosted agent 'advisor-agent-ha'", ex.Message);
+        Assert.Contains("Endpoint 'http' on resource 'weather-agent' cannot be used", ex.Message);
+        Assert.Contains("internal", ex.Message);
+    }
+
+    private sealed class Project : IProjectMetadata
+    {
+        public string ProjectPath => "project";
     }
 
 }

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Sockets;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 
@@ -59,11 +60,58 @@ public class ComputeEnvironmentValidationTests
         Assert.Same(env.Resource, api.Resource.GetComputeEnvironment());
     }
 
-    private sealed class TestComputeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
+    [Theory]
+    [InlineData(EndpointProperty.Url, "http://api.example.com:8080")]
+    [InlineData(EndpointProperty.Host, "api.example.com")]
+    [InlineData(EndpointProperty.IPV4Host, "api.example.com")]
+    [InlineData(EndpointProperty.Port, "8080")]
+    [InlineData(EndpointProperty.TargetPort, "5000")]
+    [InlineData(EndpointProperty.Scheme, "http")]
+    [InlineData(EndpointProperty.HostAndPort, "api.example.com:8080")]
+    [InlineData(EndpointProperty.TlsEnabled, "False")]
+    public async Task GetEndpointPropertyExpression_ReturnsDefaultEndpointPropertyExpression(EndpointProperty property, string expected)
     {
+        IComputeEnvironmentResource environment = new TestComputeEnvironmentResource("env");
+        var endpointReference = CreateEndpointReference("http", port: 8080, targetPort: 5000);
+
+#pragma warning disable ASPIRECOMPUTE002
+        var expression = environment.GetEndpointPropertyExpression(endpointReference.Property(property));
+#pragma warning restore ASPIRECOMPUTE002
+
+        Assert.Equal(expected, await expression.GetValueAsync(default));
     }
 
-    private sealed class TestComputeResource(string name) : Resource(name), IComputeResource
+    [Fact]
+    public void GetEndpointPropertyExpression_ThrowsWhenCustomSchemeDoesNotSpecifyPort()
+    {
+        IComputeEnvironmentResource environment = new TestComputeEnvironmentResource("env");
+        var endpointReference = CreateEndpointReference("redis", port: null, targetPort: 6379);
+
+#pragma warning disable ASPIRECOMPUTE002
+        var ex = Assert.Throws<InvalidOperationException>(() => environment.GetEndpointPropertyExpression(endpointReference.Property(EndpointProperty.Url)));
+#pragma warning restore ASPIRECOMPUTE002
+
+        Assert.Contains("Endpoint 'redis' must specify a port for scheme 'redis'.", ex.Message);
+    }
+
+    private static EndpointReference CreateEndpointReference(string uriScheme, int? port, int? targetPort)
+    {
+        var resource = new TestComputeResource("api");
+        var endpoint = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: uriScheme, name: uriScheme, port: port, targetPort: targetPort);
+        resource.Annotations.Add(endpoint);
+
+        return new EndpointReference(resource, endpoint);
+    }
+
+    private sealed class TestComputeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
+    {
+#pragma warning disable ASPIRECOMPUTE002
+        public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) =>
+            ReferenceExpression.Create($"{endpointReference.Resource.Name}.example.com");
+#pragma warning restore ASPIRECOMPUTE002
+    }
+
+    private sealed class TestComputeResource(string name) : Resource(name), IComputeResource, IResourceWithEndpoints
     {
     }
 }


### PR DESCRIPTION
## Description

`PublishAsHostedAgent(...)` resolved target environment variables through context-free value providers, which could wait forever on endpoint allocation snapshots during `aspire deploy` when a hosted agent referenced an Azure Container Apps endpoint. This change makes hosted-agent environment resolution publish-aware: endpoint values are resolved through the target compute environment's deployed endpoint expressions, including nested `ReferenceExpression` values and direct `EndpointReferenceExpression` values.

The change adds a default `IComputeEnvironmentResource.GetEndpointPropertyExpression(...)` implementation plus Azure Container Apps and App Service overrides so publish-time endpoint URL, host, port, scheme, and host-and-port behavior stays aligned with those environments. Referenced internal endpoints now fail fast with an actionable exception instead of hanging.

Fixes #16608

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No