### PR TITLE
[release/13.3] Consolidate Helm chart options on WithHelm(...) (#16759)

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/Annotations/HelmChartDescriptionAnnotation.cs
+++ b/src/Aspire.Hosting.Kubernetes/Annotations/HelmChartDescriptionAnnotation.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// An annotation placed on a <see cref="KubernetesEnvironmentResource"/> that specifies
+/// the Helm chart description written to the generated <c>Chart.yaml</c>.
+/// </summary>
+/// <param name="description">A <see cref="ReferenceExpression"/> representing the chart description value.</param>
+public sealed class HelmChartDescriptionAnnotation(ReferenceExpression description) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the Helm chart description as a <see cref="ReferenceExpression"/>.
+    /// </summary>
+    public ReferenceExpression Description { get; } = description ?? throw new ArgumentNullException(nameof(description));
+}

--- a/src/Aspire.Hosting.Kubernetes/Annotations/HelmChartNameAnnotation.cs
+++ b/src/Aspire.Hosting.Kubernetes/Annotations/HelmChartNameAnnotation.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// An annotation placed on a <see cref="KubernetesEnvironmentResource"/> that specifies
+/// the Helm chart name written to the generated <c>Chart.yaml</c>.
+/// </summary>
+/// <param name="name">A <see cref="ReferenceExpression"/> representing the chart name value.</param>
+public sealed class HelmChartNameAnnotation(ReferenceExpression name) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the Helm chart name as a <see cref="ReferenceExpression"/>.
+    /// </summary>
+    public ReferenceExpression Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+}

