### PR TITLE
Fix ReparsePointTests failing on Windows without Developer Mode

### DIFF
--- a/tests/Aspire.Cli.Tests/Utils/ReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ReparsePointTests.cs
@@ -20,9 +20,18 @@ public class ReparsePointTests(ITestOutputHelper outputHelper)
         var link = Path.Combine(root, "link");
         ReparsePoint.CreateOrReplace(link, target);
 
-        Assert.True(ReparsePoint.IsReparsePoint(link));
-        Assert.True(Directory.Exists(link));
-        Assert.Equal("hello", File.ReadAllText(Path.Combine(link, "marker")));
+        try
+        {
+            Assert.True(ReparsePoint.IsReparsePoint(link));
+            Assert.True(Directory.Exists(link));
+            Assert.Equal("hello", File.ReadAllText(Path.Combine(link, "marker")));
+        }
+        finally
+        {
+            // Remove the reparse point before workspace disposal — Directory.Delete(recursive: true)
+            // follows through junctions on Windows and would fail with UnauthorizedAccessException.
+            ReparsePoint.RemoveIfExists(link);
+        }
     }
 
     [Fact]
@@ -43,8 +52,18 @@ public class ReparsePointTests(ITestOutputHelper outputHelper)
         Assert.Equal("one", File.ReadAllText(Path.Combine(link, "id")));
 
         ReparsePoint.CreateOrReplace(link, target2);
-        Assert.Equal("two", File.ReadAllText(Path.Combine(link, "id")));
-        Assert.True(ReparsePoint.IsReparsePoint(link));
+
+        try
+        {
+            Assert.Equal("two", File.ReadAllText(Path.Combine(link, "id")));
+            Assert.True(ReparsePoint.IsReparsePoint(link));
+        }
+        finally
+        {
+            // Remove the reparse point before workspace disposal — Directory.Delete(recursive: true)
+            // follows through junctions on Windows and would fail with UnauthorizedAccessException.
+            ReparsePoint.RemoveIfExists(link);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fix `ReparsePointTests` failing on Windows without Developer Mode enabled.

The `CreateOrReplace_CreatesReparsePointToTargetDirectory` and `CreateOrReplace_ReplacesExistingReparsePoint` tests left reparse points (junctions) in the temp directory. On Windows, `Directory.Delete(recursive: true)` cannot remove directories containing junctions, causing `UnauthorizedAccessException` during `TemporaryWorkspace` disposal.

Added `try/finally` blocks to remove the reparse point before the workspace is disposed, matching the pattern already used by the Windows-specific junction tests in the same file.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
