### PR TITLE
Defer YARP resource endpoint resolution

### DIFF
--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -18,14 +18,17 @@ public class YarpCluster
     internal YarpCluster(ClusterConfig config, params object[] targets)
     {
         ClusterConfig = config;
-        Targets = targets;
+        _targets = targets;
     }
+
+    private readonly object[] _targets;
+
     /// <summary>
     /// Construct a new YarpCluster targeting the endpoint in parameter.
     /// </summary>
     /// <param name="endpoint">The endpoint to target.</param>
     internal YarpCluster(EndpointReference endpoint)
-        : this(endpoint.Resource.Name, BuildEndpointTarget(endpoint))
+        : this(endpoint.Resource.Name, endpoint)
     {
     }
 
@@ -48,7 +51,7 @@ public class YarpCluster
     /// </summary>
     /// <param name="resource">The resource to target.</param>
     internal YarpCluster(IResourceWithServiceDiscovery resource)
-        : this(resource.Name, BuildEndpointUri(resource))
+        : this(resource.Name, resource)
     {
     }
 
@@ -57,7 +60,7 @@ public class YarpCluster
     /// </summary>
     /// <param name="externalService">The external service.</param>
     internal YarpCluster(ExternalServiceResource externalService)
-        : this(externalService.Name, GetAddressFromExternalService(externalService))
+        : this(externalService.Name, externalService)
     {
     }
 
@@ -73,25 +76,74 @@ public class YarpCluster
             ClusterId = $"cluster_{resourceName}",
             Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
         };
-        Targets = targets;
+        _targets = targets;
     }
 
     internal ClusterConfig ClusterConfig { get; private set; }
 
-    internal object[] Targets { get; private set; }
+    internal object[] Targets => GetResolvedTargets();
 
     internal void Configure(Func<ClusterConfig, ClusterConfig> configure)
     {
         ClusterConfig = configure(ClusterConfig);
     }
 
-    private static object BuildEndpointUri(IResourceWithServiceDiscovery resource)
+    internal object[] GetResolvedTargets()
+    {
+        var targets = new List<object>(_targets.Length);
+        foreach (var target in _targets)
+        {
+            targets.AddRange(ResolveTargets(target));
+        }
+
+        return [.. targets];
+    }
+
+    private static IEnumerable<object> ResolveTargets(object target)
+    {
+        switch (target)
+        {
+            case EndpointReference endpoint:
+                yield return BuildEndpointTarget(endpoint);
+                break;
+            case IResourceWithServiceDiscovery resource:
+                foreach (var resourceTarget in BuildEndpointTargets(resource))
+                {
+                    yield return resourceTarget;
+                }
+                break;
+            case ExternalServiceResource externalService:
+                yield return GetAddressFromExternalService(externalService);
+                break;
+            default:
+                yield return target;
+                break;
+        }
+    }
+
+    private static object[] BuildEndpointTargets(IResourceWithServiceDiscovery resource)
     {
         var resourceName = resource.Name;
 
-        var endpoints = resource.GetEndpoints();
-        var hasHttpsEndpoint = endpoints.Any(e => e.Exists && e.IsHttps);
-        var hasHttpEndpoint = endpoints.Any(e => e.Exists && e.IsHttp);
+        var endpoints = resource.GetEndpoints()
+            .Where(e => e.Exists && !e.ExcludeReferenceEndpoint && (e.IsHttp || e.IsHttps))
+            .ToArray();
+        var schemeNamedEndpoints = endpoints
+            .Where(e => e.IsHttpSchemeNamedEndpoint)
+            .ToArray();
+
+        if (schemeNamedEndpoints.Length == 0)
+        {
+            if (endpoints.Length == 0)
+            {
+                throw new ArgumentException("Cannot find a http or https endpoint for this resource.", nameof(resource));
+            }
+
+            return [.. endpoints.Select(BuildEndpointTarget)];
+        }
+
+        var hasHttpsEndpoint = schemeNamedEndpoints.Any(e => e.IsHttps);
+        var hasHttpEndpoint = schemeNamedEndpoints.Any(e => e.IsHttp);
 
         var scheme = (hasHttpsEndpoint, hasHttpEndpoint) switch
         {
@@ -101,7 +153,7 @@ public class YarpCluster
             _ => throw new ArgumentException("Cannot find a http or https endpoint for this resource.", nameof(resource))
         };
 
-        return $"{scheme}://{resourceName}";
+        return [$"{scheme}://{resourceName}"];
     }
 
     private static object GetAddressFromExternalService(ExternalServiceResource externalService)