--- a/src/Aspire.Hosting.Kubernetes/Deployment/HelmDeploymentEngine.cs
+++ b/src/Aspire.Hosting.Kubernetes/Deployment/HelmDeploymentEngine.cs
@@ -247,31 +247,6 @@ internal static partial class HelmDeploymentEngine
         {
             try
             {
-                // Update the chart version if configured via annotation
-                if (environment.TryGetLastAnnotation<HelmChartVersionAnnotation>(out var versionAnnotation))
-                {
-                    var version = await versionAnnotation.Version.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
-                    if (!string.IsNullOrEmpty(version))
-                    {
-                        environment.HelmChartVersion = version;
-
-                        // Re-write Chart.yaml with updated version
-                        var chartFilePath = Path.Combine(outputPath, "Chart.yaml");
-                        if (File.Exists(chartFilePath))
-                        {
-                            var chartContent = await File.ReadAllTextAsync(chartFilePath, context.CancellationToken).ConfigureAwait(false);
-                            // Simple replacement of the version line in Chart.yaml.
-                            // Use a MatchEvaluator to avoid interpreting '$' in version as regex backreferences.
-                            chartContent = System.Text.RegularExpressions.Regex.Replace(
-                                chartContent,
-                                @"^version:\s*.*$",
-                                _ => $"version: {version}",
-                                System.Text.RegularExpressions.RegexOptions.Multiline);
-                            await File.WriteAllTextAsync(chartFilePath, chartContent, context.CancellationToken).ConfigureAwait(false);
-                        }
-                    }
-                }
-
                 // Resolve captured parameter/secret values and write a deploy override file.
                 // During publish, secrets and parameters without defaults are written as empty
                 // placeholders in values.yaml. During deploy, we resolve them and provide the

--- a/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
+++ b/src/Aspire.Hosting.Kubernetes/HelmChartOptions.cs
@@ -20,6 +20,8 @@ public sealed partial class HelmChartOptions
 {
     private const int KubernetesNamespaceMaxLength = 63;
     private const int HelmReleaseNameMaxLength = 53;
+    private const int HelmChartNameMaxLength = 250;
+    private const int HelmChartDescriptionMaxLength = 1024;
 
     internal IResourceBuilder<KubernetesEnvironmentResource> EnvironmentBuilder { get; }
 
@@ -119,13 +121,18 @@ public sealed partial class HelmChartOptions
     /// <summary>
     /// Sets the Helm chart version for deployment.
     /// </summary>
-    /// <param name="version">The chart version (e.g., "1.0.0").</param>
+    /// <param name="version">
+    /// The chart version. Helm accepts strict SemVer 2.0 strings (e.g. <c>"1.2.3"</c>,
+    /// <c>"1.2.3-beta.1+ef365"</c>) as well as partial versions (<c>"1"</c>, <c>"1.2"</c>) and
+    /// versions with a leading <c>v</c> (<c>"v1.2.3"</c>), which are coerced to a full
+    /// semantic version. Leading zeros are not allowed.
+    /// </param>
     /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
     [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withChartVersion dispatcher export.")]
     public HelmChartOptions WithChartVersion(string version)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
-        ValidateChartVersion(version);
+        ValidateChartVersion(version, nameof(version));
 
         var expression = ReferenceExpression.Create($"{version}");
         EnvironmentBuilder.WithAnnotation(new HelmChartVersionAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
@@ -160,6 +167,94 @@ public sealed partial class HelmChartOptions
         };
     }
 
+    /// <summary>
+    /// Sets the Helm chart name written to the generated <c>Chart.yaml</c>.
+    /// </summary>
+    /// <param name="name">The chart name. Must match Helm's chart-name format (alphanumeric, <c>-</c>, <c>_</c>, or <c>.</c>).</param>
+    /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withChartName dispatcher export.")]
+    public HelmChartOptions WithChartName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ValidateChartName(name, nameof(name));
+
+        var expression = ReferenceExpression.Create($"{name}");
+        EnvironmentBuilder.WithAnnotation(new HelmChartNameAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the Helm chart name written to the generated <c>Chart.yaml</c> using a parameter that will be prompted at deploy time.
+    /// </summary>
+    /// <param name="name">A parameter resource builder for the chart name value.</param>
+    /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withChartName dispatcher export.")]
+    public HelmChartOptions WithChartName(IResourceBuilder<ParameterResource> name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        var expression = ReferenceExpression.Create($"{name.Resource}");
+        EnvironmentBuilder.WithAnnotation(new HelmChartNameAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
+        return this;
+    }
+
+    [AspireExport(MethodName = "withChartName", Description = "Sets the Helm chart name written to the generated Chart.yaml.")]
+    internal HelmChartOptions WithChartName([AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        return name switch
+        {
+            string nameValue => WithChartName(nameValue),
+            IResourceBuilder<ParameterResource> nameParameter => WithChartName(nameParameter),
+            _ => throw new ArgumentException("Chart name must be a string or a parameter resource builder.", nameof(name))
+        };
+    }
+
+    /// <summary>
+    /// Sets the Helm chart description written to the generated <c>Chart.yaml</c>.
+    /// </summary>
+    /// <param name="description">The chart description.</param>
+    /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withChartDescription dispatcher export.")]
+    public HelmChartOptions WithChartDescription(string description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+        ValidateChartDescription(description, nameof(description));
+
+        var expression = ReferenceExpression.Create($"{description}");
+        EnvironmentBuilder.WithAnnotation(new HelmChartDescriptionAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the Helm chart description written to the generated <c>Chart.yaml</c> using a parameter that will be prompted at deploy time.
+    /// </summary>
+    /// <param name="description">A parameter resource builder for the chart description value.</param>
+    /// <returns>This <see cref="HelmChartOptions"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the union-based withChartDescription dispatcher export.")]
+    public HelmChartOptions WithChartDescription(IResourceBuilder<ParameterResource> description)
+    {
+        ArgumentNullException.ThrowIfNull(description);
+
+        var expression = ReferenceExpression.Create($"{description.Resource}");
+        EnvironmentBuilder.WithAnnotation(new HelmChartDescriptionAnnotation(expression), ResourceAnnotationMutationBehavior.Replace);
+        return this;
+    }
+
+    [AspireExport(MethodName = "withChartDescription", Description = "Sets the Helm chart description written to the generated Chart.yaml.")]
+    internal HelmChartOptions WithChartDescription([AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object description)
+    {
+        ArgumentNullException.ThrowIfNull(description);
+
+        return description switch
+        {
+            string descriptionValue => WithChartDescription(descriptionValue),
+            IResourceBuilder<ParameterResource> descriptionParameter => WithChartDescription(descriptionParameter),
+            _ => throw new ArgumentException("Chart description must be a string or a parameter resource builder.", nameof(description))
+        };
+    }
+
     private static void ValidateDnsLabel(string value, string target, int maxLength, string paramName)
     {
         if (value.Length > maxLength)
@@ -173,14 +268,44 @@ public sealed partial class HelmChartOptions
         }
     }
 
-    private static void ValidateChartVersion(string version)
+    // Matches Helm's own chart-version validation, which uses the lenient SemVer parser
+    // (Masterminds/semver/v3 NewVersion) — see helm/helm pkg/chart/v2/metadata.go isValidSemver.
+    // Helm accepts a leading "v" and partial versions (e.g. "v1", "1", "1.2"), coercing them
+    // to a full semantic version. Leading zeros are not allowed.
+    internal const SemVersionStyles ChartVersionStyles = SemVersionStyles.AllowV | SemVersionStyles.OptionalMinorPatch;
+
+    internal static void ValidateChartVersion(string version, string paramName)
     {
-        if (!SemVersion.TryParse(version, SemVersionStyles.Strict, out _))
+        if (!SemVersion.TryParse(version, ChartVersionStyles, out _))
         {
-            throw new ArgumentException($"Helm chart version '{version}' is invalid. Use a semantic version such as '1.0.0' or '1.0.0-beta.1'.", nameof(version));
+            throw new ArgumentException($"Helm chart version '{version}' is invalid. Helm accepts versions such as '1.2.3', '1.2.3-beta.1+ef365', '1', '1.2', or 'v1.2.3'.", paramName);
+        }
+    }
+
+    internal static void ValidateChartName(string name, string paramName)
+    {
+        if (name.Length > HelmChartNameMaxLength)
+        {
+            throw new ArgumentException($"Helm chart name '{name}' is invalid. It must be {HelmChartNameMaxLength} characters or fewer.", paramName);
+        }
+
+        if (!HelmChartNamePattern().IsMatch(name))
+        {
+            throw new ArgumentException($"Helm chart name '{name}' is invalid. Use alphanumeric characters, '-', '_', or '.'.", paramName);
+        }
+    }
+
+    internal static void ValidateChartDescription(string description, string paramName)
+    {
+        if (description.Length > HelmChartDescriptionMaxLength)
+        {
+            throw new ArgumentException($"Helm chart description is invalid. It must be {HelmChartDescriptionMaxLength} characters or fewer.", paramName);
         }
     }
 
     [GeneratedRegex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")]
     private static partial Regex DnsLabelPattern();
+
+    [GeneratedRegex("^[a-zA-Z0-9._-]+$")]
+    private static partial Regex HelmChartNamePattern();
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -33,19 +33,35 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     /// <summary>
     /// Gets or sets the name of the Helm chart to be generated.
     /// </summary>
-    public string HelmChartName { get; set; } = "aspire";
+    /// <remarks>
+    /// Defaults to the application name. Use
+    /// <see cref="HelmChartOptions.WithChartName(string)"/> via
+    /// <see cref="KubernetesEnvironmentExtensions.WithHelm(IResourceBuilder{KubernetesEnvironmentResource}, Action{HelmChartOptions})"/>
+    /// to customize the chart name.
+    /// </remarks>
+    internal string HelmChartName { get; set; } = "aspire";
 
     /// <summary>
     /// Gets or sets the version of the Helm chart to be generated.
     /// This property specifies the version number that will be assigned to the Helm chart,
     /// typically following semantic versioning conventions.
     /// </summary>
-    public string HelmChartVersion { get; set; } = "0.1.0";
+    /// <remarks>
+    /// Use <see cref="HelmChartOptions.WithChartVersion(string)"/> via
+    /// <see cref="KubernetesEnvironmentExtensions.WithHelm(IResourceBuilder{KubernetesEnvironmentResource}, Action{HelmChartOptions})"/>
+    /// to customize the chart version.
+    /// </remarks>
+    internal string HelmChartVersion { get; set; } = "0.1.0";
 
     /// <summary>
     /// Gets or sets the description of the Helm chart being generated.
     /// </summary>
-    public string HelmChartDescription { get; set; } = "Aspire Helm Chart";
+    /// <remarks>
+    /// Use <see cref="HelmChartOptions.WithChartDescription(string)"/> via
+    /// <see cref="KubernetesEnvironmentExtensions.WithHelm(IResourceBuilder{KubernetesEnvironmentResource}, Action{HelmChartOptions})"/>
+    /// to customize the chart description.
+    /// </remarks>
+    internal string HelmChartDescription { get; set; } = "Aspire Helm Chart";
 
     /// <summary>
     /// Determines whether to include an Aspire dashboard for telemetry visualization in this environment.
@@ -215,6 +231,10 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 Description = $"Publishes the Kubernetes environment configuration for {Name}.",
                 Action = ctx => PublishAsync(ctx)
             };
+            // Depend on publish-prereq so that process-parameters has run before we
+            // resolve Helm chart annotations (chart name/version/description) that may
+            // be backed by ParameterResource values.
+            publishStep.DependsOn(WellKnownPipelineSteps.PublishPrereq);
             publishStep.RequiredBy(WellKnownPipelineSteps.Publish);
             steps.Add(publishStep);
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -299,6 +299,8 @@ internal sealed class KubernetesPublishingContext(
 
     private async Task WriteKubernetesHelmChartAsync(KubernetesEnvironmentResource environment)
     {
+        await ResolveHelmChartMetadataAsync(environment).ConfigureAwait(false);
+
         var helmChart = new HelmChart
         {
             Name = environment.HelmChartName,
@@ -315,6 +317,45 @@ internal sealed class KubernetesPublishingContext(
         var outputFile = Path.Combine(OutputPath, "Chart.yaml");
         Directory.CreateDirectory(OutputPath);
         await File.WriteAllTextAsync(outputFile, chartYaml, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves Helm chart name/version/description annotations (set via
+    /// <see cref="HelmChartOptions"/>) and assigns the resolved values onto the
+    /// environment's internal <c>HelmChart*</c> properties so that Chart.yaml is
+    /// generated with the user-configured values on the first write.
+    /// </summary>
+    private async Task ResolveHelmChartMetadataAsync(KubernetesEnvironmentResource environment)
+    {
+        if (environment.TryGetLastAnnotation<HelmChartNameAnnotation>(out var nameAnnotation))
+        {
+            var name = await nameAnnotation.Name.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                HelmChartOptions.ValidateChartName(name, nameof(HelmChartOptions.WithChartName));
+                environment.HelmChartName = name;
+            }
+        }
+
+        if (environment.TryGetLastAnnotation<HelmChartVersionAnnotation>(out var versionAnnotation))
+        {
+            var version = await versionAnnotation.Version.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(version))
+            {
+                HelmChartOptions.ValidateChartVersion(version, nameof(HelmChartOptions.WithChartVersion));
+                environment.HelmChartVersion = version;
+            }
+        }
+
+        if (environment.TryGetLastAnnotation<HelmChartDescriptionAnnotation>(out var descriptionAnnotation))
+        {
+            var description = await descriptionAnnotation.Description.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(description))
+            {
+                HelmChartOptions.ValidateChartDescription(description, nameof(HelmChartOptions.WithChartDescription));
+                environment.HelmChartDescription = description;
+            }
+        }
     }
 
     private static void ApplyNodePoolSelector(KubernetesResource serviceResource, KubernetesNodePoolResource nodePool)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -136,7 +136,7 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
     {
         Labels = new()
         {
-            ["app.kubernetes.io/name"] = Parent.HelmChartName,
+            ["app.kubernetes.io/name"] = ".Chart.Name".ToHelmExpression(),
             ["app.kubernetes.io/component"] = resource.Name,
             ["app.kubernetes.io/instance"] = ".Release.Name".ToHelmExpression(),
         };

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesDeployTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesDeployTests.cs
@@ -168,6 +168,107 @@ public class KubernetesDeployTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void WithHelm_ConfiguresChartName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm => helm.WithChartName("my-chart"));
+
+        var app = builder.Build();
+        var env = app.Services.GetRequiredService<DistributedApplicationModel>()
+            .Resources.OfType<KubernetesEnvironmentResource>().Single();
+
+        Assert.True(env.TryGetLastAnnotation<HelmChartNameAnnotation>(out var annotation));
+        Assert.NotNull(annotation.Name);
+    }
+
+    [Fact]
+    public void WithHelm_ConfiguresChartDescription()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm => helm.WithChartDescription("My chart description"));
+
+        var app = builder.Build();
+        var env = app.Services.GetRequiredService<DistributedApplicationModel>()
+            .Resources.OfType<KubernetesEnvironmentResource>().Single();
+
+        Assert.True(env.TryGetLastAnnotation<HelmChartDescriptionAnnotation>(out var annotation));
+        Assert.NotNull(annotation.Description);
+    }
+
+    [Fact]
+    public void WithHelm_ChartNameAcceptsParameter()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var nameParam = builder.AddParameter("chart-name");
+
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm => helm.WithChartName(nameParam));
+
+        var app = builder.Build();
+        var env = app.Services.GetRequiredService<DistributedApplicationModel>()
+            .Resources.OfType<KubernetesEnvironmentResource>().Single();
+
+        Assert.True(env.TryGetLastAnnotation<HelmChartNameAnnotation>(out var annotation));
+        Assert.NotNull(annotation.Name);
+    }
+
+    [Fact]
+    public void WithHelm_ChartDescriptionAcceptsParameter()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var descParam = builder.AddParameter("chart-description");
+
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm => helm.WithChartDescription(descParam));
+
+        var app = builder.Build();
+        var env = app.Services.GetRequiredService<DistributedApplicationModel>()
+            .Resources.OfType<KubernetesEnvironmentResource>().Single();
+
+        Assert.True(env.TryGetLastAnnotation<HelmChartDescriptionAnnotation>(out var annotation));
+        Assert.NotNull(annotation.Description);
+    }
+
+    [Fact]
+    public void WithHelm_ConfiguresAllChartMetadata()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm =>
+            {
+                helm.WithChartName("acme-app");
+                helm.WithChartVersion("1.2.3");
+                helm.WithChartDescription("ACME application chart");
+            });
+
+        var app = builder.Build();
+        var env = app.Services.GetRequiredService<DistributedApplicationModel>()
+            .Resources.OfType<KubernetesEnvironmentResource>().Single();
+
+        Assert.True(env.TryGetLastAnnotation<HelmChartNameAnnotation>(out _));
+        Assert.True(env.TryGetLastAnnotation<HelmChartVersionAnnotation>(out _));
+        Assert.True(env.TryGetLastAnnotation<HelmChartDescriptionAnnotation>(out _));
+    }
+
+    [Fact]
+    public void WithHelm_RepeatedChartNameCallsReplaceAnnotations()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm => helm.WithChartName("first"))
+            .WithHelm(helm => helm.WithChartName("second"));
+
+        var app = builder.Build();
+        var env = app.Services.GetRequiredService<DistributedApplicationModel>()
+            .Resources.OfType<KubernetesEnvironmentResource>().Single();
+
+        var annotations = env.Annotations.OfType<HelmChartNameAnnotation>().ToList();
+        Assert.Single(annotations);
+    }
+
+    [Fact]
     public void WithHelm_RepeatedCallsReplaceAnnotations()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
