### PR TITLE
[release/13.3] Backport CLI AppHost debug console output fixes

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -515,11 +515,22 @@ internal sealed class RunCommand : BaseCommand
 
         grid.Columns[0].Width = longestLabelLength;
 
+        // In the extension's debug console, right-aligned labels and the surrounding padding
+        // render as visible left indentation, and the empty separator rows show up as blank
+        // lines that just push real content further down. Use a flush, single-spaced layout
+        // for the extension and keep the spaced-out look only for direct terminal output.
+        IRenderable LabelMarkup(string label)
+        {
+            var markup = new Markup($"[bold green]{label}[/]:");
+            return isExtensionHost ? markup : new Align(markup, HorizontalAlignment.Right);
+        }
+
         // AppHost row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{appHostLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(appHostRelativePath));
-        grid.AddRow(Text.Empty, Text.Empty);
+        grid.AddRow(LabelMarkup(appHostLabel), new Text(appHostRelativePath));
+        if (!isExtensionHost)
+        {
+            grid.AddRow(Text.Empty, Text.Empty);
+        }
 
         if (!isExtensionHost)
         {
@@ -527,7 +538,7 @@ internal sealed class RunCommand : BaseCommand
             if (!string.IsNullOrEmpty(dashboardUrl))
             {
                 grid.AddRow(
-                    new Align(new Markup($"[bold green]{dashboardLabel}[/]:"), HorizontalAlignment.Right),
+                    LabelMarkup(dashboardLabel),
                     new Markup($"[link={dashboardUrl}]{dashboardUrl}[/]"));
 
                 // Codespaces URL (if available)
@@ -539,28 +550,27 @@ internal sealed class RunCommand : BaseCommand
             else
             {
                 grid.AddRow(
-                    new Align(new Markup($"[bold green]{dashboardLabel}[/]:"), HorizontalAlignment.Right),
+                    LabelMarkup(dashboardLabel),
                     new Markup("[dim]N/A[/]"));
             }
             grid.AddRow(Text.Empty, Text.Empty);
         }
 
         // Logs row
-        grid.AddRow(
-            new Align(new Markup($"[bold green]{logsLabel}[/]:"), HorizontalAlignment.Right),
-            new Text(logFilePath));
+        grid.AddRow(LabelMarkup(logsLabel), new Text(logFilePath));
 
         // PID row (if provided)
         if (pid.HasValue)
         {
-            grid.AddRow(Text.Empty, Text.Empty);
-            grid.AddRow(
-                new Align(new Markup($"[bold green]{pidLabel}[/]:"), HorizontalAlignment.Right),
-                new Text(pid.Value.ToString(CultureInfo.InvariantCulture)));
+            if (!isExtensionHost)
+            {
+                grid.AddRow(Text.Empty, Text.Empty);
+            }
+            grid.AddRow(LabelMarkup(pidLabel), new Text(pid.Value.ToString(CultureInfo.InvariantCulture)));
         }
 
-        var padder = new Padder(grid, new Padding(3, 0));
-        console.DisplayRenderable(padder);
+        IRenderable summary = isExtensionHost ? grid : new Padder(grid, new Padding(3, 0));
+        console.DisplayRenderable(summary);
 
         return longestLabelLength;
     }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -339,16 +339,27 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayError(string errorMessage)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayErrorAsync(errorMessage.RemoveSpectreFormatting(), _cancellationToken));
+        // Serialize the local console write onto the same channel as the backchannel call so
+        // it stays ordered with prior queued operations (e.g. DisplayLines). Otherwise the
+        // synchronous Spectre write would land in the IDE debug console (via stdout/stderr
+        // capture) before earlier asynchronous DisplayLines RPCs had flushed, producing
+        // out-of-order output like an error message preceding the lines that explain it.
+        var result = _extensionTaskChannel.Writer.TryWrite(async () =>
+        {
+            await Backchannel.DisplayErrorAsync(errorMessage.RemoveSpectreFormatting(), _cancellationToken);
+            _consoleInteractionService.DisplayError(errorMessage);
+        });
         Debug.Assert(result);
