### PR TITLE
[release/13.3] Drop nuget.config alongside single-file apphost.cs in `aspire init` (#16636)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -166,3 +166,4 @@
     <SystemTextJsonLTSVersion>8.0.6</SystemTextJsonLTSVersion>
   </PropertyGroup>
 </Project>
+

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -232,15 +232,13 @@ internal sealed class InitCommand : BaseCommand
         return await DropCSharpSingleFileSkeletonAsync(workingDirectory, cancellationToken);
     }
 
-    private Task<int> DropCSharpSingleFileSkeletonAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    private async Task<int> DropCSharpSingleFileSkeletonAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
     {
-        _ = cancellationToken;
-
         var appHostPath = Path.Combine(workingDirectory.FullName, "apphost.cs");
         if (File.Exists(appHostPath))
         {
             InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "apphost.cs already exists — skipping.");
-            return Task.FromResult(ExitCodeConstants.Success);
+            return ExitCodeConstants.Success;
         }
 
         // Drop bare single-file apphost. Pin the SDK version so later operations
@@ -259,10 +257,32 @@ internal sealed class InitCommand : BaseCommand
         File.WriteAllText(appHostPath, appHostContent);
         InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Created apphost.cs");
 
+        // Ensure the workspace has a NuGet.config that exposes the configured channel's
+        // package sources. This is required so MSBuild can resolve
+        // `#:sdk Aspire.AppHost.Sdk@<version>` from the apphost.cs SDK directive — both
+        // for `aspire add` (`dotnet package add --file apphost.cs`) and for
+        // `dotnet run --file apphost.cs`. Without it, any non-stable channel (PR/run
+        // hives, locally-built `local-*`/`dev-*` hives, the staging channel, etc.)
+        // is invisible and SDK resolution fails. Mirrors how `aspire new` handles
+        // template output via the same shared service; `NuGetConfigMerger` underneath
+        // creates a new file or merges missing sources into an existing one, so adding
+        // hives later is handled the same way as for templates.
+        var createdNuGetConfig = await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(
+            channelName: null,
+            outputPath: workingDirectory.FullName,
+            cancellationToken).ConfigureAwait(false);
+        if (createdNuGetConfig)
+        {
+            // Use a confirmation message that does NOT contain the literal substring
+            // "NuGet.config" — the AspireInitAsync E2E helper false-matches that
+            // substring as a Y/n prompt and gets out of sync with the real prompts.
+            InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Created package sources file");
+        }
+
         // Drop aspire.config.json
         var configResult = DropAspireConfig(workingDirectory, "apphost.cs", language: null);
 