@@ -510,6 +611,71 @@ public class KubernetesDeployTests(ITestOutputHelper output)
             });
     }
 
+    [Fact]
+    public void HelmChartOptions_WithChartName_ThrowsOnEmpty()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm =>
+            {
+                Assert.Throws<ArgumentException>(() => helm.WithChartName(string.Empty));
+            });
+    }
+
+    [Fact]
+    public void HelmChartOptions_WithChartDescription_ThrowsOnEmpty()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm =>
+            {
+                Assert.Throws<ArgumentException>(() => helm.WithChartDescription(string.Empty));
+            });
+    }
+
+    [Theory]
+    [InlineData("invalid name")]
+    [InlineData("with/slash")]
+    [InlineData("with*star")]
+    public void HelmChartOptions_WithChartName_ThrowsOnInvalidName(string value)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm =>
+            {
+                Assert.Throws<ArgumentException>(() => helm.WithChartName(value));
+            });
+    }
+
+    [Fact]
+    public void HelmChartOptions_WithChartName_ThrowsWhenTooLong()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm =>
+            {
+                Assert.Throws<ArgumentException>(() => helm.WithChartName(new string('a', 251)));
+            });
+    }
+
+    [Theory]
+    [InlineData("simple-chart")]
+    [InlineData("chart_with_underscore")]
+    [InlineData("chart.with.dots")]
+    [InlineData("Chart-Mixed-Case")]
+    public void HelmChartOptions_WithChartName_AcceptsValidNames(string value)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm => helm.WithChartName(value));
+
+        var app = builder.Build();
+        var env = app.Services.GetRequiredService<DistributedApplicationModel>()
+            .Resources.OfType<KubernetesEnvironmentResource>().Single();
+
+        Assert.True(env.TryGetLastAnnotation<HelmChartNameAnnotation>(out _));
+    }
+
     [Theory]
     [InlineData("Production")]
     [InlineData("my_namespace")]
