### PR TITLE
Fix #16725: aspire run honours dev.localhost URLs from aspire.config.json

### DIFF
--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Configuration;
@@ -370,15 +371,26 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         string[]? args = null)
     {
         var runJsonFilePath = appHostFile.FullName[..^2] + "run.json";
-        if (!File.Exists(runJsonFilePath))
+        if (File.Exists(runJsonFilePath))
         {
-            AppHostEnvironmentDefaults.ApplyEffectiveEnvironment(
-                env,
-                AppHostEnvironmentDefaults.DevelopmentEnvironmentName,
-                inheritedEnvironmentVariables,
-                args);
+            // dotnet run reads the launch profile from apphost.run.json natively, so the CLI
+            // does not need to inject any environment variables itself.
+            return;
+        }
+
+        // No apphost.run.json — fall back to aspire.config.json profiles (if any), then to
+        // hardcoded defaults. ApplyEffectiveEnvironment is always called last so that explicit
+        // --environment arguments still win.
+        if (!TryApplyAspireConfigProfile(appHostFile, env, filterEnvironmentNames: false))
+        {
             ApplyDefaultSingleFileEndpoints(env);
         }
+
+        AppHostEnvironmentDefaults.ApplyEffectiveEnvironment(
+            env,
+            AppHostEnvironmentDefaults.DevelopmentEnvironmentName,
+            inheritedEnvironmentVariables,
+            args);
     }
 
     internal static void ConfigureSingleFilePublishEnvironment(
@@ -387,7 +399,8 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         IReadOnlyDictionary<string, string?>? inheritedEnvironmentVariables = null,
         string[]? args = null)
     {
-        if (!TryApplySingleFileLaunchProfileEnvironmentVariables(appHostFile, env))
+        if (!TryApplySingleFileLaunchProfileEnvironmentVariables(appHostFile, env)
+            && !TryApplyAspireConfigProfile(appHostFile, env, filterEnvironmentNames: true))
         {
             ApplyDefaultSingleFileEndpoints(env);
         }
@@ -404,6 +417,55 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         Dictionary<string, string> env)
     {
         var profiles = AspireConfigFile.ReadApphostRunProfiles(appHostFile.FullName[..^2] + "run.json");
+        return TryApplyProfile(profiles, env, filterEnvironmentNames: true);
+    }
+
+    private static bool TryApplyAspireConfigProfile(
+        FileInfo appHostFile,
+        Dictionary<string, string> env,
+        bool filterEnvironmentNames)
+    {
+        if (appHostFile.DirectoryName is not { Length: > 0 } directoryName)
+        {
+            return false;
+        }
+
+        AspireConfigFile? config;
+        try
+        {
+            config = AspireConfigFile.Load(directoryName);
+        }
+        catch (JsonException)
+        {
+            // Malformed aspire.config.json — fall back to the next source rather than failing
+            // the run/publish. This mirrors what happens when apphost.run.json is malformed.
+            return false;
+        }
+
+        if (config?.Profiles is null)
+        {
+            return false;
+        }
+
+        // If aspire.config.json names a different AppHost file, don't apply its profile to
+        // this AppHost. (Covers layouts where multiple AppHosts share a directory.)
+        if (!string.IsNullOrEmpty(config.AppHost?.Path))
+        {
+            var resolvedAppHostPath = Path.GetFullPath(Path.Combine(directoryName, config.AppHost.Path));
+            if (!string.Equals(resolvedAppHostPath, appHostFile.FullName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return TryApplyProfile(config.Profiles, env, filterEnvironmentNames);
+    }
+
+    private static bool TryApplyProfile(
+        IReadOnlyDictionary<string, AspireConfigProfile>? profiles,
+        Dictionary<string, string> env,
+        bool filterEnvironmentNames)
+    {
         AspireConfigProfile? profile;
 
         if (profiles?.TryGetValue("https", out var httpsProfile) == true)
@@ -415,21 +477,18 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             profile = profiles?.Values.FirstOrDefault();
         }
 
-        if (profile is null)
+        if (profile is null || string.IsNullOrEmpty(profile.ApplicationUrl))
         {
             return false;
         }
 
-        if (!string.IsNullOrEmpty(profile.ApplicationUrl))
-        {
-            env["ASPNETCORE_URLS"] = profile.ApplicationUrl;
-        }
+        env["ASPNETCORE_URLS"] = profile.ApplicationUrl;
 
         if (profile.EnvironmentVariables is not null)
         {
             foreach (var (key, value) in profile.EnvironmentVariables)
             {
-                if (AppHostEnvironmentDefaults.IsEnvironmentVariableName(key))
+                if (filterEnvironmentNames && AppHostEnvironmentDefaults.IsEnvironmentVariableName(key))
                 {
                     continue;
                 }

--- a/src/Aspire.Cli/Templating/Templates/empty-apphost/apphost.run.json
+++ b/src/Aspire.Cli/Templating/Templates/empty-apphost/apphost.run.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://{{hostName}}:{{httpsPort}};http://{{hostName}}:{{httpPort}}",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://{{hostName}}:{{otlpHttpsPort}}",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://{{hostName}}:{{resourceHttpsPort}}"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://{{hostName}}:{{httpPort}}",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://{{hostName}}:{{otlpHttpPort}}",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://{{hostName}}:{{resourceHttpPort}}",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    }
+  }
+}

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1165,6 +1165,85 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithCSharpEmptyTemplateAndPlainLocalhostEmitsAppHostRunJsonMatchingAspireConfigJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CreateServiceCollection(workspace);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output --localhost-tld false --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var outputDir = Path.Combine(workspace.WorkspaceRoot.FullName, "output");
+        var aspireConfigPath = Path.Combine(outputDir, "aspire.config.json");
+        var appHostRunJsonPath = Path.Combine(outputDir, "apphost.run.json");
+
+        Assert.True(File.Exists(aspireConfigPath));
+        Assert.True(File.Exists(appHostRunJsonPath), "apphost.run.json must be emitted alongside aspire.config.json so dotnet run picks up matching URLs.");
+
+        var aspireConfig = await File.ReadAllTextAsync(aspireConfigPath);
+        var appHostRunJson = await File.ReadAllTextAsync(appHostRunJsonPath);
+
+        Assert.Contains("://localhost:", appHostRunJson);
+        Assert.Contains("\"commandName\": \"Project\"", appHostRunJson);
+
+        AssertHttpsApplicationUrlMatches(aspireConfig, appHostRunJson);
+    }
+
+    [Fact]
+    public async Task NewCommandWithCSharpEmptyTemplateAndLocalhostTldEmitsAppHostRunJsonWithDevLocalhostUrls()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CreateServiceCollection(workspace);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output --localhost-tld --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var outputDir = Path.Combine(workspace.WorkspaceRoot.FullName, "output");
+        var aspireConfigPath = Path.Combine(outputDir, "aspire.config.json");
+        var appHostRunJsonPath = Path.Combine(outputDir, "apphost.run.json");
+
+        Assert.True(File.Exists(aspireConfigPath));
+        Assert.True(File.Exists(appHostRunJsonPath), "apphost.run.json must be emitted alongside aspire.config.json so dotnet run picks up matching URLs.");
+
+        var aspireConfig = await File.ReadAllTextAsync(aspireConfigPath);
+        var appHostRunJson = await File.ReadAllTextAsync(appHostRunJsonPath);
+
+        Assert.Contains("testapp.dev.localhost", appHostRunJson);
+        Assert.DoesNotContain("://localhost", appHostRunJson);
+
+        AssertHttpsApplicationUrlMatches(aspireConfig, appHostRunJson);
+    }
+
+    private static void AssertHttpsApplicationUrlMatches(string aspireConfigJson, string appHostRunJson)
+    {
+        using var aspireDoc = System.Text.Json.JsonDocument.Parse(aspireConfigJson);
+        using var runDoc = System.Text.Json.JsonDocument.Parse(appHostRunJson);
+
+        var aspireHttpsUrl = aspireDoc.RootElement
+            .GetProperty("profiles")
+            .GetProperty("https")
+            .GetProperty("applicationUrl")
+            .GetString();
+        var runHttpsUrl = runDoc.RootElement
+            .GetProperty("profiles")
+            .GetProperty("https")
+            .GetProperty("applicationUrl")
+            .GetString();
+
+        Assert.Equal(aspireHttpsUrl, runHttpsUrl);
+    }
+
+    [Fact]
     public async Task NewCommandWithEmptyTemplateAndCSharpPromptsForLocalhostTldAndUsesConfirmation()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -273,6 +273,232 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         Assert.Equal(0, exitCode);
     }
 
