### PR TITLE
Improve extension AppHost output handling and CodeLens anchors

### DIFF
--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -173,26 +173,59 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       ? Object.entries(configuredEnv).map(([name, value]) => ({ name, value: String(value) }))
       : undefined;
 
+    // Per-stream line buffers. CLI stdio chunks aren't guaranteed to arrive aligned to line
+    // boundaries; without buffering, partial lines (and split-point ANSI sequences) would be
+    // emitted as their own debug-console events, producing broken output like a bare emoji on
+    // one line followed by the rest of the message on the next.
+    let stdoutBuffer = '';
+    let stderrBuffer = '';
+
+    const flushBuffer = (buffer: string, category: 'stdout' | 'stderr') => {
+      const remainder = buffer.replace(/\r$/, '');
+      if (remainder.length > 0 && !isProgressEscapeSequence(remainder)) {
+        // Spectre's stderr is intentionally bare for non-error notifications (e.g. the version
+        // update banner). The DAP `'stderr'` category alone causes the debug console to render
+        // these lines in red; we don't add an extra `❌` because legitimate CLI errors are
+        // already emoji-prefixed by Spectre at the source.
+        this.sendMessage(remainder, true, category);
+      }
+    };
+
+    const handleChunk = (chunk: string, currentBuffer: string, category: 'stdout' | 'stderr'): string => {
+      const combined = currentBuffer + chunk;
+      const lines = combined.split('\n');
+      const partial = lines.pop() ?? '';
+      for (const line of lines) {
+        flushBuffer(line, category);
+      }
+      return partial;
+    };
+
     spawnCliProcess(
       this._terminalProvider,
       await this._terminalProvider.getAspireCliExecutablePath(),
       args,
       {
         stdoutCallback: (data) => {
-          for (const line of trimMessage(data)) {
-            this.sendMessage(line);
-          }
+          stdoutBuffer = handleChunk(data, stdoutBuffer, 'stdout');
         },
         stderrCallback: (data) => {
-          for (const line of trimMessage(data)) {
-            this.sendMessageWithEmoji("❌", line, false, 'stderr');
-          }
+          stderrBuffer = handleChunk(data, stderrBuffer, 'stderr');
         },
         errorCallback: (error) => {
           extensionLogOutputChannel.error(`Error spawning aspire process: ${error}`);
           vscode.window.showErrorMessage(processExceptionOccurred(error.message, commandLabel));
         },
         exitCallback: (code) => {
+          // Flush any partial line left in either buffer so trailing output isn't lost.
+          if (stdoutBuffer.length > 0) {
+            flushBuffer(stdoutBuffer, 'stdout');
+            stdoutBuffer = '';
+          }
+          if (stderrBuffer.length > 0) {
+            flushBuffer(stderrBuffer, 'stderr');
+            stderrBuffer = '';
+          }
           this.sendMessageWithEmoji("🔚", processExitedWithCode(code ?? '?'));
           // if the process failed, we want to stop the debug session
           this.dispose();
@@ -213,13 +246,9 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       }
     });
 
-    function trimMessage(message: string): string[] {
-      return message
-        .replace('\r\n', '\n')
-        .split('\n')
-        .map(line => line.trim())
-        // Filter empty lines and terminal progress bar escape sequences
-        .filter(line => line.length > 0 && !line.match(/^\u001b\]9;4;\d+\u001b\\$/));
+    function isProgressEscapeSequence(line: string): boolean {
+      // ConEmu/iTerm2 progress-reporting OSC sequence (`OSC 9;4;<state>;<value> ST`).
+      return /^\u001b\]9;4;\d+\u001b\\$/.test(line.trim());
     }
   }
 

--- a/extension/src/debugger/languages/cli.ts
+++ b/extension/src/debugger/languages/cli.ts
@@ -33,6 +33,10 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
         shell: false
     });
 