@@ -543,7 +709,8 @@ public class KubernetesDeployTests(ITestOutputHelper output)
     [Theory]
     [InlineData("latest")]
     [InlineData("release-candidate")]
-    [InlineData("1.0")]
+    [InlineData("1.0.0.0")]
+    [InlineData("01.2.3")]
     public void HelmChartOptions_WithChartVersion_ThrowsOnInvalidVersion(string value)
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
@@ -552,6 +719,139 @@ public class KubernetesDeployTests(ITestOutputHelper output)
             {
                 Assert.Throws<ArgumentException>(() => helm.WithChartVersion(value));
             });
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("1.2")]
+    [InlineData("1.2.3")]
+    [InlineData("1.2.3-beta.1")]
+    [InlineData("1.2.3-beta.1+ef365")]
+    [InlineData("v1")]
+    [InlineData("v1.2")]
+    [InlineData("v1.2.3")]
+    [InlineData("V1.2.3")]
+    public void HelmChartOptions_WithChartVersion_AcceptsHelmCompatibleVersions(string value)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm =>
+            {
+                helm.WithChartVersion(value);
+            });
+    }
+
+    [Fact]
+    public async Task WithHelm_PublishThrowsWhenResolvedParameterChartVersionIsInvalid()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var versionParam = builder.AddParameter("chart-version", "not-a-version");
+
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm => helm.WithChartVersion(versionParam));
+        builder.AddContainer("svc", "nginx");
+
+        using var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ExecutePipelineAsync(app));
+        Assert.Contains("not-a-version", ex.Message);
+        Assert.IsType<ArgumentException>(ex.InnerException);
+    }
+
+    private static Task ExecutePipelineAsync(DistributedApplication app)
+    {
+        var pipeline = app.Services.GetRequiredService<IDistributedApplicationPipeline>();
+        var context = new PipelineContext(
+            app.Services.GetRequiredService<DistributedApplicationModel>(),
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services,
+            app.Services.GetRequiredService<Microsoft.Extensions.Logging.ILogger<KubernetesDeployTests>>(),
+            CancellationToken.None);
+
+        return pipeline.ExecuteAsync(context);
+    }
+
+    [Fact]
+    public async Task WithHelm_PublishWritesChartMetadataToChartYaml()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm =>
+            {
+                helm.WithChartName("acme-app");
+                helm.WithChartVersion("2.5.0");
+                helm.WithChartDescription("ACME application chart");
+            });
+        builder.AddContainer("svc", "nginx");
+
+        using var app = builder.Build();
+        await app.RunAsync();
+
+        var chartYaml = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, "Chart.yaml"));
+
+        Assert.Contains("name: \"acme-app\"", chartYaml);
+        Assert.Contains("version: \"2.5.0\"", chartYaml);
+        Assert.Contains("appVersion: \"2.5.0\"", chartYaml);
+        Assert.Contains("description: \"ACME application chart\"", chartYaml);
+    }
+
+    [Fact]
+    public async Task WithHelm_PublishResolvesParameterChartMetadata()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var nameParam = builder.AddParameter("chart-name", "param-chart");
+        var versionParam = builder.AddParameter("chart-version", "3.0.0");
+        var descParam = builder.AddParameter("chart-description", "Param-resolved description");
+
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm =>
+            {
+                helm.WithChartName(nameParam);
+                helm.WithChartVersion(versionParam);
+                helm.WithChartDescription(descParam);
+            });
+        builder.AddContainer("svc", "nginx");
+
+        using var app = builder.Build();
+        await app.RunAsync();
+
+        var chartYaml = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, "Chart.yaml"));
+
+        Assert.Contains("name: \"param-chart\"", chartYaml);
+        Assert.Contains("version: \"3.0.0\"", chartYaml);
+        Assert.Contains("appVersion: \"3.0.0\"", chartYaml);
+        Assert.Contains("description: \"Param-resolved description\"", chartYaml);
+    }
+
+    [Fact]
+    public async Task PublishWritesChartNameTemplateLabelOnResources()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        builder.AddKubernetesEnvironment("env")
+            .WithHelm(helm => helm.WithChartName("custom-chart"));
+        builder.AddContainer("svc", "nginx");
+
+        using var app = builder.Build();
+        await app.RunAsync();
+
+        var deploymentYaml = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, "templates", "svc", "deployment.yaml"));
+
+        // The label should use the Helm template variable, not the literal chart name.
+        Assert.Contains("app.kubernetes.io/name: \"{{ .Chart.Name }}\"", deploymentYaml);
+        Assert.DoesNotContain("app.kubernetes.io/name: \"custom-chart\"", deploymentYaml);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -182,7 +182,7 @@ public class KubernetesPublisherTests()
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
 
         builder.AddKubernetesEnvironment("env")