+    [Fact]
+    public void ConfigureSingleFileRunEnvironment_AppliesProfileFromAspireConfigJson()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        WriteAspireConfigJson(appHostFile.DirectoryName!, """
+            {
+              "appHost": { "path": "apphost.cs" },
+              "profiles": {
+                "https": {
+                  "applicationUrl": "https://myapp.dev.localhost:17050;http://myapp.dev.localhost:15050",
+                  "environmentVariables": {
+                    "ASPNETCORE_ENVIRONMENT": "Development",
+                    "DOTNET_ENVIRONMENT": "Development",
+                    "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://myapp.dev.localhost:21050",
+                    "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://myapp.dev.localhost:22050"
+                  }
+                }
+              }
+            }
+            """);
+        var env = new Dictionary<string, string>();
+
+        DotNetAppHostProject.ConfigureSingleFileRunEnvironment(
+            appHostFile,
+            env,
+            inheritedEnvironmentVariables: new Dictionary<string, string?>());
+
+        Assert.Equal("https://myapp.dev.localhost:17050;http://myapp.dev.localhost:15050", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://myapp.dev.localhost:21050", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
+        Assert.Equal("https://myapp.dev.localhost:22050", env["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
+        // Run path copies profile env vars verbatim (matches what dotnet does when reading apphost.run.json natively).
+        Assert.Equal("Development", env["DOTNET_ENVIRONMENT"]);
+        Assert.Equal("Development", env["ASPNETCORE_ENVIRONMENT"]);
+    }
+
+    [Fact]
+    public void ConfigureSingleFilePublishEnvironment_AppliesProfileFromAspireConfigJson()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        WriteAspireConfigJson(appHostFile.DirectoryName!, """
+            {
+              "appHost": { "path": "apphost.cs" },
+              "profiles": {
+                "https": {
+                  "applicationUrl": "https://myapp.dev.localhost:17050;http://myapp.dev.localhost:15050",
+                  "environmentVariables": {
+                    "ASPNETCORE_ENVIRONMENT": "Development",
+                    "DOTNET_ENVIRONMENT": "Development",
+                    "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://myapp.dev.localhost:21050",
+                    "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://myapp.dev.localhost:22050"
+                  }
+                }
+              }
+            }
+            """);
+        var env = new Dictionary<string, string>();
+
+        DotNetAppHostProject.ConfigureSingleFilePublishEnvironment(
+            appHostFile,
+            env,
+            inheritedEnvironmentVariables: new Dictionary<string, string?>());
+
+        Assert.Equal("https://myapp.dev.localhost:17050;http://myapp.dev.localhost:15050", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://myapp.dev.localhost:21050", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
+        Assert.Equal("https://myapp.dev.localhost:22050", env["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
+        // Publish path filters env-name vars from profile, then ApplyEffectiveEnvironment sets DOTNET_ENVIRONMENT=Production.
+        Assert.Equal("Production", env["DOTNET_ENVIRONMENT"]);
+        Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+    }
+
+    [Fact]
+    public void ConfigureSingleFilePublishEnvironment_AppHostRunJsonWinsOverAspireConfigJson()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        File.WriteAllText(Path.Combine(appHostFile.DirectoryName!, "apphost.run.json"), """
+            {
+              "profiles": {
+                "https": {
+                  "applicationUrl": "https://from-run-json:19000",
+                  "environmentVariables": {
+                    "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://from-run-json:21000"
+                  }
+                }
+              }
+            }
+            """);
+        WriteAspireConfigJson(appHostFile.DirectoryName!, """
+            {
+              "appHost": { "path": "apphost.cs" },
+              "profiles": {
+                "https": {
+                  "applicationUrl": "https://from-config-json:17050",
+                  "environmentVariables": {
+                    "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://from-config-json:21050"
+                  }
+                }
+              }
+            }
+            """);
+        var env = new Dictionary<string, string>();
+
+        DotNetAppHostProject.ConfigureSingleFilePublishEnvironment(
+            appHostFile,
+            env,
+            inheritedEnvironmentVariables: new Dictionary<string, string?>());
+
+        Assert.Equal("https://from-run-json:19000", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://from-run-json:21000", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
+    }
+
+    [Fact]
+    public void ConfigureSingleFileRunEnvironment_FallsBackToDefaultsWhenAspireConfigJsonHasNoProfiles()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        WriteAspireConfigJson(appHostFile.DirectoryName!, """
+            {
+              "appHost": { "path": "apphost.cs" }
+            }
+            """);
+        var env = new Dictionary<string, string>();
+
+        DotNetAppHostProject.ConfigureSingleFileRunEnvironment(
+            appHostFile,
+            env,
+            inheritedEnvironmentVariables: new Dictionary<string, string?>());
+
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+        Assert.Equal("Development", env["DOTNET_ENVIRONMENT"]);
+    }
+
+    [Fact]
+    public void ConfigureSingleFileRunEnvironment_FallsBackToDefaultsWhenProfileLacksApplicationUrl()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        WriteAspireConfigJson(appHostFile.DirectoryName!, """
+            {
+              "appHost": { "path": "apphost.cs" },
+              "profiles": {
+                "https": {
+                  "environmentVariables": {
+                    "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://shouldnotapply:21050"
+                  }
+                }
+              }
+            }
+            """);
+        var env = new Dictionary<string, string>();
+
+        DotNetAppHostProject.ConfigureSingleFileRunEnvironment(
+            appHostFile,
+            env,
+            inheritedEnvironmentVariables: new Dictionary<string, string?>());
+
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://localhost:21293", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
+    }
+
+    [Fact]
+    public void ConfigureSingleFileRunEnvironment_SkipsAspireConfigWhenAppHostPathMismatches()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        WriteAspireConfigJson(appHostFile.DirectoryName!, """
+            {
+              "appHost": { "path": "other-apphost.cs" },
+              "profiles": {
+                "https": {
+                  "applicationUrl": "https://shouldnotapply:17050"
+                }
+              }
+            }
+            """);
+        var env = new Dictionary<string, string>();
+
+        DotNetAppHostProject.ConfigureSingleFileRunEnvironment(
+            appHostFile,
+            env,
+            inheritedEnvironmentVariables: new Dictionary<string, string?>());
+
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+    }
+
+    [Fact]
+    public void ConfigureSingleFileRunEnvironment_FallsBackToDefaultsWhenAspireConfigJsonIsMalformed()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        WriteAspireConfigJson(appHostFile.DirectoryName!, "{ this is not valid json");
+        var env = new Dictionary<string, string>();
+
+        DotNetAppHostProject.ConfigureSingleFileRunEnvironment(
+            appHostFile,
+            env,
+            inheritedEnvironmentVariables: new Dictionary<string, string?>());
+
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+        Assert.Equal("Development", env["DOTNET_ENVIRONMENT"]);
+    }
+
+    [Fact]
+    public void ConfigureSingleFileRunEnvironment_EnvironmentArgumentOverridesProfileDotNetEnvironment()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        WriteAspireConfigJson(appHostFile.DirectoryName!, """
+            {
+              "appHost": { "path": "apphost.cs" },
+              "profiles": {
+                "https": {
+                  "applicationUrl": "https://myapp.dev.localhost:17050",
+                  "environmentVariables": {
+                    "DOTNET_ENVIRONMENT": "Development"
+                  }
+                }
+              }
+            }
+            """);
+        var env = new Dictionary<string, string>();
+
+        DotNetAppHostProject.ConfigureSingleFileRunEnvironment(
+            appHostFile,
+            env,
+            inheritedEnvironmentVariables: new Dictionary<string, string?>(),
+            args: ["--environment", "Staging"]);
+
+        Assert.Equal("Staging", env["DOTNET_ENVIRONMENT"]);
+        Assert.Equal("https://myapp.dev.localhost:17050", env["ASPNETCORE_URLS"]);
+    }
+
     private FileInfo CreateSingleFileAppHost()
     {
         var appHostPath = Path.Combine(_workspace.WorkspaceRoot.FullName, "apphost.cs");
@@ -297,4 +523,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         _serviceProviders.Add(provider);
         return provider.GetRequiredService<DotNetAppHostProject>();
     }