+    // Set UTF-8 encoding so Node reassembles multi-byte characters across chunk boundaries instead of yielding broken bytes.
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
     if (options?.lineCallback) {
         const rl = readline.createInterface(child.stdout);
         rl.on('line', line => {
@@ -40,12 +44,12 @@ export function spawnCliProcess(terminalProvider: AspireTerminalProvider, comman
         });
     }
 
-    child.stdout.on("data", (data) => {
-        options?.stdoutCallback?.(new String(data).toString());
+    child.stdout.on("data", (data: string) => {
+        options?.stdoutCallback?.(data);
     });
 
-    child.stderr.on("data", (data) => {
-        options?.stderrCallback?.(new String(data).toString());
+    child.stderr.on("data", (data: string) => {
+        options?.stderrCallback?.(data);
     });
 
     child.on('error', (error) => {

--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -78,14 +78,25 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
 
         for (const resource of resources) {
             // For pipeline steps the whole statement maps to a single Add*(...) call, so
-            // anchoring at the top of the chain reads naturally. For resources, however,
-            // a single fluent chain can declare several (e.g.
-            // `builder.AddPostgres("pg").AddDatabase("db")`) and collapsing them all to
-            // the chain's start line would stack two state/action lenses on the same
-            // line — the user can't tell which "Stopped" / which "Stop" belongs to which
-            // resource. Anchor each resource lens at its own call line instead.
-            const lensLine = resource.kind === 'pipelineStep'
-                ? (resource.statementStartLine ?? resource.range.start.line)
+            // anchoring at the top of the chain reads naturally.
+            //
+            // For resources, a single fluent chain can declare several (e.g.
+            // `builder.AddPostgres("pg").AddDatabase("db")`). If we collapsed all of those
+            // to the chain's start line their state/action lenses would stack on the same
+            // line and the user couldn't tell which "Stopped" / which "Stop" belongs to
+            // which resource. So when more than one resource shares a statement we anchor
+            // each at its own call line; when a chain declares just one resource we use
+            // the statement-start line so the lens sits above the whole declaration
+            // (e.g. above `const nodePlayer = await builder` rather than between that
+            // line and the `.addNodeApp(...)` call).
+            const statementStart = resource.statementStartLine ?? resource.range.start.line;
+            const sharedWithOthers = resource.kind === 'resource'
+                && resources.some(other =>
+                    other !== resource
+                    && other.kind === 'resource'
+                    && (other.statementStartLine ?? other.range.start.line) === statementStart);
+            const lensLine = (resource.kind === 'pipelineStep' || !sharedWithOthers)
+                ? statementStart
                 : resource.range.start.line;
             const lineRange = new vscode.Range(lensLine, 0, lensLine, 0);
 

--- a/extension/src/test/aspireCodeLensProvider.test.ts
+++ b/extension/src/test/aspireCodeLensProvider.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="mocha" />
+
 import * as assert from 'assert';
 import * as path from 'path';
 import * as sinon from 'sinon';
@@ -305,6 +307,96 @@ suite('AspireCodeLensProvider builder lens', () => {
         for (const lens of builderLenses) {
             assert.strictEqual(lens.range.start.line, 0);
         }
+        harness.dispose();
+    });
+});
+
+suite('AspireCodeLensProvider resource lens anchoring', () => {
+    let getConfigStub: sinon.SinonStub;
+
+    setup(() => {
+        getConfigStub = sinon.stub(vscode.workspace, 'getConfiguration').returns({
+            get: () => true,
+            has: () => true,
+            inspect: () => undefined,
+            update: () => Promise.resolve(),
+        } as any);
+    });
+
+    teardown(() => {
+        getConfigStub.restore();
+    });
+
+    function getResourceLenses(lenses: vscode.CodeLens[]): vscode.CodeLens[] {
+        return lenses.filter(l =>
+            l.command?.command !== 'aspire-vscode.codeLensOpenDashboard'
+            && l.command?.command !== 'aspire-vscode.codeLensViewAppHostLogs'
+            && l.command?.command !== 'aspire-vscode.codeLensDebugPipelineStep'
+        );
+    }
+
+    test('single-resource fluent chain anchors lens at the statement-start line, not the .add* call line', () => {
+        const docPath = p('repo', 'AppHost', 'apphost.ts');
+        const hostPath = p('repo', 'AppHost', 'apphost.ts');
+        // Multi-line chain: declaration starts at line 2 ("const nodePlayer = await builder")
+        // and the .addNodeApp(...) call is on line 3. Line 0 carries the createBuilder()
+        // entry point so the parser recognizes this as an AppHost file.
+        const content = [
+            'const builder = await createBuilder();',                               // line 0
+            '',                                                                     // line 1
+            '// Node Knight (Player 2)',                                            // line 2
+            'const nodePlayer = await builder',                                     // line 3
+            '    .addNodeApp("node-player", "./node-player", "src/server.ts")',     // line 4
+            '    .withRunScript("dev");',                                           // line 5
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [makeResource('node-player')],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const resourceLenses = getResourceLenses(lenses);
+
+        assert.ok(resourceLenses.length > 0, 'expected at least one resource lens for node-player');
+        for (const lens of resourceLenses) {
+            assert.strictEqual(
+                lens.range.start.line,
+                3,
+                `resource lens should anchor at statement-start line 3 (above 'const nodePlayer'), got ${lens.range.start.line}`
+            );
+        }
+        harness.dispose();
+    });
+
+    test('multi-resource fluent chain anchors each resource lens at its own .add* call line', () => {
+        const docPath = p('repo', 'AppHost', 'apphost.ts');
+        const hostPath = p('repo', 'AppHost', 'apphost.ts');
+        // Single fluent chain declaring two resources. Statement starts at line 2,
+        // pg call is on line 2, db call on line 3. We expect each resource's lens
+        // to anchor at its own .addX line so they don't stack.
+        const content = [
+            'const builder = await createBuilder();',         // line 0
+            '',                                                // line 1
+            'const db = builder.addPostgres("pg")',            // line 2 (statement-start AND pg call)
+            '    .addDatabase("db");',                          // line 3 (db call)
+        ].join('\n');
+
+        const harness = createHarness({
+            workspaceAppHostPath: hostPath,
+            workspaceResources: [makeResource('pg'), makeResource('db')],
+        });
+
+        const doc = createMockDocument(content, docPath);
+        const lenses = harness.provider.provideCodeLenses(doc, cancellationToken) as vscode.CodeLens[];
+        const resourceLenses = getResourceLenses(lenses);
+
+        const lines = new Set(resourceLenses.map(l => l.range.start.line));
+        assert.ok(
+            lines.has(2) && lines.has(3),
+            `expected resource lenses on both line 2 (pg) and line 3 (db) so they don't stack; got lines [${[...lines].join(', ')}]`
+        );
         harness.dispose();
     });
 });

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -334,32 +334,38 @@ export class AppHostDataRepository {
                     extensionLogOutputChannel.info(`aspire describe --follow exited with code ${code}`);
                     this._describeProcess = undefined;
 
-                    if (!this._disposed) {
-                        if (!this._describeReceivedData && code !== 0) {
-                            // The process exited with a non-zero code without ever producing valid data.
-                            // This is expected when no apphost is running. Don't set the error state
-                            // since that would show the "CLI not supported" banner; instead just show
-                            // the normal "no running apphost" welcome.
-                            extensionLogOutputChannel.warn('aspire describe --follow exited without producing data; no running apphost or CLI may not support this feature.');
-                            this._workspaceResources.clear();
-                            this._updateWorkspaceContext();
-                        } else {
-                            this._workspaceResources.clear();
-                            this._setError(undefined);
-                            this._updateWorkspaceContext();
-
-                            // Auto-restart with exponential backoff
-                            const delay = this._describeRestartDelay;
-                            this._describeRestartDelay = Math.min(this._describeRestartDelay * 2, this._getPollingIntervalMs());
-                            extensionLogOutputChannel.info(`Restarting describe --follow in ${delay}ms`);
-                            this._describeRestartTimer = setTimeout(() => {
-                                this._describeRestartTimer = undefined;
-                                if (!this._disposed && this._shouldWatchWorkspace) {
-                                    this._startDescribeWatch();
-                                }
-                            }, delay);
-                        }
+                    if (this._disposed) {
+                        return;
                     }
+
+                    // If this attempt never produced any data, there is no running apphost
+                    // to follow (or the CLI doesn't support --follow). Stop quietly: do not
+                    // set the error state (which would show the "CLI not supported" banner)
+                    // and do not auto-restart on a 5s loop forever — the panel will refresh
+                    // when the user explicitly retries or when activity resumes.
+                    if (!this._describeReceivedData) {
+                        extensionLogOutputChannel.warn(`aspire describe --follow exited (code ${code}) without producing data; not auto-restarting.`);
+                        this._workspaceResources.clear();
+                        this._updateWorkspaceContext();
+                        return;
+                    }
+
+                    // We had a working stream that ended (apphost shut down). Reset and try
+                    // once more with backoff in case the apphost is restarting; if that
+                    // attempt also produces no data we'll fall into the branch above.
+                    this._workspaceResources.clear();
+                    this._setError(undefined);
+                    this._updateWorkspaceContext();
+
+                    const delay = this._describeRestartDelay;
+                    this._describeRestartDelay = Math.min(this._describeRestartDelay * 2, this._getPollingIntervalMs());
+                    extensionLogOutputChannel.info(`Restarting describe --follow in ${delay}ms`);
+                    this._describeRestartTimer = setTimeout(() => {
+                        this._describeRestartTimer = undefined;
+                        if (!this._disposed && this._shouldWatchWorkspace) {
+                            this._startDescribeWatch();
+                        }
+                    }, delay);
                 },
                 errorCallback: (error) => {
                     if (this._describeProcess !== describeProcess) {


### PR DESCRIPTION
## Description

Improves several extension-only AppHost UX paths without requiring CLI or hosting changes:

- Buffers Aspire CLI stdout/stderr by line in the debug session so partial chunks do not split output across debug-console lines.
- Sets CLI child-process stdout/stderr encoding to UTF-8 so multi-byte characters are preserved across chunk boundaries.
- Stops prefixing every stderr line with `❌`; CLI/Spectre error output already includes the appropriate prefix, while benign stderr messages such as update notifications should not be labeled as failures.
- Avoids an infinite `aspire describe --follow` restart loop when the follow process exits before producing data.
- Anchors CodeLens state/actions for single-resource fluent chains at the statement start, while preserving per-call anchoring for multi-resource chains.

Validation:
- `npm run compile-tests`
- `npm run unit-test | grep -A3 "AspireCodeLensProvider resource lens anchoring"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