-                   .WithProperties(k => k.HelmChartName = "my-chart");
+                   .WithHelm(helm => helm.WithChartName("my-chart"));
 
         var param0 = builder.AddParameter("param0");
         var param1 = builder.AddParameter("param1", secret: true);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/config.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/config.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "servicea-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "ServiceA"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/deployment.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/deployment.verified.yaml
@@ -4,14 +4,14 @@ kind: "Deployment"
 metadata:
   name: "servicea-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "ServiceA"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "ServiceA"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "ServiceA"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/service.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/service.verified.yaml
@@ -4,13 +4,13 @@ kind: "Service"
 metadata:
   name: "servicea-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "ServiceA"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "ServiceA"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/env1-dashboard/deployment.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/env1-dashboard/deployment.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env1-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env1-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env1-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env1-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/env1-dashboard/service.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/env1-dashboard/service.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env1-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env1-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env1-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/config.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/config.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "serviceb-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "ServiceB"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/deployment.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/deployment.verified.yaml
@@ -4,14 +4,14 @@ kind: "Deployment"
 metadata:
   name: "serviceb-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "ServiceB"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "ServiceB"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "ServiceB"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/service.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/service.verified.yaml
@@ -4,13 +4,13 @@ kind: "Service"
 metadata:
   name: "serviceb-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "ServiceB"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "ServiceB"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/env2-dashboard/deployment.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/env2-dashboard/deployment.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env2-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env2-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env2-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env2-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/env2-dashboard/service.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/env2-dashboard/service.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env2-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env2-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env2-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.PublishingKubernetesEnvironmentPublishesFile#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.PublishingKubernetesEnvironmentPublishesFile#02.verified.yaml
