### PR TITLE
Use shell integration for Aspire terminal commands

### DIFF
--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -58,6 +58,8 @@ suite('AspireTerminalProvider tests', () => {
     });
 
     suite('sendAspireCommandToAspireTerminal', () => {
+        const expectedCommand = process.platform === 'win32' ? '& "aspire" logs' : 'aspire logs';
+
         test('uses shell integration to execute command when available', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
             const sentTexts: string[] = [];
@@ -85,7 +87,7 @@ suite('AspireTerminalProvider tests', () => {
             try {
                 await terminalProvider.sendAspireCommandToAspireTerminal('logs');
 
-                assert.strictEqual(executedCommand, 'aspire logs');
+                assert.strictEqual(executedCommand, expectedCommand);
                 assert.deepStrictEqual(sentTexts, []);
                 assert.strictEqual(shown, true);
             }
@@ -113,7 +115,7 @@ suite('AspireTerminalProvider tests', () => {
 
                 assert.deepStrictEqual(sentTexts, [
                     { text: '\x03', shouldExecute: false },
-                    { text: 'aspire logs', shouldExecute: undefined }
+                    { text: expectedCommand, shouldExecute: undefined }
                 ]);
             }
             finally {

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -56,4 +56,69 @@ suite('AspireTerminalProvider tests', () => {
             assert.strictEqual(result, 'C:\\Program Files\\Aspire\\aspire.exe');
         });
     });
+
+    suite('sendAspireCommandToAspireTerminal', () => {
+        test('uses shell integration to execute command when available', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const sentTexts: string[] = [];
+            let executedCommand: string | undefined;
+            let shown = false;
+            const terminal = {
+                shellIntegration: {
+                    executeCommand: (commandLine: string) => {
+                        executedCommand = commandLine;
+                        return {} as vscode.TerminalShellExecution;
+                    }
+                },
+                sendText: (text: string) => {
+                    sentTexts.push(text);
+                },
+                show: () => {
+                    shown = true;
+                }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await terminalProvider.sendAspireCommandToAspireTerminal('logs');
+
+                assert.strictEqual(executedCommand, 'aspire logs');
+                assert.deepStrictEqual(sentTexts, []);
+                assert.strictEqual(shown, true);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
+
+        test('sends Ctrl+C before command when shell integration is unavailable', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const sentTexts: { text: string; shouldExecute?: boolean }[] = [];
+            const terminal = {
+                sendText: (text: string, shouldExecute?: boolean) => {
+                    sentTexts.push({ text, shouldExecute });
+                },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await terminalProvider.sendAspireCommandToAspireTerminal('logs');
+
+                assert.deepStrictEqual(sentTexts, [
+                    { text: '\x03', shouldExecute: false },
+                    { text: 'aspire logs', shouldExecute: undefined }
+                ]);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
+    });
 });

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import * as cliPathModule from '../utils/cliPath';
+import { EnvironmentVariables } from '../utils/environment';
 
 suite('AspireTerminalProvider tests', () => {
     let terminalProvider: AspireTerminalProvider;
@@ -59,6 +60,25 @@ suite('AspireTerminalProvider tests', () => {
 
     suite('sendAspireCommandToAspireTerminal', () => {
         const expectedCommand = process.platform === 'win32' ? '& "aspire" logs' : 'aspire logs';
+        let originalStopOnEntry: string | undefined;
+        let isCliDebugLoggingEnabledStub: sinon.SinonStub;
+
+        setup(() => {
+            originalStopOnEntry = process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY];
+            delete process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY];
+            isCliDebugLoggingEnabledStub = sinon.stub(terminalProvider, 'isCliDebugLoggingEnabled').returns(false);
+        });
+
+        teardown(() => {
+            isCliDebugLoggingEnabledStub.restore();
+
+            if (originalStopOnEntry === undefined) {
+                delete process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY];
+            }
+            else {
+                process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY] = originalStopOnEntry;
+            }
+        });
 
         test('uses shell integration to execute command when available', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -98,17 +98,16 @@ export class AspireTerminalProvider implements vscode.Disposable {
         const aspireTerminal = this.getAspireTerminal();
         extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${command}`);
 
-        // Send Ctrl+C (\x03 / ETX) before the new command. This serves two purposes:
-        //  1. If a previous Aspire command (e.g. `aspire logs ... --follow`) is still
-        //     running in the foreground of the terminal, the new command would otherwise
-        //     be delivered to that process's stdin instead of the shell. Ctrl+C sends
-        //     SIGINT to interrupt it so the shell prompt comes back.
-        //  2. At an idle shell prompt, Ctrl+C cancels any pre-existing typed text on the
-        //     current line (bash/zsh as SIGINT-on-empty-line cancels input; PSReadLine
-        //     treats it as a cancel) — preserving the previous "clear input buffer" intent.
-        aspireTerminal.terminal.sendText('\x03', false);
+        if (aspireTerminal.terminal.shellIntegration) {
+            aspireTerminal.terminal.shellIntegration.executeCommand(command);
+        }
+        else {
+            // Without shell integration, VS Code can't tell whether the terminal is idle or
+            // a foreground process is running, so keep the previous safe interruption behavior.
+            aspireTerminal.terminal.sendText('\x03', false);
+            aspireTerminal.terminal.sendText(command);
+        }
 
-        aspireTerminal.terminal.sendText(command);
         if (showTerminal) {
             aspireTerminal.terminal.show();
         }


### PR DESCRIPTION
## Description

Use VS Code terminal shell integration when sending Aspire CLI commands to the Aspire terminal. This lets VS Code interrupt a running terminal command when needed while avoiding an extra Ctrl+C at an idle empty prompt. When shell integration is unavailable, the previous Ctrl+C fallback is preserved because VS Code does not expose reliable foreground-process state in that case.

Adds regression coverage for both the shell-integration path and the unsupported-shell fallback.

Fixes #16833

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
