### PR TITLE
Add --yes validation to UpdateCommand and share validation logic

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Globalization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 
@@ -102,5 +104,18 @@ internal abstract class BaseCommand : Command
         telemetry.RecordError(errorMessage, ex);
         interactionService.DisplayError(errorMessage);
         return exitCode;
+    }
+
+    internal static void AddNonInteractiveRequiresYesValidator(Command command, Option<bool> yesOption)
+    {
+        command.Validators.Add(result =>
+        {
+            var nonInteractive = result.GetValue(RootCommand.NonInteractiveOption);
+            var yes = result.GetValue(yesOption);
+            if (nonInteractive && !yes)
+            {
+                result.AddError(string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.NonInteractiveRequiresYesFormat, command.Name));
+            }
+        });
     }
 }

--- a/src/Aspire.Cli/Commands/DestroyCommand.cs
+++ b/src/Aspire.Cli/Commands/DestroyCommand.cs
@@ -30,15 +30,7 @@ internal sealed class DestroyCommand : PipelineCommandBase
         };
         Options.Add(_yesOption);
 
-        Validators.Add(result =>
-        {
-            var nonInteractive = result.GetValue(RootCommand.NonInteractiveOption);
-            var yes = result.GetValue(_yesOption);
-            if (nonInteractive && !yes)
-            {
-                result.AddError(DestroyCommandStrings.NonInteractiveRequiresYes);
-            }
-        });
+        AddNonInteractiveRequiresYesValidator(this, _yesOption);
     }
 
     protected override string OperationCompletedPrefix => DestroyCommandStrings.OperationCompletedPrefix;

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -80,6 +80,8 @@ internal sealed class UpdateCommand : BaseCommand
         Options.Add(s_yesOption);
         Options.Add(s_nugetConfigDirOption);
 
+        AddNonInteractiveRequiresYesValidator(this, s_yesOption);
+
         // Customize description based on whether staging channel is enabled
         var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(_features, _configuration);
 
@@ -222,7 +224,7 @@ internal sealed class UpdateCommand : BaseCommand
             }
 
             // Update packages using the appropriate project handler
-            var confirmBinding = PromptBinding.CreateWithInteractiveDefault(parseResult, s_yesOption, true);
+            var confirmBinding = PromptBinding.Create(parseResult, s_yesOption, defaultValue: true);
             var nugetConfigDirBinding = PromptBinding.Create(parseResult, s_nugetConfigDirOption);
             var updateContext = new UpdatePackagesContext
             {

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -224,6 +224,9 @@ internal sealed class UpdateCommand : BaseCommand
             }
 
             // Update packages using the appropriate project handler
+            // The validator ensures --yes is required when --non-interactive is specified,
+            // so by this point --yes is always explicitly provided in non-interactive mode.
+            // defaultValue: true means the interactive prompt defaults to "yes" (accept).
             var confirmBinding = PromptBinding.Create(parseResult, s_yesOption, defaultValue: true);
             var nugetConfigDirBinding = PromptBinding.Create(parseResult, s_nugetConfigDirOption);
             var updateContext = new UpdatePackagesContext

--- a/src/Aspire.Cli/Interaction/PromptBinding.cs
+++ b/src/Aspire.Cli/Interaction/PromptBinding.cs
@@ -109,13 +109,6 @@ internal static class PromptBinding
         new(parseResult, FormatOptionName(option), BuildOptionResolver(option), defaultValue, hasExplicitDefault: true);
 
     /// <summary>
-    /// Creates a <see cref="PromptBinding{T}"/> that uses <paramref name="interactiveDefault"/> as the
-    /// default for interactive prompts but still requires the CLI option in non-interactive mode.
-    /// </summary>
-    public static PromptBinding<T> CreateWithInteractiveDefault<T>(ParseResult parseResult, Option<T> option, T interactiveDefault) =>
-        new(parseResult, FormatOptionName(option), BuildOptionResolver(option), interactiveDefault, hasExplicitDefault: false);
-
-    /// <summary>
     /// Creates a <see cref="PromptBinding{T}"/> with only a default value and no CLI symbol binding.
     /// Use when there is no corresponding CLI option or argument for the prompt.
     /// </summary>

