### PR TITLE
Fix dashboard static assets outside Development

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -32,6 +32,7 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Hosting.StaticWebAssets;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Server.Kestrel;
@@ -132,6 +133,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         AppContext.SetData("Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize.MaxItemCount", 10_000);
 
         var builder = options is not null ? WebApplication.CreateBuilder(options) : WebApplication.CreateBuilder();
+        StaticWebAssetsLoader.UseStaticWebAssets(builder.Environment, builder.Configuration);
 
         preConfigureBuilder?.Invoke(builder);
 

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Nodes;
 using Aspire.Dashboard.Configuration;
@@ -33,6 +34,41 @@ namespace Aspire.Dashboard.Tests.Integration;
 
 public class StartupTests(ITestOutputHelper testOutputHelper)
 {
+    [Fact]
+    public async Task StaticWebAssets_NonDevelopmentEnvironment_FluentUiAssetsAvailable()
+    {
+        const string aspireDashboardAssemblyName = "Aspire.Dashboard";
+        var currentAssemblyName = Assembly.GetExecutingAssembly().GetName().Name!;
+        var currentAssemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var aspireAssemblyDirectory = currentAssemblyDirectory.Replace(currentAssemblyName, aspireDashboardAssemblyName);
+
+        await using var app = new DashboardWebApplication(
+            options: new WebApplicationOptions
+            {
+                EnvironmentName = "Staging",
+                ContentRootPath = aspireAssemblyDirectory,
+                WebRootPath = Path.Combine(aspireAssemblyDirectory, "wwwroot"),
+                ApplicationName = aspireDashboardAssemblyName
+            },
+            preConfigureBuilder: builder =>
+            {
+                RemoveEnvironmentVariableSources(builder);
+                builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "http://127.0.0.1:0",
+                    [DashboardConfigNames.DashboardOtlpGrpcUrlName.ConfigKey] = "http://127.0.0.1:0",
+                    [DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://127.0.0.1:0",
+                    [DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = nameof(OtlpAuthMode.Unsecured),
+                    [DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.Unsecured),
+                });
+            });
+
+        var environment = app.Services.GetRequiredService<IWebHostEnvironment>();
+        var file = environment.WebRootFileProvider.GetFileInfo("_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js");
+
+        Assert.True(file.Exists, $"Expected static web asset to exist at '{file.PhysicalPath ?? file.Name}'.");
+    }
+
     [Fact]
     public async Task EndPointAccessors_AppStarted_EndPointPortsAssigned()
     {


### PR DESCRIPTION
## Description

Fixes #16069

The dashboard can be launched from build output by AppHost projects. ASP.NET Core only enables static web assets automatically in `Development`, so when `ASPNETCORE_ENVIRONMENT` is unset or set to another value, generated/RCL assets like `Aspire.Dashboard.styles.css`, FluentUI `reboot.css`, and `Microsoft.FluentUI.AspNetCore.Components.lib.module.js` are not available and the dashboard renders as a blank page.

This change explicitly loads static web assets during `DashboardWebApplication` startup for all environments while preserving the existing static-file middleware and cache-control behavior.

Validation:

```bash
dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-method "*.StaticWebAssets_NonDevelopmentEnvironment_FluentUiAssetsAvailable" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Manual validation:

1. From the repo root, run `dotnet run --project playground/FileBasedApp/FileBasedApp.AppHost/FileBasedApp.AppHost.csproj` with `ASPNETCORE_ENVIRONMENT` unset or set to a non-Development value.
2. Open the dashboard URL printed by the AppHost.
3. Confirm the dashboard UI renders instead of a blank page.
4. In browser dev tools, confirm these requests return 200 rather than 404: `Aspire.Dashboard.styles.css`, `_content/Microsoft.FluentUI.AspNetCore.Components/css/reboot.css`, and `_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