@@ -4,14 +4,14 @@ kind: "Deployment"
 metadata:
   name: "service-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "service"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "service"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -21,7 +21,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "service"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#03.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#04.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "api-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "api"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "api"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#05.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "api-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#06.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "api-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#07.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#07.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "gateway-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "gateway"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "gateway"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "gateway"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#08.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#08.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "gateway-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "gateway"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#03.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#04.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "project1-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "project1"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "project1"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -40,7 +40,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "project1"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#05.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "project1-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "project1"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "project1"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#06.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "project1-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "project1"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#07.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#07.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "api-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "api"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -24,7 +24,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "api"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#08.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#08.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "api-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAppliesServiceCustomizations.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAppliesServiceCustomizations.verified.yaml
@@ -4,14 +4,14 @@ kind: "Deployment"
 metadata:
   name: "service-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "service"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "service"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -24,7 +24,7 @@ spec:
           imagePullPolicy: "Always"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "service"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#03.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#04.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "myapp-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "myapp"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -24,7 +24,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "myapp"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#05.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "myapp-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#03.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#04.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "argoproj.io/v1alpha1"
 kind: "Rollout"
 metadata:
   name: "myapp-rollout"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "myapp"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -29,6 +29,6 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "myapp"
       app.kubernetes.io/instance: "{{ .Release.Name }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#05.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "myapp-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#06.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "myapp-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#07.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#07.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "keda.sh/v1alpha1"
 kind: "ScaledObject"
 metadata:
   name: "myapp-scaler"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#03.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#04.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "project1-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "project1"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "project1"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -24,7 +24,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "project1"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#05.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "project1-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "project1"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#06.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "myapp-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "myapp"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -39,7 +39,7 @@ spec:
           emptyDir: {}
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "myapp"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#07.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#07.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "myapp-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#08.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#08.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "myapp-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#09.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#09.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Secret"
 metadata:
   name: "myapp-secrets"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 stringData:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#03.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#04.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "myapp-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "myapp"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -24,7 +24,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "myapp"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#05.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "myapp-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#03.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env-dashboard-service"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#04.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "myapp-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "myapp"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -24,7 +24,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "myapp"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#05.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "myapp-config"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "my-chart"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "my-chart"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#03.verified.yaml