+
+    private static void WriteAspireConfigJson(string directory, string content)
+        => File.WriteAllText(Path.Combine(directory, "aspire.config.json"), content);
 }


### PR DESCRIPTION
## Description

Fix #16725: `aspire run` ignored `*.dev.localhost` URLs configured by `aspire.config.json`. After `aspire new aspire-empty --localhost-tld --name test1`, `aspire run` was bringing the dashboard up at `https://localhost:17193/...` instead of `https://test1.dev.localhost:17159/...`.

There were two independent gaps causing this:

1. **Writer (template) gap.** The empty-apphost C# template emits `aspire.config.json` but never emitted `apphost.run.json`. With no launch profile on disk, `dotnet run apphost.cs` had nothing to read, and the CLI fell through to the hardcoded `localhost:17193` defaults in `DotNetAppHostProject.ApplyDefaultSingleFileEndpoints`. (PR #16812 closed the analogous gap for `aspire init`, but `aspire new` goes through `CliTemplateFactory` and was untouched.)
2. **Reader gap.** `DotNetAppHostProject.ConfigureSingleFile{Run,Publish}Environment` only ever read `apphost.run.json` and never looked at the `profiles` section of `aspire.config.json` — even though `GuestAppHostProject.ReadProfileFromAspireConfig` already implements exactly this fallback for TS/Python/Go.

