### PR TITLE
Require --yes with --non-interactive for destroy cmd

### DIFF
--- a/src/Aspire.Cli/Commands/DestroyCommand.cs
+++ b/src/Aspire.Cli/Commands/DestroyCommand.cs
@@ -29,6 +29,16 @@ internal sealed class DestroyCommand : PipelineCommandBase
             Description = DestroyCommandStrings.YesOptionDescription
         };
         Options.Add(_yesOption);
+
+        Validators.Add(result =>
+        {
+            var nonInteractive = result.GetValue(RootCommand.NonInteractiveOption);
+            var yes = result.GetValue(_yesOption);
+            if (nonInteractive && !yes)
+            {
+                result.AddError(DestroyCommandStrings.NonInteractiveRequiresYes);
+            }
+        });
     }
 
     protected override string OperationCompletedPrefix => DestroyCommandStrings.OperationCompletedPrefix;

--- a/src/Aspire.Cli/Resources/DestroyCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DestroyCommandStrings.Designer.cs
@@ -77,6 +77,15 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("Description", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The destroy command requires --yes when the --non-interactive option is specified..
+        /// </summary>
+        public static string NonInteractiveRequiresYes {
+            get {
+                return ResourceManager.GetString("NonInteractiveRequiresYes", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to The output path containing the deployment artifacts to destroy.

--- a/src/Aspire.Cli/Resources/DestroyCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DestroyCommandStrings.resx
@@ -120,6 +120,9 @@
   <data name="Description" xml:space="preserve">
     <value>Destroy a previously deployed AppHost environment (Preview)</value>
   </data>
+  <data name="NonInteractiveRequiresYes" xml:space="preserve">
+    <value>The destroy command requires --yes when the --non-interactive option is specified.</value>
+  </data>
   <data name="OutputPathArgumentDescription" xml:space="preserve">
     <value>The output path containing the deployment artifacts to destroy</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYes">
+        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/tests/Aspire.Cli.Tests/Commands/DestroyCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DestroyCommandTests.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.DependencyInjection;
@@ -116,8 +119,49 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
     }
 
-    [Fact]
-    public async Task DestroyCommandForwardsYesFlag()
+    [Theory]
+    [InlineData("destroy --non-interactive")]
+    [InlineData("--non-interactive destroy")]
+    public async Task DestroyCommandFailsFastWhenNonInteractiveWithoutYes(string commandLine)
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+        var appHostStarted = false;
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    RunAsyncCallback = (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        appHostStarted = true;
+                        return Task.FromResult(0);
+                    }
+                };
+
+                return runner;
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse(commandLine);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Contains(result.Errors, error => string.Equals(error.Message, DestroyCommandStrings.NonInteractiveRequiresYes, StringComparison.Ordinal));
+        Assert.False(appHostStarted);
+    }
+
+    [Theory]
+    [InlineData("destroy --yes")]
+    [InlineData("destroy --non-interactive --yes")]
+    [InlineData("--non-interactive destroy --yes")]
+    public async Task DestroyCommandForwardsYesFlag(string commandLine)
     {
         using var tempRepo = TemporaryWorkspace.Create(outputHelper);
 
@@ -167,7 +211,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
-        var result = command.Parse("destroy --yes");
+        var result = command.Parse(commandLine);
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(0, exitCode);
@@ -229,5 +273,113 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task DestroyCommandReturnsNonZeroExitCodeWhenDestroyActivitiesFail()
+    {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
+
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, true, VersionHelper.GetDefaultTemplateVersion());
+                    },
+
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        var destroyCompleted = new TaskCompletionSource();
+                        var backchannel = new TestAppHostBackchannel
+                        {
+                            RequestStopAsyncCalled = destroyCompleted,
+                            GetPublishingActivitiesAsyncCallback = GetFailedDestroyActivities
+                        };
+                        backchannelCompletionSource?.SetResult(backchannel);
+                        await destroyCompleted.Task.DefaultTimeout();
+                        return 0;
+                    }
+                };
+
+                return runner;
+            };
+
+            options.PublishCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                return new TestDeployCommandPrompter(interactionService);
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse("destroy --yes");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
+
+        static async IAsyncEnumerable<PublishingActivity> GetFailedDestroyActivities([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Step,
+                Data = new PublishingActivityData
+                {
+                    Id = "destroy-step",
+                    StatusText = "Destroying resources",
+                    CompletionState = CompletionStates.InProgress,
+                    StepId = null
+                }
+            };
+
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Task,
+                Data = new PublishingActivityData
+                {
+                    Id = "destroy-compose",
+                    StatusText = "Stopping containers",
+                    CompletionState = CompletionStates.InProgress,
+                    StepId = "destroy-step"
+                }
+            };
+
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Task,
+                Data = new PublishingActivityData
+                {
+                    Id = "destroy-compose",
+                    StatusText = "Stopping containers failed",
+                    CompletionMessage = "Failed to stop containers",
+                    CompletionState = CompletionStates.CompletedWithError,
+                    StepId = "destroy-step"
+                }
+            };
+
+            // Simulate publish complete with error
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.PublishComplete,
+                Data = new PublishingActivityData
+                {
+                    Id = "publish-complete",
+                    StatusText = "Deployment completed with errors",
+                    CompletionState = CompletionStates.CompletedWithError,
+                    StepId = null
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
Added validation to enforce --yes when --non-interactive is used with the destroy command, returning a localized error if omitted. Introduced a new NonInteractiveRequiresYes resource and updated all localization files. Expanded DestroyCommandTests to cover new validation, multiple CLI permutations, and error scenarios for failed destroy activities.

Fix #16623

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