@@ -1,16 +1,16 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Service"
 metadata:
   name: "env-dashboard-service"
   labels:
-    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   type: "ClusterIP"
   selector:
-    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#04.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "special-app-deployment"
   labels:
-    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "SpeciaL-ApP"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "my-chart"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "SpeciaL-ApP"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -26,7 +26,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "my-chart"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "SpeciaL-ApP"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#05.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: "special-app-config"
   labels:
-    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "SpeciaL-ApP"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 data:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#06.verified.yaml
@@ -1,10 +1,10 @@
-﻿---
+---
 apiVersion: "v1"
 kind: "Secret"
 metadata:
   name: "special-app-secrets"
   labels:
-    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "SpeciaL-ApP"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 stringData:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ResourceWithProbes#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ResourceWithProbes#00.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "env-dashboard-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "env-dashboard"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "env-dashboard"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "env-dashboard"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ResourceWithProbes#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ResourceWithProbes#01.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "myapp-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "myapp"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "myapp"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "myapp"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ResourceWithProbes#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ResourceWithProbes#02.verified.yaml
@@ -1,17 +1,17 @@
-﻿---
+---
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "project1-deployment"
   labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "project1"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
         app.kubernetes.io/component: "project1"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
       app.kubernetes.io/component: "project1"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
@@ -4,23 +4,23 @@ void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
         var helmNamespace = builder.addParameter("helm-namespace");
         var helmReleaseName = builder.addParameter("helm-release-name");
+        var helmChartName = builder.addParameter("helm-chart-name");
         var helmChartVersion = builder.addParameter("helm-chart-version");