This PR fixes both, defense-in-depth:

### (b) Template — emit `apphost.run.json` alongside `aspire.config.json`

Added `src/Aspire.Cli/Templating/Templates/empty-apphost/apphost.run.json` using the same `{{hostName}}`/`{{httpsPort}}`/`{{httpPort}}`/`{{otlpHttpsPort}}`/`{{otlpHttpPort}}`/`{{resourceHttpsPort}}`/`{{resourceHttpPort}}` tokens that `aspire.config.json` already uses. `CopyTemplateTreeToDiskAsync` performs the substitution uniformly so the two files cannot drift in URLs.

### (c) Reader — fall back to `aspire.config.json` profiles when `apphost.run.json` is missing

`DotNetAppHostProject` now mirrors `GuestAppHostProject`'s precedence:

1. `apphost.run.json` (existing)
2. `aspire.config.json` `profiles` (new)
3. Hardcoded `localhost:17193` defaults (existing)

The new `TryApplyAspireConfigProfile` helper:
- Loads `aspire.config.json` from the AppHost's directory only (no upward walk).
- Validates `appHost.path` resolves to the AppHost being launched (or is null) — protects multi-AppHost layouts.
- Prefers the `https` profile, falls back to the first one.
- Only applies if `applicationUrl` is non-empty.
- Catches `JsonException` and falls through silently (matches existing `apphost.run.json` behavior on malformed JSON).

