### PR TITLE
Render AppHost summary flush in extension host

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -515,11 +515,22 @@ internal sealed class RunCommand : BaseCommand
 
         grid.Columns[0].Width = longestLabelLength;
 
+        // In the extension's debug console, right-aligned labels and the surrounding padding
+        // render as visible left indentation, and the empty separator rows show up as blank
+        // lines that just push real content further down. Use a flush, single-spaced layout
+        // for the extension and keep the spaced-out look only for direct terminal output.
+        IRenderable LabelMarkup(string label)
+        {
+            var markup = new Markup($"[bold green]{label}[/]:");
+            return isExtensionHost ? markup : new Align(markup, HorizontalAlignment.Right);
+        }
+
         // AppHost row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{appHostLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(appHostRelativePath));
-        grid.AddRow(Text.Empty, Text.Empty);
+        grid.AddRow(LabelMarkup(appHostLabel), new Text(appHostRelativePath));
+        if (!isExtensionHost)
+        {
+            grid.AddRow(Text.Empty, Text.Empty);
+        }
 
         if (!isExtensionHost)
         {
@@ -527,7 +538,7 @@ internal sealed class RunCommand : BaseCommand
             if (!string.IsNullOrEmpty(dashboardUrl))
             {
                 grid.AddRow(
-                    new Align(new Markup($"[bold green]{dashboardLabel}[/]:"), HorizontalAlignment.Right),
+                    LabelMarkup(dashboardLabel),
                     new Markup($"[link={dashboardUrl}]{dashboardUrl}[/]"));
 
                 // Codespaces URL (if available)
@@ -539,28 +550,27 @@ internal sealed class RunCommand : BaseCommand
             else
             {
                 grid.AddRow(
-                    new Align(new Markup($"[bold green]{dashboardLabel}[/]:"), HorizontalAlignment.Right),
+                    LabelMarkup(dashboardLabel),
                     new Markup("[dim]N/A[/]"));
             }
             grid.AddRow(Text.Empty, Text.Empty);
         }
 
         // Logs row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(logFilePath));
+        grid.AddRow(LabelMarkup(logsLabel), new Text(logFilePath));
 
         // PID row (if provided)
         if (pid.HasValue)
         {
-            grid.AddRow(Text.Empty, Text.Empty);
-            grid.AddRow(
-                new Align(new Markup($"[bold green]{pidLabel}[/]:"), HorizontalAlignment.Right),
-                new Text(pid.Value.ToString(CultureInfo.InvariantCulture)));
+            if (!isExtensionHost)
+            {
+                grid.AddRow(Text.Empty, Text.Empty);
+            }
+            grid.AddRow(LabelMarkup(pidLabel), new Text(pid.Value.ToString(CultureInfo.InvariantCulture)));
         }
 
-        var padder = new Padder(grid, new Padding(3, 0));
-        console.DisplayRenderable(padder);
+        IRenderable summary = isExtensionHost ? grid : new Padder(grid, new Padding(3, 0));
+        console.DisplayRenderable(summary);
 
         return longestLabelLength;
     }


### PR DESCRIPTION
## Description

Adjusts the AppHost startup summary layout when `aspire run` is hosted by the VS Code extension.

The terminal-oriented summary uses left padding, right-aligned labels, and blank separator rows for readability. In the extension debug console those choices show up as unwanted indentation and extra blank lines. This change keeps the existing terminal layout unchanged, but renders the extension-host summary flush and single-spaced:

```text
AppHost: apphost.ts
Logs: /Users/.../cli_....log
```

Validation:
- `./dotnet.sh build src/Aspire.Cli/Aspire.Cli.csproj /p:SkipNativeBuild=true`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