+        var helmChartDescription = builder.addParameter("helm-chart-description");
         var kubernetes = builder.addKubernetesEnvironment("kube");
         kubernetes.withHelm((helm) -> {
             helm.withNamespace("validation-namespace");
             helm.withReleaseName("validation-release");
+            helm.withChartName("validation-kubernetes");
             helm.withChartVersion("1.2.3");
+            helm.withChartDescription("Validation Helm Chart");
             helm.withNamespace(helmNamespace);
             helm.withReleaseName(helmReleaseName);
+            helm.withChartName(helmChartName);
             helm.withChartVersion(helmChartVersion);
+            helm.withChartDescription(helmChartDescription);
         });
         kubernetes.withProperties((environment) -> {
-            environment.setHelmChartName("validation-kubernetes");
-            var _configuredHelmChartName = environment.helmChartName();
-            environment.setHelmChartVersion("1.2.3");
-            var _configuredHelmChartVersion = environment.helmChartVersion();
-            environment.setHelmChartDescription("Validation Helm Chart");
-            var _configuredHelmChartDescription = environment.helmChartDescription();
             environment.setDefaultStorageType("pvc");
             var _configuredDefaultStorageType = environment.defaultStorageType();
             environment.setDefaultStorageClassName("fast-storage");
@@ -34,7 +34,6 @@ void main() throws Exception {
             environment.setDefaultServiceType("LoadBalancer");
             var _configuredDefaultServiceType = environment.defaultServiceType();
         });
-        var _resolvedHelmChartName = kubernetes.helmChartName();
         var _resolvedDefaultStorageClassName = kubernetes.defaultStorageClassName();
         var _resolvedDefaultServiceType = kubernetes.defaultServiceType();
         var gateway = kubernetes.addGateway("public-gateway");
@@ -46,8 +45,7 @@ void main() throws Exception {
         var serviceContainer = builder.addContainer("kube-service", "redis:alpine");
         serviceContainer.publishAsKubernetesService((service) -> {
             var _serviceName = service.name();
-            var serviceParent = service.parent();
-            var _serviceParentChartName = serviceParent.helmChartName();
+            var _serviceParent = service.parent();
         });
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
@@ -7,20 +7,25 @@ from aspire_app import create_builder
 with create_builder() as builder:
     helm_namespace = builder.add_parameter("helm-namespace")
     helm_release_name = builder.add_parameter("helm-release-name")
+    helm_chart_name = builder.add_parameter("helm-chart-name")
     helm_chart_version = builder.add_parameter("helm-chart-version")
+    helm_chart_description = builder.add_parameter("helm-chart-description")
     kubernetes = builder.add_kubernetes_environment("resource")
 
     def configure_helm(helm):
         helm.with_namespace("validation-namespace")
         helm.with_release_name("validation-release")
+        helm.with_chart_name("validation-kubernetes")
         helm.with_chart_version("1.2.3")
+        helm.with_chart_description("Validation Helm Chart")
         helm.with_namespace(helm_namespace)
         helm.with_release_name(helm_release_name)
+        helm.with_chart_name(helm_chart_name)
         helm.with_chart_version(helm_chart_version)
+        helm.with_chart_description(helm_chart_description)
 
     kubernetes.with_helm(configure_helm)
     kubernetes.with_properties()
-    _resolved_helm_chart_name = kubernetes.helm_chart_name
     _resolved_default_storage_class_name = kubernetes.default_storage_class_name
     _resolved_default_service_type = kubernetes.default_service_type
     gateway = kubernetes.add_gateway("public-gateway")

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -4,7 +4,9 @@ const builder = await createBuilder();
 
 const helmNamespace = await builder.addParameter('helm-namespace');
 const helmReleaseName = await builder.addParameter('helm-release-name');
+const helmChartName = await builder.addParameter('helm-chart-name');
 const helmChartVersion = await builder.addParameter('helm-chart-version');
+const helmChartDescription = await builder.addParameter('helm-chart-description');
 
 const kubernetes = await builder.addKubernetesEnvironment('kube');
 
@@ -12,23 +14,18 @@ await kubernetes.withHelm({
     configure: async (helm) => {
         await helm.withNamespace('validation-namespace');
         await helm.withReleaseName('validation-release');
+        await helm.withChartName('validation-kubernetes');
         await helm.withChartVersion('1.2.3');
+        await helm.withChartDescription('Validation Helm Chart');
         await helm.withNamespace(helmNamespace);
         await helm.withReleaseName(helmReleaseName);
+        await helm.withChartName(helmChartName);
         await helm.withChartVersion(helmChartVersion);
+        await helm.withChartDescription(helmChartDescription);
     },
 });
 
 await kubernetes.withProperties(async (environment) => {
-    await environment.helmChartName.set('validation-kubernetes');
-    const _configuredHelmChartName: string = await environment.helmChartName.get();
-
-    await environment.helmChartVersion.set('1.2.3');
-    const _configuredHelmChartVersion: string = await environment.helmChartVersion.get();
-
-    await environment.helmChartDescription.set('Validation Helm Chart');
-    const _configuredHelmChartDescription: string = await environment.helmChartDescription.get();
-
     await environment.defaultStorageType.set('pvc');
     const _configuredDefaultStorageType: string = await environment.defaultStorageType.get();
 
@@ -48,7 +45,6 @@ await kubernetes.withProperties(async (environment) => {
     const _configuredDefaultServiceType: string = await environment.defaultServiceType.get();
 });
 
-const _resolvedHelmChartName: string = await kubernetes.helmChartName.get();
 const _resolvedDefaultStorageClassName: string | undefined = await kubernetes.defaultStorageClassName.get();
 const _resolvedDefaultServiceType: string = await kubernetes.defaultServiceType.get();
 
@@ -63,8 +59,7 @@ await ingress.withTls('ingress-tls');
 const serviceContainer = await builder.addContainer('kube-service', 'redis:alpine');
 await serviceContainer.publishAsKubernetesService(async (service) => {
     const _serviceName: string = await service.name();
-    const serviceParent = await service.parent();
-    const _serviceParentChartName: string = await serviceParent.helmChartName.get();
+    const _serviceParent = await service.parent();
 });
 
 await builder.build().run();


### PR DESCRIPTION
Backport of #16759 to release/13.3

/cc @mitchdenny @eerhardt

## Description

Consolidates the Helm chart configuration surface on `KubernetesEnvironmentResource` onto the existing `WithHelm(...)` extension, addressing API-review feedback on PR #16602.

Adds `WithChartName(...)` and `WithChartDescription(...)` overloads to `HelmChartOptions` (mirroring existing `WithChartVersion`), and internalizes the `HelmChartName`/`HelmChartVersion`/`HelmChartDescription` properties on `KubernetesEnvironmentResource` so `WithHelm` is the single configuration entry point. Also fixes a latent bug where the deploy-time rewrite of `Chart.yaml` only updated `version` but not `appVersion` when the chart version was parameter-backed.

## Customer Impact

Customers using `KubernetesEnvironmentResource` get a single, consistent API for configuring Helm chart name, version, and description. Without this change, customers would continue to have two parallel APIs (annotation-based `WithHelm` and property-based `WithProperties`) for what should be the same configuration, and parameter-backed chart versions would only update `version` (not `appVersion`) in the generated `Chart.yaml`.

## Testing

- Cherry-pick applied cleanly except for one merge conflict in `tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go` — the Go polyglot Kubernetes apphost does not exist in `release/13.3` (it was added later), so the deletion was honored.
- Built `Aspire.Hosting.Kubernetes.Tests` locally on Windows: 0 warnings, 0 errors.
- Ran `Aspire.Hosting.Kubernetes.Tests` locally: 146/146 passing.

## Risk

Low. The change is scoped to `Aspire.Hosting.Kubernetes` and tightens the public API surface (internalizes a few properties, adds new `WithChart*` overloads). The deploy-time `Chart.yaml` rewrite removal is safe because `aspire deploy` always runs publish first (`--operation publish --step deploy`), so publish now writes the correct `Chart.yaml` on the first pass.

## Regression?

No