-        _consoleInteractionService.DisplayError(errorMessage);
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayMessageAsync(emoji.Name, message.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(async () =>
+        {
+            await Backchannel.DisplayMessageAsync(emoji.Name, message.RemoveSpectreFormatting(), _cancellationToken);
+            _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup);
+        });
         Debug.Assert(result);
-        _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup);
     }
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
@@ -378,11 +389,20 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(lines.Select(line => new DisplayLineState(
+        // Materialize so we can iterate twice without re-enumerating a possibly lazy/one-shot source.
+        var materialized = lines as IReadOnlyCollection<(OutputLineStream Stream, string Line)> ?? lines.ToList();
+
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(materialized.Select(line => new DisplayLineState(
             line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
             line.Line.RemoveSpectreFormatting())), _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayLines(lines);
+
+        // Intentionally do NOT also write to the local console here. Unlike most Display* methods
+        // (whose backchannel sinks are distinct from the debug console — popups, status bar, log
+        // channel, etc.), the extension's `displayLines` RPC routes the lines into the active
+        // AppHost debug console. The CLI's stdout/stderr is also captured by the extension and
+        // forwarded into that same debug console, so calling _consoleInteractionService.DisplayLines
+        // here would surface every line twice.
     }
 
     public void DisplayCancellationMessage()

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -523,19 +523,19 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             var (guestExitCode, guestOutput) = await ExecuteGuestAppHostAsync(
                 appHostFile, directory, environmentVariables, enableHotReload, rpcClient, launcher, cancellationToken);
 
-            if (launcher is ExtensionGuestLauncher)
-            {
-                // Extension manages the guest app host lifecycle via VS Code debug session.
-                // Wait for the AppHost server to exit (Ctrl+C or extension termination).
-                await appHostServerProcess.WaitForExitAsync(cancellationToken);
-                return appHostServerProcess.ExitCode;
-            }
-
+            // A non-zero exit code at this point means the in-CLI portion of the guest run
+            // (typically a PreExecute step like `tsc --noEmit` for TypeScript) failed before
+            // the actual AppHost was launched. Surface the failure regardless of launcher
+            // type, otherwise the extension flow would silently hang in
+            // appHostServerProcess.WaitForExitAsync waiting for an apphost that was never started.
             if (guestExitCode != 0)
             {
                 _logger.LogError("{Language} apphost exited with code {ExitCode}", DisplayName, guestExitCode);
 
-                // Display the output (same pattern as DotNetCliRunner)
+                // Surface the captured output (e.g. tsc errors from a TypeScript PreExecute step)
+                // so the user can see why the apphost failed. In the extension flow,
+                // ExtensionInteractionService.DisplayLines routes these lines through the
+                // backchannel without also writing them to the CLI's captured stdout/stderr.
                 if (guestOutput is not null)
                 {
                     _interactionService.DisplayLines(guestOutput.GetLines());
@@ -559,6 +559,14 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 }
 
                 return guestExitCode;
+            }
+
+            if (launcher is ExtensionGuestLauncher)
+            {
+                // Extension manages the guest app host lifecycle via VS Code debug session.
+                // Wait for the AppHost server to exit (Ctrl+C or extension termination).
+                await appHostServerProcess.WaitForExitAsync(cancellationToken);
+                return appHostServerProcess.ExitCode;
             }
 
             // In watch mode, wait for server to exit (Ctrl+C or orphan detection)


### PR DESCRIPTION
Backport of #16795 to release/13.3

/cc @danegsta

## Customer Impact

When using the Aspire VS Code extension, AppHost startup output from the CLI side is missing or misordered: TypeScript guest AppHost pre-launch failures (e.g. `tsc --noEmit`) are not surfaced, so the extension can hang at "Connecting to AppHost…"; captured AppHost output is duplicated in the debug console; errors can appear before the streamed output that explains them; and the AppHost summary renders with terminal padding/blank rows that look broken in the extension debug console.

## Testing

I've tested this with a variety of C# and TS apphosts

## Risk

Low. Scoped to Aspire CLI extension interaction/output formatting paths used by the VS Code extension. No public API changes.

## Regression?

Kind of? Build failures did not cause a hang in 13.2 TS apphosts, and now they do.