### PR TITLE
Surface guest AppHost failures in extension flow

### DIFF
--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -339,16 +339,27 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayError(string errorMessage)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayErrorAsync(errorMessage.RemoveSpectreFormatting(), _cancellationToken));
+        // Serialize the local console write onto the same channel as the backchannel call so
+        // it stays ordered with prior queued operations (e.g. DisplayLines). Otherwise the
+        // synchronous Spectre write would land in the IDE debug console (via stdout/stderr
+        // capture) before earlier asynchronous DisplayLines RPCs had flushed, producing
+        // out-of-order output like an error message preceding the lines that explain it.
+        var result = _extensionTaskChannel.Writer.TryWrite(async () =>
+        {
+            await Backchannel.DisplayErrorAsync(errorMessage.RemoveSpectreFormatting(), _cancellationToken);
+            _consoleInteractionService.DisplayError(errorMessage);
+        });
         Debug.Assert(result);
-        _consoleInteractionService.DisplayError(errorMessage);
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayMessageAsync(emoji.Name, message.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(async () =>
+        {
+            await Backchannel.DisplayMessageAsync(emoji.Name, message.RemoveSpectreFormatting(), _cancellationToken);
+            _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup);
+        });
         Debug.Assert(result);
-        _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup);
     }
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
@@ -378,11 +389,20 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(lines.Select(line => new DisplayLineState(
+        // Materialize so we can iterate twice without re-enumerating a possibly lazy/one-shot source.
+        var materialized = lines as IReadOnlyCollection<(OutputLineStream Stream, string Line)> ?? lines.ToList();
+
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(materialized.Select(line => new DisplayLineState(
             line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
             line.Line.RemoveSpectreFormatting())), _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayLines(lines);
+
+        // Intentionally do NOT also write to the local console here. Unlike most Display* methods
+        // (whose backchannel sinks are distinct from the debug console — popups, status bar, log
+        // channel, etc.), the extension's `displayLines` RPC routes the lines into the active
+        // AppHost debug console. The CLI's stdout/stderr is also captured by the extension and
+        // forwarded into that same debug console, so calling _consoleInteractionService.DisplayLines
+        // here would surface every line twice.
     }
 
     public void DisplayCancellationMessage()

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -503,19 +503,19 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             var (guestExitCode, guestOutput) = await ExecuteGuestAppHostAsync(
                 appHostFile, directory, environmentVariables, enableHotReload, rpcClient, launcher, cancellationToken);
 
-            if (launcher is ExtensionGuestLauncher)
-            {
-                // Extension manages the guest app host lifecycle via VS Code debug session.
-                // Wait for the AppHost server to exit (Ctrl+C or extension termination).
-                await appHostServerProcess.WaitForExitAsync(cancellationToken);
-                return appHostServerProcess.ExitCode;
-            }
-
+            // A non-zero exit code at this point means the in-CLI portion of the guest run
+            // (typically a PreExecute step like `tsc --noEmit` for TypeScript) failed before
+            // the actual AppHost was launched. Surface the failure regardless of launcher
+            // type, otherwise the extension flow would silently hang in
+            // appHostServerProcess.WaitForExitAsync waiting for an apphost that was never started.
             if (guestExitCode != 0)
             {
                 _logger.LogError("{Language} apphost exited with code {ExitCode}", DisplayName, guestExitCode);
 
-                // Display the output (same pattern as DotNetCliRunner)
+                // Surface the captured output (e.g. tsc errors from a TypeScript PreExecute step)
+                // so the user can see why the apphost failed. In the extension flow,
+                // ExtensionInteractionService.DisplayLines routes these lines through the
+                // backchannel without also writing them to the CLI's captured stdout/stderr.
                 if (guestOutput is not null)
                 {
                     _interactionService.DisplayLines(guestOutput.GetLines());
@@ -539,6 +539,14 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 }
 
                 return guestExitCode;
+            }
+
+            if (launcher is ExtensionGuestLauncher)
+            {
+                // Extension manages the guest app host lifecycle via VS Code debug session.
+                // Wait for the AppHost server to exit (Ctrl+C or extension termination).
+                await appHostServerProcess.WaitForExitAsync(cancellationToken);
+                return appHostServerProcess.ExitCode;
             }
 
             // In watch mode, wait for server to exit (Ctrl+C or orphan detection)


### PR DESCRIPTION
## Description

Surfaces guest-language AppHost startup failures to the user when running through the VS Code extension.

For TypeScript/Node AppHosts, pre-execute failures such as `tsc --noEmit` errors could exit before the extension launcher path reported the failure. The CLI would then wait for an AppHost/backchannel that never started. This change checks the guest exit code before the extension-launcher short-circuit, displays captured output, signals the backchannel completion source with the failure, and tears down the shim server.

It also fixes extension output fan-out for captured lines:

- `ExtensionInteractionService.DisplayLines` now sends captured lines through the extension backchannel without also writing them to the CLI's captured stdout/stderr, avoiding duplicate debug-console output.
- `DisplayError` and `DisplayMessage` enqueue the local console write on the same task channel as the backchannel call so captured failure lines appear before the follow-up error/log messages.

Validation:
- `./dotnet.sh build src/Aspire.Cli/Aspire.Cli.csproj /p:SkipNativeBuild=true`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