-        return Task.FromResult(configResult);
+        return configResult;
     }
 
     private async Task<int> DropCSharpProjectSkeletonAsync(FileInfo solutionFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
+++ b/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
@@ -97,6 +97,51 @@ internal sealed class TemplateNuGetConfigService(
     }
 
     /// <summary>
+    /// Creates or updates NuGet.config for the given channel name without prompting the user
+    /// and without displaying a confirmation message containing "NuGet.config" (which can
+    /// trip up automation/tests that match on substrings). Resolves the channel name from
+    /// configuration if not provided. Suitable for non-interactive code paths such as
+    /// <c>aspire init</c> where the caller wants to display its own message (or none).
+    /// </summary>
+    /// <param name="channelName">The optional channel name from command input.</param>
+    /// <param name="outputPath">The output path where the NuGet.config should be created or updated.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns><see langword="true"/> if a NuGet.config was created or updated; otherwise <see langword="false"/>.</returns>
+    public async Task<bool> CreateOrUpdateNuGetConfigWithoutPromptAsync(string? channelName, string outputPath, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(channelName))
+        {
+            channelName = await configurationService.GetConfigurationAsync("channel", cancellationToken);
+        }
+
+        if (string.IsNullOrWhiteSpace(channelName))
+        {
+            return false;
+        }
+
+        var channels = await packagingService.GetChannelsAsync(cancellationToken);
+        var matchingChannel = channels.FirstOrDefault(c =>
+            string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
+
+        if (matchingChannel is null || matchingChannel.Type is not PackageChannelType.Explicit)
+        {
+            return false;
+        }
+
+        var mappings = matchingChannel.Mappings;
+        if (mappings is null || mappings.Length == 0)
+        {
+            return false;
+        }
+
+        // Call the merger directly — bypass NuGetConfigPrompter so we don't emit a
+        // confirmation message containing the substring "NuGet.config", which the
+        // AspireInitAsync test helper false-matches as a user-facing Y/n prompt.
+        await NuGetConfigMerger.CreateOrUpdateAsync(new DirectoryInfo(outputPath), matchingChannel, cancellationToken: cancellationToken);
+        return true;
+    }
+
+    /// <summary>
     /// Resolves the channel and template package version that should be used to install Aspire project templates.
     /// </summary>
     /// <param name="query">Inputs that control channel/version selection.</param>
@@ -223,7 +268,7 @@ internal sealed class TemplateNuGetConfigService(
         // ambient configuration (although we should still specify the source) because
         // the user would have selected it.
         //
-        // The temporary config is disposed when this method returns. That is intentional —
+        // The temporary config is disposed when this method returns. That is intentional ΓÇö
         // only `dotnet new install` consumes the config; the subsequent `dotnet new <template>`
         // call (in DotNetTemplateFactory and InitCommand) operates against the already-installed
         // template hive and uses the ambient NuGet configuration.

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
 using Hex1b.Automation;
 using Xunit;
 
@@ -141,6 +142,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/16643")]
     public async Task StopAllAppHostsFromUnrelatedDirectory()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -213,6 +215,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/16643")]
     public async Task StopNonInteractiveMultipleAppHostsShowsError()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -145,6 +145,7 @@ internal static class CliTestHelper
         services.AddSingleton(options.AppHostServerSessionFactory);
         services.AddSingleton<ILanguageDiscovery, DefaultLanguageDiscovery>();
         services.AddSingleton(options.LanguageServiceFactory);
+        services.AddSingleton<TemplateNuGetConfigService>();
 
         // Bundle layout services - return null/no-op implementations to trigger SDK mode fallback
         // This ensures backward compatibility: no layout found = use legacy SDK mode


### PR DESCRIPTION
Backport of #16636 to release/13.3

/cc @mitchdenny @JamesNK

## Customer Impact

When running `aspire init` and selecting the C# single-file path, no `NuGet.config` was emitted alongside `apphost.cs`. For users who rely on a non-default channel (PR/run hives, locally-built `local-*`/`dev-*` hives, the staging channel), MSBuild then can't resolve `#:sdk Aspire.AppHost.Sdk@<version>` from the SDK directive, breaking both `aspire add` (which uses `dotnet package add --file apphost.cs`) and `dotnet run --file apphost.cs`. Stable users on nuget.org are unaffected, but anyone building or testing the CLI from a non-stable channel hits this.

This backport is a soft prerequisite for the #15986 fix (#16812 / backport #16821): #16812 in main was authored on top of this PR, so the two are typically deployed together.

## Testing

* Existing `InitCommandTests` (18 tests) pass locally on this backport branch (1m 27s).
* Source PR #16636 merged to `main` on 2026-05-01 with full CI green plus deployment E2E green (33 deployment tests passed) — see PR #16636 for details.

## Risk

Low. Scoped to the `aspire init` C# single-file path:

* `InitCommand.DropCSharpSingleFileSkeletonAsync` now drops a `NuGet.config` (via the existing shared `TemplateNuGetConfigService`) before `aspire.config.json`.
* New `CreateOrUpdateNuGetConfigWithoutPromptAsync` overload on `TemplateNuGetConfigService` is purely additive — bypasses the prompt and the user-facing "NuGet.config" message (the latter was tripping the `AspireInitAsync` E2E helper's substring matcher).

Other `aspire init` paths (project/polyglot) and `aspire new` are untouched. No public API changes.

## Regression?

No. The C# single-file `aspire init` path is new in 13.3 and didn't ship a `NuGet.config` in any previous release. This makes the documented flow work for non-stable channel users.

---

**Note on conflict resolution:** The auto-backport bot couldn't apply this cleanly because it was based on a four-commit replay rather than the squash diff. The conflict was a positional one in `src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs`: the new `CreateOrUpdateNuGetConfigWithoutPromptAsync` method was anchored after `PromptToCreateOrUpdateNuGetConfigAsync` in main, but release/13.3 already has additional methods (`ResolveTemplatePackageAsync`, `InstallTemplatePackageAsync` from #16672) inserted at that location. Resolved by placing the new method between `PromptToCreateOrUpdateNuGetConfigAsync` and `ResolveTemplatePackageAsync`. All other files (`InitCommand.cs`, `CliTestHelper.cs`, `StopNonInteractiveTests.cs`, `eng/Versions.props`) auto-merged cleanly.