--- a/src/Aspire.Hosting.Yarp/YarpEnvConfigGenerator.cs
+++ b/src/Aspire.Hosting.Yarp/YarpEnvConfigGenerator.cs
@@ -25,9 +25,10 @@ internal class YarpEnvConfigGenerator
         foreach (var cluster in clusters)
         {
             FlattenToEnvVars(environmentVariables, cluster.ClusterConfig, $"{Prefix}CLUSTERS__{cluster.ClusterConfig.ClusterId}");
-            for (var i =0; i < cluster.Targets.Length; i++)
+            var targets = cluster.GetResolvedTargets();
+            for (var i = 0; i < targets.Length; i++)
             {
-                environmentVariables[$"{Prefix}CLUSTERS__{cluster.ClusterConfig.ClusterId}__DESTINATIONS__destination{i + 1}__ADDRESS"] = cluster.Targets[i];
+                environmentVariables[$"{Prefix}CLUSTERS__{cluster.ClusterConfig.ClusterId}__DESTINATIONS__destination{i + 1}__ADDRESS"] = targets[i];
             }
             // Hack: YARP throws if ClusterConfig.ClusterId is populated in the config.
             // YARP will get the ClusterId from the config key and populate the value in the ClusterConfig itself.

--- a/tests/Aspire.Hosting.Yarp.Tests/AddYarpTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/AddYarpTests.cs
@@ -84,6 +84,29 @@ public class AddYarpTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void VerifyResourceRouteDestinationUsesLatestEndpointScheme()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var backend = builder.AddResource(new TestServiceDiscoveryResource("backend"))
+            .WithHttpEndpoint();
+
+        var yarp = builder.AddYarp("yarp")
+            .WithConfiguration(config =>
+            {
+                config.AddRoute("/api/{**catchall}", backend);
+            });
+
+        backend.WithEndpoint("http", endpoint => endpoint.UriScheme = "https");
+
+        var env = new Dictionary<string, object>();
+        YarpEnvConfigGenerator.PopulateEnvVariables(env, yarp.Resource.Routes, yarp.Resource.Clusters);
+
+        var address = Assert.Contains("REVERSEPROXY__CLUSTERS__cluster_backend__DESTINATIONS__destination1__ADDRESS", env);
+        Assert.Equal("https://backend", address);
+    }
+
+    [Fact]
     public async Task VerifyWithStaticFilesAddsEnvironmentVariable()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
@@ -450,5 +473,12 @@ public class AddYarpTests(ITestOutputHelper testOutputHelper)
 
     private sealed class TestContainerFilesResource(string name) : ContainerResource(name), IResourceWithContainerFiles
     {
+    }
+
+    private sealed class TestServiceDiscoveryResource(string name) : IResourceWithServiceDiscovery
+    {
+        public string Name => name;
+
+        public ResourceAnnotationCollection Annotations { get; } = new ResourceAnnotationCollection();
     }
 }

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpClusterTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpClusterTests.cs
@@ -91,6 +91,18 @@ public class YarpClusterTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void Create_YarpCluster_From_Resource_With_Named_Endpoint()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var service = builder.AddResource(new TestResource("ServiceC"))
+                             .WithEndpoint(name: "api", scheme: "http");
+
+        var cluster = new YarpCluster(service.Resource);
+
+        Assert.Equal("http://_api.ServiceC", Assert.Single(cluster.Targets));
+    }
+
+    [Fact]
     public void Create_YarpCluster_From_Resource_With_Both_Endpoints()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);


### PR DESCRIPTION
## Description

Defer YARP cluster target resolution for resource, endpoint, and external service destinations until environment configuration is generated. This ensures resource endpoint scheme changes made late in AppHost startup, such as `AddUvicornApp` automatically upgrading its primary endpoint to HTTPS when a developer certificate is available, are reflected in YARP's generated reverse proxy destinations.

Resource targets now resolve through endpoint-aware logic consistent with explicit endpoint targets: scheme-named endpoints resolve as `scheme://resource`, while named endpoints resolve with the DNS-SD named endpoint form such as `http://_api.resource`.

Added regression coverage for late endpoint scheme updates and named endpoint resource resolution.

Fixes #16831

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