For `aspire run`, env vars are copied verbatim. For `aspire publish`, env-name vars (`DOTNET_ENVIRONMENT`/`ASPNETCORE_ENVIRONMENT`/`ASPIRE_ENVIRONMENT`) are filtered out so `ApplyEffectiveEnvironment(Production)` still wins. `ApplyEffectiveEnvironment` is always called last so explicit `--environment Foo` arguments still take precedence over what's in the profile.

## Verification

End-to-end with a locally-built native AOT CLI on a fresh `aspire new aspire-empty --name test1 --localhost-tld --suppress-agent-init --non-interactive` project:

```
   Dashboard:  https://test1.dev.localhost:17159/login?t=...
```

Bonus: deleted `apphost.run.json` after generation and re-ran `aspire run` — fix C alone (reader fallback to `aspire.config.json`) still produces the correct dev.localhost URL.

## Tests

8 new tests in `DotNetAppHostProjectTests`:
- `ConfigureSingleFileRunEnvironment_AppliesProfileFromAspireConfigJson`
- `ConfigureSingleFilePublishEnvironment_AppliesProfileFromAspireConfigJson`
- `ConfigureSingleFilePublishEnvironment_AppHostRunJsonWinsOverAspireConfigJson`
- `ConfigureSingleFileRunEnvironment_FallsBackToDefaultsWhenAspireConfigJsonHasNoProfiles`
- `ConfigureSingleFileRunEnvironment_FallsBackToDefaultsWhenProfileLacksApplicationUrl`
- `ConfigureSingleFileRunEnvironment_SkipsAspireConfigWhenAppHostPathMismatches`
- `ConfigureSingleFileRunEnvironment_FallsBackToDefaultsWhenAspireConfigJsonIsMalformed`
- `ConfigureSingleFileRunEnvironment_EnvironmentArgumentOverridesProfileDotNetEnvironment`

2 new tests in `NewCommandTests`:
- `NewCommandWithCSharpEmptyTemplateAndPlainLocalhostEmitsAppHostRunJsonMatchingAspireConfigJson`
- `NewCommandWithCSharpEmptyTemplateAndLocalhostTldEmitsAppHostRunJsonWithDevLocalhostUrls`

Full `Aspire.Cli.Tests` suite: **2564/2575 passed, 0 failures** (11 OS-conditional skips).

## Follow-ups (intentionally out of scope)

- `InitCommand.DropAppHostRunJson` still constructs the JSON literal in C# rather than sharing the template. Both code paths produce byte-identical shapes today, but a future cleanup could route `aspire init` through the same template renderer to eliminate the drift surface entirely.

Fixes #16725

## Checklist
- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