--- a/src/Aspire.Cli/Resources/DestroyCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DestroyCommandStrings.Designer.cs
@@ -77,15 +77,6 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("Description", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The destroy command requires --yes when the --non-interactive option is specified..
-        /// </summary>
-        public static string NonInteractiveRequiresYes {
-            get {
-                return ResourceManager.GetString("NonInteractiveRequiresYes", resourceCulture);
-            }
-        }
         
         /// <summary>
         ///   Looks up a localized string similar to The output path containing the deployment artifacts to destroy.

--- a/src/Aspire.Cli/Resources/DestroyCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DestroyCommandStrings.resx
@@ -120,9 +120,6 @@
   <data name="Description" xml:space="preserve">
     <value>Destroy a previously deployed AppHost environment (Preview)</value>
   </data>
-  <data name="NonInteractiveRequiresYes" xml:space="preserve">
-    <value>The destroy command requires --yes when the --non-interactive option is specified.</value>
-  </data>
   <data name="OutputPathArgumentDescription" xml:space="preserve">
     <value>The output path containing the deployment artifacts to destroy</value>
   </data>

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -146,5 +146,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("PipelineStepsSummaryTitle", resourceCulture);
             }
         }
+
+        internal static string NonInteractiveRequiresYesFormat {
+            get {
+                return ResourceManager.GetString("NonInteractiveRequiresYesFormat", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -169,4 +169,8 @@
   <data name="PipelineStepsSummaryTitle" xml:space="preserve">
     <value>Steps Summary:</value>
   </data>
+  <data name="NonInteractiveRequiresYesFormat" xml:space="preserve">
+    <value>The {0} command requires --yes when the --non-interactive option is specified.</value>
+    <comment>{0} is the command name.</comment>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.cs.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.de.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.es.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.fr.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.it.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ja.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ko.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pl.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ru.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.tr.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="new">The destroy operation was canceled.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonInteractiveRequiresYes">
-        <source>The destroy command requires --yes when the --non-interactive option is specified.</source>
-        <target state="new">The destroy command requires --yes when the --non-interactive option is specified.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>Destroy completed</source>
         <target state="new">Destroy completed</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresYesFormat">
+        <source>The {0} command requires --yes when the --non-interactive option is specified.</source>
+        <target state="new">The {0} command requires --yes when the --non-interactive option is specified.</target>
+        <note>{0} is the command name.</note>
+      </trans-unit>
       <trans-unit id="PipelineEnvironmentOptionDescription">
         <source>The environment to use for the operation. The default is 'Production'.</source>
         <target state="new">The environment to use for the operation. The default is 'Production'.</target>

--- a/tests/Aspire.Cli.Tests/Commands/DestroyCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DestroyCommandTests.cs
@@ -153,7 +153,8 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
-        Assert.Contains(result.Errors, error => string.Equals(error.Message, DestroyCommandStrings.NonInteractiveRequiresYes, StringComparison.Ordinal));
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(string.Format(System.Globalization.CultureInfo.CurrentCulture, SharedCommandStrings.NonInteractiveRequiresYesFormat, "destroy"), error.Message);
         Assert.False(appHostStarted);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -36,6 +36,25 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
+    [Theory]
+    [InlineData("update --non-interactive")]
+    [InlineData("--non-interactive update")]
+    public async Task UpdateCommandFailsFastWhenNonInteractiveWithoutYes(string commandLine)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse(commandLine);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(string.Format(System.Globalization.CultureInfo.CurrentCulture, SharedCommandStrings.NonInteractiveRequiresYesFormat, "update"), error.Message);
+    }
+
     [Fact]
     public async Task UpdateCommand_WhenProjectOptionSpecified_PassesProjectFileToProjectLocator()
     {


### PR DESCRIPTION
## Summary

Add `--yes` option validation to `UpdateCommand` (matching `DestroyCommand` behavior) and refactor the validation into a shared helper.

## Changes

- **Shared validation helper**: Added `BaseCommand.AddNonInteractiveRequiresYesValidator()` that any command can call to enforce `--yes` when `--non-interactive` is specified
- **Shared error message**: Added `NonInteractiveRequiresYesFormat` to `SharedCommandStrings` as a parameterized format string (`"The {0} command requires --yes when the --non-interactive option is specified."`)
- **UpdateCommand**: Now validates that `--yes` is provided in non-interactive mode
- **DestroyCommand**: Refactored to use the shared validator instead of inline logic
- **Removed `PromptBinding.CreateWithInteractiveDefault`**: No longer needed since the validator ensures `--yes` is always explicitly provided in non-interactive mode. Replaced with `PromptBinding.Create(parseResult, s_yesOption, defaultValue: true)`
- **Tests**: Added `UpdateCommandFailsFastWhenNonInteractiveWithoutYes` test; updated `DestroyCommandTests` to use shared string and `Assert.Single` for more precise assertions