### PR TITLE
Support JavaScript monorepos in Dockerfile generation (incl. pnpm + PublishAsNpmScript)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -133,6 +133,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
+    <PackageVersion Include="YamlDotNet" Version="17.1.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Sigstore" Version="0.5.0" />

--- a/src/Aspire.Hosting.JavaScript/Aspire.Hosting.JavaScript.csproj
+++ b/src/Aspire.Hosting.JavaScript/Aspire.Hosting.JavaScript.csproj
@@ -20,4 +20,15 @@
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      YamlDotNet is used to parse pnpm-workspace.yaml when emitting Dockerfiles for
+      pnpm monorepos. We take an explicit dependency rather than relying on the
+      transitive flow through Aspire.Hosting -> KubernetesClient -> YamlDotNet, so
+      that this package's behavior is not silently affected by a change in the
+      Hosting graph.
+    -->
+    <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.Hosting.JavaScript/Internal/ContainerFilesPaths.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/ContainerFilesPaths.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Builds the <c>SourcePath</c> values used by ContainerFilesSourceAnnotation
+// and rewrites annotations attached before WithWorkspaceRoot was called.
+//
+// In single-app mode the container layout puts every app file under <c>/app</c>.
+// In workspace mode the same files live under <c>/app/&lt;AppRelativePath&gt;</c>
+// because the Docker build context is the workspace root and the app is a
+// member directory beneath it. ContainerFilesSourceAnnotation can be captured
+// before <c>WithWorkspaceRoot</c> runs (e.g. when <c>PublishAsStaticWebsite</c>
+// is configured first), so existing annotations get rewritten on a best-effort
+// basis.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.JavaScript.Internal;
+
+internal static class ContainerFilesPaths
+{
+    private const string ContainerAppRoot = "/app";
+
+    /// <summary>
+    /// Maps an output sub-path (e.g. <c>"dist"</c>) to its in-container path
+    /// for a single-app deployment: <c>/app[/dist]</c>.
+    /// </summary>
+    public static string ForApp(string outputPath)
+    {
+        var normalized = JavaScriptResourceValidation.NormalizeRelativePath(outputPath);
+        return string.IsNullOrEmpty(normalized) || normalized == "."
+            ? ContainerAppRoot
+            : $"{ContainerAppRoot}/{normalized}";
+    }
+
+    /// <summary>
+    /// Maps an output sub-path to its in-container path inside the workspace
+    /// member directory: <c>/app/&lt;AppRelativePath&gt;[/&lt;output&gt;]</c>.
+    /// </summary>
+    public static string ForWorkspace(string outputPath, JavaScriptWorkspaceAnnotation workspace)
+    {
+        var normalized = JavaScriptResourceValidation.NormalizeRelativePath(outputPath);
+        var basePath = $"{ContainerAppRoot}/{workspace.AppRelativePath}";
+        return string.IsNullOrEmpty(normalized) || normalized == "."
+            ? basePath
+            : $"{basePath}/{normalized}";
+    }
+
+    /// <summary>
+    /// Rewrites <see cref="ContainerFilesSourceAnnotation"/> entries that point
+    /// at <c>/app[/...]</c> so they instead point at
+    /// <c>/app/&lt;AppRelativePath&gt;[/...]</c>. Called by
+    /// <c>WithWorkspaceRoot</c> when annotations were captured by an earlier
+    /// <c>PublishAsStaticWebsite</c> / <c>PublishAsNodeServer</c> call.
+    /// </summary>
+    public static void RewriteForWorkspace(IResource resource, JavaScriptWorkspaceAnnotation workspace)
+    {
+        var existing = resource.Annotations.OfType<ContainerFilesSourceAnnotation>().ToList();
+        if (existing.Count == 0)
+        {
+            return;
+        }
+
+        var prefix = $"{ContainerAppRoot}/{workspace.AppRelativePath}";
+        foreach (var ann in existing)
+        {
+            var src = ann.SourcePath;
+            string newSrc;
+            if (src == ContainerAppRoot)
+            {
+                newSrc = prefix;
+            }
+            else if (src.StartsWith($"{ContainerAppRoot}/", StringComparison.Ordinal))
+            {
+                newSrc = $"{prefix}/{src.Substring($"{ContainerAppRoot}/".Length)}";
+            }
+            else
+            {
+                continue;
+            }
+
+            resource.Annotations.Remove(ann);
+            resource.Annotations.Add(new ContainerFilesSourceAnnotation { SourcePath = newSrc });
+        }
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/JavaScriptDockerfileEmitter.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/JavaScriptDockerfileEmitter.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+
+//
+// Helpers that translate JavaScriptPackageManagerAnnotation +
+// JavaScriptInstallCommandAnnotation + (optionally) JavaScriptWorkspaceAnnotation
+// into the actual lines emitted by the Dockerfile builder. These are kept
+// separate from the public extension class so the builder callbacks (which
+// already do a lot of resource-shape branching) stay focused on shape and
+// delegate the "what gets written" decisions to single-purpose helpers.
+
+using Aspire.Hosting.ApplicationModel.Docker;
+
+namespace Aspire.Hosting.JavaScript.Internal;
+
+internal static class JavaScriptDockerfileEmitter
+{
+    /// <summary>
+    /// Emits a <c>RUN &lt;pm&gt; install [args...]</c> line, using a BuildKit cache
+    /// mount when the package manager declares one (so package downloads are
+    /// reused across builds).
+    /// </summary>
+    public static void EmitInstall(
+        DockerfileStage stage,
+        JavaScriptPackageManagerAnnotation packageManager,
+        JavaScriptInstallCommandAnnotation installCommand)
+    {
+        var installCmd = $"{packageManager.ExecutableName} {string.Join(' ', installCommand.Args)}";
+        if (!string.IsNullOrEmpty(packageManager.CacheMount))
+        {
+            stage.Run($"--mount=type=cache,target={packageManager.CacheMount} {installCmd}");
+        }
+        else
+        {
+            stage.Run(installCmd);
+        }
+    }
+
+    /// <summary>
+    /// Emits the workspace manifest layer: workspace-root files (lockfile,
+    /// pnpm-workspace.yaml, .yarnrc.yml, etc.), workspace-root directories
+    /// (Yarn Berry's <c>.yarn</c>), and every declared workspace member's
+    /// <c>package.json</c>. Copying member manifests ahead of source means a
+    /// single file change in app code does not bust the install layer cache.
+    /// </summary>
+    public static void EmitWorkspaceManifestLayer(DockerfileStage stage, JavaScriptWorkspaceAnnotation workspace)
+    {
+        foreach (var rootFile in workspace.RootFiles)
+        {
+            stage.Copy(rootFile, "./" + rootFile);
+        }
+
+        foreach (var rootDir in workspace.RootDirs)
+        {
+            stage.Copy(rootDir, "./" + rootDir);
+        }
+
+        foreach (var dir in workspace.WorkspaceDirs)
+        {
+            stage.Copy($"{dir}/package.json", $"./{dir}/package.json");
+        }
+    }
+
+    /// <summary>
+    /// Builds the argv used to invoke a script via the configured package
+    /// manager. In workspace mode this routes through the package manager's
+    /// native workspace filter (npm <c>--workspace=&lt;name&gt;</c>, yarn
+    /// <c>workspace</c>, pnpm/bun <c>--filter</c>) so build/run scripts execute
+    /// in the right member directory; otherwise it falls back to the plain
+    /// <c>&lt;pm&gt; [run] &lt;script&gt; [args...]</c> shape.
+    /// </summary>
+    public static IReadOnlyList<string> BuildPackageManagerCommand(
+        JavaScriptPackageManagerAnnotation packageManager,
+        string scriptName,
+        IReadOnlyList<string> scriptArgs,
+        JavaScriptWorkspaceAnnotation? workspace)
+    {
+        if (workspace is not null && packageManager.WorkspaceCommandFactory is { } factory)
+        {
+            return factory(workspace.AppName, scriptName, scriptArgs);
+        }
+
+        var commandArgs = new List<string> { packageManager.ExecutableName };
+        if (!string.IsNullOrEmpty(packageManager.ScriptCommand))
+        {
+            commandArgs.Add(packageManager.ScriptCommand);
+        }
+        commandArgs.Add(scriptName);
+        commandArgs.AddRange(scriptArgs);
+        return commandArgs;
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/JavaScriptPublishModeChoiceAnnotation.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/JavaScriptPublishModeChoiceAnnotation.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.JavaScript.Internal;
+
+/// <summary>
+/// Sentinel annotation written by every <c>PublishAs*</c> method, regardless of execution mode.
+/// Used solely to detect "the user called more than one publish method on the same resource" —
+/// a contradiction in their AppHost code, not a configuration error. The publish mode behavior
+/// itself is still driven by <see cref="JavaScriptPublishModeAnnotation"/>, which is added only
+/// in publish mode.
+/// </summary>
+internal sealed class JavaScriptPublishModeChoiceAnnotation(string methodName) : IResourceAnnotation
+{
+    /// <summary>
+    /// Name of the publish method the user called (e.g. <c>"PublishAsStaticWebsite"</c>).
+    /// Surfaced verbatim in the duplicate-call exception message.
+    /// </summary>
+    public string MethodName { get; } = methodName;
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/JavaScriptResourceValidation.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/JavaScriptResourceValidation.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Validation and path-normalization helpers for JavaScript hosting APIs.
+// These are kept in one place so the public extension class doesn't need to
+// describe the validation rules inline at every call site.
+
+namespace Aspire.Hosting.JavaScript.Internal;
+
+internal static class JavaScriptResourceValidation
+{
+    private static readonly string[] s_nextConfigFileNames = ["next.config.ts", "next.config.js", "next.config.mjs"];
+
+    /// <summary>
+    /// Recognized Next.js config file names, in lookup order.
+    /// </summary>
+    public static IReadOnlyList<string> NextConfigFileNames => s_nextConfigFileNames;
+
+    /// <summary>
+    /// Verifies that the path is URL-safe (alphanumerics plus <c>/</c>, <c>-</c>, <c>_</c>).
+    /// Used by the Yarp-fronted static-website publish path so the API mount
+    /// point cannot inject query strings or path-traversal segments.
+    /// </summary>
+    public static void ValidateApiPath(string apiPath)
+    {
+        foreach (var c in apiPath)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c is not '/' and not '-' and not '_')
+            {
+                throw new ArgumentException($"The apiPath must contain only URL-safe path characters (alphanumeric, '/', '-', '_'). Invalid character: '{c}'", nameof(apiPath));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Normalizes a relative virtual container path to use forward slashes,
+    /// strips leading <c>./</c>, and rejects absolute paths or <c>..</c>
+    /// segments. Operates on container-virtual paths, so platform-specific
+    /// resolution (e.g. <see cref="Path.GetFullPath(string)"/>) is intentionally
+    /// avoided.
+    /// </summary>
+    public static string NormalizeRelativePath(string path)
+    {
+        var normalizedPath = path.Replace('\\', '/');
+
+        if (normalizedPath.StartsWith("./", StringComparison.Ordinal))
+        {
+            normalizedPath = normalizedPath[2..];
+        }
+
+        if (normalizedPath.StartsWith('/'))
+        {
+            throw new ArgumentException("The path must be a relative path.", nameof(path));
+        }
+
+        // Reject path traversal segments. These are virtual Docker container paths (not host
+        // filesystem paths), so Path.GetFullPath cannot be used — it produces platform-specific
+        // results (e.g. D:\app\dist on Windows). Segment-based validation works correctly
+        // cross-platform for container paths.
+        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var segment in segments)
+        {
+            if (segment == "..")
+            {
+                throw new ArgumentException("The path must not contain \"..\" segments.", nameof(path));
+            }
+        }
+
+        return string.Join('/', segments);
+    }
+
+    /// <summary>
+    /// Validates that a Next.js config file in <paramref name="appDirectory"/>
+    /// declares <c>output: "standalone"</c>. Required by AddNextJsApp so the
+    /// generated Dockerfile can copy the standalone-mode build artifacts.
+    /// </summary>
+    public static void ValidateNextJsStandaloneOutput(string appDirectory)
+    {
+        foreach (var configFileName in s_nextConfigFileNames)
+        {
+            var configPath = Path.Combine(appDirectory, configFileName);
+            if (!File.Exists(configPath))
+            {
+                continue;
+            }
+
+            try
+            {
+                var content = File.ReadAllText(configPath);
+
+                // Check for quoted "standalone" (double or single quotes) to reduce false positives
+                if (!content.Contains("\"standalone\"") && !content.Contains("'standalone'"))
+                {
+                    throw new InvalidOperationException(
+                        $"The Next.js config file '{configFileName}' does not contain 'output: \"standalone\"'. " +
+                        "AddNextJsApp requires Next.js standalone output mode to generate a working Dockerfile. " +
+                        "Add 'output: \"standalone\"' to the nextConfig object in your Next.js config file.");
+                }
+            }
+            catch (IOException)
+            {
+                // If we can't read the config, skip the check — the Docker build will surface the error.
+            }
+
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "No Next.js configuration file found. AddNextJsApp expects one of: " +
+            string.Join(", ", s_nextConfigFileNames));
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/JavaScriptWorkspaceConfigAnnotation.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/JavaScriptWorkspaceConfigAnnotation.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.JavaScript.Internal;
+
+/// <summary>
+/// Lightweight "the user called WithWorkspaceRoot" intent annotation.
+/// Carries only the resolved workspace root path; no I/O or filesystem
+/// validation has been performed yet.
+/// </summary>
+/// <remarks>
+/// This is written eagerly when <c>WithWorkspaceRoot</c> is called. It allows
+/// downstream API-time consumers (the package-manager <c>WithNpm</c> /
+/// <c>WithYarn</c> / <c>WithPnpm</c> / <c>WithBun</c> methods) to know that
+/// the resource opted into workspace mode, without forcing the AppHost
+/// constructor to do any disk reads or fail with "your repo is misconfigured"
+/// errors.
+/// <para/>
+/// The fully validated, computed counterpart is <see cref="JavaScriptWorkspaceAnnotation"/>,
+/// which is written by <see cref="Workspace.WorkspaceConfigurationValidator"/>
+/// during publish-mode Dockerfile generation or run-mode installer startup.
+/// </remarks>
+internal sealed class JavaScriptWorkspaceConfigAnnotation : IResourceAnnotation
+{
+    public JavaScriptWorkspaceConfigAnnotation(string rootPath, string appDirectory)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rootPath);
+        ArgumentException.ThrowIfNullOrEmpty(appDirectory);
+        RootPath = rootPath;
+        AppDirectory = appDirectory;
+    }
+
+    /// <summary>
+    /// Absolute, normalized path to the workspace root the user requested.
+    /// </summary>
+    public string RootPath { get; }
+
+    /// <summary>
+    /// Absolute, normalized path to the application directory captured at API time.
+    /// Stored here so the validator can compute relative paths even after the
+    /// resource has been wrapped (for example, after <c>PublishAsDockerFile</c>
+    /// converts the executable into a <c>ContainerResource</c>).
+    /// </summary>
+    public string AppDirectory { get; }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/NodeVersionResolver.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/NodeVersionResolver.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Resolves the Node.js major version to use in the generated Dockerfile.
+//
+// Follows the same shape as Cloud Native Buildpacks-style tooling for Node
+// selection: pinned toolchain files (.nvmrc, .node-version, .tool-versions)
+// are treated as authoritative runtime intent; package.json#engines.node is
+// compatibility metadata rather than a deployment image pin. If there is no
+// explicit toolchain pin, we fall back to a preferred Node major.
+//
+// References:
+//   .nvmrc          — https://github.com/nvm-sh/nvm#nvmrc
+//   .node-version   — https://github.com/shadowspawn/node-version-usage
+//   .tool-versions  — https://asdf-vm.com/manage/configuration.html#tool-versions
+//   buildpacks Node — https://github.com/heroku/heroku-buildpack-nodejs
+//
+// Example .nvmrc:                          22
+// Example .node-version:                   v22.1.0
+// Example .tool-versions (asdf-style):
+//   nodejs 22.1.0
+//   python 3.12
+
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.JavaScript.Internal;
+
+internal static class NodeVersionResolver
+{
+    /// <summary>
+    /// Default Node.js major used when no toolchain pin is found.
+    /// </summary>
+    public const string DefaultNodeVersion = "22";
+
+    /// <summary>
+    /// Returns a default Node.js base image of the form
+    /// <c>node:&lt;major&gt;-&lt;suffix&gt;</c>, with <c>&lt;major&gt;</c>
+    /// resolved from local toolchain files when present.
+    /// </summary>
+    /// <param name="appDirectory">Application directory to inspect for toolchain files.</param>
+    /// <param name="defaultSuffix">Image variant suffix (for example <c>"alpine"</c> or <c>"slim"</c>).</param>
+    /// <param name="serviceProvider">Service provider used to resolve the logger.</param>
+    /// <param name="workspaceRoot">
+    /// Optional workspace root path. When set, the resolver inspects the workspace root first;
+    /// monorepos commonly pin the Node version with a root-level <c>.nvmrc</c> /
+    /// <c>.tool-versions</c> rather than per-app.
+    /// </param>
+    public static string GetDefaultBaseImage(string appDirectory, string defaultSuffix, IServiceProvider serviceProvider, string? workspaceRoot = null)
+    {
+        var logger = serviceProvider.GetService<ILogger<JavaScriptAppResource>>() ?? NullLogger<JavaScriptAppResource>.Instance;
+        var nodeVersion = ResolveNodeVersion(appDirectory, logger, workspaceRoot);
+        return $"node:{nodeVersion}-{defaultSuffix}";
+    }
+
+    /// <summary>
+    /// Resolves the Node.js major version for a project by checking common
+    /// configuration files. Returns <see cref="DefaultNodeVersion"/> when no
+    /// toolchain pin is found.
+    /// </summary>
+    /// <remarks>
+    /// In workspace mode the workspace root is checked first because the dominant convention is
+    /// to pin Node version at the monorepo root with <c>.nvmrc</c> / <c>.tool-versions</c>; only
+    /// a minority of repos pin per-app. The app directory is checked second so that an explicit
+    /// per-app override still wins.
+    /// </remarks>
+    public static string ResolveNodeVersion(string workingDirectory, ILogger logger, string? workspaceRoot = null)
+    {
+        if (workspaceRoot is not null &&
+            !string.Equals(Path.GetFullPath(workspaceRoot), Path.GetFullPath(workingDirectory), StringComparison.Ordinal) &&
+            TryDetectPinnedNodeVersion(workspaceRoot, logger, out var rootPinned))
+        {
+            return rootPinned;
+        }
+
+        if (TryDetectPinnedNodeVersion(workingDirectory, logger, out var pinnedNodeVersion))
+        {
+            return pinnedNodeVersion;
+        }
+
+        logger.LogDebug("No Node.js version detected, using default version {DefaultVersion}", DefaultNodeVersion);
+        return DefaultNodeVersion;
+    }
+
+    private static bool TryDetectPinnedNodeVersion(string workingDirectory, ILogger logger, out string nodeVersion)
+    {
+        nodeVersion = string.Empty;
+
+        var nvmrcPath = Path.Combine(workingDirectory, ".nvmrc");
+        if (File.Exists(nvmrcPath))
+        {
+            var versionString = File.ReadAllText(nvmrcPath).Trim();
+            if (TryParseNodeVersion(versionString, out var version))
+            {
+                logger.LogDebug("Detected Node.js version {Version} from .nvmrc file", version);
+                nodeVersion = version;
+                return true;
+            }
+        }
+
+        var nodeVersionPath = Path.Combine(workingDirectory, ".node-version");
+        if (File.Exists(nodeVersionPath))
+        {
+            var versionString = File.ReadAllText(nodeVersionPath).Trim();
+            if (TryParseNodeVersion(versionString, out var version))
+            {
+                logger.LogDebug("Detected Node.js version {Version} from .node-version file", version);
+                nodeVersion = version;
+                return true;
+            }
+        }
+
+        var toolVersionsPath = Path.Combine(workingDirectory, ".tool-versions");
+        if (File.Exists(toolVersionsPath))
+        {
+            // Each line is "<tool> <version> [<version>...]". We scan for nodejs/node entries
+            // and take their first version token.
+            //
+            // Example .tool-versions content:
+            //   nodejs 22.1.0
+            //   python 3.12.0
+            var lines = File.ReadAllLines(toolVersionsPath);
+            foreach (var line in lines)
+            {
+                var trimmedLine = line.Trim();
+                var parts = trimmedLine.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length > 1 &&
+                    (string.Equals(parts[0], "nodejs", StringComparison.Ordinal) ||
+                     string.Equals(parts[0], "node", StringComparison.Ordinal)))
+                {
+                    if (TryParseNodeVersion(parts[1], out var version))
+                    {
+                        logger.LogDebug("Detected Node.js version {Version} from .tool-versions file", version);
+                        nodeVersion = version;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to parse a Node.js version string and extract the major
+    /// version. Accepts forms such as <c>22</c>, <c>v22.1.0</c>, <c>&gt;=20.12</c>,
+    /// <c>^18.0.0</c>.
+    /// </summary>
+    private static bool TryParseNodeVersion(string versionString, out string majorVersion)
+    {
+        majorVersion = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(versionString))
+        {
+            return false;
+        }
+
+        // Remove common prefixes and operators (handle multi-character operators first).
+        var cleaned = versionString.Trim();
+        string[] operators = [">=", "<=", "==", ">", "<", "=", "~", "^", "v", "V"];
+        foreach (var op in operators)
+        {
+            if (cleaned.StartsWith(op, StringComparison.Ordinal))
+            {
+                cleaned = cleaned.Substring(op.Length).TrimStart();
+                break;
+            }
+        }
+        var cleanedVersion = cleaned.Split('.', '-', ' ')[0]; // major component only
+
+        if (int.TryParse(cleanedVersion, NumberStyles.None, CultureInfo.InvariantCulture, out var majorVersionNumber) && majorVersionNumber > 0)
+        {
+            majorVersion = majorVersionNumber.ToString(CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/PackageJsonWorkspacesParser.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/PackageJsonWorkspacesParser.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Parses the "workspaces" field from a package.json document. This is the
+// declaration shared by npm, Yarn, and bun workspaces.
+//
+// Spec / reference implementations:
+//   - npm RFC 0026 (workspaces):
+//     https://github.com/npm/rfcs/blob/main/accepted/0026-workspaces.md
+//   - npm CLI reference impl:
+//     https://github.com/npm/cli/blob/latest/lib/utils/get-workspaces.js
+//   - Yarn classic workspaces:
+//     https://classic.yarnpkg.com/lang/en/docs/workspaces/
+//   - Yarn Berry workspaces:
+//     https://yarnpkg.com/features/workspaces
+//   - bun workspaces:
+//     https://bun.sh/docs/install/workspaces
+//
+// Supported package.json declaration shapes:
+//   {
+//     "name": "workspace-root",
+//     "private": true,
+//     "workspaces": ["packages/*", "apps/web"]     // string array (npm/yarn classic/bun)
+//   }
+//   {
+//     "name": "workspace-root",
+//     "private": true,
+//     "workspaces": {
+//       "packages": ["packages/*", "apps/*"]       // object form (yarn classic)
+//     }
+//   }
+//
+// All glob semantics (recursive, negated, non-trailing star) are handled by
+// callers (see WorkspacePatternValidator and WorkspacePatternMatcher) — this
+// parser just extracts the strings.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal static class PackageJsonWorkspacesParser
+{
+    /// <summary>
+    /// Reads workspace patterns from a package.json document.
+    /// </summary>
+    /// <param name="packageJsonContent">The textual content of a <c>package.json</c> file.</param>
+    /// <returns>
+    /// The list of pattern strings declared under <c>workspaces</c>, in declaration order.
+    /// Returns an empty list when the document is invalid JSON, has no <c>workspaces</c>
+    /// field, or has a workspace declaration shape that does not match the documented npm/Yarn forms.
+    /// </returns>
+    public static IReadOnlyList<string> Parse(string packageJsonContent)
+    {
+        ArgumentNullException.ThrowIfNull(packageJsonContent);
+
+        var arrayDeclaration = TryDeserialize<PackageJsonWorkspaceArrayDeclaration>(packageJsonContent);
+        if (arrayDeclaration?.Workspaces is not null)
+        {
+            return FilterPatterns(arrayDeclaration.Workspaces);
+        }
+
+        var objectDeclaration = TryDeserialize<PackageJsonWorkspaceObjectDeclaration>(packageJsonContent);
+        if (objectDeclaration?.Workspaces?.Packages is not null)
+        {
+            return FilterPatterns(objectDeclaration.Workspaces.Packages);
+        }
+
+        return [];
+    }
+
+    private static T? TryDeserialize<T>(string packageJsonContent)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<T>(packageJsonContent);
+        }
+        catch (JsonException)
+        {
+            return default;
+        }
+    }
+
+    private static IReadOnlyList<string> FilterPatterns(IEnumerable<string?> patterns) =>
+        patterns.Where(static p => !string.IsNullOrEmpty(p)).Select(static p => p!).ToArray();
+
+    private sealed class PackageJsonWorkspaceArrayDeclaration
+    {
+        [JsonPropertyName("workspaces")]
+        public List<string?>? Workspaces { get; set; }
+    }
+
+    private sealed class PackageJsonWorkspaceObjectDeclaration
+    {
+        [JsonPropertyName("workspaces")]
+        public PackageJsonWorkspaceObject? Workspaces { get; set; }
+    }
+
+    private sealed class PackageJsonWorkspaceObject
+    {
+        [JsonPropertyName("packages")]
+        public List<string?>? Packages { get; set; }
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/PnpmPackageManagerVersion.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/PnpmPackageManagerVersion.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal static class PnpmPackageManagerVersion
+{
+    public static int? TryReadMajorVersion(string workspaceRoot)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(workspaceRoot);
+
+        var packageManager = TryReadPackageManagerField(workspaceRoot);
+        if (packageManager is null)
+        {
+            return null;
+        }
+
+        return TryParseMajorVersion(packageManager);
+    }
+
+    public static int? TryParseMajorVersion(string packageManager)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(packageManager);
+
+        const string Prefix = "pnpm@";
+        if (!packageManager.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var versionStart = Prefix.Length;
+        var versionEnd = packageManager.IndexOfAny(['.', '-', '+'], versionStart);
+        var majorText = versionEnd < 0
+            ? packageManager[versionStart..]
+            : packageManager[versionStart..versionEnd];
+
+        return int.TryParse(majorText, out var major) ? major : null;
+    }
+
+    private static string? TryReadPackageManagerField(string rootPath)
+    {
+        var path = Path.Combine(rootPath, "package.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            var packageJson = JsonSerializer.Deserialize<PackageJsonPackageManagerInfo>(stream);
+
+            // Corepack treats top-level packageManager as the primary package-manager contract.
+            // If that is absent, it can fall back to devEngines.packageManager:
+            //   https://nodejs.org/api/corepack.html#devenginespackagemanager
+            //
+            // Raw shape:
+            //   "devEngines": {
+            //     "packageManager": {
+            //       "name": "pnpm",
+            //       "version": "11.0.8+sha224..."
+            //     }
+            //   }
+            //
+            // Only exact pnpm versions are useful for Dockerfile deploy-mode routing. Ranges
+            // such as ">=11.0.0" intentionally remain unknown and use the compatibility path.
+            if (packageJson?.PackageManager is { } packageManager)
+            {
+                return packageManager;
+            }
+
+            if (packageJson?.DevEngines?.PackageManager is { Version: { } versionString } devEnginesPackageManager &&
+                string.Equals(devEnginesPackageManager.Name, "pnpm", StringComparison.Ordinal))
+            {
+                return "pnpm@" + versionString;
+            }
+        }
+        catch (JsonException) { }
+        catch (IOException) { }
+
+        return null;
+    }
+
+    private sealed class PackageJsonPackageManagerInfo
+    {
+        [JsonPropertyName("packageManager")]
+        public string? PackageManager { get; set; }
+
+        [JsonPropertyName("devEngines")]
+        public DevEnginesInfo? DevEngines { get; set; }
+    }
+
+    private sealed class DevEnginesInfo
+    {
+        [JsonPropertyName("packageManager")]
+        public DevEnginesPackageManagerInfo? PackageManager { get; set; }
+    }
+
+    private sealed class DevEnginesPackageManagerInfo
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("version")]
+        public string? Version { get; set; }
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/PnpmWorkspaceYamlParser.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/PnpmWorkspaceYamlParser.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Parses the top-level "packages" sequence from a pnpm-workspace.yaml document.
+//
+// Spec / reference implementation:
+//   - pnpm workspaces docs: https://pnpm.io/workspaces
+//   - pnpm-workspace.yaml schema:
+//     https://pnpm.io/pnpm-workspace_yaml#packages
+//   - pnpm CLI reference impl (find-workspace-packages):
+//     https://github.com/pnpm/pnpm/tree/main/workspace/find-workspace-packages
+//
+// Supported pnpm-workspace.yaml shape:
+//   packages:
+//     - "packages/*"
+//     - "apps/web"
+//
+// Flow-style YAML parses to the same sequence:
+//   packages: ["packages/*", "apps/web"]
+//
+// We deserialize only the fields Aspire needs instead of modeling pnpm's whole
+// workspace schema. Real pnpm-workspace.yaml files often contain unrelated
+// settings such as catalog, overrides, onlyBuiltDependencies, trustPolicy, etc.;
+// those must remain tolerated because pnpm, not Aspire, owns their semantics.
+//
+// All glob semantics (recursive, negated, non-trailing star) are handled by
+// callers (see WorkspacePatternValidator and WorkspacePatternMatcher).
+
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal static class PnpmWorkspaceYamlParser
+{
+    private static readonly IDeserializer s_deserializer = new DeserializerBuilder()
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Reads workspace patterns from the <c>packages:</c> field of a
+    /// <c>pnpm-workspace.yaml</c> document.
+    /// </summary>
+    /// <param name="yamlContent">The textual content of a <c>pnpm-workspace.yaml</c> file.</param>
+    /// <returns>
+    /// The list of pattern strings declared under <c>packages</c>, in declaration order.
+    /// Returns an empty list when the document is invalid YAML, the root is not a mapping,
+    /// the <c>packages</c> key is missing, or its value is not a sequence.
+    /// </returns>
+    public static IReadOnlyList<string> Parse(string yamlContent)
+    {
+        ArgumentNullException.ThrowIfNull(yamlContent);
+
+        var workspace = TryDeserialize(yamlContent);
+        return workspace?.Packages?.Where(static p => !string.IsNullOrEmpty(p)).ToArray() ?? [];
+    }
+
+    /// <summary>
+    /// Reads the optional <c>injectWorkspacePackages</c> setting used by pnpm 10's non-legacy
+    /// <c>pnpm deploy</c> implementation.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> or <see langword="false"/> when the setting is present as a
+    /// boolean scalar; otherwise <see langword="null"/>.
+    /// </returns>
+    public static bool? ParseInjectWorkspacePackages(string yamlContent)
+    {
+        ArgumentNullException.ThrowIfNull(yamlContent);
+
+        var workspace = TryDeserialize(yamlContent);
+        return workspace?.InjectWorkspacePackages ?? workspace?.InjectWorkspacePackagesKebab;
+    }
+
+    private static PnpmWorkspaceYaml? TryDeserialize(string yamlContent)
+    {
+        if (yamlContent.Length == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            using var reader = new StringReader(yamlContent);
+            return s_deserializer.Deserialize<PnpmWorkspaceYaml>(reader);
+        }
+        catch (YamlDotNet.Core.YamlException)
+        {
+            return null;
+        }
+    }
+
+    private sealed class PnpmWorkspaceYaml
+    {
+        [YamlMember(Alias = "packages")]
+        public List<string>? Packages { get; set; }
+
+        [YamlMember(Alias = "injectWorkspacePackages")]
+        public bool? InjectWorkspacePackages { get; set; }
+
+        [YamlMember(Alias = "inject-workspace-packages")]
+        public bool? InjectWorkspacePackagesKebab { get; set; }
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspaceCommandFactories.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspaceCommandFactories.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Per-package-manager factories that turn an (workspace member name, script,
+// extra args) tuple into the argv that runs the script *via the package
+// manager's native workspace filter*. These run at Dockerfile build time and
+// at run time, so the shape mirrors what each PM expects on the CLI:
+//
+//   npm  : npm run <script> --workspace=<name> [-- <args...>]
+//          https://docs.npmjs.com/cli/v10/using-npm/workspaces
+//   yarn : yarn workspace <name> run <script> [args...]
+//          https://yarnpkg.com/cli/workspace
+//   pnpm : pnpm --filter <name>... run <script> [args...]
+//          https://pnpm.io/filtering — the trailing "..." selects <name> AND
+//          its workspace dependencies in topological order, so building a
+//          target also builds the workspace libraries it depends on.
+//   bun  : bun run --filter <name> <script> [args...]
+//          https://bun.com/docs/pm/filter#running-scripts-in-workspaces
+//
+// These delegates are stored on JavaScriptPackageManagerAnnotation so the
+// Dockerfile generator and the run-mode wiring don't have to switch on
+// executable name in multiple places.
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+/// <summary>
+/// Workspace-aware run-script command factories for npm/yarn/pnpm/bun. Each
+/// factory is the same shape: <c>(workspaceName, scriptName, scriptArgs) =&gt;
+/// argv</c>.
+/// </summary>
+internal static class WorkspaceCommandFactories
+{
+    public static readonly Func<string, string, IReadOnlyList<string>, IReadOnlyList<string>> Npm =
+        static (workspaceName, scriptName, scriptArgs) =>
+        {
+            var argv = new List<string> { "npm", "run", scriptName, $"--workspace={workspaceName}" };
+            if (scriptArgs.Count > 0)
+            {
+                argv.Add("--");
+                argv.AddRange(scriptArgs);
+            }
+            return argv;
+        };
+
+    public static readonly Func<string, string, IReadOnlyList<string>, IReadOnlyList<string>> Yarn =
+        static (workspaceName, scriptName, scriptArgs) =>
+        {
+            var argv = new List<string> { "yarn", "workspace", workspaceName, "run", scriptName };
+            argv.AddRange(scriptArgs);
+            return argv;
+        };
+
+    public static readonly Func<string, string, IReadOnlyList<string>, IReadOnlyList<string>> Pnpm =
+        static (workspaceName, scriptName, scriptArgs) =>
+        {
+            // pnpm filter syntax: "<name>..." (suffix) selects <name> AND its workspace dependencies
+            // in topological order. When the package has no workspace deps, this is equivalent to
+            // "--filter <name>". This makes monorepo builds correct by default — a target's workspace
+            // libraries are built before the target itself. See https://pnpm.io/filtering.
+            var argv = new List<string> { "pnpm", "--filter", $"{workspaceName}...", "run", scriptName };
+            argv.AddRange(scriptArgs);
+            return argv;
+        };
+
+    public static readonly Func<string, string, IReadOnlyList<string>, IReadOnlyList<string>> Bun =
+        static (workspaceName, scriptName, scriptArgs) =>
+        {
+            // Bun's --filter selects workspaces for the next script name; putting "run" after
+            // the filter makes Bun look for a workspace script literally named "run".
+            var argv = new List<string> { "bun", "run", "--filter", workspaceName, scriptName };
+            argv.AddRange(scriptArgs);
+            return argv;
+        };
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspaceConfigurationValidator.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspaceConfigurationValidator.cs
@@ -1,0 +1,696 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+
+//
+// Validates the JavaScript workspace state for a resource. Runs at publish-mode
+// Dockerfile generation time and at run-mode installer startup, NOT at
+// AppHost construction. This means errors in the workspace declaration,
+// lockfiles, or member layout surface as `aspire publish` / `aspire do build`
+// / run-mode resource errors — not as exceptions thrown from the user's
+// AppHost code. The user experience matches "my repo configuration is wrong"
+// rather than "my .NET code is wrong".
+//
+// The validator collects ALL discovered issues into a single
+// DistributedApplicationException so the user sees every problem at once,
+// rather than one per round-trip through the publish pipeline.
+//
+// On success, the rich JavaScriptWorkspaceAnnotation is attached to the
+// resource and downstream consumers (the Dockerfile generator, AddInstaller)
+// read it as before.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aspire.Hosting.ApplicationModel;
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal static class WorkspaceConfigurationValidator
+{
+    private static readonly IDeserializer s_yamlDeserializer = new DeserializerBuilder()
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Validates the workspace configuration for the resource and, on success,
+    /// attaches a fully-populated <see cref="JavaScriptWorkspaceAnnotation"/>.
+    /// </summary>
+    /// <returns>
+    /// The validated annotation when configuration is valid, or <see langword="null"/>
+    /// when the resource has no <see cref="JavaScriptWorkspaceConfigAnnotation"/>
+    /// (i.e. the user did not opt into workspace mode).
+    /// </returns>
+    /// <exception cref="DistributedApplicationException">
+    /// Thrown when one or more problems are detected. All problems are reported
+    /// in a single message; the message format is line-oriented so users can
+    /// fix everything in one pass.
+    /// </exception>
+    public static JavaScriptWorkspaceAnnotation? ValidateAndAttach(IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        // If validation already ran (idempotency), return the existing annotation.
+        if (resource.TryGetLastAnnotation<JavaScriptWorkspaceAnnotation>(out var existing))
+        {
+            return existing;
+        }
+
+        if (!resource.TryGetLastAnnotation<JavaScriptWorkspaceConfigAnnotation>(out var config))
+        {
+            return null;
+        }
+
+        var appDir = config.AppDirectory;
+
+        var diagnostics = new List<string>();
+        var validated = TryValidate(resource, config.RootPath, appDir, diagnostics);
+
+        if (diagnostics.Count > 0)
+        {
+            throw new DistributedApplicationException(BuildErrorMessage(resource.Name, diagnostics));
+        }
+
+        if (validated is null)
+        {
+            // Should not happen — TryValidate either returns the annotation or fills diagnostics.
+            throw new DistributedApplicationException($"Internal: workspace validation produced no annotation and no diagnostics for resource '{resource.Name}'.");
+        }
+        resource.Annotations.Add(validated);
+        // Now that we know the workspace layout, fix up any ContainerFilesSourceAnnotation entries
+        // captured by an earlier Publish* call so they live under /app/<AppRelativePath> instead of
+        // bare /app.
+        ContainerFilesPaths.RewriteForWorkspace(resource, validated);
+        return validated;
+    }
+
+    /// <summary>
+    /// Public entry point used by tests and other callers that want to drive
+    /// validation against an explicit root + app directory pair without going
+    /// through resource annotations.
+    /// </summary>
+    internal static JavaScriptWorkspaceAnnotation Validate(
+        string resourceName,
+        string resolvedRoot,
+        string appDir,
+        IReadOnlyList<string>? buildScriptNames = null,
+        string? configuredPackageManager = null,
+        string? startScriptName = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+        ArgumentException.ThrowIfNullOrEmpty(resolvedRoot);
+        ArgumentException.ThrowIfNullOrEmpty(appDir);
+
+        var diagnostics = new List<string>();
+        var ann = TryValidate(
+            resourceName,
+            resolvedRoot,
+            appDir,
+            diagnostics,
+            buildScriptNames,
+            configuredPackageManager,
+            startScriptName);
+
+        if (diagnostics.Count > 0)
+        {
+            throw new DistributedApplicationException(BuildErrorMessage(resourceName, diagnostics));
+        }
+
+        return ann!;
+    }
+
+    private static JavaScriptWorkspaceAnnotation? TryValidate(
+        IResource resource,
+        string resolvedRoot,
+        string appDir,
+        List<string> diagnostics)
+    {
+        var buildScripts = resource.Annotations.OfType<JavaScriptBuildScriptAnnotation>()
+            .Select(a => a.ScriptName)
+            .ToList();
+        var configuredPm = resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var pm)
+            ? pm.ExecutableName
+            : null;
+        var startScript = resource.TryGetLastAnnotation<JavaScriptPublishModeAnnotation>(out var publishMode) &&
+                          publishMode.Mode == JavaScriptPublishMode.PackageScript
+            ? publishMode.ScriptName
+            : null;
+
+        return TryValidate(resource.Name, resolvedRoot, appDir, diagnostics, buildScripts, configuredPm, startScript);
+    }
+
+    private static JavaScriptWorkspaceAnnotation? TryValidate(
+        string resourceName,
+        string resolvedRoot,
+        string appDir,
+        List<string> diagnostics,
+        IReadOnlyList<string>? buildScriptNames,
+        string? configuredPackageManager,
+        string? startScriptName)
+    {
+        // 1. Root directory exists.
+        if (!Directory.Exists(resolvedRoot))
+        {
+            diagnostics.Add($"Workspace root '{resolvedRoot}' does not exist.");
+            return null;
+        }
+
+        // 2. App directory is a strict descendant of the root.
+        var rootFull = PathWithSeparator(resolvedRoot);
+        var appFull = PathWithSeparator(appDir);
+        if (!appFull.StartsWith(rootFull, StringComparison.OrdinalIgnoreCase))
+        {
+            diagnostics.Add($"Application directory '{appDir}' is not a descendant of workspace root '{resolvedRoot}'.");
+            return null;
+        }
+
+        if (appFull.Length == rootFull.Length)
+        {
+            diagnostics.Add($"Application directory '{appDir}' is the workspace root; expected a workspace member subdirectory.");
+            return null;
+        }
+
+        var appRelative = appFull[rootFull.Length..]
+            .TrimEnd(Path.DirectorySeparatorChar)
+            .Replace(Path.DirectorySeparatorChar, '/');
+
+        // 3. App package.json must exist and have a name.
+        var appName = TryReadAppPackageName(appDir, resourceName, diagnostics);
+
+        // 4. Workspace declaration: read & parse manifests, surfacing parse errors.
+        var rawPatterns = ReadWorkspacePatterns(resolvedRoot, diagnostics);
+
+        if (diagnostics.Count > 0)
+        {
+            // If any of the above produced errors, there's no point continuing pattern expansion.
+            return null;
+        }
+
+        if (rawPatterns.Count == 0)
+        {
+            diagnostics.Add(
+                $"No workspace patterns declared at '{resolvedRoot}'. " +
+                "Expected a 'workspaces' field in package.json or a 'packages' list in pnpm-workspace.yaml.");
+            return null;
+        }
+
+        // 5. Pattern shape validation (negated, recursive, non-trailing star).
+        try
+        {
+            WorkspacePatternValidator.Validate(rawPatterns, resolvedRoot);
+        }
+        catch (DistributedApplicationException ex)
+        {
+            diagnostics.Add(ex.Message);
+            return null;
+        }
+
+        // 6. Pattern expansion. Track per-pattern resolution to detect "matched dirs but
+        //    none had package.json" cases.
+        var allDirs = new SortedSet<string>(StringComparer.Ordinal);
+        var unresolvedPatterns = new List<string>();
+        foreach (var pattern in rawPatterns)
+        {
+            var resolved = WorkspacePatternExpander.Expand(resolvedRoot, [pattern]);
+            if (resolved.Count == 0 && !pattern.StartsWith('!'))
+            {
+                unresolvedPatterns.Add(pattern);
+            }
+            foreach (var dir in resolved)
+            {
+                allDirs.Add(dir);
+            }
+        }
+
+        if (unresolvedPatterns.Count > 0)
+        {
+            diagnostics.Add(
+                $"Workspace pattern{(unresolvedPatterns.Count > 1 ? "s" : "")} " +
+                $"{string.Join(", ", unresolvedPatterns.Select(p => $"'{p}'"))} " +
+                $"in '{resolvedRoot}' did not match any directory containing a package.json. " +
+                "Aspire only treats directories with a package.json as workspace members.");
+            return null;
+        }
+
+        var workspaceDirs = allDirs.ToList();
+
+        // 7. Duplicate package names across resolved members.
+        var nameToDir = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var dir in workspaceDirs)
+        {
+            var packageName = JavaScriptWorkspaceReader.TryReadPackageName(Path.Combine(resolvedRoot, dir.Replace('/', Path.DirectorySeparatorChar)));
+            if (string.IsNullOrEmpty(packageName))
+            {
+                continue;
+            }
+            if (nameToDir.TryGetValue(packageName, out var existingDir))
+            {
+                diagnostics.Add(
+                    $"Workspace package name '{packageName}' is declared by both '{existingDir}/package.json' and '{dir}/package.json'. " +
+                    "Workspace package names must be unique because Aspire invokes scripts by package name.");
+            }
+            else
+            {
+                nameToDir[packageName] = dir;
+            }
+        }
+
+        // 8. App must be in member set.
+        if (!workspaceDirs.Contains(appRelative, StringComparer.OrdinalIgnoreCase))
+        {
+            diagnostics.Add(
+                $"Application directory '{appRelative}' is not a declared workspace member of '{resolvedRoot}'. " +
+                $"Declared members: {string.Join(", ", workspaceDirs)}");
+        }
+
+        // 9. Manifests / lockfile detection.
+        var manifests = WorkspaceManifestDiscovery.Discover(resolvedRoot);
+        if (!manifests.HasPackageJson)
+        {
+            diagnostics.Add($"Workspace root '{resolvedRoot}' is missing package.json.");
+        }
+        if (!manifests.HasLockfile)
+        {
+            diagnostics.Add(
+                $"Workspace root '{resolvedRoot}' has no recognized lockfile " +
+                $"(expected one of: {string.Join(", ", WorkspaceManifestDiscovery.RecognizedLockfileNames)}). " +
+                "Run 'npm install' / 'yarn install' / 'pnpm install' / 'bun install' at the workspace root before publishing.");
+        }
+
+        // 10. Package manager vs lockfile / packageManager field cross-check.
+        if (!string.IsNullOrEmpty(configuredPackageManager))
+        {
+            ValidatePackageManagerConsistency(resolvedRoot, configuredPackageManager, diagnostics);
+        }
+
+        // 11. Explicit pnpm 10+ workspace PublishAsPackageScript uses pnpm 10's non-legacy deploy implementation.
+        if (string.Equals(configuredPackageManager, "pnpm", StringComparison.Ordinal) &&
+            !string.IsNullOrEmpty(startScriptName) &&
+            PnpmPackageManagerVersion.TryReadMajorVersion(resolvedRoot) >= 10)
+        {
+            ValidatePnpmDeployConfiguration(resolvedRoot, diagnostics);
+        }
+
+        // 12. Configured build / start scripts must exist in app's package.json.
+        if (!string.IsNullOrEmpty(appName))
+        {
+            ValidateAppScripts(appDir, appName, buildScriptNames, startScriptName, diagnostics);
+        }
+
+        if (diagnostics.Count > 0 || string.IsNullOrEmpty(appName))
+        {
+            return null;
+        }
+
+        return new JavaScriptWorkspaceAnnotation(
+            resolvedRoot,
+            appName!,
+            appRelative,
+            workspaceDirs,
+            manifests.RootFiles,
+            manifests.RootDirs);
+    }
+
+    private static string? TryReadAppPackageName(string appDir, string resourceName, List<string> diagnostics)
+    {
+        var packageJsonPath = Path.Combine(appDir, "package.json");
+        if (!File.Exists(packageJsonPath))
+        {
+            diagnostics.Add(
+                $"Application '{resourceName}' is missing '{packageJsonPath}'. " +
+                "Workspace mode requires a package.json with a 'name' field at the application directory.");
+            return null;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(packageJsonPath);
+            var packageJson = JsonSerializer.Deserialize<PackageJsonNameInfo>(stream);
+            if (packageJson?.Name is { Length: > 0 } name)
+            {
+                return name;
+            }
+
+            diagnostics.Add(
+                $"'{packageJsonPath}' has no non-empty 'name' field. " +
+                "Workspace mode invokes scripts by package name; add a unique 'name' value.");
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            diagnostics.Add($"Failed to parse '{packageJsonPath}': {ex.Message}");
+            return null;
+        }
+        catch (IOException ex)
+        {
+            diagnostics.Add($"Failed to read '{packageJsonPath}': {ex.Message}");
+            return null;
+        }
+    }
+
+    private static List<string> ReadWorkspacePatterns(string rootPath, List<string> diagnostics)
+    {
+        var patterns = new List<string>();
+
+        var packageJsonPath = Path.Combine(rootPath, "package.json");
+        if (File.Exists(packageJsonPath))
+        {
+            try
+            {
+                var content = File.ReadAllText(packageJsonPath);
+                var (parsed, shapeError) = ParsePackageJsonWorkspacesStrict(content, packageJsonPath);
+                if (shapeError is not null)
+                {
+                    diagnostics.Add(shapeError);
+                }
+                patterns.AddRange(parsed);
+            }
+            catch (JsonException ex)
+            {
+                diagnostics.Add($"Failed to parse '{packageJsonPath}': {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                diagnostics.Add($"Failed to read '{packageJsonPath}': {ex.Message}");
+            }
+        }
+
+        var pnpmYamlPath = Path.Combine(rootPath, "pnpm-workspace.yaml");
+        if (File.Exists(pnpmYamlPath))
+        {
+            try
+            {
+                var content = File.ReadAllText(pnpmYamlPath);
+                var (parsed, shapeError) = ParsePnpmPackagesStrict(content, pnpmYamlPath);
+                if (shapeError is not null)
+                {
+                    diagnostics.Add(shapeError);
+                }
+                patterns.AddRange(parsed);
+            }
+            catch (YamlDotNet.Core.YamlException ex)
+            {
+                diagnostics.Add($"Failed to parse '{pnpmYamlPath}': {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                diagnostics.Add($"Failed to read '{pnpmYamlPath}': {ex.Message}");
+            }
+        }
+
+        return patterns;
+    }
+
+    private static (IReadOnlyList<string> Patterns, string? ShapeError) ParsePackageJsonWorkspacesStrict(string content, string filePath)
+    {
+        try
+        {
+            var arrayDeclaration = JsonSerializer.Deserialize<PackageJsonWorkspaceArrayDeclaration>(content);
+            if (arrayDeclaration?.Workspaces is null)
+            {
+                return ([], $"'{filePath}#workspaces' is null. Expected a string array or an object with 'packages: string[]'.");
+            }
+
+            return (FilterPatterns(arrayDeclaration.Workspaces), null);
+        }
+        catch (JsonException)
+        {
+            // The package.json workspaces contract is a JSON union:
+            //   "workspaces": ["packages/*"]
+            //   "workspaces": { "packages": ["packages/*"], "nohoist": ["**/react"] }
+            // System.Text.Json intentionally binds DTOs to one shape at a time, so an
+            // object-form declaration fails the array DTO above and is retried with the
+            // object DTO below. If both fail, the original caller reports the JSON parse
+            // error with the file path.
+        }
+
+        var objectDeclaration = JsonSerializer.Deserialize<PackageJsonWorkspaceObjectDeclaration>(content);
+        if (objectDeclaration?.Workspaces is null)
+        {
+            return ([], null);
+        }
+
+        if (objectDeclaration.Workspaces.Packages is null)
+        {
+            return ([], $"'{filePath}#workspaces.packages' is null. Expected a string array.");
+        }
+
+        var keys = objectDeclaration.Workspaces.ExtensionData?.Keys.ToArray() ?? [];
+        return objectDeclaration.Workspaces.Packages.Count == 0 && keys.Length > 0
+            ? ([], $"'{filePath}#workspaces' object must contain a 'packages' array; found keys: {string.Join(", ", keys)}.")
+            : (FilterPatterns(objectDeclaration.Workspaces.Packages), null);
+    }
+
+    private static (IReadOnlyList<string> Patterns, string? ShapeError) ParsePnpmPackagesStrict(string content, string filePath)
+    {
+        if (content.Length == 0)
+        {
+            return ([], null);
+        }
+
+        using var reader = new StringReader(content);
+        var workspace = s_yamlDeserializer.Deserialize<PnpmWorkspacePackagesDeclaration>(reader);
+
+        if (workspace?.Packages is null)
+        {
+            return ([], $"'{filePath}#packages' is null. Expected a YAML sequence of strings.");
+        }
+
+        return (FilterPatterns(workspace.Packages), null);
+    }
+
+    private static void ValidatePackageManagerConsistency(string resolvedRoot, string configuredPm, List<string> diagnostics)
+    {
+        var hasNpmLock = File.Exists(Path.Combine(resolvedRoot, "package-lock.json")) ||
+                         File.Exists(Path.Combine(resolvedRoot, "npm-shrinkwrap.json"));
+        var hasYarnLock = File.Exists(Path.Combine(resolvedRoot, "yarn.lock"));
+        var hasPnpmLock = File.Exists(Path.Combine(resolvedRoot, "pnpm-lock.yaml"));
+        var hasBunLock = File.Exists(Path.Combine(resolvedRoot, "bun.lock")) ||
+                         File.Exists(Path.Combine(resolvedRoot, "bun.lockb"));
+        var hasPnpmWorkspaceYaml = File.Exists(Path.Combine(resolvedRoot, "pnpm-workspace.yaml"));
+
+        var lockfilePm = (hasNpmLock, hasYarnLock, hasPnpmLock, hasBunLock) switch
+        {
+            (true, false, false, false) => "npm",
+            (false, true, false, false) => "yarn",
+            (false, false, true, false) => "pnpm",
+            (false, false, false, true) => "bun",
+            _ => null,
+        };
+
+        if (lockfilePm is not null && !string.Equals(lockfilePm, configuredPm, StringComparison.Ordinal))
+        {
+            diagnostics.Add(
+                $"Workspace root '{resolvedRoot}' has a {lockfilePm} lockfile, but the resource is configured to use {configuredPm}. " +
+                $"Either call .With{Capitalize(lockfilePm)}() instead of .With{Capitalize(configuredPm)}(), or remove the {lockfilePm} lockfile.");
+        }
+
+        if (hasPnpmWorkspaceYaml && !string.Equals(configuredPm, "pnpm", StringComparison.Ordinal))
+        {
+            diagnostics.Add(
+                $"Workspace root '{resolvedRoot}' contains 'pnpm-workspace.yaml' but the resource is configured to use {configuredPm}. " +
+                "pnpm-workspace.yaml is pnpm-specific; call .WithPnpm() or remove the file.");
+        }
+
+        var packageManagerField = TryReadPackageManagerField(resolvedRoot);
+        if (packageManagerField is not null && !packageManagerField.StartsWith(configuredPm + "@", StringComparison.Ordinal) && packageManagerField != configuredPm)
+        {
+            var declaredPm = packageManagerField.Split('@')[0];
+            if (!string.Equals(declaredPm, configuredPm, StringComparison.Ordinal))
+            {
+                diagnostics.Add(
+                    $"Workspace root 'package.json#packageManager' is '{packageManagerField}' but the resource is configured to use {configuredPm}. " +
+                    $"Either call .With{Capitalize(declaredPm)}() instead of .With{Capitalize(configuredPm)}(), or update 'packageManager' in package.json.");
+            }
+        }
+    }
+
+    private static void ValidatePnpmDeployConfiguration(string resolvedRoot, List<string> diagnostics)
+    {
+        var pnpmYamlPath = Path.Combine(resolvedRoot, "pnpm-workspace.yaml");
+        if (!File.Exists(pnpmYamlPath))
+        {
+            return;
+        }
+
+        try
+        {
+            var injectWorkspacePackages = PnpmWorkspaceYamlParser.ParseInjectWorkspacePackages(File.ReadAllText(pnpmYamlPath));
+            if (injectWorkspacePackages != true)
+            {
+                diagnostics.Add(
+                    $"Workspace root '{resolvedRoot}' uses pnpm with PublishAsPackageScript, which generates a pnpm 10 Dockerfile using 'pnpm deploy'. " +
+                    $"Set 'injectWorkspacePackages: true' in '{pnpmYamlPath}' so pnpm 10 can deploy workspace dependencies without legacy deploy mode.");
+            }
+        }
+        catch (YamlDotNet.Core.YamlException)
+        {
+            // Malformed pnpm-workspace.yaml is already reported while reading workspace patterns.
+        }
+        catch (IOException ex)
+        {
+            diagnostics.Add($"Failed to read '{pnpmYamlPath}': {ex.Message}");
+        }
+    }
+
+    private static string? TryReadPackageManagerField(string rootPath)
+    {
+        var path = Path.Combine(rootPath, "package.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            return JsonSerializer.Deserialize<PackageJsonPackageManagerInfo>(stream)?.PackageManager;
+        }
+        catch (JsonException) { }
+        catch (IOException) { }
+
+        return null;
+    }
+
+    private static void ValidateAppScripts(
+        string appDir,
+        string appName,
+        IReadOnlyList<string>? buildScriptNames,
+        string? startScriptName,
+        List<string> diagnostics)
+    {
+        var allScripts = new List<string>();
+        if (buildScriptNames is not null)
+        {
+            allScripts.AddRange(buildScriptNames);
+        }
+        if (!string.IsNullOrEmpty(startScriptName))
+        {
+            allScripts.Add(startScriptName);
+        }
+
+        if (allScripts.Count == 0)
+        {
+            return;
+        }
+
+        var packageJsonPath = Path.Combine(appDir, "package.json");
+        HashSet<string>? declaredScripts;
+        try
+        {
+            using var stream = File.OpenRead(packageJsonPath);
+            declaredScripts = ReadScriptNames(JsonSerializer.Deserialize<PackageJsonScriptsInfo>(stream));
+        }
+        catch (JsonException)
+        {
+            return; // already diagnosed by app-name reader
+        }
+        catch (IOException)
+        {
+            return;
+        }
+
+        if (declaredScripts is null)
+        {
+            return;
+        }
+
+        foreach (var script in allScripts.Distinct(StringComparer.Ordinal))
+        {
+            if (!declaredScripts.Contains(script))
+            {
+                diagnostics.Add(
+                    $"Application '{appName}' references script '{script}' but '{packageJsonPath}' does not declare 'scripts.{script}'. " +
+                    $"Declared scripts: {(declaredScripts.Count == 0 ? "(none)" : string.Join(", ", declaredScripts.OrderBy(s => s, StringComparer.Ordinal)))}.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the set of declared script names, or <see langword="null"/> when the package.json
+    /// has no <c>scripts</c> field at all (in which case we don't validate — the user has not
+    /// declared any scripts at all, so there's nothing to cross-check against).
+    /// </summary>
+    private static HashSet<string>? ReadScriptNames(PackageJsonScriptsInfo? packageJson)
+    {
+        if (packageJson?.Scripts is null)
+        {
+            return null;
+        }
+
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var scriptName in packageJson.Scripts.Keys)
+        {
+            set.Add(scriptName);
+        }
+        return set;
+    }
+
+    private static IReadOnlyList<string> FilterPatterns(IEnumerable<string?> patterns) =>
+        patterns.Where(static p => !string.IsNullOrEmpty(p)).Select(static p => p!).ToArray();
+
+    private sealed class PackageJsonNameInfo
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+    }
+
+    private sealed class PackageJsonWorkspaceArrayDeclaration
+    {
+        [JsonPropertyName("workspaces")]
+        public List<string?>? Workspaces { get; set; } = [];
+    }
+
+    private sealed class PackageJsonWorkspaceObjectDeclaration
+    {
+        [JsonPropertyName("workspaces")]
+        public PackageJsonWorkspaceObject? Workspaces { get; set; }
+    }
+
+    private sealed class PackageJsonWorkspaceObject
+    {
+        [JsonPropertyName("packages")]
+        public List<string?>? Packages { get; set; } = [];
+
+        [JsonExtensionData]
+        public Dictionary<string, object?>? ExtensionData { get; set; }
+    }
+
+    private sealed class PnpmWorkspacePackagesDeclaration
+    {
+        [YamlMember(Alias = "packages")]
+        public List<string?>? Packages { get; set; } = [];
+    }
+
+    private sealed class PackageJsonPackageManagerInfo
+    {
+        [JsonPropertyName("packageManager")]
+        public string? PackageManager { get; set; }
+    }
+
+    private sealed class PackageJsonScriptsInfo
+    {
+        [JsonPropertyName("scripts")]
+        public Dictionary<string, object?>? Scripts { get; set; }
+    }
+
+    private static string PathWithSeparator(string path) =>
+        path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
+
+    private static string Capitalize(string value) =>
+        string.IsNullOrEmpty(value) ? value : char.ToUpperInvariant(value[0]) + value[1..];
+
+    private static string BuildErrorMessage(string resourceName, List<string> diagnostics)
+    {
+        var sb = new StringBuilder();
+        sb.Append("JavaScript workspace configuration for resource '").Append(resourceName).Append("' is invalid:");
+        foreach (var diag in diagnostics)
+        {
+            sb.AppendLine();
+            sb.Append("  - ").Append(diag);
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspaceManifestDiscovery.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspaceManifestDiscovery.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Classifies the contents of a JS workspace root directory: which lockfile is
+// present, which optional config files exist, which directories must be
+// included in the Dockerfile manifest layer, and whether the root has a
+// package.json. The output drives Dockerfile generation; callers turn this
+// into validation errors and COPY directives.
+//
+// Lockfile precedence mirrors what each package manager looks at:
+//   - npm  : package-lock.json, npm-shrinkwrap.json
+//   - yarn : yarn.lock
+//   - pnpm : pnpm-lock.yaml
+//   - bun  : bun.lock (textual), bun.lockb (binary)
+//
+// Optional root config files that we copy into the manifest layer when present:
+//   - pnpm-workspace.yaml — defines pnpm workspace members
+//   - .yarnrc.yml         — Yarn Berry config
+//   - .yarnrc             — Yarn classic config
+//   - .npmrc              — npm/yarn classic config (registry, auth, etc.)
+//   - bunfig.toml         — bun config
+//
+// Optional root directories that we copy into the manifest layer when present:
+//   - .yarn               — Yarn Berry zero-installs cache, releases, etc.
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal sealed record WorkspaceRootManifests(
+    IReadOnlyList<string> RootFiles,
+    IReadOnlyList<string> RootDirs,
+    bool HasPackageJson,
+    bool HasLockfile);
+
+internal static class WorkspaceManifestDiscovery
+{
+    private static readonly string[] s_lockfileNames =
+    [
+        "package-lock.json",
+        "npm-shrinkwrap.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "bun.lock",
+        "bun.lockb",
+    ];
+
+    private static readonly string[] s_optionalRootManifestFiles =
+    [
+        "pnpm-workspace.yaml",
+        ".yarnrc.yml",
+        ".yarnrc",
+        ".npmrc",
+        "bunfig.toml",
+    ];
+
+    private static readonly string[] s_optionalRootDirs =
+    [
+        ".yarn",
+    ];
+
+    /// <summary>
+    /// The set of recognized lockfile names, ordered by package-manager precedence.
+    /// </summary>
+    public static IReadOnlyList<string> RecognizedLockfileNames => s_lockfileNames;
+
+    /// <summary>
+    /// Inspects <paramref name="rootPath"/> and returns the set of files and directories
+    /// that should be copied into the Dockerfile manifest layer.
+    /// </summary>
+    public static WorkspaceRootManifests Discover(string rootPath)
+    {
+        ArgumentNullException.ThrowIfNull(rootPath);
+
+        var rootFiles = new List<string>();
+        var hasPackageJson = File.Exists(Path.Combine(rootPath, "package.json"));
+        if (hasPackageJson)
+        {
+            rootFiles.Add("package.json");
+        }
+
+        var hasLockfile = false;
+        foreach (var lockName in s_lockfileNames)
+        {
+            if (File.Exists(Path.Combine(rootPath, lockName)))
+            {
+                rootFiles.Add(lockName);
+                hasLockfile = true;
+            }
+        }
+
+        foreach (var optional in s_optionalRootManifestFiles)
+        {
+            if (File.Exists(Path.Combine(rootPath, optional)))
+            {
+                rootFiles.Add(optional);
+            }
+        }
+
+        var rootDirs = new List<string>();
+        foreach (var dir in s_optionalRootDirs)
+        {
+            if (Directory.Exists(Path.Combine(rootPath, dir)))
+            {
+                rootDirs.Add(dir);
+            }
+        }
+
+        return new WorkspaceRootManifests(rootFiles, rootDirs, hasPackageJson, hasLockfile);
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspacePackageManagerReconfigurer.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspacePackageManagerReconfigurer.cs
@@ -1,0 +1,192 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+
+//
+// Re-attaches the package manager and install-command annotations using the
+// workspace root for lockfile detection. Called from
+// JavaScriptWorkspaceExtensions.WithWorkspaceRoot when the user configured the
+// workspace AFTER a package manager (or after an auto-attached npm).
+//
+// The lockfile-dependent verb (npm "ci" vs "install") and lockfile flags
+// (--frozen-lockfile / --immutable) are recomputed against the workspace root
+// because their value depends on which lockfile is present at the install
+// location. User-supplied extras from a previous WithNpm/WithYarn/WithPnpm/
+// WithBun call (other than the install verb itself and any well-known lockfile
+// flag) are preserved here, so that:
+//
+//   builder.AddViteApp("web", "./apps/web")
+//          .WithNpm("ci", ["--audit"])
+//          .WithWorkspaceRoot("..")
+//
+// keeps "--audit" in the final Dockerfile invocation.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal static class WorkspacePackageManagerReconfigurer
+{
+    // Well-known lockfile-related flags that we may emit ourselves and therefore strip from the
+    // user's pre-existing install args before re-merging. We do not strip the inverse forms
+    // (--no-frozen-lockfile, --no-immutable); a user that wants to keep them should call
+    // WithYarn/WithPnpm/WithBun *after* WithWorkspaceRoot so the install annotation is built
+    // fresh against the workspace root.
+    private static readonly HashSet<string> s_workspaceLockfileFlags = new(StringComparer.Ordinal)
+    {
+        "--frozen-lockfile",
+        "--immutable",
+    };
+
+    /// <summary>
+    /// Re-attaches package manager and install command annotations using the
+    /// workspace root for lockfile detection.
+    /// </summary>
+    public static void Reconfigure<TResource>(IResourceBuilder<TResource> builder, string executableName, string workspaceRoot)
+        where TResource : JavaScriptAppResource
+    {
+        var existingArgs = builder.Resource.TryGetLastAnnotation<JavaScriptInstallCommandAnnotation>(out var existingInstall)
+            ? existingInstall.Args
+            : [];
+
+        switch (executableName)
+        {
+            case "npm":
+                ReconfigureNpm(builder, workspaceRoot, existingArgs);
+                break;
+            case "yarn":
+                ReconfigureYarn(builder, workspaceRoot, existingArgs);
+                break;
+            case "pnpm":
+                ReconfigurePnpm(builder, workspaceRoot, existingArgs);
+                break;
+            case "bun":
+                ReconfigureBun(builder, workspaceRoot, existingArgs);
+                break;
+        }
+    }
+
+    private static void ReconfigureNpm<TResource>(IResourceBuilder<TResource> builder, string workspaceRoot, string[] existingArgs)
+        where TResource : JavaScriptAppResource
+    {
+        var installCommand = File.Exists(Path.Combine(workspaceRoot, "package-lock.json")) &&
+                             builder.ApplicationBuilder.ExecutionContext.IsPublishMode
+            ? "ci"
+            : "install";
+
+        builder
+            .WithAnnotation(new JavaScriptPackageManagerAnnotation("npm", runScriptCommand: "run", cacheMount: "/root/.npm")
+            {
+                PackageFilesPatterns = { new CopyFilePattern("package*.json", "./") },
+                WorkspaceCommandFactory = WorkspaceCommandFactories.Npm,
+            })
+            .WithAnnotation(new JavaScriptInstallCommandAnnotation(MergeNpmInstallArgs(installCommand, existingArgs))
+            {
+                ProductionInstallArgs = "--omit=dev"
+            });
+    }
+
+    private static void ReconfigureYarn<TResource>(IResourceBuilder<TResource> builder, string workspaceRoot, string[] existingArgs)
+        where TResource : JavaScriptAppResource
+    {
+        var hasYarnLock = File.Exists(Path.Combine(workspaceRoot, "yarn.lock"));
+        var hasYarnrc = File.Exists(Path.Combine(workspaceRoot, ".yarnrc.yml"));
+        var hasYarnBerryDir = Directory.Exists(Path.Combine(workspaceRoot, ".yarn"));
+        var hasYarnBerry = hasYarnrc || hasYarnBerryDir;
+
+        string[] lockfileFlags = builder.ApplicationBuilder.ExecutionContext.IsPublishMode && hasYarnLock
+            ? hasYarnBerry ? ["--immutable"] : ["--frozen-lockfile"]
+            : [];
+
+        var cacheMount = hasYarnBerry ? ".yarn/cache" : "/root/.cache/yarn";
+        builder
+            .WithAnnotation(new JavaScriptPackageManagerAnnotation("yarn", runScriptCommand: "run", cacheMount)
+            {
+                CommandSeparator = null,
+                WorkspaceCommandFactory = WorkspaceCommandFactories.Yarn,
+            })
+            .WithAnnotation(new JavaScriptInstallCommandAnnotation(MergeInstallArgs(existingArgs, lockfileFlags))
+            {
+                ProductionInstallArgs = "--production"
+            });
+    }
+
+    private static void ReconfigurePnpm<TResource>(IResourceBuilder<TResource> builder, string workspaceRoot, string[] existingArgs)
+        where TResource : JavaScriptAppResource
+    {
+        var hasPnpmLock = File.Exists(Path.Combine(workspaceRoot, "pnpm-lock.yaml"));
+        string[] lockfileFlags = builder.ApplicationBuilder.ExecutionContext.IsPublishMode && hasPnpmLock
+            ? ["--frozen-lockfile"]
+            : [];
+
+        builder
+            .WithAnnotation(new JavaScriptPackageManagerAnnotation("pnpm", runScriptCommand: "run", cacheMount: "/pnpm/store")
+            {
+                CommandSeparator = null,
+                InitializeDockerBuildStage = stage => stage.Run("corepack enable pnpm"),
+                WorkspaceCommandFactory = WorkspaceCommandFactories.Pnpm,
+            })
+            .WithAnnotation(new JavaScriptInstallCommandAnnotation(MergeInstallArgs(existingArgs, lockfileFlags))
+            {
+                ProductionInstallArgs = "--prod"
+            });
+    }
+
+    private static void ReconfigureBun<TResource>(IResourceBuilder<TResource> builder, string workspaceRoot, string[] existingArgs)
+        where TResource : JavaScriptAppResource
+    {
+        var hasBunLock = File.Exists(Path.Combine(workspaceRoot, "bun.lock")) ||
+                         File.Exists(Path.Combine(workspaceRoot, "bun.lockb"));
+        string[] lockfileFlags = builder.ApplicationBuilder.ExecutionContext.IsPublishMode && hasBunLock
+            ? ["--frozen-lockfile"]
+            : [];
+
+        builder
+            .WithAnnotation(new JavaScriptPackageManagerAnnotation("bun", runScriptCommand: "run", cacheMount: "/root/.bun/install/cache")
+            {
+                CommandSeparator = null,
+                WorkspaceCommandFactory = WorkspaceCommandFactories.Bun,
+            })
+            .WithAnnotation(new JavaScriptInstallCommandAnnotation(MergeInstallArgs(existingArgs, lockfileFlags))
+            {
+                ProductionInstallArgs = "--production"
+            });
+    }
+
+    // npm install args have the lockfile-dependent verb in args[0] ("ci" vs "install"). Replace
+    // args[0] with the workspace-derived verb and preserve everything else (e.g. --audit).
+    private static string[] MergeNpmInstallArgs(string installCommand, string[] existingArgs)
+    {
+        if (existingArgs.Length <= 1)
+        {
+            return [installCommand];
+        }
+        var merged = new string[existingArgs.Length];
+        merged[0] = installCommand;
+        Array.Copy(existingArgs, 1, merged, 1, existingArgs.Length - 1);
+        return merged;
+    }
+
+    // yarn/pnpm/bun install args are always [install, *flags]. Drop any prior well-known
+    // lockfile flag so we don't duplicate it, then prepend the workspace-derived flag(s) and
+    // re-append the user's remaining extras.
+    private static string[] MergeInstallArgs(string[] existingArgs, string[] lockfileFlags)
+    {
+        var merged = new List<string>(1 + lockfileFlags.Length + Math.Max(0, existingArgs.Length - 1))
+        {
+            "install",
+        };
+        merged.AddRange(lockfileFlags);
+        for (var i = 1; i < existingArgs.Length; i++)
+        {
+            var arg = existingArgs[i];
+            if (s_workspaceLockfileFlags.Contains(arg))
+            {
+                continue;
+            }
+            merged.Add(arg);
+        }
+        return [.. merged];
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspacePatternExpander.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspacePatternExpander.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Walks the workspace root filesystem and resolves a list of workspace glob
+// patterns to actual member directories. Each candidate is checked for
+// presence of a package.json (the marker for a JS package directory).
+//
+// Example:
+//   root/
+//     package.json
+//     packages/
+//       web/package.json
+//       api/package.json
+//       docs/README.md
+//
+//   patterns: ["packages/*"]
+//   result:   ["packages/api", "packages/web"]
+//
+// This is the only filesystem-touching component of the workspace reader
+// pipeline — the JSON/YAML parsers, validator, and matcher are all pure.
+//
+// Unsupported pattern shapes (negated, recursive, non-trailing star) should be
+// rejected upstream by WorkspacePatternValidator. This expander is permissive
+// (silently skips unsupported shapes) so that the validator owns the error
+// surface.
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal static class WorkspacePatternExpander
+{
+    /// <summary>
+    /// Expands workspace glob patterns to forward-slash relative paths under
+    /// <paramref name="rootPath"/>. Each result has a <c>package.json</c>.
+    /// </summary>
+    /// <returns>The resolved set of workspace directories, sorted ordinally.</returns>
+    public static IReadOnlyList<string> Expand(string rootPath, IEnumerable<string> patterns)
+    {
+        ArgumentNullException.ThrowIfNull(rootPath);
+        ArgumentNullException.ThrowIfNull(patterns);
+
+        var results = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (var rawPattern in patterns)
+        {
+            var pattern = rawPattern?.Trim() ?? string.Empty;
+            if (pattern.Length == 0 || pattern[0] == '!')
+            {
+                continue;
+            }
+
+            var normalized = pattern.Replace('\\', '/');
+            if (normalized.StartsWith("./", StringComparison.Ordinal))
+            {
+                normalized = normalized[2..];
+            }
+            if (normalized.EndsWith('/'))
+            {
+                normalized = normalized[..^1];
+            }
+            if (normalized.Length == 0)
+            {
+                continue;
+            }
+
+            var lastSlash = normalized.LastIndexOf('/');
+            var lastSegment = lastSlash < 0 ? normalized : normalized[(lastSlash + 1)..];
+
+            if (lastSegment == "*")
+            {
+                ExpandTrailingStar(rootPath, normalized, lastSlash, results);
+            }
+            else if (!normalized.Contains('*', StringComparison.Ordinal))
+            {
+                AddIfPackage(rootPath, normalized, results);
+            }
+            // Other shapes are rejected upstream by WorkspacePatternValidator.
+        }
+
+        return [.. results];
+    }
+
+    private static void ExpandTrailingStar(string rootPath, string normalized, int lastSlash, SortedSet<string> results)
+    {
+        var parentRel = lastSlash < 0 ? string.Empty : normalized[..lastSlash];
+        var parentAbs = parentRel.Length == 0
+            ? rootPath
+            : Path.Combine(rootPath, parentRel.Replace('/', Path.DirectorySeparatorChar));
+
+        if (!Directory.Exists(parentAbs))
+        {
+            return;
+        }
+
+        foreach (var childDir in Directory.EnumerateDirectories(parentAbs))
+        {
+            var childName = Path.GetFileName(childDir);
+            if (childName.StartsWith('.'))
+            {
+                continue;
+            }
+            if (!File.Exists(Path.Combine(childDir, "package.json")))
+            {
+                continue;
+            }
+            var rel = parentRel.Length == 0 ? childName : $"{parentRel}/{childName}";
+            results.Add(rel);
+        }
+    }
+
+    private static void AddIfPackage(string rootPath, string normalized, SortedSet<string> results)
+    {
+        var abs = Path.Combine(rootPath, normalized.Replace('/', Path.DirectorySeparatorChar));
+        if (File.Exists(Path.Combine(abs, "package.json")))
+        {
+            results.Add(normalized);
+        }
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspacePatternMatcher.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspacePatternMatcher.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Matches a single workspace glob pattern against a forward-slash candidate
+// directory path, using the subset of glob syntax that Aspire's Dockerfile
+// generator supports.
+//
+// Supported shapes (validated by WorkspacePatternValidator, replicated here for
+// the matcher's benefit):
+//   - Literal: "apps/web" matches exactly "apps/web" (after trimming "./" and
+//     trailing "/")
+//   - Trailing single-star: "packages/*" matches "packages/<name>" where
+//     <name> does not start with '.' (dotted directories like ".git" are
+//     excluded by convention to mirror minimatch / pnpm matcher defaults).
+//
+// Pattern-level validation should be performed by the caller before invoking
+// this matcher; the matcher returns false for unsupported shapes rather than
+// throwing.
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal static class WorkspacePatternMatcher
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="candidatePath"/>
+    /// (a forward-slash relative path) matches <paramref name="pattern"/>.
+    /// </summary>
+    public static bool IsMatch(string pattern, string candidatePath)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(candidatePath);
+
+        var normalizedPattern = Normalize(pattern);
+        var normalizedCandidate = Normalize(candidatePath);
+
+        if (normalizedPattern.Length == 0 || normalizedCandidate.Length == 0)
+        {
+            return false;
+        }
+
+        var lastSlash = normalizedPattern.LastIndexOf('/');
+        var lastSegment = lastSlash < 0 ? normalizedPattern : normalizedPattern[(lastSlash + 1)..];
+
+        if (lastSegment == "*")
+        {
+            var parent = lastSlash < 0 ? string.Empty : normalizedPattern[..lastSlash];
+            var candidateLastSlash = normalizedCandidate.LastIndexOf('/');
+            var candidateParent = candidateLastSlash < 0 ? string.Empty : normalizedCandidate[..candidateLastSlash];
+            var candidateName = candidateLastSlash < 0 ? normalizedCandidate : normalizedCandidate[(candidateLastSlash + 1)..];
+
+            if (candidateName.StartsWith('.'))
+            {
+                return false;
+            }
+
+            return string.Equals(candidateParent, parent, StringComparison.Ordinal);
+        }
+
+        if (normalizedPattern.Contains('*', StringComparison.Ordinal))
+        {
+            // Validator should have rejected this; treat as no-match.
+            return false;
+        }
+
+        return string.Equals(normalizedPattern, normalizedCandidate, StringComparison.Ordinal);
+    }
+
+    private static string Normalize(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        if (normalized.StartsWith("./", StringComparison.Ordinal))
+        {
+            normalized = normalized[2..];
+        }
+        if (normalized.EndsWith('/'))
+        {
+            normalized = normalized[..^1];
+        }
+        return normalized;
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspacePatternValidator.cs
+++ b/src/Aspire.Hosting.JavaScript/Internal/Workspace/WorkspacePatternValidator.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Validates workspace glob patterns declared in package.json/pnpm-workspace.yaml
+// against the subset Aspire's Dockerfile generator supports.
+//
+// Supported pattern shapes (all forward-slash):
+//   - Literal path segment: "apps/web", "packages/utils"
+//   - Trailing star matching one segment: "packages/*"
+//
+// Unsupported pattern shapes (we throw rather than silently skip):
+//   - Negated: "!apps/legacy"
+//   - Recursive: "packages/**"
+//   - Non-trailing star: "apps/*-svc", "apps/api-*", "*/api"
+//
+// Throwing eagerly (rather than silently dropping the pattern as the underlying
+// directory walker would) gives the user a clear error that points at the
+// declaration site, instead of a confusing "is not a declared workspace member"
+// error far downstream.
+//
+// Real-world workspace tooling resolves these patterns with minimatch (npm/yarn
+// classic/bun) or pnpm's own matcher, both of which support the full glob
+// vocabulary. We intentionally support only the dominant subset and report the
+// rest as unsupported.
+
+namespace Aspire.Hosting.JavaScript.Internal.Workspace;
+
+internal static class WorkspacePatternValidator
+{
+    /// <summary>
+    /// Validates that every pattern uses one of the supported shapes.
+    /// </summary>
+    /// <exception cref="DistributedApplicationException">
+    /// Thrown when a pattern is negated, recursive, or uses a non-trailing star.
+    /// </exception>
+    public static void Validate(IEnumerable<string> patterns, string rootPath)
+    {
+        ArgumentNullException.ThrowIfNull(patterns);
+        ArgumentNullException.ThrowIfNull(rootPath);
+
+        foreach (var pattern in patterns)
+        {
+            ValidateOne(pattern, rootPath);
+        }
+    }
+
+    private static void ValidateOne(string pattern, string rootPath)
+    {
+        if (string.IsNullOrEmpty(pattern))
+        {
+            return;
+        }
+
+        if (pattern[0] == '!')
+        {
+            throw new DistributedApplicationException(
+                $"Negated workspace pattern '{pattern}' at '{rootPath}' is not supported.");
+        }
+
+        if (pattern.Contains("**", StringComparison.Ordinal))
+        {
+            throw new DistributedApplicationException(
+                $"Recursive workspace pattern '{pattern}' at '{rootPath}' is not supported.");
+        }
+
+        // The only star we accept is a segment that is exactly "*" and is the
+        // last segment of the pattern (e.g. "packages/*"). Anything else
+        // (e.g. "apps/*-svc", "apps/api-*", "*/api") is rejected.
+        var normalized = pattern.Replace('\\', '/');
+        var segments = normalized.Split('/');
+        for (var i = 0; i < segments.Length; i++)
+        {
+            var segment = segments[i];
+            if (!segment.Contains('*', StringComparison.Ordinal))
+            {
+                continue;
+            }
+            if (segment == "*" && i == segments.Length - 1)
+            {
+                continue;
+            }
+            throw new DistributedApplicationException(
+                $"Workspace pattern '{pattern}' at '{rootPath}' uses an unsupported glob shape. "
+                + "Supported shapes are literal paths (for example, 'apps/web') or a single "
+                + "trailing star (for example, 'packages/*').");
+        }
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -7,19 +7,19 @@
 #pragma warning disable ASPIREEXTENSION001
 
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.ApplicationModel.Docker;
 using Aspire.Hosting.JavaScript;
+using Aspire.Hosting.JavaScript.Internal;
+using Aspire.Hosting.JavaScript.Internal.Workspace;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting;
 
@@ -29,7 +29,6 @@ namespace Aspire.Hosting;
 public static class JavaScriptHostingExtensions
 {
     private const string BrowserCapability = "browser";
-    private const string DefaultNodeVersion = "22";
     private const string DefaultJavaScriptRunScriptName = "dev";
     private const string DefaultYarpImage = Yarp.YarpContainerImageTags.Registry + "/" + Yarp.YarpContainerImageTags.Image + ":" + Yarp.YarpContainerImageTags.Tag;
 
@@ -161,9 +160,16 @@ public static class JavaScriptHostingExtensions
                     return;
                 }
 
+                // Workspace mode: WithWorkspaceRoot is called AFTER PublishAsDockerFile in the user's
+                // chain, so we can't read it eagerly here. We default the build context to the app
+                // directory; if WithWorkspaceRoot is later invoked, it will replace the
+                // DockerfileBuildAnnotation with one whose ContextPath is the workspace root.
                 c.WithDockerfileBuilder(resource.WorkingDirectory, dockerfileContext =>
                 {
-                    var defaultBaseImage = new Lazy<string>(() => GetDefaultBaseImage(appDirectory, "alpine", dockerfileContext.Services));
+                    WorkspaceConfigurationValidator.ValidateAndAttach(dockerfileContext.Resource);
+                    dockerfileContext.Resource.TryGetLastAnnotation<JavaScriptWorkspaceAnnotation>(out var workspace);
+
+                    var defaultBaseImage = new Lazy<string>(() => NodeVersionResolver.GetDefaultBaseImage(appDirectory, "alpine", dockerfileContext.Services, workspace?.RootPath));
 
                     // Get custom base image from annotation, if present
                     dockerfileContext.Resource.TryGetLastAnnotation<DockerfileBaseImageAnnotation>(out var baseImageAnnotation);
@@ -184,9 +190,13 @@ public static class JavaScriptHostingExtensions
                         var copiedAllSource = false;
                         if (resource.TryGetLastAnnotation<JavaScriptInstallCommandAnnotation>(out var installCommand))
                         {
-                            // Copy package files first for better layer caching
-                            if (packageManager.PackageFilesPatterns.Count > 0)
+                            if (workspace is not null)
                             {
+                                JavaScriptDockerfileEmitter.EmitWorkspaceManifestLayer(builderStage, workspace);
+                            }
+                            else if (packageManager.PackageFilesPatterns.Count > 0)
+                            {
+                                // Copy package files first for better layer caching
                                 foreach (var packageFilePattern in packageManager.PackageFilesPatterns)
                                 {
                                     builderStage.Copy(packageFilePattern.Source, packageFilePattern.Destination);
@@ -198,7 +208,7 @@ public static class JavaScriptHostingExtensions
                                 copiedAllSource = true;
                             }
 
-                            builderStage.AddInstallCommand(packageManager, installCommand);
+                            JavaScriptDockerfileEmitter.EmitInstall(builderStage, packageManager, installCommand);
                         }
 
                         if (!copiedAllSource)
@@ -209,16 +219,8 @@ public static class JavaScriptHostingExtensions
 
                         if (resource.TryGetLastAnnotation<JavaScriptBuildScriptAnnotation>(out var buildCommand))
                         {
-                            var commandArgs = new List<string>() { packageManager.ExecutableName };
-                            if (!string.IsNullOrEmpty(packageManager.ScriptCommand))
-                            {
-                                commandArgs.Add(packageManager.ScriptCommand);
-                            }
-                            commandArgs.Add(buildCommand.ScriptName);
-                            commandArgs.AddRange(buildCommand.Args);
-
                             builderStage.EmptyLine()
-                                .Run(string.Join(' ', commandArgs));
+                                .Run(string.Join(' ', JavaScriptDockerfileEmitter.BuildPackageManagerCommand(packageManager, buildCommand.ScriptName, buildCommand.Args, workspace)));
                         }
                     }
                     else
@@ -231,10 +233,11 @@ public static class JavaScriptHostingExtensions
                     dockerfileContext.Builder.AddContainerFilesStages(dockerfileContext.Resource, logger);
 
                     var baseRuntimeImage = baseImageAnnotation?.RuntimeImage ?? defaultBaseImage.Value;
+                    var runtimeWorkDir = workspace is not null ? $"/app/{workspace.AppRelativePath}" : "/app";
                     var runtimeBuilder = dockerfileContext.Builder
                         .From(baseRuntimeImage, "runtime")
                             .EmptyLine()
-                            .WorkDir("/app")
+                            .WorkDir(runtimeWorkDir)
                             .CopyFrom("build", "/app", "/app")
                             .AddContainerFiles(dockerfileContext.Resource, "/app", logger)
                             .EmptyLine()
@@ -468,7 +471,7 @@ public static class JavaScriptHostingExtensions
                                 copiedAllSource = true;
                             }
 
-                            builderStage.AddInstallCommand(packageManager, installCommand);
+                            JavaScriptDockerfileEmitter.EmitInstall(builderStage, packageManager, installCommand);
                         }
 
                         if (!copiedAllSource)
@@ -798,6 +801,8 @@ public static class JavaScriptHostingExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(options.OutputPath);
 
+        ThrowIfPublishModeAlreadySet(builder.Resource, nameof(PublishAsStaticWebsite));
+
         if (apiPath is not null && apiTarget is null)
         {
             throw new ArgumentException("apiTarget is required when apiPath is specified.", nameof(apiTarget));
@@ -822,7 +827,7 @@ public static class JavaScriptHostingExtensions
                 throw new ArgumentException("The apiPath must not be '/' — it would match all requests and make the static site unreachable.", nameof(apiPath));
             }
 
-            ValidateApiPath(apiPath);
+            JavaScriptResourceValidation.ValidateApiPath(apiPath);
             builder.WithReference(apiTarget);
         }
 
@@ -864,7 +869,7 @@ public static class JavaScriptHostingExtensions
 
         builder.WithAnnotation(annotation)
                .ClearContainerFilesSources()
-               .WithContainerFilesSource(GetContainerFilesSourcePath(options.OutputPath))
+               .WithContainerFilesSource(ContainerFilesPaths.ForApp(options.OutputPath))
                .WithOtlpExporter();
 
         if (builder.Resource.TryGetLastAnnotation<DockerfileBuildAnnotation>(out var dockerfileBuildAnnotation))
@@ -909,6 +914,8 @@ public static class JavaScriptHostingExtensions
         ArgumentException.ThrowIfNullOrEmpty(entryPoint);
         ArgumentException.ThrowIfNullOrEmpty(outputPath);
 
+        ThrowIfPublishModeAlreadySet(builder.Resource, nameof(PublishAsNodeServer));
+
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
             return builder;
@@ -922,7 +929,7 @@ public static class JavaScriptHostingExtensions
 
         builder.WithAnnotation(annotation)
                .ClearContainerFilesSources()
-               .WithContainerFilesSource(GetContainerFilesSourcePath(outputPath))
+               .WithContainerFilesSource(ContainerFilesPaths.ForApp(outputPath))
                .WithOtlpExporter()
                .WithEnvironment("HOST", "0.0.0.0")
                .WithEnvironment("HOSTNAME", "0.0.0.0");
@@ -973,6 +980,8 @@ public static class JavaScriptHostingExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(scriptName);
 
+        ThrowIfPublishModeAlreadySet(builder.Resource, nameof(PublishAsPackageScript));
+
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
             return builder;
@@ -998,26 +1007,13 @@ public static class JavaScriptHostingExtensions
         return builder;
     }
 
-    private static void AddInstallCommand(this DockerfileStage builderStage, JavaScriptPackageManagerAnnotation packageManager, JavaScriptInstallCommandAnnotation installCommand)
-    {
-        // Use BuildKit cache mount for package manager cache if available
-        var installCmd = $"{packageManager.ExecutableName} {string.Join(' ', installCommand.Args)}";
-        if (!string.IsNullOrEmpty(packageManager.CacheMount))
-        {
-            builderStage.Run($"--mount=type=cache,target={packageManager.CacheMount} {installCmd}");
-        }
-        else
-        {
-            builderStage.Run(installCmd);
-        }
-    }
-
     private static string GetPackageScriptRuntimeImage(
         string appDirectory,
         IServiceProvider services,
         DockerfileBaseImageAnnotation? baseImageAnnotation,
         JavaScriptPackageManagerAnnotation packageManager,
-        string buildImage)
+        string buildImage,
+        JavaScriptWorkspaceAnnotation? workspace)
     {
         if (!string.IsNullOrEmpty(baseImageAnnotation?.RuntimeImage))
         {
@@ -1025,7 +1021,7 @@ public static class JavaScriptHostingExtensions
         }
 
         return packageManager.ResolvePackageScriptRuntimeImage?.Invoke(buildImage)
-            ?? GetDefaultBaseImage(appDirectory, "alpine", services);
+            ?? NodeVersionResolver.GetDefaultBaseImage(appDirectory, "alpine", services, workspace?.RootPath);
     }
 
     private static IResourceBuilder<TResource> CreateDefaultJavaScriptAppBuilder<TResource>(
@@ -1067,15 +1063,21 @@ public static class JavaScriptHostingExtensions
                     return;
                 }
 
+                // Workspace mode: WithWorkspaceRoot is called AFTER PublishAsDockerFile in the user's
+                // chain, so we can't read it eagerly here. We default the build context to the app
+                // directory; if WithWorkspaceRoot is later invoked, it will replace the
+                // DockerfileBuildAnnotation with one whose ContextPath is the workspace root.
                 c.WithDockerfileBuilder(appDirectory, dockerfileContext =>
                 {
+                    WorkspaceConfigurationValidator.ValidateAndAttach(dockerfileContext.Resource);
+                    dockerfileContext.Resource.TryGetLastAnnotation<JavaScriptWorkspaceAnnotation>(out var workspace);
                     dockerfileContext.Resource.TryGetLastAnnotation<JavaScriptPublishModeAnnotation>(out var publishMode);
 
                     if (c.Resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var packageManager))
                     {
                         // Get custom base image from annotation, if present
                         dockerfileContext.Resource.TryGetLastAnnotation<DockerfileBaseImageAnnotation>(out var baseImageAnnotation);
-                        var baseImage = baseImageAnnotation?.BuildImage ?? GetDefaultBaseImage(appDirectory, "slim", dockerfileContext.Services);
+                        var baseImage = baseImageAnnotation?.BuildImage ?? NodeVersionResolver.GetDefaultBaseImage(appDirectory, "slim", dockerfileContext.Services, workspace?.RootPath);
 
                         var dockerBuilder = publishMode is not null
                             ? dockerfileContext.Builder.From(baseImage, "build").WorkDir("/app")
@@ -1087,9 +1089,13 @@ public static class JavaScriptHostingExtensions
 
                         var copiedAllSource = false;
 
-                        // Copy package files first for better layer caching
-                        if (packageManager.PackageFilesPatterns.Count > 0)
+                        if (workspace is not null)
                         {
+                            JavaScriptDockerfileEmitter.EmitWorkspaceManifestLayer(dockerBuilder, workspace);
+                        }
+                        else if (packageManager.PackageFilesPatterns.Count > 0)
+                        {
+                            // Copy package files first for better layer caching
                             foreach (var packageFilePattern in packageManager.PackageFilesPatterns)
                             {
                                 dockerBuilder.Copy(packageFilePattern.Source, packageFilePattern.Destination);
@@ -1103,7 +1109,7 @@ public static class JavaScriptHostingExtensions
 
                         if (c.Resource.TryGetLastAnnotation<JavaScriptInstallCommandAnnotation>(out var installCommand))
                         {
-                            dockerBuilder.AddInstallCommand(packageManager, installCommand);
+                            JavaScriptDockerfileEmitter.EmitInstall(dockerBuilder, packageManager, installCommand);
                         }
 
                         if (!copiedAllSource)
@@ -1114,23 +1120,21 @@ public static class JavaScriptHostingExtensions
 
                         if (c.Resource.TryGetLastAnnotation<JavaScriptBuildScriptAnnotation>(out var buildCommand))
                         {
-                            var commandArgs = new List<string>() { packageManager.ExecutableName };
-                            if (!string.IsNullOrEmpty(packageManager.ScriptCommand))
-                            {
-                                commandArgs.Add(packageManager.ScriptCommand);
-                            }
-                            commandArgs.Add(buildCommand.ScriptName);
-                            commandArgs.AddRange(buildCommand.Args);
-
-                            dockerBuilder.Run(string.Join(' ', commandArgs));
+                            dockerBuilder.Run(string.Join(' ', JavaScriptDockerfileEmitter.BuildPackageManagerCommand(packageManager, buildCommand.ScriptName, buildCommand.Args, workspace)));
                         }
+
+                        // In workspace mode, build outputs land under /app/<AppRelativePath>/...; in single-app
+                        // mode they land directly under /app/...
+                        var workspaceAppDir = workspace is not null ? $"/app/{workspace.AppRelativePath}" : "/app";
 
                         switch (publishMode?.Mode)
                         {
                             case JavaScriptPublishMode.StaticWebsite:
                             {
                                 var runtimeImage = baseImageAnnotation?.RuntimeImage ?? DefaultYarpImage;
-                                var distPath = GetContainerFilesSourcePath(publishMode.OutputPath);
+                                var distPath = workspace is not null
+                                    ? ContainerFilesPaths.ForWorkspace(publishMode.OutputPath, workspace)
+                                    : ContainerFilesPaths.ForApp(publishMode.OutputPath);
                                 dockerfileContext.Builder
                                     .From(runtimeImage, "runtime")
                                     .WorkDir("/app")
@@ -1140,8 +1144,13 @@ public static class JavaScriptHostingExtensions
                             }
                             case JavaScriptPublishMode.NodeServer:
                             {
-                                var runtimeImage = baseImageAnnotation?.RuntimeImage ?? GetDefaultBaseImage(appDirectory, "alpine", dockerfileContext.Services);
-                                var outputPath = GetContainerFilesSourcePath(publishMode.OutputPath);
+                                var runtimeImage = baseImageAnnotation?.RuntimeImage ?? NodeVersionResolver.GetDefaultBaseImage(appDirectory, "alpine", dockerfileContext.Services, workspace?.RootPath);
+                                var outputPath = workspace is not null
+                                    ? ContainerFilesPaths.ForWorkspace(publishMode.OutputPath, workspace)
+                                    : ContainerFilesPaths.ForApp(publishMode.OutputPath);
+                                var entrypointPath = workspace is not null
+                                    ? $"{workspace.AppRelativePath}/{JavaScriptResourceValidation.NormalizeRelativePath(publishMode.EntryPoint!)}"
+                                    : JavaScriptResourceValidation.NormalizeRelativePath(publishMode.EntryPoint!);
 
                                 dockerfileContext.Builder
                                     .From(runtimeImage, "runtime")
@@ -1149,12 +1158,57 @@ public static class JavaScriptHostingExtensions
                                     .CopyFrom("build", outputPath, outputPath)
                                     .Env("NODE_ENV", "production")
                                     .User("node")
-                                    .Entrypoint(["node", NormalizeRelativePath(publishMode.EntryPoint!)]);
+                                    .Entrypoint(["node", entrypointPath]);
                                 break;
                             }
                             case JavaScriptPublishMode.PackageScript:
                             {
-                                var runtimeImage = GetPackageScriptRuntimeImage(appDirectory, dockerfileContext.Services, baseImageAnnotation, packageManager, baseImage);
+                                var runtimeImage = GetPackageScriptRuntimeImage(appDirectory, dockerfileContext.Services, baseImageAnnotation, packageManager, baseImage, workspace);
+
+                                // pnpm in workspace mode: use 'pnpm deploy' to materialize a self-contained
+                                // bundle. The standard prod-deps overlay does not work with pnpm workspaces
+                                // because pnpm uses a symlinked node_modules layout (per-app node_modules,
+                                // virtual store under .pnpm, workspace package symlinks pointing into the
+                                // source tree). 'pnpm deploy' copies the target package and its production
+                                // dependencies (workspace deps materialized as content) into a portable
+                                // directory that runs without the workspace tree.
+                                // Prefer pnpm 10's non-legacy deploy only when the project explicitly opts into
+                                // pnpm 10 via package.json#packageManager. Corepack treats that field as the
+                                // project's package-manager contract, so "pnpm@8.x" / "pnpm@9.x" means the app
+                                // was authored and lockfile-tested against that older pnpm major. For those
+                                // projects (and for missing/unparseable packageManager), we keep the legacy
+                                // deploy compatibility path instead of silently forcing pnpm 10 and potentially
+                                // changing lockfile resolution, workspace linking, or deploy semantics. pnpm 10's
+                                // non-legacy deploy also requires injectWorkspacePackages: true; the validator
+                                // checks that only for explicit pnpm 10+ projects so users get an Aspire pipeline
+                                // error before Docker reaches deploy.
+                                // See https://pnpm.io/cli/deploy.
+                                if (workspace is not null && string.Equals(packageManager.ExecutableName, "pnpm", StringComparison.Ordinal))
+                                {
+                                    var deployCommand = PnpmPackageManagerVersion.TryReadMajorVersion(workspace.RootPath) >= 10
+                                        ? $"pnpm --filter={workspace.AppName} --prod deploy /prod/deploy"
+                                        : $"npm_config_force_legacy_deploy=true pnpm --filter={workspace.AppName} --prod deploy /prod/deploy";
+                                    dockerBuilder.Run(deployCommand);
+
+                                    var deployRuntimeStage = dockerfileContext.Builder
+                                        .From(runtimeImage, "runtime")
+                                        .WorkDir("/app")
+                                        .CopyFrom("build", "/prod/deploy", "/app");
+
+                                    IReadOnlyList<string> deployRunArgs = string.IsNullOrWhiteSpace(publishMode.RunScriptArguments)
+                                        ? []
+                                        : [publishMode.RunScriptArguments];
+                                    var deployRunArgv = new List<string> { "pnpm", "run", publishMode.ScriptName! };
+                                    deployRunArgv.AddRange(deployRunArgs);
+                                    var deployRunCommand = string.Join(' ', deployRunArgv);
+
+                                    packageManager.InitializeDockerRuntimeStage?.Invoke(deployRuntimeStage);
+
+                                    deployRuntimeStage
+                                        .Env("NODE_ENV", "production")
+                                        .Entrypoint(["sh", "-c", $"exec {deployRunCommand}"]);
+                                    break;
+                                }
 
                                 // Production dependencies stage for optimized image
                                 var prodDepsStage = dockerfileContext.Builder
@@ -1163,7 +1217,11 @@ public static class JavaScriptHostingExtensions
 
                                 packageManager.InitializeDockerBuildStage?.Invoke(prodDepsStage);
 
-                                if (packageManager.PackageFilesPatterns.Count > 0)
+                                if (workspace is not null)
+                                {
+                                    JavaScriptDockerfileEmitter.EmitWorkspaceManifestLayer(prodDepsStage, workspace);
+                                }
+                                else if (packageManager.PackageFilesPatterns.Count > 0)
                                 {
                                     foreach (var packageFilePattern in packageManager.PackageFilesPatterns)
                                     {
@@ -1195,15 +1253,17 @@ public static class JavaScriptHostingExtensions
                                 }
 
                                 // Runtime stage: copy build output then overlay prod deps
-                                var runCommand = string.IsNullOrWhiteSpace(publishMode.RunScriptArguments)
-                                    ? $"{packageManager.ExecutableName} {packageManager.ScriptCommand ?? "run"} {publishMode.ScriptName}"
-                                    : $"{packageManager.ExecutableName} {packageManager.ScriptCommand ?? "run"} {publishMode.ScriptName} {publishMode.RunScriptArguments}";
+                                IReadOnlyList<string> runArgs = string.IsNullOrWhiteSpace(publishMode.RunScriptArguments)
+                                    ? []
+                                    : [publishMode.RunScriptArguments];
+                                var runArgv = JavaScriptDockerfileEmitter.BuildPackageManagerCommand(packageManager, publishMode.ScriptName!, runArgs, workspace);
+                                var runCommand = string.Join(' ', runArgv);
 
                                 var runtimeStage = dockerfileContext.Builder
                                     .From(runtimeImage, "runtime")
-                                    .WorkDir("/app")
+                                    .WorkDir(workspaceAppDir)
                                     .CopyFrom("build", "/app", "/app")
-                                    .CopyFrom("prod-deps", "/app/node_modules", "./node_modules");
+                                    .CopyFrom("prod-deps", "/app/node_modules", "/app/node_modules");
 
                                 packageManager.InitializeDockerRuntimeStage?.Invoke(runtimeStage);
 
@@ -1214,7 +1274,7 @@ public static class JavaScriptHostingExtensions
                             }
                             case JavaScriptPublishMode.NextStandalone:
                             {
-                                var runtimeImage = baseImageAnnotation?.RuntimeImage ?? GetDefaultBaseImage(appDirectory, "alpine", dockerfileContext.Services);
+                                var runtimeImage = baseImageAnnotation?.RuntimeImage ?? NodeVersionResolver.GetDefaultBaseImage(appDirectory, "alpine", dockerfileContext.Services, workspace?.RootPath);
 
                                 // Match the ownership pattern from the official Next.js sample:
                                 // https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
@@ -1222,11 +1282,11 @@ public static class JavaScriptHostingExtensions
                                     .From(runtimeImage, "runtime")
                                     .WorkDir("/app")
                                     .Env("NODE_ENV", "production")
-                                    .CopyFrom("build", "/app/public", "./public", "node:node")
+                                    .CopyFrom("build", $"{workspaceAppDir}/public", "./public", "node:node")
                                     .Run("mkdir .next")
                                     .Run("chown node:node .next")
-                                    .CopyFrom("build", "/app/.next/standalone", "./", "node:node")
-                                    .CopyFrom("build", "/app/.next/static", "./.next/static", "node:node")
+                                    .CopyFrom("build", $"{workspaceAppDir}/.next/standalone", "./", "node:node")
+                                    .CopyFrom("build", $"{workspaceAppDir}/.next/static", "./.next/static", "node:node")
                                     .User("node")
                                     .Entrypoint(["node", "server.js"]);
                                 break;
@@ -1582,6 +1642,11 @@ public static class JavaScriptHostingExtensions
             }
         }
 
+        // Mark this resource as having a publish-mode choice (NextStandalone) so any later
+        // PublishAsStaticWebsite / PublishAsNodeServer / PublishAsPackageScript call throws instead
+        // of silently last-wins.
+        resourceBuilder.WithAnnotation(new JavaScriptPublishModeChoiceAnnotation(nameof(AddNextJsApp)));
+
         // Add a publish prereq step that validates the Next.js config has standalone output enabled.
         // This runs at deploy time (not resource creation time) so it doesn't block `aspire start`.
         // Can be disabled with .DisableBuildValidation().
@@ -1598,7 +1663,7 @@ public static class JavaScriptHostingExtensions
                 {
                     if (!resourceBuilder.Resource.TryGetLastAnnotation<SuppressPublishValidationAnnotation>(out var suppress))
                     {
-                        ValidateNextJsStandaloneOutput(appDirectory);
+                        JavaScriptResourceValidation.ValidateNextJsStandaloneOutput(appDirectory);
                     }
 
                     return Task.CompletedTask;
@@ -1669,12 +1734,18 @@ public static class JavaScriptHostingExtensions
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        installCommand ??= GetDefaultNpmInstallCommand(resource);
+        var workspaceRoot = TryGetWorkspaceRoot(resource.Resource);
+        var effectiveDir = workspaceRoot ?? resource.Resource.WorkingDirectory;
+        installCommand ??= File.Exists(Path.Combine(effectiveDir, "package-lock.json")) &&
+                           resource.ApplicationBuilder.ExecutionContext.IsPublishMode
+            ? "ci"
+            : "install";
 
         resource
             .WithAnnotation(new JavaScriptPackageManagerAnnotation("npm", runScriptCommand: "run", cacheMount: "/root/.npm")
             {
                 PackageFilesPatterns = { new CopyFilePattern("package*.json", "./") },
+                WorkspaceCommandFactory = WorkspaceCommandFactories.Npm,
             })
             .WithAnnotation(new JavaScriptInstallCommandAnnotation([installCommand, .. installArgs ?? []])
             {
@@ -1719,18 +1790,19 @@ public static class JavaScriptHostingExtensions
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        var workingDirectory = resource.Resource.WorkingDirectory;
-        var hasBunLock = File.Exists(Path.Combine(workingDirectory, "bun.lock")) ||
-            File.Exists(Path.Combine(workingDirectory, "bun.lockb"));
+        var workspaceRoot = TryGetWorkspaceRoot(resource.Resource);
+        var effectiveDir = workspaceRoot ?? resource.Resource.WorkingDirectory;
+        var hasBunLock = File.Exists(Path.Combine(effectiveDir, "bun.lock")) ||
+            File.Exists(Path.Combine(effectiveDir, "bun.lockb"));
 
         installArgs ??= GetDefaultBunInstallArgs(resource, hasBunLock);
 
         var packageFilesSourcePattern = "package.json";
-        if (File.Exists(Path.Combine(workingDirectory, "bun.lock")))
+        if (File.Exists(Path.Combine(effectiveDir, "bun.lock")))
         {
             packageFilesSourcePattern += " bun.lock";
         }
-        if (File.Exists(Path.Combine(workingDirectory, "bun.lockb")))
+        if (File.Exists(Path.Combine(effectiveDir, "bun.lockb")))
         {
             packageFilesSourcePattern += " bun.lockb";
         }
@@ -1742,6 +1814,7 @@ public static class JavaScriptHostingExtensions
                 // bun supports passing script flags without the `--` separator.
                 CommandSeparator = null,
                 ResolvePackageScriptRuntimeImage = buildImage => buildImage,
+                WorkspaceCommandFactory = WorkspaceCommandFactories.Bun,
             })
             .WithAnnotation(new JavaScriptInstallCommandAnnotation(["install", .. installArgs])
             {
@@ -1769,11 +1842,8 @@ public static class JavaScriptHostingExtensions
             ? ["--frozen-lockfile"]
             : [];
 
-    private static string GetDefaultNpmInstallCommand(IResourceBuilder<JavaScriptAppResource> resource) =>
-        resource.ApplicationBuilder.ExecutionContext.IsPublishMode &&
-            File.Exists(Path.Combine(resource.Resource.WorkingDirectory, "package-lock.json"))
-            ? "ci"
-            : "install";
+    private static string? TryGetWorkspaceRoot(IResource resource) =>
+        resource.TryGetLastAnnotation<JavaScriptWorkspaceConfigAnnotation>(out var ws) ? ws.RootPath : null;
 
     /// <summary>
     /// Configures the Node.js resource to use yarn as the package manager and optionally installs packages before the application starts.
@@ -1788,10 +1858,12 @@ public static class JavaScriptHostingExtensions
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        var workingDirectory = resource.Resource.WorkingDirectory;
-        var hasYarnLock = File.Exists(Path.Combine(workingDirectory, "yarn.lock"));
-        var hasYarnrc = File.Exists(Path.Combine(workingDirectory, ".yarnrc.yml"));
-        var hasYarnBerryDir = Directory.Exists(Path.Combine(workingDirectory, ".yarn"));
+        var workspaceRoot = TryGetWorkspaceRoot(resource.Resource);
+        var inWorkspace = workspaceRoot is not null;
+        var effectiveDir = workspaceRoot ?? resource.Resource.WorkingDirectory;
+        var hasYarnLock = File.Exists(Path.Combine(effectiveDir, "yarn.lock"));
+        var hasYarnrc = File.Exists(Path.Combine(effectiveDir, ".yarnrc.yml"));
+        var hasYarnBerryDir = Directory.Exists(Path.Combine(effectiveDir, ".yarn"));
         var hasYarnBerry = hasYarnrc || hasYarnBerryDir;
 
         installArgs ??= GetDefaultYarnInstallArgs(resource, hasYarnLock, hasYarnBerry);
@@ -1803,21 +1875,28 @@ public static class JavaScriptHostingExtensions
             // Yarn v1 strips the separator automatically but produces the warning suggesting to remove it.
             // Later Yarn versions don't strip the separator and pass it to the script as-is, causing Vite to ignore subsequent arguments.
             CommandSeparator = null,
+            WorkspaceCommandFactory = WorkspaceCommandFactories.Yarn,
         };
-        var packageFilesSourcePattern = "package.json";
-        if (hasYarnLock)
-        {
-            packageFilesSourcePattern += " yarn.lock";
-        }
-        if (hasYarnrc)
-        {
-            packageFilesSourcePattern += " .yarnrc.yml";
-        }
-        packageManager.PackageFilesPatterns.Add(new CopyFilePattern(packageFilesSourcePattern, "./"));
 
-        if (hasYarnBerryDir)
+        // Workspace mode uses the workspace annotation's RootFiles/RootDirs for the manifest layer; the
+        // per-app PackageFilesPatterns is only meaningful for single-app mode.
+        if (!inWorkspace)
         {
-            packageManager.PackageFilesPatterns.Add(new CopyFilePattern(".yarn", "./.yarn"));
+            var packageFilesSourcePattern = "package.json";
+            if (hasYarnLock)
+            {
+                packageFilesSourcePattern += " yarn.lock";
+            }
+            if (hasYarnrc)
+            {
+                packageFilesSourcePattern += " .yarnrc.yml";
+            }
+            packageManager.PackageFilesPatterns.Add(new CopyFilePattern(packageFilesSourcePattern, "./"));
+
+            if (hasYarnBerryDir)
+            {
+                packageManager.PackageFilesPatterns.Add(new CopyFilePattern(".yarn", "./.yarn"));
+            }
         }
 
         resource
@@ -1867,9 +1946,10 @@ public static class JavaScriptHostingExtensions
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        var workingDirectory = resource.Resource.WorkingDirectory;
-        var hasPnpmLock = File.Exists(Path.Combine(workingDirectory, "pnpm-lock.yaml"));
-        var hasPnpmWorkspace = File.Exists(Path.Combine(workingDirectory, "pnpm-workspace.yaml"));
+        var workspaceRoot = TryGetWorkspaceRoot(resource.Resource);
+        var effectiveDir = workspaceRoot ?? resource.Resource.WorkingDirectory;
+        var hasPnpmLock = File.Exists(Path.Combine(effectiveDir, "pnpm-lock.yaml"));
+        var hasPnpmWorkspace = File.Exists(Path.Combine(effectiveDir, "pnpm-workspace.yaml"));
 
         installArgs ??= GetDefaultPnpmInstallArgs(resource, hasPnpmLock);
 
@@ -1898,6 +1978,7 @@ public static class JavaScriptHostingExtensions
                     // the first container start can try to download pnpm before running the app.
                     stage.Run("corepack enable pnpm && pnpm --version");
                 },
+                WorkspaceCommandFactory = WorkspaceCommandFactories.Pnpm,
             })
             .WithAnnotation(new JavaScriptInstallCommandAnnotation(["install", .. installArgs])
             {
@@ -2151,6 +2232,11 @@ public static class JavaScriptHostingExtensions
 
             resource.ApplicationBuilder.OnBeforeStart((_, _) =>
             {
+                // Validate workspace configuration (if any) before reading annotations. This makes
+                // misconfigured workspaces surface as a resource startup error rather than during
+                // the installer's actual `npm/yarn/pnpm/bun install` invocation.
+                WorkspaceConfigurationValidator.ValidateAndAttach(resource.Resource);
+
                 // set the installer's working directory to match the resource's working directory
                 // and set the install command and args based on the resource's annotations
                 if (!resource.Resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var packageManager) ||
@@ -2159,9 +2245,15 @@ public static class JavaScriptHostingExtensions
                     throw new InvalidOperationException("JavaScriptPackageManagerAnnotation and JavaScriptInstallCommandAnnotation are required when installing packages.");
                 }
 
+                // In workspace mode, run install at the workspace root so the lockfile and
+                // workspace config (pnpm-workspace.yaml, package.json#workspaces, etc.) are picked up.
+                var installWorkingDirectory = resource.Resource.TryGetLastAnnotation<JavaScriptWorkspaceAnnotation>(out var workspace)
+                    ? workspace.RootPath
+                    : resource.Resource.WorkingDirectory;
+
                 installerBuilder
                     .WithCommand(packageManager.ExecutableName)
-                    .WithWorkingDirectory(resource.Resource.WorkingDirectory)
+                    .WithWorkingDirectory(installWorkingDirectory)
                     .WithArgs(installCommand.Args);
 
                 return Task.CompletedTask;
@@ -2182,23 +2274,6 @@ public static class JavaScriptHostingExtensions
             resource.WithAnnotation(new JavaScriptPackageInstallerAnnotation(installer));
         }
     }
-
-    private static string GetDefaultBaseImage(string appDirectory, string defaultSuffix, IServiceProvider serviceProvider)
-    {
-        var logger = serviceProvider.GetService<ILogger<JavaScriptAppResource>>() ?? NullLogger<JavaScriptAppResource>.Instance;
-        var nodeVersion = ResolveNodeVersion(appDirectory, logger);
-        return $"node:{nodeVersion}-{defaultSuffix}";
-    }
-
-    private static string GetContainerFilesSourcePath(string outputPath)
-    {
-        var normalizedPath = NormalizeRelativePath(outputPath);
-        return string.IsNullOrEmpty(normalizedPath) || normalizedPath == "."
-            ? "/app"
-            : $"/app/{normalizedPath}";
-    }
-
-    private static readonly string[] s_nextConfigFileNames = ["next.config.ts", "next.config.js", "next.config.mjs"];
 
     /// <summary>
     /// Builds a service discovery URL for the given resource, preferring HTTPS when available.
@@ -2222,198 +2297,18 @@ public static class JavaScriptHostingExtensions
     }
 
     /// <summary>
-    /// Validates that the Next.js config file contains <c>output: "standalone"</c>.
+    /// Throws if the resource already has a publish-mode choice attached. This catches users
+    /// who chained two contradictory <c>PublishAs*</c> calls (or chained <c>PublishAs*</c>
+    /// after <c>AddNextJsApp</c>, which itself implies a publish mode).
     /// </summary>
-    internal static void ValidateNextJsStandaloneOutput(string appDirectory)
+    private static void ThrowIfPublishModeAlreadySet(IResource resource, string callerName)
     {
-        foreach (var configFileName in s_nextConfigFileNames)
+        if (resource.TryGetLastAnnotation<JavaScriptPublishModeChoiceAnnotation>(out var existing))
         {
-            var configPath = Path.Combine(appDirectory, configFileName);
-            if (!File.Exists(configPath))
-            {
-                continue;
-            }
-
-            try
-            {
-                var content = File.ReadAllText(configPath);
-
-                // Check for quoted "standalone" (double or single quotes) to reduce false positives
-                if (!content.Contains("\"standalone\"") && !content.Contains("'standalone'"))
-                {
-                    throw new InvalidOperationException(
-                        $"The Next.js config file '{configFileName}' does not contain 'output: \"standalone\"'. " +
-                        "AddNextJsApp requires Next.js standalone output mode to generate a working Dockerfile. " +
-                        "Add 'output: \"standalone\"' to the nextConfig object in your Next.js config file.");
-                }
-            }
-            catch (IOException)
-            {
-                // If we can't read the config, skip the check — the Docker build will surface the error.
-            }
-
-            return;
+            throw new InvalidOperationException(
+                $"Resource '{resource.Name}' already has a publish mode set by {existing.MethodName}; " +
+                $"{callerName} cannot also be applied. Remove one of the two publish-mode calls.");
         }
-
-        throw new InvalidOperationException(
-            "No Next.js configuration file found. AddNextJsApp expects one of: " +
-            string.Join(", ", s_nextConfigFileNames));
-    }
-
-    private static void ValidateApiPath(string apiPath)
-    {
-        foreach (var c in apiPath)
-        {
-            if (!char.IsAsciiLetterOrDigit(c) && c is not '/' and not '-' and not '_')
-            {
-                throw new ArgumentException($"The apiPath must contain only URL-safe path characters (alphanumeric, '/', '-', '_'). Invalid character: '{c}'", nameof(apiPath));
-            }
-        }
-    }
-
-    private static string NormalizeRelativePath(string path)
-    {
-        var normalizedPath = path.Replace('\\', '/');
-
-        if (normalizedPath.StartsWith("./", StringComparison.Ordinal))
-        {
-            normalizedPath = normalizedPath[2..];
-        }
-
-        if (normalizedPath.StartsWith('/'))
-        {
-            throw new ArgumentException("The path must be a relative path.", nameof(path));
-        }
-
-        // Reject path traversal segments. These are virtual Docker container paths (not host
-        // filesystem paths), so Path.GetFullPath cannot be used — it produces platform-specific
-        // results (e.g. D:\app\dist on Windows). Segment-based validation works correctly
-        // cross-platform for container paths.
-        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        foreach (var segment in segments)
-        {
-            if (segment == "..")
-            {
-                throw new ArgumentException("The path must not contain \"..\" segments.", nameof(path));
-            }
-        }
-
-        return string.Join('/', segments);
-    }
-
-    /// <summary>
-    /// Resolves the Node.js version to use for a project by checking common configuration files.
-    /// </summary>
-    /// <param name="workingDirectory">The working directory of the Node.js project.</param>
-    /// <param name="logger">The logger for diagnostic messages.</param>
-    /// <returns>The resolved Node.js major version number as a string.</returns>
-    private static string ResolveNodeVersion(string workingDirectory, ILogger logger)
-    {
-        // Follow the same shape as Cloud Native Buildpacks-style tooling for Node selection:
-        // pinned toolchain files (.nvmrc, .node-version, .tool-versions) are treated as
-        // authoritative runtime intent, while package.json engines.node is compatibility
-        // metadata rather than a deployment image pin. If there is no explicit toolchain pin,
-        // generated Dockerfiles fall back to Aspire's preferred default Node major.
-        if (TryDetectPinnedNodeVersion(workingDirectory, logger, out var pinnedNodeVersion))
-        {
-            return pinnedNodeVersion;
-        }
-
-        logger.LogDebug("No Node.js version detected, using default version {DefaultVersion}", DefaultNodeVersion);
-        return DefaultNodeVersion;
-    }
-
-    private static bool TryDetectPinnedNodeVersion(string workingDirectory, ILogger logger, out string nodeVersion)
-    {
-        nodeVersion = string.Empty;
-
-        // Check .nvmrc file
-        var nvmrcPath = Path.Combine(workingDirectory, ".nvmrc");
-        if (File.Exists(nvmrcPath))
-        {
-            var versionString = File.ReadAllText(nvmrcPath).Trim();
-            if (TryParseNodeVersion(versionString, out var version))
-            {
-                logger.LogDebug("Detected Node.js version {Version} from .nvmrc file", version);
-                nodeVersion = version;
-                return true;
-            }
-        }
-
-        // Check .node-version file
-        var nodeVersionPath = Path.Combine(workingDirectory, ".node-version");
-        if (File.Exists(nodeVersionPath))
-        {
-            var versionString = File.ReadAllText(nodeVersionPath).Trim();
-            if (TryParseNodeVersion(versionString, out var version))
-            {
-                logger.LogDebug("Detected Node.js version {Version} from .node-version file", version);
-                nodeVersion = version;
-                return true;
-            }
-        }
-
-        // Check .tool-versions file (asdf)
-        var toolVersionsPath = Path.Combine(workingDirectory, ".tool-versions");
-        if (File.Exists(toolVersionsPath))
-        {
-            var lines = File.ReadAllLines(toolVersionsPath);
-            foreach (var line in lines)
-            {
-                var trimmedLine = line.Trim();
-                var parts = trimmedLine.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length > 1 &&
-                    (string.Equals(parts[0], "nodejs", StringComparison.Ordinal) ||
-                     string.Equals(parts[0], "node", StringComparison.Ordinal)))
-                {
-                    if (TryParseNodeVersion(parts[1], out var version))
-                    {
-                        logger.LogDebug("Detected Node.js version {Version} from .tool-versions file", version);
-                        nodeVersion = version;
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Attempts to parse a Node.js version string and extract the major version number.
-    /// </summary>
-    /// <param name="versionString">The version string to parse (e.g., "22", "v22.1.0", ">=20.12", "^18.0.0").</param>
-    /// <param name="majorVersion">The extracted major version number as a string.</param>
-    /// <returns>True if the version was successfully parsed, false otherwise.</returns>
-    private static bool TryParseNodeVersion(string versionString, out string majorVersion)
-    {
-        majorVersion = string.Empty;
-
-        if (string.IsNullOrWhiteSpace(versionString))
-        {
-            return false;
-        }
-
-        // Remove common prefixes and operators (handle multi-character operators first)
-        var cleaned = versionString.Trim();
-        string[] operators = [">=", "<=", "==", ">", "<", "=", "~", "^", "v", "V"];
-        foreach (var op in operators)
-        {
-            if (cleaned.StartsWith(op, StringComparison.Ordinal))
-            {
-                cleaned = cleaned.Substring(op.Length).TrimStart();
-                break;
-            }
-        }
-        var cleanedVersion = cleaned.Split('.', '-', ' ')[0]; // Take only the major version part
-
-        // Try to parse as integer
-        if (int.TryParse(cleanedVersion, NumberStyles.None, CultureInfo.InvariantCulture, out var majorVersionNumber) && majorVersionNumber > 0)
-        {
-            majorVersion = majorVersionNumber.ToString(CultureInfo.InvariantCulture);
-            return true;
-        }
-
-        return false;
+        resource.Annotations.Add(new JavaScriptPublishModeChoiceAnnotation(callerName));
     }
 }

--- a/src/Aspire.Hosting.JavaScript/JavaScriptPackageManagerAnnotation.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptPackageManagerAnnotation.cs
@@ -57,4 +57,9 @@ public sealed class JavaScriptPackageManagerAnnotation(string executableName, st
     /// Gets or sets a callback to resolve the default <c>PublishAsPackageScript</c> runtime image from the build image.
     /// </summary>
     internal Func<string, string>? ResolvePackageScriptRuntimeImage { get; init; }
+
+    /// <summary>
+    /// Gets or sets a callback that builds the command arguments for invoking a script on a workspace member.
+    /// </summary>
+    internal Func<string, string, IReadOnlyList<string>, IReadOnlyList<string>>? WorkspaceCommandFactory { get; init; }
 }

--- a/src/Aspire.Hosting.JavaScript/JavaScriptWorkspaceAnnotation.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptWorkspaceAnnotation.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.JavaScript;
+
+/// <summary>
+/// Indicates that a JavaScript application is a member of a JavaScript workspace (yarn / npm / pnpm / bun
+/// monorepo) and carries the metadata required to generate a workspace-aware Dockerfile.
+/// </summary>
+/// <remarks>
+/// This annotation is attached by <c>WithWorkspaceRoot</c>. When present, Dockerfile generation switches
+/// the build context to <see cref="RootPath"/>, copies workspace-level manifests, runs install at the root,
+/// and uses the package manager's native workspace filter to build and start <see cref="AppName"/>.
+/// </remarks>
+public sealed class JavaScriptWorkspaceAnnotation : IResourceAnnotation
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JavaScriptWorkspaceAnnotation"/> class.
+    /// </summary>
+    /// <param name="rootPath">The absolute path to the workspace root directory.</param>
+    /// <param name="appName">The package name of the application as declared in <c>&lt;appDir&gt;/package.json</c>.</param>
+    /// <param name="appRelativePath">The forward-slash relative path from <paramref name="rootPath"/> to the application directory.</param>
+    /// <param name="workspaceDirs">Resolved workspace member directories (forward-slash relative paths under <paramref name="rootPath"/>).</param>
+    /// <param name="rootFiles">Workspace-root files to copy into the manifest layer (forward-slash relative paths). Includes the lockfile and PM-specific config files when present.</param>
+    /// <param name="rootDirs">Workspace-root directories to copy into the manifest layer (forward-slash relative paths). For example, Yarn Berry's <c>.yarn</c> directory.</param>
+    public JavaScriptWorkspaceAnnotation(
+        string rootPath,
+        string appName,
+        string appRelativePath,
+        IReadOnlyList<string> workspaceDirs,
+        IReadOnlyList<string> rootFiles,
+        IReadOnlyList<string> rootDirs)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rootPath);
+        ArgumentException.ThrowIfNullOrEmpty(appName);
+        ArgumentException.ThrowIfNullOrEmpty(appRelativePath);
+        ArgumentNullException.ThrowIfNull(workspaceDirs);
+        ArgumentNullException.ThrowIfNull(rootFiles);
+        ArgumentNullException.ThrowIfNull(rootDirs);
+
+        RootPath = rootPath;
+        AppName = appName;
+        AppRelativePath = appRelativePath;
+        WorkspaceDirs = workspaceDirs;
+        RootFiles = rootFiles;
+        RootDirs = rootDirs;
+    }
+
+    /// <summary>
+    /// Gets the absolute path to the workspace root directory. This becomes the Docker build context.
+    /// </summary>
+    public string RootPath { get; }
+
+    /// <summary>
+    /// Gets the package name of this application as declared in its <c>package.json</c>. Used to drive
+    /// the package manager's native workspace filter (for example <c>pnpm --filter &lt;name&gt;</c>).
+    /// </summary>
+    public string AppName { get; }
+
+    /// <summary>
+    /// Gets the forward-slash relative path from <see cref="RootPath"/> to this application's directory.
+    /// Used to set the runtime stage <c>WORKDIR</c> so that entry points and build outputs resolve correctly.
+    /// </summary>
+    public string AppRelativePath { get; }
+
+    /// <summary>
+    /// Gets the resolved workspace member directories (forward-slash relative paths under
+    /// <see cref="RootPath"/>). Each entry's <c>package.json</c> is copied into the Dockerfile manifest
+    /// layer for cache-friendly dependency installation.
+    /// </summary>
+    public IReadOnlyList<string> WorkspaceDirs { get; }
+
+    /// <summary>
+    /// Gets the workspace-root files to copy into the Dockerfile manifest layer (forward-slash relative
+    /// paths). Includes the lockfile and any package-manager-specific config files (for example
+    /// <c>pnpm-workspace.yaml</c>, <c>.yarnrc.yml</c>, <c>.npmrc</c>, <c>bunfig.toml</c>) when present.
+    /// </summary>
+    public IReadOnlyList<string> RootFiles { get; }
+
+    /// <summary>
+    /// Gets the workspace-root directories to copy into the Dockerfile manifest layer (forward-slash
+    /// relative paths). For example, Yarn Berry's <c>.yarn</c> directory.
+    /// </summary>
+    public IReadOnlyList<string> RootDirs { get; }
+}

--- a/src/Aspire.Hosting.JavaScript/JavaScriptWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptWorkspaceExtensions.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.JavaScript;
+using Aspire.Hosting.JavaScript.Internal;
+using Aspire.Hosting.JavaScript.Internal.Workspace;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Workspace-related extensions for JavaScript application resources.
+/// </summary>
+public static class JavaScriptWorkspaceExtensions
+{
+    /// <summary>
+    /// Marks the JavaScript application as a member of a JavaScript workspace (yarn / npm / pnpm / bun
+    /// monorepo) rooted at <paramref name="rootPath"/>. In publish mode, the auto-generated Dockerfile
+    /// uses the workspace root as its build context, copies workspace-level manifests, runs install at the
+    /// root, and uses the configured package manager's native workspace filter to build and start this
+    /// resource.
+    /// </summary>
+    /// <ats-summary>Marks the JavaScript application as a member of a workspace and specifies the workspace root path.</ats-summary>
+    /// <typeparam name="TResource">The JavaScript application resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="rootPath">
+    /// Path to the workspace root directory. Resolved against the AppHost's directory when relative.
+    /// The directory must contain either a <c>package.json</c> with a <c>workspaces</c> field, or a
+    /// <c>pnpm-workspace.yaml</c>.
+    /// </param>
+    /// <returns>The resource builder for chaining.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="rootPath"/> is null or empty (an API contract violation).
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when this method is called more than once on the same resource — the user
+    /// contradicted themselves in code by declaring two different workspace roots.
+    /// </exception>
+    /// <remarks>
+    /// Workspace state is validated at publish time (during <c>aspire publish</c> /
+    /// <c>aspire do build</c>) and at run-mode startup (during <c>dotnet run</c> on the AppHost).
+    /// Misconfigured workspaces — missing or malformed <c>package.json</c>, no lockfile, the app not
+    /// being declared as a member, etc. — surface there as a single
+    /// <see cref="DistributedApplicationException"/> listing every problem found, rather than as
+    /// exceptions thrown from this method. The intent is that "my repo configuration is wrong" feels
+    /// like an Aspire pipeline / run-mode error, not like a bug in the AppHost code.
+    /// </remarks>
+    /// <example>
+    /// Configure a Vite app inside a pnpm workspace:
+    /// <code lang="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// builder.AddViteApp("web", "../monorepo/packages/web")
+    ///        .WithWorkspaceRoot("../monorepo")
+    ///        .WithPnpm();
+    ///
+    /// builder.Build().Run();
+    /// </code>
+    /// </example>
+    [Experimental("ASPIREJAVASCRIPT001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExport]
+    public static IResourceBuilder<TResource> WithWorkspaceRoot<TResource>(this IResourceBuilder<TResource> builder, string rootPath)
+        where TResource : JavaScriptAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(rootPath);
+
+        var resource = builder.Resource;
+
+        if (resource.TryGetLastAnnotation<JavaScriptWorkspaceConfigAnnotation>(out var existing))
+        {
+            throw new InvalidOperationException(
+                $"Resource '{resource.Name}' already has a workspace root '{existing.RootPath}'. " +
+                $"{nameof(WithWorkspaceRoot)} can only be called once per resource.");
+        }
+
+        // Resolve the path. This is pure path arithmetic — no I/O, no validation. The validator runs
+        // later (publish-mode Dockerfile generation, run-mode installer startup) and is responsible
+        // for surfacing all configuration errors as a DistributedApplicationException.
+        var resolvedRoot = PathNormalizer.NormalizePathForCurrentPlatform(
+            Path.GetFullPath(rootPath, builder.ApplicationBuilder.AppHostDirectory));
+        var resolvedAppDir = PathNormalizer.NormalizePathForCurrentPlatform(
+            Path.GetFullPath(resource.WorkingDirectory));
+
+        builder.WithAnnotation(new JavaScriptWorkspaceConfigAnnotation(resolvedRoot, resolvedAppDir));
+
+        // If a package manager has already been configured (e.g. AddViteApp auto-attaches WithNpm),
+        // re-evaluate the install command using the workspace root so 'npm ci' / pnpm 'frozen-lockfile'
+        // etc. correctly reflect the lockfile location. This is a best-effort I/O read — if files
+        // aren't there yet, the reconfigurer falls back to defaults; the validator catches any actual
+        // problem.
+        if (resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var pm))
+        {
+            WorkspacePackageManagerReconfigurer.Reconfigure(builder, pm.ExecutableName, resolvedRoot);
+        }
+
+        // PublishAsDockerFile invokes its configure callback eagerly at registration time. When
+        // WithWorkspaceRoot is called after PublishAsDockerFile (the typical case for AddNodeApp /
+        // AddViteApp / AddNextJsApp where PublishAsDockerFile is wired up internally), the
+        // DockerfileBuildAnnotation has already been created with the application directory as its
+        // context path. We need to swap that for the workspace root so Docker actually sees the
+        // root-level package.json and lockfile.
+        if (resource.TryGetLastAnnotation<DockerfileBuildAnnotation>(out var oldDockerfileAnnotation))
+        {
+            var newAnnotation = new DockerfileBuildAnnotation(
+                contextPath: resolvedRoot,
+                dockerfilePath: oldDockerfileAnnotation.DockerfilePath,
+                stage: oldDockerfileAnnotation.Stage)
+            {
+                DockerfileFactory = oldDockerfileAnnotation.DockerfileFactory,
+                ImageName = oldDockerfileAnnotation.ImageName,
+                ImageTag = oldDockerfileAnnotation.ImageTag,
+                HasEntrypoint = oldDockerfileAnnotation.HasEntrypoint,
+            };
+            foreach (var kvp in oldDockerfileAnnotation.BuildArguments)
+            {
+                newAnnotation.BuildArguments[kvp.Key] = kvp.Value;
+            }
+            foreach (var kvp in oldDockerfileAnnotation.BuildSecrets)
+            {
+                newAnnotation.BuildSecrets[kvp.Key] = kvp.Value;
+            }
+            builder.WithAnnotation(newAnnotation, ResourceAnnotationMutationBehavior.Replace);
+        }
+
+        return builder;
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/JavaScriptWorkspaceReader.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptWorkspaceReader.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aspire.Hosting.JavaScript.Internal.Workspace;
+
+namespace Aspire.Hosting.JavaScript;
+
+/// <summary>
+/// Thin facade over the workspace reader components in
+/// <see cref="Internal.Workspace"/>. Existing call sites in
+/// <see cref="JavaScriptWorkspaceExtensions"/> use this entry point; new code
+/// should prefer the more focused helpers under <c>Internal.Workspace</c>.
+/// </summary>
+internal static class JavaScriptWorkspaceReader
+{
+    /// <summary>
+    /// Reads the <c>name</c> field from <c>&lt;directory&gt;/package.json</c>, e.g.
+    /// <c>{ "name": "@example/web" }</c>.
+    /// </summary>
+    /// <returns>
+    /// The package name, or <see langword="null"/> when the file does not exist or has no
+    /// <c>name</c> field.
+    /// </returns>
+    public static string? TryReadPackageName(string directory)
+    {
+        var packageJsonPath = Path.Combine(directory, "package.json");
+        if (!File.Exists(packageJsonPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(packageJsonPath);
+            var packageJson = JsonSerializer.Deserialize<PackageJsonNameInfo>(stream);
+            if (packageJson?.Name is { Length: > 0 } name)
+            {
+                return name;
+            }
+        }
+        catch (JsonException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reads workspace member glob patterns declared at the given root by combining
+    /// <c>package.json#workspaces</c> (string array form, or <c>{ "packages": [...] }</c>
+    /// form) and <c>pnpm-workspace.yaml#packages</c> (for example,
+    /// <c>packages: ["packages/*", "apps/web"]</c>).
+    /// </summary>
+    /// <returns>
+    /// The list of glob patterns in declaration order. Negated and otherwise
+    /// unsupported patterns are returned for caller validation; see
+    /// <see cref="WorkspacePatternValidator"/>.
+    /// </returns>
+    public static IReadOnlyList<string> ReadWorkspacePatterns(string rootPath)
+    {
+        var patterns = new List<string>();
+
+        var packageJsonPath = Path.Combine(rootPath, "package.json");
+        if (File.Exists(packageJsonPath))
+        {
+            try
+            {
+                var content = File.ReadAllText(packageJsonPath);
+                patterns.AddRange(PackageJsonWorkspacesParser.Parse(content));
+            }
+            catch (IOException)
+            {
+            }
+        }
+
+        var pnpmYamlPath = Path.Combine(rootPath, "pnpm-workspace.yaml");
+        if (File.Exists(pnpmYamlPath))
+        {
+            try
+            {
+                var content = File.ReadAllText(pnpmYamlPath);
+                patterns.AddRange(PnpmWorkspaceYamlParser.Parse(content));
+            }
+            catch (IOException)
+            {
+            }
+        }
+
+        return patterns;
+    }
+
+    /// <summary>
+    /// Expands workspace glob patterns to actual member directories under
+    /// <paramref name="rootPath"/>.
+    /// </summary>
+    public static IReadOnlyList<string> ExpandWorkspacePatterns(string rootPath, IEnumerable<string> patterns)
+        => WorkspacePatternExpander.Expand(rootPath, patterns);
+
+    private sealed class PackageJsonNameInfo
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+    }
+}

--- a/src/Aspire.Hosting.JavaScript/README.md
+++ b/src/Aspire.Hosting.JavaScript/README.md
@@ -24,6 +24,61 @@ builder.AddJavaScriptApp("frontend", "../frontend", "app.js");
 builder.Build().Run();
 ```
 
+## Monorepo / workspace support
+
+When the JavaScript app lives inside an npm / yarn / pnpm / bun workspace (a monorepo), the auto-generated Dockerfile must use the workspace **root** as its build context so the root `package.json`, lockfile, and sibling workspace member manifests are visible to `docker build`. Use `WithWorkspaceRoot` to opt in:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddViteApp("web", "../monorepo/packages/web")
+       .WithWorkspaceRoot("../monorepo")
+       .WithPnpm();
+
+builder.Build().Run();
+```
+
+`WithWorkspaceRoot` accepts a path relative to the AppHost directory (or an absolute path) pointing at the workspace root. The root must contain:
+
+- A `package.json` with a `workspaces` field (npm / yarn / bun), **or** a `pnpm-workspace.yaml` listing `packages`.
+- A recognized lockfile: `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, or `bun.lockb`.
+
+The application's directory must be a declared workspace member, and its `package.json` must have a non-empty `name` field (the name is used by the package manager's workspace filter to build and run only this app).
+
+The generated Dockerfile will:
+
+1. Use the workspace root as the build context.
+2. Copy the workspace root's `package.json`, lockfile, optional manifest files (`pnpm-workspace.yaml`, `.yarnrc.yml`, `.npmrc`, `bunfig.toml`), the `.yarn/` directory if present, and every workspace member's `package.json` (cache-friendly).
+3. Run `install` at the workspace root so transitive deps and `workspace:*` dependencies resolve correctly.
+4. Run `build` (and `start` for `PublishAsPackageScript`) using the package manager's native workspace filter syntax:
+   - `npm run <script> --workspace=<app-package-name>`
+   - `yarn workspace <app-package-name> run <script>`
+   - `pnpm --filter <app-package-name> run <script>`
+   - `bun run --filter <app-package-name> <script>`
+5. Set the runtime stage `WORKDIR` to `/app/<app-relative-path>` so existing entrypoint paths keep working.
+
+> **pnpm + `PublishAsPackageScript`**: pnpm's symlinked `node_modules` layout cannot be flattened via the standard production-deps overlay used for npm/yarn/bun. For pnpm workspace apps that use `PublishAsPackageScript`, the generated Dockerfile uses [`pnpm deploy`](https://pnpm.io/cli/deploy) to materialize the target package and its production dependencies (workspace deps copied as content) into a self-contained directory. The runtime stage runs `pnpm run <start-script>` against this deployed bundle. If the workspace root declares `packageManager: "pnpm@10..."`, Aspire uses pnpm 10's non-legacy deploy path and validates that `pnpm-workspace.yaml` contains `injectWorkspacePackages: true`. For pnpm 8/9 or missing/unparseable pnpm versions, Aspire keeps the legacy deploy compatibility path instead of silently overriding the project's declared package-manager major version.
+
+### Required `.dockerignore`
+
+The build context becomes the entire workspace root, so a `.dockerignore` at the workspace root is strongly recommended to keep the build context small and avoid leaking sensitive files. A reasonable starting point:
+
+```text
+**/node_modules
+**/.git
+**/.next
+**/dist
+**/build
+**/coverage
+**/.turbo
+**/.cache
+**/.env*
+!**/.env.example
+**/*.log
+```
+
+Aspire does not generate or modify `.dockerignore`; you must commit one yourself.
+
 ## Additional documentation
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-javascript
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-node

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptWorkspacePublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaScriptWorkspacePublishTests.cs
@@ -1,0 +1,185 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end test for the JavaScript workspace (npm/yarn/pnpm/bun monorepo) publish flow. Creates
+/// a TypeScript AppHost in a workspace root that contains a single Node.js workspace member, calls
+/// <c>withWorkspaceRoot</c>, and verifies that <c>aspire publish</c> generates a Dockerfile whose
+/// build context is the workspace root and which copies workspace-level manifests before installing.
+/// </summary>
+public sealed class JavaScriptWorkspacePublishTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task PublishWithWorkspaceRoot_NpmMonorepo_GeneratesWorkspaceDockerfile()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        using var workspace = TemporaryWorkspace.Create(output);
+
+        // Lay out a tiny npm workspace before launching the CLI:
+        //
+        //   <workspace>/
+        //     package.json          (root, declares "packages/*" workspace)
+        //     package-lock.json     (lockfile required by WithWorkspaceRoot)
+        //     apphost/              (AppHost lives here; aspire init runs from this dir)
+        //     packages/
+        //       web/
+        //         package.json      (declares name "@example/web")
+        //         server.js
+        var root = workspace.WorkspaceRoot.FullName;
+        File.WriteAllText(
+            Path.Combine(root, "package.json"),
+            "{\"name\":\"workspace-root\",\"private\":true,\"workspaces\":[\"packages/*\"]}");
+        File.WriteAllText(
+            Path.Combine(root, "package-lock.json"),
+            """
+            {
+              "name": "workspace-root",
+              "lockfileVersion": 3,
+              "requires": true,
+              "packages": {
+                "": {
+                  "name": "workspace-root",
+                  "workspaces": [
+                    "packages/*"
+                  ]
+                },
+                "node_modules/@example/web": {
+                  "resolved": "packages/web",
+                  "link": true
+                },
+                "packages/web": {
+                  "name": "@example/web",
+                  "version": "1.0.0"
+                }
+              }
+            }
+            """);
+
+        var webDir = Path.Combine(root, "packages", "web");
+        Directory.CreateDirectory(webDir);
+        File.WriteAllText(
+            Path.Combine(webDir, "package.json"),
+            "{\"name\":\"@example/web\",\"version\":\"1.0.0\",\"scripts\":{\"start\":\"node server.js\"}}");
+        File.WriteAllText(
+            Path.Combine(webDir, "server.js"),
+            "require('http').createServer((_,r)=>r.end('ok')).listen(3000);");
+
+        var appHostDir = Path.Combine(root, "apphost");
+        Directory.CreateDirectory(appHostDir);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.DotNet, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.EnablePolyglotSupportAsync(counter);
+
+        // cd into the apphost subdir so aspire init only writes apphost files there, leaving the
+        // workspace root cleanly intact for use as the docker build context.
+        await auto.TypeAsync("cd apphost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire init");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Which language would you like to use?", timeout: TimeSpan.FromSeconds(30));
+        await auto.KeyAsync(Hex1bKey.DownArrow);
+        await auto.WaitUntilTextAsync("> TypeScript (Node.js)", timeout: TimeSpan.FromSeconds(5));
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.JavaScript");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.Docker");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+
+        await auto.TypeAsync("aspire restore");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        var appHostPath = Path.Combine(appHostDir, "apphost.ts");
+        File.WriteAllText(appHostPath, """
+            import { createBuilder } from './.modules/aspire.js';
+
+            const builder = await createBuilder();
+            await builder.addDockerComposeEnvironment('compose');
+
+            await builder.addNodeApp('web', '../packages/web', 'server.js')
+                .withWorkspaceRoot('..')
+                .withExternalHttpEndpoints();
+
+            await builder.build().run();
+            """);
+
+        await auto.TypeAsync("unset ASPIRE_PLAYGROUND");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire publish -o artifacts --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, timeout: TimeSpan.FromMinutes(5));
+
+        // Verify the Aspire publishing pipeline can build the workspace-backed image end-to-end,
+        // not just that the generated Dockerfile has the expected text.
+        await auto.TypeAsync("aspire do build --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, timeout: TimeSpan.FromMinutes(5));
+
+        // Locate the generated Dockerfile (its name is templated). Show its content first for
+        // diagnostics, then assert the workspace-style COPY layout.
+        await auto.TypeAsync("find artifacts -name 'web*.Dockerfile' -print");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("cat artifacts/web*.Dockerfile");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Workspace-root manifests must be copied into /app, not the app subdir. Sibling member
+        // package.json must also be copied so npm install can resolve workspace:* refs.
+        await auto.TypeAsync("grep -F 'COPY package.json ./package.json' artifacts/web*.Dockerfile");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("grep -F 'COPY package-lock.json ./package-lock.json' artifacts/web*.Dockerfile");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("grep -F 'COPY packages/web/package.json ./packages/web/package.json' artifacts/web*.Dockerfile");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("grep -F 'WORKDIR /app/packages/web' artifacts/web*.Dockerfile");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("docker build --progress=plain -f artifacts/web*.Dockerfile -t aspire-js-workspace-e2e ..");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, timeout: TimeSpan.FromMinutes(5));
+
+        await auto.TypeAsync("docker image rm aspire-js-workspace-e2e");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, timeout: TimeSpan.FromSeconds(30));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddJavaScriptAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddJavaScriptAppTests.cs
@@ -371,7 +371,7 @@ public class AddJavaScriptAppTests
         var dockerfilePath = Path.Combine(tempDir.Path, "pnpm-app.Dockerfile");
         Assert.True(File.Exists(dockerfilePath), $"Dockerfile should exist at {dockerfilePath}");
 
-        // Read the generated Dockerfile and verify it contains the corepack enable pnpm command
+        // Read the generated Dockerfile and verify it enables pnpm through Corepack.
         var dockerfileContent = await File.ReadAllTextAsync(dockerfilePath);
         Assert.Contains("corepack enable pnpm", dockerfileContent);
 

--- a/tests/Aspire.Hosting.JavaScript.Tests/Internal/WorkspaceParserTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/Internal/WorkspaceParserTests.cs
@@ -1,0 +1,527 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Pure unit tests for the workspace parsing/validation/matching helpers.
+//
+// Test data is drawn (with attribution) from the canonical upstream package
+// manager test suites and example fixtures, so the cases here exercise the
+// real-world shapes that npm/yarn/pnpm/bun/Turborepo monorepos produce. We
+// don't import the upstream sources — we mirror the input shape and assert
+// our own behavior against it.
+
+using Aspire.Hosting.JavaScript.Internal.Workspace;
+
+namespace Aspire.Hosting.JavaScript.Tests.Internal;
+
+public class WorkspaceParserTests
+{
+    public class PackageJsonWorkspacesParserTests
+    {
+        [Fact]
+        public void Parse_ArrayForm_ReturnsPatterns()
+        {
+            // shape from npm/cli get-workspaces fixtures (npm 7+):
+            //   https://github.com/npm/cli/blob/latest/test/lib/utils/get-workspaces.js
+            var json = """{ "name": "root", "workspaces": ["packages/*", "apps/web"] }""";
+
+            var patterns = PackageJsonWorkspacesParser.Parse(json);
+
+            Assert.Equal(["packages/*", "apps/web"], patterns);
+        }
+
+        [Fact]
+        public void Parse_ObjectFormWithPackages_ReturnsPatterns()
+        {
+            // shape from yarn classic / npm RFC 0026 (workspaces object form):
+            //   https://github.com/npm/rfcs/blob/main/accepted/0026-workspaces.md
+            //   https://classic.yarnpkg.com/blog/2018/02/15/nohoist
+            var json = """
+                {
+                  "name": "root",
+                  "private": true,
+                  "workspaces": {
+                    "packages": ["packages/*", "tools/*"],
+                    "nohoist": ["**/react"]
+                  }
+                }
+                """;
+
+            var patterns = PackageJsonWorkspacesParser.Parse(json);
+
+            Assert.Equal(["packages/*", "tools/*"], patterns);
+        }
+
+        [Fact]
+        public void Parse_TurborepoBasicExample_ReturnsPatterns()
+        {
+            // shape from vercel/turborepo examples/basic/package.json:
+            //   https://github.com/vercel/turborepo/tree/main/examples/basic
+            var json = """
+                {
+                  "name": "basic",
+                  "private": true,
+                  "workspaces": ["apps/*", "packages/*"]
+                }
+                """;
+
+            var patterns = PackageJsonWorkspacesParser.Parse(json);
+
+            Assert.Equal(["apps/*", "packages/*"], patterns);
+        }
+
+        [Fact]
+        public void Parse_NoWorkspacesField_ReturnsEmpty()
+        {
+            var json = """{ "name": "single-package" }""";
+
+            Assert.Empty(PackageJsonWorkspacesParser.Parse(json));
+        }
+
+        [Fact]
+        public void Parse_EmptyArray_ReturnsEmpty()
+        {
+            var json = """{ "workspaces": [] }""";
+
+            Assert.Empty(PackageJsonWorkspacesParser.Parse(json));
+        }
+
+        [Fact]
+        public void Parse_ObjectWithoutPackagesKey_ReturnsEmpty()
+        {
+            // yarn nohoist-only form (rare in practice; npm rejects it)
+            var json = """{ "workspaces": { "nohoist": ["**/react"] } }""";
+
+            Assert.Empty(PackageJsonWorkspacesParser.Parse(json));
+        }
+
+        [Fact]
+        public void Parse_MalformedJson_ReturnsEmpty()
+        {
+            Assert.Empty(PackageJsonWorkspacesParser.Parse("{not json"));
+        }
+
+        [Fact]
+        public void Parse_NonObjectRoot_ReturnsEmpty()
+        {
+            Assert.Empty(PackageJsonWorkspacesParser.Parse("[1, 2, 3]"));
+        }
+
+        [Fact]
+        public void Parse_MixedTypeArrayEntries_ReturnsEmpty()
+        {
+            // npm's parser rejects non-string entries, and the DTO parser treats the
+            // whole declaration as unsupported rather than partly accepting invalid data.
+            var json = """{ "workspaces": ["apps/web", null, 42, "packages/*", { "x": 1 }] }""";
+
+            Assert.Empty(PackageJsonWorkspacesParser.Parse(json));
+        }
+
+        [Fact]
+        public void Parse_ScopedPackagePattern_IsPreserved()
+        {
+            // shape sometimes seen in npm orgs (e.g. shopify/cli, microsoft/rushstack):
+            //   https://github.com/microsoft/rushstack
+            var json = """{ "workspaces": ["packages/@scope/*"] }""";
+
+            Assert.Equal(["packages/@scope/*"], PackageJsonWorkspacesParser.Parse(json));
+        }
+    }
+
+    public class PnpmWorkspaceYamlParserTests
+    {
+        [Fact]
+        public void Parse_BlockForm_ReturnsPatterns()
+        {
+            // canonical pnpm form from pnpm-workspace.yaml docs:
+            //   https://pnpm.io/pnpm-workspace_yaml#packages
+            var yaml = """
+                packages:
+                  - 'apps/*'
+                  - 'packages/*'
+                """;
+
+            Assert.Equal(["apps/*", "packages/*"], PnpmWorkspaceYamlParser.Parse(yaml));
+        }
+
+        [Fact]
+        public void Parse_FlowForm_ReturnsPatterns()
+        {
+            // YAML 1.2 flow-sequence form; this is what tripped the prior
+            // hand-rolled scanner (it returned empty)
+            var yaml = "packages: [apps/*, packages/*]\n";
+
+            Assert.Equal(["apps/*", "packages/*"], PnpmWorkspaceYamlParser.Parse(yaml));
+        }
+
+        [Fact]
+        public void Parse_WithComments_ReturnsPatterns()
+        {
+            // shape from pnpm/pnpm find-workspace-packages fixtures:
+            //   https://github.com/pnpm/pnpm/tree/main/workspace/find-workspace-packages/test/fixtures
+            var yaml = """
+                # workspace declaration
+                packages:
+                  - 'apps/*'   # all apps
+                  - 'packages/*' # all libs
+                  # legacy services live elsewhere
+                  - 'services/auth'
+                """;
+
+            Assert.Equal(["apps/*", "packages/*", "services/auth"], PnpmWorkspaceYamlParser.Parse(yaml));
+        }
+
+        [Fact]
+        public void Parse_TurborepoWithPnpmExample_ReturnsPatterns()
+        {
+            // shape from vercel/turborepo examples/with-pnpm/pnpm-workspace.yaml:
+            //   https://github.com/vercel/turborepo/tree/main/examples/with-pnpm
+            var yaml = """
+                packages:
+                  - "apps/*"
+                  - "packages/*"
+                """;
+
+            Assert.Equal(["apps/*", "packages/*"], PnpmWorkspaceYamlParser.Parse(yaml));
+        }
+
+        [Fact]
+        public void Parse_QuotedAndUnquotedScalars_ReturnsPatterns()
+        {
+            var yaml = """
+                packages:
+                  - apps/web
+                  - 'apps/api'
+                  - "packages/*"
+                """;
+
+            Assert.Equal(["apps/web", "apps/api", "packages/*"], PnpmWorkspaceYamlParser.Parse(yaml));
+        }
+
+        [Fact]
+        public void Parse_WithCatalogField_ReturnsPackagesOnly()
+        {
+            // pnpm 9+ catalog feature: catalogs sit alongside packages and must
+            // be ignored. See https://pnpm.io/catalogs
+            var yaml = """
+                packages:
+                  - 'packages/*'
+                catalog:
+                  react: ^18.2.0
+                  react-dom: ^18.2.0
+                """;
+
+            Assert.Equal(["packages/*"], PnpmWorkspaceYamlParser.Parse(yaml));
+        }
+
+        [Fact]
+        public void ParseInjectWorkspacePackages_WhenTrue_ReturnsTrue()
+        {
+            // pnpm 10 non-legacy deploy requires this workspace-level setting:
+            //   https://pnpm.io/cli/deploy
+            var yaml = """
+                packages:
+                  - 'packages/*'
+                injectWorkspacePackages: true
+                """;
+
+            Assert.True(PnpmWorkspaceYamlParser.ParseInjectWorkspacePackages(yaml));
+        }
+
+        [Fact]
+        public void ParseInjectWorkspacePackages_WhenMissing_ReturnsNull()
+        {
+            var yaml = """
+                packages:
+                  - 'packages/*'
+                """;
+
+            Assert.Null(PnpmWorkspaceYamlParser.ParseInjectWorkspacePackages(yaml));
+        }
+
+        [Fact]
+        public void ParseInjectWorkspacePackages_WhenFalse_ReturnsFalse()
+        {
+            var yaml = """
+                packages:
+                  - 'packages/*'
+                injectWorkspacePackages: false
+                """;
+
+            Assert.False(PnpmWorkspaceYamlParser.ParseInjectWorkspacePackages(yaml));
+        }
+
+        [Fact]
+        public void Parse_MissingPackagesKey_ReturnsEmpty()
+        {
+            var yaml = """
+                catalog:
+                  react: ^18.2.0
+                """;
+
+            Assert.Empty(PnpmWorkspaceYamlParser.Parse(yaml));
+        }
+
+        [Fact]
+        public void Parse_NonMappingRoot_ReturnsEmpty()
+        {
+            Assert.Empty(PnpmWorkspaceYamlParser.Parse("- 'apps/*'\n"));
+        }
+
+        [Fact]
+        public void Parse_Empty_ReturnsEmpty()
+        {
+            Assert.Empty(PnpmWorkspaceYamlParser.Parse(string.Empty));
+            Assert.Empty(PnpmWorkspaceYamlParser.Parse("\n"));
+        }
+
+        [Fact]
+        public void Parse_MalformedYaml_ReturnsEmpty()
+        {
+            // unbalanced quote — must not throw
+            Assert.Empty(PnpmWorkspaceYamlParser.Parse("packages:\n  - 'apps/*\n"));
+        }
+
+        [Fact]
+        public void Parse_PreservesNegationPrefix()
+        {
+            // negation is not supported by us (Validator throws), but the
+            // parser must surface the raw pattern so the validator can report
+            // it with attribution. Don't silently drop it here.
+            var yaml = """
+                packages:
+                  - 'apps/*'
+                  - '!apps/legacy'
+                """;
+
+            Assert.Equal(["apps/*", "!apps/legacy"], PnpmWorkspaceYamlParser.Parse(yaml));
+        }
+    }
+
+    public class PnpmPackageManagerVersionTests
+    {
+        [Theory]
+        [InlineData("pnpm@10.33.4", 10)]
+        [InlineData("pnpm@9.15.9+sha224.deadbeef", 9)]
+        [InlineData("pnpm@8.15.9", 8)]
+        [InlineData("pnpm@10.0.0-beta.1", 10)]
+        public void TryParseMajorVersion_PnpmVersion_ReturnsMajor(string packageManager, int expected)
+        {
+            Assert.Equal(expected, PnpmPackageManagerVersion.TryParseMajorVersion(packageManager));
+        }
+
+        [Theory]
+        [InlineData("npm@10.9.0")]
+        [InlineData("pnpm")]
+        [InlineData("pnpm@latest")]
+        public void TryParseMajorVersion_NonVersionedOrNonPnpm_ReturnsNull(string packageManager)
+        {
+            Assert.Null(PnpmPackageManagerVersion.TryParseMajorVersion(packageManager));
+        }
+
+        [Fact]
+        public void TryReadMajorVersion_PackageManagerField_ReturnsMajor()
+        {
+            using var tempDir = new TestTempDirectory();
+            File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+                """{"packageManager":"pnpm@10.33.4+sha224.deadbeef"}""");
+
+            Assert.Equal(10, PnpmPackageManagerVersion.TryReadMajorVersion(tempDir.Path));
+        }
+
+        [Fact]
+        public void TryReadMajorVersion_DevEnginesPackageManagerFallback_ReturnsMajor()
+        {
+            using var tempDir = new TestTempDirectory();
+            File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+                """
+                {
+                  "devEngines": {
+                    "packageManager": {
+                      "name": "pnpm",
+                      "version": "11.0.8+sha224.deadbeef"
+                    }
+                  }
+                }
+                """);
+
+            Assert.Equal(11, PnpmPackageManagerVersion.TryReadMajorVersion(tempDir.Path));
+        }
+
+        [Fact]
+        public void TryReadMajorVersion_DevEnginesPackageManagerRange_ReturnsNull()
+        {
+            using var tempDir = new TestTempDirectory();
+            File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+                """
+                {
+                  "devEngines": {
+                    "packageManager": {
+                      "name": "pnpm",
+                      "version": ">=11.0.0"
+                    }
+                  }
+                }
+                """);
+
+            Assert.Null(PnpmPackageManagerVersion.TryReadMajorVersion(tempDir.Path));
+        }
+    }
+
+    public class WorkspacePatternValidatorTests
+    {
+        [Theory]
+        [InlineData("apps/web")]
+        [InlineData("packages/utils")]
+        [InlineData("packages/*")]
+        [InlineData("apps/*")]
+        [InlineData("services/auth")]
+        // Turborepo basic / with-pnpm examples
+        [InlineData("packages/@scope/utils")]
+        public void Validate_SupportedShape_DoesNotThrow(string pattern)
+        {
+            WorkspacePatternValidator.Validate([pattern], "/root");
+        }
+
+        [Theory]
+        // negation — pnpm-workspace.yaml supports this; we don't.
+        [InlineData("!apps/legacy", "Negated workspace pattern")]
+        // recursive — minimatch & pnpm matcher both support; we don't.
+        [InlineData("packages/**", "Recursive workspace pattern")]
+        [InlineData("**/internal", "Recursive workspace pattern")]
+        // non-trailing star — supported by minimatch; we don't because the
+        // matcher would silently drop them.
+        [InlineData("apps/*-svc", "unsupported glob shape")]
+        [InlineData("apps/api-*", "unsupported glob shape")]
+        [InlineData("*/api", "unsupported glob shape")]
+        public void Validate_UnsupportedShape_Throws(string pattern, string fragment)
+        {
+            var ex = Assert.Throws<DistributedApplicationException>(() =>
+                WorkspacePatternValidator.Validate([pattern], "/root"));
+            Assert.Contains(fragment, ex.Message);
+        }
+
+        [Fact]
+        public void Validate_EmptyAndNullPatternsTolerated()
+        {
+            // empty entries are no-ops (some YAML/JSON files emit them);
+            // matcher / discovery later resolves to no members.
+            WorkspacePatternValidator.Validate([string.Empty], "/root");
+        }
+
+        [Fact]
+        public void Validate_FirstFailure_PointsAtPattern()
+        {
+            var ex = Assert.Throws<DistributedApplicationException>(() =>
+                WorkspacePatternValidator.Validate(["apps/web", "!apps/legacy", "packages/*"], "/some/root"));
+            Assert.Contains("'!apps/legacy'", ex.Message);
+            Assert.Contains("/some/root", ex.Message);
+        }
+    }
+
+    public class WorkspacePatternMatcherTests
+    {
+        [Theory]
+        // literal exact match
+        [InlineData("apps/web", "apps/web", true)]
+        [InlineData("apps/web", "apps/api", false)]
+        [InlineData("apps/web", "apps/web/sub", false)]
+        // trailing star matches direct children only (one segment deep)
+        [InlineData("packages/*", "packages/utils", true)]
+        [InlineData("packages/*", "packages/utils/sub", false)]
+        [InlineData("packages/*", "apps/web", false)]
+        // dotted dirs are excluded by trailing star (mirrors minimatch default)
+        [InlineData("packages/*", "packages/.git", false)]
+        [InlineData("packages/*", "packages/.cache", false)]
+        // backslash candidate paths normalize to forward slash
+        [InlineData("packages/*", "packages\\utils", true)]
+        // leading "./" is stripped from both pattern and candidate
+        [InlineData("./apps/web", "apps/web", true)]
+        [InlineData("apps/web", "./apps/web", true)]
+        // trailing "/" is stripped
+        [InlineData("apps/web/", "apps/web", true)]
+        // unsupported shape (validator should reject upstream); matcher is
+        // lenient and returns false
+        [InlineData("apps/*-svc", "apps/auth-svc", false)]
+        public void IsMatch_BehavesAsDocumented(string pattern, string candidate, bool expected)
+        {
+            Assert.Equal(expected, WorkspacePatternMatcher.IsMatch(pattern, candidate));
+        }
+
+        [Fact]
+        public void IsMatch_TopLevelTrailingStar_MatchesFirstLevelDirs()
+        {
+            // "*" alone matches any first-level directory
+            Assert.True(WorkspacePatternMatcher.IsMatch("*", "apps"));
+            Assert.False(WorkspacePatternMatcher.IsMatch("*", "apps/web"));
+            Assert.False(WorkspacePatternMatcher.IsMatch("*", ".git"));
+        }
+    }
+
+    public class WorkspacePatternExpanderTests
+    {
+        [Fact]
+        public void Expand_TrailingStar_ReturnsPackageDirectoriesSorted()
+        {
+            // Filesystem shape mirrors the WorkspacePatternExpander comment and the
+            // common npm/yarn/pnpm/Turborepo "packages/*" monorepo layout:
+            //
+            //   root/
+            //     packages/
+            //       web/package.json
+            //       api/package.json
+            //       docs/README.md
+            using var tempDir = new TestTempDirectory();
+            WritePackageJson(tempDir.Path, "packages/web");
+            WritePackageJson(tempDir.Path, "packages/api");
+            Directory.CreateDirectory(Path.Combine(tempDir.Path, "packages", "docs"));
+            File.WriteAllText(Path.Combine(tempDir.Path, "packages", "docs", "README.md"), "# docs");
+
+            var result = WorkspacePatternExpander.Expand(tempDir.Path, ["packages/*"]);
+
+            Assert.Equal(["packages/api", "packages/web"], result);
+        }
+
+        [Fact]
+        public void Expand_LiteralPath_ReturnsPackageDirectory()
+        {
+            using var tempDir = new TestTempDirectory();
+            WritePackageJson(tempDir.Path, "apps/web");
+            Directory.CreateDirectory(Path.Combine(tempDir.Path, "apps", "docs"));
+
+            var result = WorkspacePatternExpander.Expand(tempDir.Path, ["apps/web", "apps/docs"]);
+
+            Assert.Equal(["apps/web"], result);
+        }
+
+        [Fact]
+        public void Expand_SkipsDottedDirectoriesAndUnsupportedShapes()
+        {
+            using var tempDir = new TestTempDirectory();
+            WritePackageJson(tempDir.Path, "packages/web");
+            WritePackageJson(tempDir.Path, "packages/.cache");
+            WritePackageJson(tempDir.Path, "apps/auth-svc");
+
+            var result = WorkspacePatternExpander.Expand(tempDir.Path, ["packages/*", "apps/*-svc", "!apps/legacy"]);
+
+            Assert.Equal(["packages/web"], result);
+        }
+
+        [Fact]
+        public void Expand_NormalizesLeadingDotBackslashAndTrailingSlash()
+        {
+            using var tempDir = new TestTempDirectory();
+            WritePackageJson(tempDir.Path, "apps/web");
+
+            var result = WorkspacePatternExpander.Expand(tempDir.Path, [".\\apps\\web\\"]);
+
+            Assert.Equal(["apps/web"], result);
+        }
+
+        private static void WritePackageJson(string rootPath, string relativePath)
+        {
+            var packageDir = Path.Combine(rootPath, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(packageDir);
+            File.WriteAllText(Path.Combine(packageDir, "package.json"), """{ "name": "fixture" }""");
+        }
+    }
+}

--- a/tests/Aspire.Hosting.JavaScript.Tests/JavaScriptWorkspaceIntegrationTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/JavaScriptWorkspaceIntegrationTests.cs
@@ -1,0 +1,485 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Integration tests for monorepo Dockerfile generation. These exercise the
+// filesystem-touching parts of the workspace pipeline (manifest discovery,
+// pattern expansion, package-manager re-resolution) end-to-end through the
+// existing Aspire publish pipeline. Pure parser/matcher/validator tests live
+// in tests/Aspire.Hosting.JavaScript.Tests/Internal/WorkspaceParserTests.cs.
+
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+#pragma warning disable ASPIREJAVASCRIPT001
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.JavaScript.Tests;
+
+public class JavaScriptWorkspaceIntegrationTests
+{
+    // ----- Item #1 / #9: install args preservation + PM-order matrix -----
+
+    [Fact]
+    public async Task WithNpm_InstallArgsBeforeWithWorkspaceRoot_PreservedInDockerfile()
+    {
+        // The pre-A1 bug: WithNpm(installArgs: [...]) followed by WithWorkspaceRoot
+        // dropped the user's args because the reconfigure path built a fresh
+        // install annotation from scratch. Verify they survive.
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithNpm(installArgs: ["--audit=false", "--fund=false"])
+            .WithWorkspaceRoot(tempDir.Path);
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        // Lockfile-derived verb is recomputed against the workspace root (ci, since lockfile present).
+        // User's --audit=false / --fund=false survive.
+        Assert.Contains("npm ci --audit=false --fund=false", dockerfile);
+    }
+
+    [Fact]
+    public async Task WithYarn_InstallArgsBeforeWithWorkspaceRoot_PreservedInDockerfile()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web"]);
+        File.WriteAllText(Path.Combine(tempDir.Path, "yarn.lock"), "");
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithYarn(installArgs: ["--ignore-scripts"])
+            .WithWorkspaceRoot(tempDir.Path);
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        // Workspace yarn.lock present (yarn classic — no .yarnrc.yml or .yarn/) => --frozen-lockfile;
+        // user's --ignore-scripts survives.
+        Assert.Contains("yarn install --frozen-lockfile --ignore-scripts", dockerfile);
+    }
+
+    [Fact]
+    public async Task WithNpm_InstallArgsContainingFlagsAndDuplicateLockfileFlag_AreNotDuplicated()
+    {
+        // If the user passes --frozen-lockfile (yarn) explicitly, our merge
+        // strips it from extras and re-adds it once, avoiding "yarn install
+        // --frozen-lockfile --frozen-lockfile" in the Dockerfile.
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web"]);
+        File.WriteAllText(Path.Combine(tempDir.Path, "yarn.lock"), "");
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithYarn(installArgs: ["--frozen-lockfile", "--silent"])
+            .WithWorkspaceRoot(tempDir.Path);
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        Assert.Contains("yarn install --frozen-lockfile --silent", dockerfile);
+        Assert.DoesNotContain("--frozen-lockfile --frozen-lockfile", dockerfile);
+    }
+
+    [Fact]
+    public void WithPnpm_RunMode_AddInstaller_AttachesInstallerResource()
+    {
+        // Run-mode AddInstaller in workspace mode: verify the installer resource is created
+        // alongside the parent. The installer's effective WorkingDirectory is set lazily
+        // in OnBeforeStart (so it can read the JavaScriptWorkspaceAnnotation that
+        // WithWorkspaceRoot attached); validating the actual cwd value requires running
+        // OnBeforeStart hooks which is out of scope for unit tests here.
+        using var tempDir = new TestTempDirectory();
+        WritePnpmWorkspace(tempDir.Path, ["packages/web"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Run)
+            .WithResourceCleanUp(true);
+
+        builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithPnpm(install: true);
+
+        using var app = builder.Build();
+        var installerResources = app.Services
+            .GetRequiredService<DistributedApplicationModel>()
+            .Resources
+            .OfType<JavaScriptInstallerResource>()
+            .ToList();
+
+        Assert.Single(installerResources);
+        Assert.Equal("web-installer", installerResources[0].Name);
+    }
+
+    // ----- Item #4: PublishAsStaticWebsite + workspace -----
+
+    [Fact]
+    public async Task PublishAsStaticWebsite_WithWorkspaceRoot_RewritesYarpSourcePathToWorkspaceLayout()
+    {
+        // Vite app published as static website inside a workspace: the Yarp
+        // wrapper container needs the static asset path under the workspace
+        // app subdirectory ("/app/<member>/dist"), not "/app/dist".
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["apps/web"]);
+        var appDir = Path.Combine(tempDir.Path, "apps", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var viteApp = builder.AddViteApp("web", appDir)
+            .WithWorkspaceRoot(tempDir.Path)
+            .PublishAsStaticWebsite();
+
+        await ManifestUtils.GetManifest(viteApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        Assert.Contains("WORKDIR /app", dockerfile);
+        Assert.Contains("COPY apps/web/package.json ./apps/web/package.json", dockerfile);
+        Assert.Contains("npm run build --workspace=@example/web", dockerfile);
+
+        // ContainerFilesSource path is rewritten under apps/web for the Yarp host.
+        var source = viteApp.Resource.Annotations
+            .OfType<ContainerFilesSourceAnnotation>()
+            .Single();
+        Assert.Equal("/app/apps/web/dist", source.SourcePath);
+    }
+
+    [Fact]
+    public async Task PublishAsStaticWebsite_BeforeWithWorkspaceRoot_StillRewritesYarpSourcePath()
+    {
+        // RewriteContainerFilesSourcesForWorkspace branch: PublishAsStaticWebsite
+        // captures the source path eagerly (as "/app/dist"), then WithWorkspaceRoot
+        // must rewrite it to "/app/apps/web/dist".
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["apps/web"]);
+        var appDir = Path.Combine(tempDir.Path, "apps", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var viteApp = builder.AddViteApp("web", appDir)
+            .PublishAsStaticWebsite()
+            .WithWorkspaceRoot(tempDir.Path);
+
+        await ManifestUtils.GetManifest(viteApp.Resource, tempDir.Path);
+
+        var source = viteApp.Resource.Annotations
+            .OfType<ContainerFilesSourceAnnotation>()
+            .Single();
+        Assert.Equal("/app/apps/web/dist", source.SourcePath);
+    }
+
+    // ----- Item #5: PublishAsNextStandalone + workspace -----
+
+    [Fact]
+    public async Task PublishAsNextStandalone_WithWorkspaceRoot_PrefixesEntrypointAndCopyPaths()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["apps/web"]);
+        var appDir = Path.Combine(tempDir.Path, "apps", "web");
+        WriteAppPackageJson(appDir, "@example/web", scripts: """{"build":"next build","start":"next start"}""");
+        File.WriteAllText(Path.Combine(appDir, "next.config.js"), "module.exports = { output: 'standalone' };\n");
+        Directory.CreateDirectory(Path.Combine(appDir, "public"));
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nextApp = builder.AddNextJsApp("web", appDir)
+            .WithWorkspaceRoot(tempDir.Path);
+
+        await ManifestUtils.GetManifest(nextApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        Assert.Contains("WORKDIR /app", dockerfile);
+        Assert.Contains("COPY apps/web/package.json ./apps/web/package.json", dockerfile);
+        Assert.Contains("npm run build --workspace=@example/web", dockerfile);
+        // Standalone copies live under the app subdir (next emits .next/standalone, .next/static, public).
+        Assert.Contains("/app/apps/web/.next/standalone", dockerfile);
+        Assert.Contains("/app/apps/web/.next/static", dockerfile);
+        Assert.Contains("/app/apps/web/public", dockerfile);
+    }
+
+    // ----- Item #6: PublishAsNodeServer + pnpm + workspace (existing test only covers npm) -----
+
+    [Fact]
+    public async Task PublishAsNodeServer_PnpmWorkspace_PrefixesOutputPathUnderDeployBundle()
+    {
+        using var tempDir = new TestTempDirectory();
+        WritePnpmWorkspace(tempDir.Path, ["packages/api"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir, runScriptName: "start")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithPnpm()
+            .PublishAsNodeServer(entryPoint: "dist/index.js", outputPath: "dist");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+
+        Assert.Contains("WORKDIR /app", dockerfile);
+        Assert.Contains("COPY packages/api/package.json ./packages/api/package.json", dockerfile);
+        Assert.Contains("pnpm --filter @example/api... run build", dockerfile);
+        Assert.Contains("COPY --from=build /app/packages/api/dist /app/packages/api/dist", dockerfile);
+        Assert.Contains("ENTRYPOINT [\"node\",\"packages/api/dist/index.js\"]", dockerfile);
+    }
+
+    // ----- Item #7: WithBuildScript shape for npm/yarn/bun in workspace mode -----
+
+    [Fact]
+    public async Task WithBuildScript_NpmWorkspace_UsesNpmRunWorkspaceFilter()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/api"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir)
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithBuildScript("build");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+        Assert.Contains("npm run build --workspace=@example/api", dockerfile);
+    }
+
+    [Fact]
+    public async Task WithBuildScript_YarnWorkspace_UsesYarnWorkspaceCommand()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/api"]);
+        File.WriteAllText(Path.Combine(tempDir.Path, "yarn.lock"), "");
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir)
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithYarn()
+            .WithBuildScript("build");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+        Assert.Contains("yarn workspace @example/api run build", dockerfile);
+    }
+
+    [Fact]
+    public async Task WithBuildScript_BunWorkspace_UsesBunFilterCommand()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/api"]);
+        File.WriteAllText(Path.Combine(tempDir.Path, "bun.lock"), "");
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir)
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithBun()
+            .WithBuildScript("build");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+        Assert.Contains("bun run --filter @example/api build", dockerfile);
+    }
+
+    // ----- Item #10: alternate manifest forms -----
+
+    [Fact]
+    public async Task WithWorkspaceRoot_NpmShrinkwrap_RecognizedAsLockfile()
+    {
+        // npm 7+ honors npm-shrinkwrap.json over package-lock.json. Verify it
+        // also satisfies our "must have a recognized lockfile" requirement.
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web"]);
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        File.WriteAllText(Path.Combine(tempDir.Path, "npm-shrinkwrap.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        Assert.Contains("COPY npm-shrinkwrap.json ./npm-shrinkwrap.json", dockerfile);
+    }
+
+    [Fact]
+    public async Task WithWorkspaceRoot_BunTextLockfile_RecognizedAsLockfile()
+    {
+        // Bun 1.1+ ships a text-format bun.lock alongside the legacy bun.lockb.
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web"]);
+        File.WriteAllText(Path.Combine(tempDir.Path, "bun.lock"), "");
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithBun();
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        Assert.Contains("COPY bun.lock ./bun.lock", dockerfile);
+        Assert.Contains("bun install --frozen-lockfile", dockerfile);
+    }
+
+    [Fact]
+    public async Task WithWorkspaceRoot_PackageJsonObjectFormWorkspaces_ResolvesMembers()
+    {
+        // Yarn classic's { workspaces: { packages: [...] } } form resolves
+        // identically to the array form.
+        using var tempDir = new TestTempDirectory();
+        Directory.CreateDirectory(tempDir.Path);
+        File.WriteAllText(
+            Path.Combine(tempDir.Path, "package.json"),
+            """{ "name":"root", "private":true, "workspaces":{ "packages":["packages/*"], "nohoist":["**/react"] } }""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        Assert.Contains("COPY packages/web/package.json ./packages/web/package.json", dockerfile);
+        Assert.Contains("npm ci", dockerfile);
+    }
+
+    // ----- helpers (mirror JavaScriptWorkspaceTests) -----
+
+    private static void WriteNpmWorkspace(string rootPath, string[] patterns)
+    {
+        Directory.CreateDirectory(rootPath);
+        var patternsJson = string.Join(",", patterns.Select(p => "\"" + p + "\""));
+        File.WriteAllText(
+            Path.Combine(rootPath, "package.json"),
+            $$"""{"name":"workspace-root","private":true,"workspaces":[{{patternsJson}}]}""");
+        File.WriteAllText(Path.Combine(rootPath, "package-lock.json"), "{}");
+
+        foreach (var pattern in patterns)
+        {
+            if (pattern.Contains('*', StringComparison.Ordinal))
+            {
+                continue;
+            }
+            var memberDir = Path.Combine(rootPath, pattern.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(memberDir);
+            var stubName = "@example/" + Path.GetFileName(pattern);
+            File.WriteAllText(Path.Combine(memberDir, "package.json"), "{\"name\":\"" + stubName + "\"}");
+        }
+    }
+
+    private static void WritePnpmWorkspace(string rootPath, string[] packages)
+    {
+        Directory.CreateDirectory(rootPath);
+        File.WriteAllText(
+            Path.Combine(rootPath, "package.json"),
+            "{\"name\":\"workspace-root\",\"private\":true}");
+        var lines = string.Join("\n", packages.Select(p => "  - '" + p + "'"));
+        File.WriteAllText(
+            Path.Combine(rootPath, "pnpm-workspace.yaml"),
+            "packages:\n" + lines + "\n");
+        File.WriteAllText(Path.Combine(rootPath, "pnpm-lock.yaml"), "");
+
+        foreach (var pattern in packages)
+        {
+            if (pattern.Contains('*', StringComparison.Ordinal))
+            {
+                continue;
+            }
+            var memberDir = Path.Combine(rootPath, pattern.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(memberDir);
+            var stubName = "@example/" + Path.GetFileName(pattern);
+            File.WriteAllText(Path.Combine(memberDir, "package.json"), "{\"name\":\"" + stubName + "\"}");
+        }
+    }
+
+    private static void WriteAppPackageJson(string appDir, string name, string? scripts = null)
+    {
+        Directory.CreateDirectory(appDir);
+        var payload = scripts is null
+            ? "{\"name\":\"" + name + "\"}"
+            : "{\"name\":\"" + name + "\",\"scripts\":" + scripts + "}";
+        File.WriteAllText(Path.Combine(appDir, "package.json"), payload);
+    }
+
+    private static string ReadDockerfile(string outputPath, string resourceName)
+    {
+        var path = Path.Combine(outputPath, resourceName + ".Dockerfile");
+        return File.ReadAllText(path);
+    }
+}

--- a/tests/Aspire.Hosting.JavaScript.Tests/JavaScriptWorkspaceTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/JavaScriptWorkspaceTests.cs
@@ -1,0 +1,619 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+#pragma warning disable ASPIREJAVASCRIPT001
+
+using Aspire.Hosting.JavaScript.Internal.Workspace;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.JavaScript.Tests;
+
+public class JavaScriptWorkspaceTests
+{
+    [Fact]
+    public async Task AddNodeApp_WithWorkspaceRoot_NpmWorkspace_GeneratesWorkspaceDockerfile()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web", "packages/api", "packages/shared"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        var expected = """
+            FROM node:22-alpine AS build
+
+            WORKDIR /app
+            COPY package.json ./package.json
+            COPY package-lock.json ./package-lock.json
+            COPY packages/api/package.json ./packages/api/package.json
+            COPY packages/shared/package.json ./packages/shared/package.json
+            COPY packages/web/package.json ./packages/web/package.json
+            RUN --mount=type=cache,target=/root/.npm npm ci
+            COPY . .
+
+            FROM node:22-alpine AS runtime
+
+            WORKDIR /app/packages/web
+            COPY --from=build /app /app
+
+            ENV NODE_ENV=production
+
+            USER node
+
+            ENTRYPOINT ["node","app.js"]
+
+            """.Replace("\r\n", "\n");
+
+        Assert.Equal(expected, dockerfile);
+    }
+
+    [Fact]
+    public async Task AddNodeApp_WithWorkspaceRoot_PnpmWorkspace_GeneratesWorkspaceDockerfile()
+    {
+        using var tempDir = new TestTempDirectory();
+        WritePnpmWorkspace(tempDir.Path, ["packages/web", "packages/api"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithPnpm();
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        var expected = """
+            FROM node:22-alpine AS build
+
+            WORKDIR /app
+            RUN corepack enable pnpm
+            COPY package.json ./package.json
+            COPY pnpm-lock.yaml ./pnpm-lock.yaml
+            COPY pnpm-workspace.yaml ./pnpm-workspace.yaml
+            COPY packages/api/package.json ./packages/api/package.json
+            COPY packages/web/package.json ./packages/web/package.json
+            RUN --mount=type=cache,target=/pnpm/store pnpm install --frozen-lockfile
+            COPY . .
+
+            FROM node:22-alpine AS runtime
+
+            WORKDIR /app/packages/web
+            COPY --from=build /app /app
+
+            ENV NODE_ENV=production
+
+            USER node
+
+            ENTRYPOINT ["node","app.js"]
+
+            """.Replace("\r\n", "\n");
+
+        Assert.Equal(expected, dockerfile);
+    }
+
+    [Fact]
+    public async Task AddNodeApp_WithWorkspaceRoot_YarnWorkspace_GeneratesWorkspaceDockerfile()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web"]);
+        File.WriteAllText(Path.Combine(tempDir.Path, "yarn.lock"), "");
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithYarn();
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        var expected = """
+            FROM node:22-alpine AS build
+
+            WORKDIR /app
+            COPY package.json ./package.json
+            COPY yarn.lock ./yarn.lock
+            COPY packages/web/package.json ./packages/web/package.json
+            RUN --mount=type=cache,target=/root/.cache/yarn yarn install --frozen-lockfile
+            COPY . .
+
+            FROM node:22-alpine AS runtime
+
+            WORKDIR /app/packages/web
+            COPY --from=build /app /app
+
+            ENV NODE_ENV=production
+
+            USER node
+
+            ENTRYPOINT ["node","app.js"]
+
+            """.Replace("\r\n", "\n");
+
+        Assert.Equal(expected, dockerfile);
+    }
+
+    [Fact]
+    public async Task AddNodeApp_WithWorkspaceRoot_BunWorkspace_GeneratesWorkspaceDockerfile()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web"]);
+        File.WriteAllText(Path.Combine(tempDir.Path, "bun.lockb"), "");
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithBun();
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "web");
+
+        Assert.Contains("FROM oven/bun", dockerfile);
+        Assert.Contains("WORKDIR /app", dockerfile);
+        Assert.Contains("COPY package.json ./package.json", dockerfile);
+        Assert.Contains("COPY bun.lockb ./bun.lockb", dockerfile);
+        Assert.Contains("COPY packages/web/package.json ./packages/web/package.json", dockerfile);
+        Assert.Contains("bun install --frozen-lockfile", dockerfile);
+        Assert.Contains("WORKDIR /app/packages/web", dockerfile);
+    }
+
+    [Fact]
+    public async Task AddJavaScriptApp_WithWorkspaceRoot_PublishAsNodeServer_PrefixesOutputPath()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/api"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build","start":"node dist/index.js"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir, runScriptName: "start")
+            .WithWorkspaceRoot(tempDir.Path)
+            .PublishAsNodeServer(entryPoint: "dist/index.js", outputPath: "dist");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+
+        Assert.Contains("WORKDIR /app", dockerfile);
+        Assert.Contains("COPY package.json ./package.json", dockerfile);
+        Assert.Contains("COPY packages/api/package.json ./packages/api/package.json", dockerfile);
+        // Build/run uses workspace filter command
+        Assert.Contains("npm run build --workspace=@example/api", dockerfile);
+        // Runtime stage scoped to the app's directory
+        Assert.Contains("COPY --from=build /app/packages/api/dist /app/packages/api/dist", dockerfile);
+        Assert.Contains("ENTRYPOINT [\"node\",\"packages/api/dist/index.js\"]", dockerfile);
+    }
+
+    [Fact]
+    public void WithWorkspaceRoot_NonExistentRoot_FailsValidation()
+    {
+        using var tempDir = new TestTempDirectory();
+        var appDir = Path.Combine(tempDir.Path, "app");
+        Directory.CreateDirectory(appDir);
+        WriteAppPackageJson(appDir, "@example/app");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("app", appDir, "app.js")
+            .WithWorkspaceRoot(Path.Combine(tempDir.Path, "does-not-exist"));
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(nodeApp.Resource));
+
+        Assert.Contains("does not exist", ex.Message);
+    }
+
+    [Fact]
+    public void WithWorkspaceRoot_AppNotDescendantOfRoot_FailsValidation()
+    {
+        using var rootDir = new TestTempDirectory();
+        using var appOutsideDir = new TestTempDirectory();
+        WriteNpmWorkspace(rootDir.Path, ["packages/*"]);
+        WriteAppPackageJson(appOutsideDir.Path, "@example/app");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("app", appOutsideDir.Path, "app.js")
+            .WithWorkspaceRoot(rootDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(nodeApp.Resource));
+
+        Assert.Contains("not a descendant", ex.Message);
+    }
+
+    [Fact]
+    public void WithWorkspaceRoot_AppMissingPackageName_FailsValidation()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/web"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        Directory.CreateDirectory(appDir);
+        File.WriteAllText(Path.Combine(appDir, "package.json"), "{}"); // no "name"
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(nodeApp.Resource));
+
+        Assert.Contains("name", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WithWorkspaceRoot_AppNotMemberOfWorkspace_FailsValidation()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/api"]);
+        var appDir = Path.Combine(tempDir.Path, "apps", "web"); // outside any workspace pattern
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(nodeApp.Resource));
+
+        Assert.Contains("not a declared workspace member", ex.Message);
+    }
+
+    [Fact]
+    public void WithWorkspaceRoot_NegatedPnpmPattern_FailsValidation()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n  - '!packages/excluded'\n");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-lock.yaml"), "");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"), "{\"name\":\"root\",\"private\":true}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(nodeApp.Resource));
+
+        Assert.Contains("Negated workspace pattern", ex.Message);
+    }
+
+    [Fact]
+    public void WithWorkspaceRoot_RecursiveWorkspacePattern_FailsValidation()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            "{\"name\":\"root\",\"private\":true,\"workspaces\":[\"**/packages/*\"]}");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(nodeApp.Resource));
+
+        Assert.Contains("Recursive workspace pattern", ex.Message);
+    }
+
+    [Fact]
+    public void WithWorkspaceRoot_NoLockfile_FailsValidation()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            "{\"name\":\"root\",\"private\":true,\"workspaces\":[\"packages/*\"]}");
+        // no lockfile
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(nodeApp.Resource));
+
+        Assert.Contains("lockfile", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WithWorkspaceRoot_RootHasNoWorkspaceField_FailsValidation()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            "{\"name\":\"single\",\"private\":true}");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(nodeApp.Resource));
+
+        Assert.Contains("workspace", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WithBuildScript_PnpmWorkspace_BuildsTargetAndWorkspaceDependencies()
+    {
+        using var tempDir = new TestTempDirectory();
+        WritePnpmWorkspace(tempDir.Path, ["packages/api", "packages/logger"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var nodeApp = builder.AddNodeApp("api", appDir, "dist/index.cjs")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithPnpm()
+            .WithBuildScript("build");
+
+        await ManifestUtils.GetManifest(nodeApp.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+
+        // pnpm filter "<name>..." (suffix) selects target package + workspace deps in topological order.
+        // This is the default for pnpm workspaces — workspace libraries the target depends on are built
+        // before the target itself, which is what monorepos almost always need.
+        Assert.Contains("RUN pnpm --filter @example/api... run build", dockerfile);
+    }
+
+    [Fact]
+    public async Task PublishAsPackageScript_PnpmWorkspace_UsesPnpmDeploy()
+    {
+        using var tempDir = new TestTempDirectory();
+        WritePnpmWorkspace(tempDir.Path, ["packages/api"], injectWorkspacePackages: true, packageManager: "pnpm@10.33.4");
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build","start":"node dist/index.js"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir, runScriptName: "start")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithPnpm()
+            .PublishAsPackageScript("start");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+
+        // pnpm + workspace + PackageScript uses pnpm 10's non-legacy 'pnpm deploy'
+        // instead of the prod-deps overlay.
+        Assert.Contains("RUN pnpm --filter=@example/api --prod deploy /prod/deploy", dockerfile);
+        Assert.Contains("COPY --from=build /prod/deploy /app", dockerfile);
+        Assert.Contains("ENTRYPOINT [\"sh\",\"-c\",\"exec pnpm run start\"]", dockerfile);
+
+        // The deploy-based path skips the prod-deps stage entirely.
+        Assert.DoesNotContain("AS prod-deps", dockerfile);
+        Assert.DoesNotContain("--from=prod-deps", dockerfile);
+
+        // pnpm must be available in both build and runtime stages (the deployed bundle is
+        // executed via 'pnpm run <script>').
+        var corepackOccurrences = System.Text.RegularExpressions.Regex.Matches(dockerfile, "corepack enable pnpm").Count;
+        Assert.Equal(2, corepackOccurrences);
+    }
+
+    [Fact]
+    public async Task PublishAsPackageScript_PnpmWorkspace_UnknownPnpmVersionUsesLegacyDeploy()
+    {
+        using var tempDir = new TestTempDirectory();
+        WritePnpmWorkspace(tempDir.Path, ["packages/api"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build","start":"node dist/index.js"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir, runScriptName: "start")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithPnpm()
+            .PublishAsPackageScript("start");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+
+        Assert.Contains("RUN npm_config_force_legacy_deploy=true pnpm --filter=@example/api --prod deploy /prod/deploy", dockerfile);
+        Assert.DoesNotContain("COREPACK_ENABLE_PROJECT_SPEC", dockerfile);
+        Assert.DoesNotContain("corepack install -g pnpm@10", dockerfile);
+    }
+
+    [Fact]
+    public async Task PublishAsPackageScript_PnpmWorkspace_PassesRunScriptArguments()
+    {
+        using var tempDir = new TestTempDirectory();
+        WritePnpmWorkspace(tempDir.Path, ["packages/api"], injectWorkspacePackages: true);
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build","start":"node dist/index.js"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir, runScriptName: "start")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithPnpm()
+            .PublishAsPackageScript("start", "-- --port $PORT");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+
+        Assert.Contains("ENTRYPOINT [\"sh\",\"-c\",\"exec pnpm run start -- --port $PORT\"]", dockerfile);
+    }
+
+    [Fact]
+    public async Task PublishAsPackageScript_NpmWorkspace_UsesProdDepsOverlay()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/api"]);
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build","start":"node dist/index.js"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir, runScriptName: "start")
+            .WithWorkspaceRoot(tempDir.Path)
+            .PublishAsPackageScript("start");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+
+        // npm in workspace mode keeps the existing prod-deps overlay (no pnpm deploy).
+        Assert.Contains("AS prod-deps", dockerfile);
+        Assert.Contains("--from=prod-deps /app/node_modules", dockerfile);
+        Assert.DoesNotContain("pnpm deploy", dockerfile);
+        Assert.Contains("ENTRYPOINT [\"sh\",\"-c\",\"exec npm run start --workspace=@example/api\"]", dockerfile);
+    }
+
+    [Fact]
+    public async Task PublishAsPackageScript_BunWorkspace_UsesBunRunFilterCommand()
+    {
+        using var tempDir = new TestTempDirectory();
+        WriteNpmWorkspace(tempDir.Path, ["packages/api"]);
+        File.WriteAllText(Path.Combine(tempDir.Path, "bun.lock"), "");
+        File.Delete(Path.Combine(tempDir.Path, "package-lock.json"));
+        var appDir = Path.Combine(tempDir.Path, "packages", "api");
+        WriteAppPackageJson(appDir, "@example/api", scripts: """{"build":"echo build","start":"bun dist/index.js"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish, outputPath: tempDir.Path)
+            .WithResourceCleanUp(true);
+
+        var app = builder.AddJavaScriptApp("api", appDir, runScriptName: "start")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithBun()
+            .PublishAsPackageScript("start");
+
+        await ManifestUtils.GetManifest(app.Resource, tempDir.Path);
+
+        var dockerfile = ReadDockerfile(tempDir.Path, "api");
+
+        Assert.Contains("RUN bun run --filter @example/api build", dockerfile);
+        Assert.Contains("AS prod-deps", dockerfile);
+        Assert.Contains("--from=prod-deps /app/node_modules", dockerfile);
+        Assert.Contains("ENTRYPOINT [\"sh\",\"-c\",\"exec bun run --filter @example/api start\"]", dockerfile);
+        Assert.DoesNotContain("bun --filter @example/api run", dockerfile);
+        Assert.DoesNotContain("pnpm deploy", dockerfile);
+    }
+
+    private static void WriteNpmWorkspace(string rootPath, string[] patterns)
+    {
+        Directory.CreateDirectory(rootPath);
+        var patternsJson = string.Join(",", patterns.Select(p => "\"" + p + "\""));
+        File.WriteAllText(
+            Path.Combine(rootPath, "package.json"),
+            $"{{\"name\":\"workspace-root\",\"private\":true,\"workspaces\":[{patternsJson}]}}");
+        File.WriteAllText(Path.Combine(rootPath, "package-lock.json"), "{}");
+
+        // Create stub package.json files for each declared workspace member so the workspace
+        // expander includes them in the manifest layer. Tests that need a richer member
+        // package.json (e.g. with scripts) can overwrite the file afterwards via WriteAppPackageJson.
+        foreach (var pattern in patterns)
+        {
+            if (pattern.Contains('*', StringComparison.Ordinal))
+            {
+                continue;
+            }
+            var memberDir = Path.Combine(rootPath, pattern.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(memberDir);
+            var stubName = "@example/" + Path.GetFileName(pattern);
+            File.WriteAllText(Path.Combine(memberDir, "package.json"), "{\"name\":\"" + stubName + "\"}");
+        }
+    }
+
+    private static void WritePnpmWorkspace(string rootPath, string[] packages, bool injectWorkspacePackages = false, string? packageManager = null)
+    {
+        Directory.CreateDirectory(rootPath);
+        var packageManagerJson = packageManager is null ? "" : $",\"packageManager\":\"{packageManager}\"";
+        File.WriteAllText(
+            Path.Combine(rootPath, "package.json"),
+            "{\"name\":\"workspace-root\",\"private\":true" + packageManagerJson + "}");
+        var lines = string.Join("\n", packages.Select(p => "  - '" + p + "'"));
+        var injectWorkspacePackagesLine = injectWorkspacePackages ? "injectWorkspacePackages: true\n" : "";
+        File.WriteAllText(
+            Path.Combine(rootPath, "pnpm-workspace.yaml"),
+            "packages:\n" + lines + "\n" + injectWorkspacePackagesLine);
+        File.WriteAllText(Path.Combine(rootPath, "pnpm-lock.yaml"), "");
+
+        foreach (var pattern in packages)
+        {
+            if (pattern.Contains('*', StringComparison.Ordinal))
+            {
+                continue;
+            }
+            var memberDir = Path.Combine(rootPath, pattern.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(memberDir);
+            var stubName = "@example/" + Path.GetFileName(pattern);
+            File.WriteAllText(Path.Combine(memberDir, "package.json"), "{\"name\":\"" + stubName + "\"}");
+        }
+    }
+
+    private static void WriteAppPackageJson(string appDir, string name, string? scripts = null)
+    {
+        Directory.CreateDirectory(appDir);
+        var payload = scripts is null
+            ? "{\"name\":\"" + name + "\"}"
+            : "{\"name\":\"" + name + "\",\"scripts\":" + scripts + "}";
+        File.WriteAllText(Path.Combine(appDir, "package.json"), payload);
+    }
+
+    private static string ReadDockerfile(string outputPath, string resourceName)
+    {
+        var path = Path.Combine(outputPath, resourceName + ".Dockerfile");
+        return File.ReadAllText(path);
+    }
+}

--- a/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddJavaScriptAppTests.VerifyDockerfileWhenPublishedAsPackageScript.verified.txt
+++ b/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddJavaScriptAppTests.VerifyDockerfileWhenPublishedAsPackageScript.verified.txt
@@ -13,6 +13,6 @@ RUN --mount=type=cache,target=/root/.cache/yarn yarn install --immutable --produ
 FROM node:22-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app /app
-COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=prod-deps /app/node_modules /app/node_modules
 ENV NODE_ENV=production
 ENTRYPOINT ["sh","-c","exec yarn run start -- --port $PORT"]

--- a/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddViteAppTests.VerifyDockerfileWhenPackageScriptUsesPnpm.verified.txt
+++ b/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddViteAppTests.VerifyDockerfileWhenPackageScriptUsesPnpm.verified.txt
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/pnpm/store pnpm install --frozen-lockfile --prod
 FROM node:22-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app /app
-COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=prod-deps /app/node_modules /app/node_modules
 RUN corepack enable pnpm && pnpm --version
 ENV NODE_ENV=production
 ENTRYPOINT ["sh","-c","exec pnpm run start"]

--- a/tests/Aspire.Hosting.JavaScript.Tests/WorkspaceErrorExperienceTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/WorkspaceErrorExperienceTests.cs
@@ -1,0 +1,970 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+#pragma warning disable ASPIREJAVASCRIPT001
+
+using System.Text;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.JavaScript.Internal.Workspace;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.JavaScript.Tests;
+
+/// <summary>
+/// Exercises every API-misuse and pipeline-time configuration error path and verifies the
+/// user-facing exception message. This file doubles as the source-of-truth catalog for
+/// "what does the user see when they configure the workspace incorrectly" — when a test
+/// here fails, it is because we changed an error message that someone depends on, and
+/// the new message should be reviewed for clarity before snapshot is updated.
+/// </summary>
+public class WorkspaceErrorExperienceTests
+{
+    // -----------------------------------------------------------------------
+    // API-misuse exceptions: thrown synchronously from the user's AppHost code.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void DoubleWithWorkspaceRoot_Throws_InvalidOperationException()
+    {
+        using var tempDir = new TestTempDirectory();
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        Directory.CreateDirectory(appDir);
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => node.WithWorkspaceRoot(tempDir.Path));
+
+        Assert.Contains("already has a workspace root", ex.Message);
+        Assert.Contains("WithWorkspaceRoot can only be called once", ex.Message);
+    }
+
+    [Fact]
+    public void DoublePublishAs_Throws_InvalidOperationException()
+    {
+        using var tempDir = new TestTempDirectory();
+        var appDir = Path.Combine(tempDir.Path, "app");
+        Directory.CreateDirectory(appDir);
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish)
+            .WithResourceCleanUp(true);
+
+        var node = builder.AddViteApp("web", appDir);
+
+        // AddViteApp does not set a publish mode by itself; the second PublishAs* should throw.
+        node.PublishAsStaticWebsite();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            node.PublishAsPackageScript("start"));
+
+        Assert.Contains("already has a publish mode set by PublishAsStaticWebsite", ex.Message);
+        Assert.Contains("PublishAsPackageScript cannot also be applied", ex.Message);
+    }
+
+    [Fact]
+    public void PublishAsStaticWebsite_AfterAddNextJsApp_Throws_InvalidOperationException()
+    {
+        using var tempDir = new TestTempDirectory();
+        var appDir = Path.Combine(tempDir.Path, "app");
+        Directory.CreateDirectory(appDir);
+        File.WriteAllText(Path.Combine(appDir, "package.json"),
+            """{"name":"web","scripts":{"build":"next build","start":"next start","dev":"next dev"}}""");
+        File.WriteAllText(Path.Combine(appDir, "next.config.js"),
+            "module.exports = { output: \"standalone\" };");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish)
+            .WithResourceCleanUp(true);
+
+        var next = builder.AddNextJsApp("web", appDir);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => next.PublishAsStaticWebsite());
+
+        Assert.Contains("already has a publish mode set by AddNextJsApp", ex.Message);
+        Assert.Contains("PublishAsStaticWebsite cannot also be applied", ex.Message);
+    }
+
+    // -----------------------------------------------------------------------
+    // Configuration errors: thrown by the validator, surfaced to the user as
+    // a single DistributedApplicationException listing every issue at once.
+    // These would surface during `aspire publish` / `aspire do build` or at
+    // run-mode resource startup — never from the AppHost constructor.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Config_NonExistentRoot_DoesNotThrowAtCallSite()
+    {
+        // The classic test that this MUST NOT throw at API time.
+        using var tempDir = new TestTempDirectory();
+        var appDir = Path.Combine(tempDir.Path, "app");
+        Directory.CreateDirectory(appDir);
+        WriteAppPackageJson(appDir, "@example/app");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        // The user can call WithWorkspaceRoot with a bogus path and the AppHost still constructs.
+        // The error surfaces at validation time, not here.
+        var node = builder.AddNodeApp("app", appDir, "app.js")
+            .WithWorkspaceRoot(Path.Combine(tempDir.Path, "does-not-exist"));
+
+        Assert.NotNull(node);
+    }
+
+    [Fact]
+    public void Config_NonExistentRoot_ValidatorThrows()
+    {
+        using var tempDir = new TestTempDirectory();
+        var appDir = Path.Combine(tempDir.Path, "app");
+        Directory.CreateDirectory(appDir);
+        WriteAppPackageJson(appDir, "@example/app");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("app", appDir, "app.js")
+            .WithWorkspaceRoot(Path.Combine(tempDir.Path, "does-not-exist"));
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "app", "does not exist");
+    }
+
+    [Fact]
+    public void Config_MalformedPackageJson_ValidatorReportsFile()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"), "{ not valid json,");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "Failed to parse", "package.json");
+    }
+
+    [Fact]
+    public void Config_MalformedPnpmYaml_ValidatorReportsFile()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            "{\"name\":\"root\",\"private\":true}");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-lock.yaml"), "");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-workspace.yaml"),
+            "packages:\n  - 'apps/*\n"); // unbalanced quote
+        var appDir = Path.Combine(tempDir.Path, "apps", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "Failed to parse", "pnpm-workspace.yaml");
+    }
+
+    [Fact]
+    public void Config_AppDirectoryIsWorkspaceRoot_ValidatorReportsMemberSubdirectoryRequirement()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"@example/web","private":true,"workspaces":["packages/*"]}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", tempDir.Path, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "is the workspace root", "workspace member subdirectory");
+    }
+
+    [Fact]
+    public void Config_AppMissingPackageJson_ValidatorReportsMissingPackageJson()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":["packages/*"]}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        Directory.CreateDirectory(appDir);
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "is missing", "package.json", "with a 'name' field");
+    }
+
+    [Fact]
+    public void Config_RootMissingPackageJson_ValidatorReportsMissingRootManifest()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-lock.yaml"), "");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "Workspace root", "is missing package.json");
+    }
+
+    [Fact]
+    public void Config_NoWorkspacePatterns_ValidatorReportsMissingWorkspaceDeclaration()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "No workspace patterns declared", "workspaces", "packages");
+    }
+
+    [Fact]
+    public void Config_InvalidWorkspacesShape_ValidatorReportsShape()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":{"foo":"bar"}}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "object must contain a 'packages' array", "found keys: foo");
+    }
+
+    [Fact]
+    public void Config_WorkspacesNull_ValidatorReportsShape()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":null}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "workspaces", "is null", "string array");
+    }
+
+    [Fact]
+    public void Config_WorkspacesPackagesNull_ValidatorReportsShape()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":{"packages":null}}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "workspaces.packages", "is null", "string array");
+    }
+
+    [Fact]
+    public void Config_PnpmYamlPackagesNull_ValidatorReportsShape()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            "{\"name\":\"root\",\"private\":true}");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-lock.yaml"), "");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-workspace.yaml"), "packages: ~\n");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "is null", "Expected a YAML sequence of strings");
+    }
+
+    [Fact]
+    public void Config_PnpmYamlPackagesScalar_ValidatorReportsFile()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            "{\"name\":\"root\",\"private\":true}");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-lock.yaml"), "");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-workspace.yaml"), "packages: 'packages/*'\n");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "Failed to parse", "pnpm-workspace.yaml");
+    }
+
+    [Fact]
+    public void Config_PatternMatchesNoPackageDirs_ValidatorReportsPattern()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":["packages/*"]}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        // Create a 'packages/' dir but with a child that has NO package.json (e.g. a docs folder).
+        Directory.CreateDirectory(Path.Combine(tempDir.Path, "packages", "docs"));
+        File.WriteAllText(Path.Combine(tempDir.Path, "packages", "docs", "README.md"), "# docs");
+        // The app the user is configuring lives at apps/web — does not match the pattern.
+        var appDir = Path.Combine(tempDir.Path, "apps", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "Workspace pattern", "'packages/*'", "did not match any directory containing a package.json");
+    }
+
+    [Fact]
+    public void Config_DuplicatePackageNames_ValidatorReportsBoth()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":["apps/*"]}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        // Two members both declaring "name": "web"
+        var webDir = Path.Combine(tempDir.Path, "apps", "web");
+        var legacyWebDir = Path.Combine(tempDir.Path, "apps", "legacy-web");
+        WriteAppPackageJson(webDir, "web");
+        WriteAppPackageJson(legacyWebDir, "web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", webDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "Workspace package name 'web' is declared by both", "apps/legacy-web/package.json", "apps/web/package.json");
+    }
+
+    [Fact]
+    public void Config_PackageManagerVsLockfile_ValidatorReportsConflict()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":["packages/*"]}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-lock.yaml"), "");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        // User configured npm but the workspace clearly uses pnpm.
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithNpm();
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "has a pnpm lockfile", "configured to use npm", "Either call .WithPnpm()");
+        AssertValidationMessage(ex, "web", "pnpm-workspace.yaml", "pnpm-specific");
+    }
+
+    [Fact]
+    public void Config_PackageManagerVsPackageManagerField_ValidatorReportsConflict()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"packageManager":"yarn@4.0.0","workspaces":["packages/*"]}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web");
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var node = builder.AddNodeApp("web", appDir, "app.js")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithNpm();
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "package.json#packageManager' is 'yarn@4.0.0'", "configured to use npm", "call .WithYarn()");
+    }
+
+    [Fact]
+    public void Config_PnpmPublishAsPackageScriptWithoutInjectedWorkspacePackages_ValidatorReportsPnpm10Requirement()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"packageManager":"pnpm@10.33.4"}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-lock.yaml"), "");
+        File.WriteAllText(Path.Combine(tempDir.Path, "pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web", scripts: """{"start":"node index.js"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish)
+            .WithResourceCleanUp(true);
+
+        var node = builder.AddJavaScriptApp("web", appDir, runScriptName: "start")
+            .WithWorkspaceRoot(tempDir.Path)
+            .WithPnpm()
+            .PublishAsPackageScript("start");
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(node.Resource));
+
+        AssertValidationMessage(ex, "web", "pnpm 10 Dockerfile", "injectWorkspacePackages: true", "without legacy deploy mode");
+    }
+
+    [Fact]
+    public void Config_MissingBuildScript_ValidatorReportsScriptList()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":["packages/*"]}""");
+        File.WriteAllText(Path.Combine(tempDir.Path, "package-lock.json"), "{}");
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        // User declares scripts but not 'build' — the auto-attached WithBuildScript("build")
+        // by AddViteApp will then fail.
+        WriteAppPackageJson(appDir, "@example/web", scripts: """{"dev":"vite","start":"vite preview"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish)
+            .WithResourceCleanUp(true);
+
+        var vite = builder.AddViteApp("web", appDir)
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(vite.Resource));
+
+        AssertValidationMessage(ex, "web", "references script 'build'", "does not declare 'scripts.build'", "Declared scripts: dev, start");
+    }
+
+    [Fact]
+    public void Config_MultipleErrorsCollectedAtOnce_OneExceptionPerCall()
+    {
+        // The validator surfaces every problem at once so the user can fix them in one pass
+        // instead of round-tripping through `aspire publish` per fix.
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"),
+            """{"name":"root","private":true,"workspaces":["packages/*"]}""");
+        // No lockfile.
+        var appDir = Path.Combine(tempDir.Path, "packages", "web");
+        WriteAppPackageJson(appDir, "@example/web", scripts: """{"start":"node app.js"}""");
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(DistributedApplicationOperation.Publish)
+            .WithResourceCleanUp(true);
+
+        var vite = builder.AddViteApp("web", appDir)
+            .WithWorkspaceRoot(tempDir.Path);
+
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+            WorkspaceConfigurationValidator.ValidateAndAttach(vite.Resource));
+
+        // Three issues should be reported in the same exception.
+        Assert.Contains("no recognized lockfile", ex.Message);
+        Assert.Contains("references script 'build'", ex.Message);
+        // Make sure it's a single DistributedApplicationException, not a chain.
+        Assert.Null(ex.InnerException);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static void AssertValidationMessage(DistributedApplicationException ex, string resourceName, params string[] expectedSubstrings)
+    {
+        Assert.Contains($"resource '{resourceName}'", ex.Message);
+        foreach (var s in expectedSubstrings)
+        {
+            Assert.Contains(s, ex.Message);
+        }
+    }
+
+    private static void WriteAppPackageJson(string appDir, string name, string? scripts = null)
+    {
+        Directory.CreateDirectory(appDir);
+        var payload = scripts is null
+            ? "{\"name\":\"" + name + "\"}"
+            : "{\"name\":\"" + name + "\",\"scripts\":" + scripts + "}";
+        File.WriteAllText(Path.Combine(appDir, "package.json"), payload);
+    }
+}
+
+/// <summary>
+/// Captures the user-facing error message for every error scenario into a single text file.
+/// This is run as a test and intentionally produces a snapshot-like output that can be
+/// inspected by the maintainer when reviewing UX for the JS workspace feature.
+/// </summary>
+public class WorkspaceErrorExperienceSnapshotTests
+{
+    [Fact]
+    public void CaptureUserExperience_WritesAllErrorMessagesToOutput()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# JavaScript workspace error UX catalog");
+        sb.AppendLine();
+        sb.AppendLine("This file is generated by `WorkspaceErrorExperienceSnapshotTests.CaptureUserExperience_WritesAllErrorMessagesToOutput`.");
+        sb.AppendLine("Each section shows the exact text the user sees for a single misconfiguration.");
+        sb.AppendLine();
+
+        AppendApiMisuse(sb, "Double WithWorkspaceRoot",
+            () =>
+            {
+                using var tempDir = new TestTempDirectory();
+                var appDir = Path.Combine(tempDir.Path, "packages", "web");
+                Directory.CreateDirectory(appDir);
+
+                using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+                var node = builder.AddNodeApp("web", appDir, "app.js").WithWorkspaceRoot(tempDir.Path);
+                node.WithWorkspaceRoot(tempDir.Path);
+            });
+
+        AppendApiMisuse(sb, "Double PublishAs*",
+            () =>
+            {
+                using var tempDir = new TestTempDirectory();
+                var appDir = Path.Combine(tempDir.Path, "app");
+                Directory.CreateDirectory(appDir);
+                using var builder = TestDistributedApplicationBuilder
+                    .Create(DistributedApplicationOperation.Publish)
+                    .WithResourceCleanUp(true);
+                var vite = builder.AddViteApp("web", appDir);
+                vite.PublishAsStaticWebsite();
+                vite.PublishAsPackageScript("start");
+            });
+
+        AppendValidator(sb, "Workspace root does not exist",
+            (scenarioRoot, app) => app.WithWorkspaceRoot("/path/that/does/not/exist"));
+
+        AppendValidator(sb, "Malformed package.json",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"), "{ not valid,");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "web", "package.json"),
+                    """{"name":"@example/web"}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "Application directory is workspace root",
+            (scenarioRoot, app) =>
+            {
+                File.WriteAllText(Path.Combine(scenarioRoot, "package.json"),
+                    """{"name":"@example/web","private":true,"workspaces":["packages/*"]}""");
+                File.WriteAllText(Path.Combine(scenarioRoot, "package-lock.json"), "{}");
+                app.WithWorkspaceRoot(scenarioRoot);
+            },
+            appDirRelative: string.Empty);
+
+        AppendValidator(sb, "Application package.json is missing",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":["packages/*"]}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                File.Delete(Path.Combine(root, "ws", "packages", "web", "package.json"));
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "Workspace root package.json is missing",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-lock.yaml"), "");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-workspace.yaml"),
+                    "packages:\n  - 'packages/*'\n");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "No workspace patterns declared",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "package.json workspaces is null",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":null}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "Workspace declared as object without 'packages'",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":{"foo":"bar"}}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "web", "package.json"),
+                    """{"name":"@example/web"}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "Workspace object packages is null",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":{"packages":null}}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "pnpm-workspace.yaml packages is null",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"packageManager":"pnpm@10.33.4"}""");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-lock.yaml"), "");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-workspace.yaml"), "packages: ~\n");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "web", "package.json"),
+                    """{"name":"@example/web"}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "pnpm-workspace.yaml packages is scalar",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true}""");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-lock.yaml"), "");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-workspace.yaml"), "packages: 'packages/*'\n");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "Pattern matched directories but none have package.json",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":["packages/*"]}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "docs"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "docs", "README.md"), "# docs");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "apps", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "apps", "web", "package.json"),
+                    """{"name":"@example/web"}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/apps/web");
+
+        AppendValidator(sb, "Duplicate package names",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":["apps/*"]}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "apps", "web"));
+                Directory.CreateDirectory(Path.Combine(root, "ws", "apps", "legacy-web"));
+                File.WriteAllText(Path.Combine(root, "ws", "apps", "web", "package.json"), """{"name":"web"}""");
+                File.WriteAllText(Path.Combine(root, "ws", "apps", "legacy-web", "package.json"), """{"name":"web"}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/apps/web",
+            appPackageName: "web");
+
+        AppendValidator(sb, "PM mismatch: WithNpm but pnpm-lock.yaml present",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":["packages/*"]}""");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-lock.yaml"), "");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-workspace.yaml"),
+                    "packages:\n  - 'packages/*'\n");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "web", "package.json"),
+                    """{"name":"@example/web"}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws")).WithNpm();
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "PM mismatch: packageManager field is yarn but WithNpm",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"packageManager":"yarn@4.0.0","workspaces":["packages/*"]}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "web", "package.json"),
+                    """{"name":"@example/web"}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws")).WithNpm();
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "pnpm PublishAsPackageScript missing injectWorkspacePackages",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"packageManager":"pnpm@10.33.4"}""");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-lock.yaml"), "");
+                File.WriteAllText(Path.Combine(root, "ws", "pnpm-workspace.yaml"),
+                    "packages:\n  - 'packages/*'\n");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "web", "package.json"),
+                    """{"name":"@example/web","scripts":{"start":"node index.js"}}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws")).WithPnpm().PublishAsPackageScript("start");
+            },
+            appDirRelative: "ws/packages/web");
+
+        AppendValidator(sb, "Missing 'build' script in package.json#scripts",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":["packages/*"]}""");
+                File.WriteAllText(Path.Combine(root, "ws", "package-lock.json"), "{}");
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "web", "package.json"),
+                    """{"name":"@example/web","scripts":{"dev":"vite","start":"vite preview"}}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web",
+            useViteApp: true);
+
+        AppendValidator(sb, "Multiple errors at once",
+            (scenarioRoot, app) =>
+            {
+                var root = scenarioRoot;
+                Directory.CreateDirectory(Path.Combine(root, "ws"));
+                File.WriteAllText(Path.Combine(root, "ws", "package.json"),
+                    """{"name":"r","private":true,"workspaces":["packages/*"]}""");
+                // No lockfile, AND member missing 'build' script.
+                Directory.CreateDirectory(Path.Combine(root, "ws", "packages", "web"));
+                File.WriteAllText(Path.Combine(root, "ws", "packages", "web", "package.json"),
+                    """{"name":"@example/web","scripts":{"dev":"vite"}}""");
+                app.WithWorkspaceRoot(Path.Combine(root, "ws"));
+            },
+            appDirRelative: "ws/packages/web",
+            useViteApp: true);
+
+        var output = sb.ToString();
+
+        // Write to test output dir for human inspection.
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "WorkspaceErrorExperience");
+        Directory.CreateDirectory(outputDir);
+        var outputFile = Path.Combine(outputDir, "error-catalog.md");
+        File.WriteAllText(outputFile, output);
+
+        // The test's assertion: the catalog must mention every category the user might encounter.
+        // If a section is missing, someone removed an error path without updating the snapshot.
+        Assert.Contains("Double WithWorkspaceRoot", output);
+        Assert.Contains("Double PublishAs*", output);
+        Assert.Contains("Workspace root does not exist", output);
+        Assert.Contains("Malformed package.json", output);
+        Assert.Contains("Application directory is workspace root", output);
+        Assert.Contains("Application package.json is missing", output);
+        Assert.Contains("Workspace root package.json is missing", output);
+        Assert.Contains("No workspace patterns declared", output);
+        Assert.Contains("package.json workspaces is null", output);
+        Assert.Contains("Workspace object packages is null", output);
+        Assert.Contains("pnpm-workspace.yaml packages is null", output);
+        Assert.Contains("pnpm-workspace.yaml packages is scalar", output);
+        Assert.Contains("Pattern matched directories but none have package.json", output);
+        Assert.Contains("Duplicate package names", output);
+        Assert.Contains("PM mismatch", output);
+        Assert.Contains("Missing 'build' script", output);
+        Assert.Contains("Multiple errors at once", output);
+    }
+
+    private static void AppendApiMisuse(StringBuilder sb, string title, Action runner)
+    {
+        sb.Append("## API misuse: ").AppendLine(title);
+        sb.AppendLine();
+        sb.AppendLine("```");
+        try
+        {
+            runner();
+            sb.AppendLine("(no exception thrown — TEST BUG)");
+        }
+        catch (Exception ex)
+        {
+            sb.Append(ex.GetType().Name).Append(": ").AppendLine(ex.Message);
+        }
+        sb.AppendLine("```");
+        sb.AppendLine();
+    }
+
+    private static void AppendValidator(
+        StringBuilder sb,
+        string title,
+        Action<string, IResourceBuilder<JavaScriptAppResource>> setup,
+        string? appDirRelative = null,
+        string? appPackageName = null,
+        bool useViteApp = false)
+    {
+        sb.Append("## Validator: ").AppendLine(title);
+        sb.AppendLine();
+        sb.AppendLine("```");
+        try
+        {
+            // Use a unique temp directory per scenario so state from one scenario does not leak
+            // into the next. We also make the catalog deterministic by replacing the temp
+            // directory path with a fixed token in the output.
+            using var scenarioTemp = new TestTempDirectory();
+            using var builder = TestDistributedApplicationBuilder
+                .Create(DistributedApplicationOperation.Publish)
+                .WithResourceCleanUp(true);
+
+            var resolvedAppDir = appDirRelative is null
+                ? Path.Combine(scenarioTemp.Path, "app")
+                : Path.Combine(scenarioTemp.Path, appDirRelative);
+
+            // Ensure the app dir exists and has a minimal package.json so the WithWorkspaceRoot
+            // call has somewhere to point.
+            Directory.CreateDirectory(resolvedAppDir);
+            if (!File.Exists(Path.Combine(resolvedAppDir, "package.json")))
+            {
+                File.WriteAllText(Path.Combine(resolvedAppDir, "package.json"),
+                    appPackageName is null
+                        ? """{"name":"@example/web"}"""
+                        : $"{{\"name\":\"{appPackageName}\"}}");
+            }
+
+            IResourceBuilder<JavaScriptAppResource> app = useViteApp
+                ? builder.AddViteApp("web", resolvedAppDir)
+                : builder.AddNodeApp("web", resolvedAppDir, "app.js");
+
+            setup(scenarioTemp.Path, app);
+
+            WorkspaceConfigurationValidator.ValidateAndAttach(app.Resource);
+            sb.AppendLine("(no exception thrown — TEST BUG)");
+        }
+        catch (DistributedApplicationException ex)
+        {
+            sb.AppendLine(ScrubPath(ex.Message));
+        }
+        catch (Exception ex)
+        {
+            sb.Append(ex.GetType().Name).Append(": ").AppendLine(ScrubPath(ex.Message));
+        }
+        sb.AppendLine("```");
+        sb.AppendLine();
+    }
+
+    private static string ScrubPath(string message)
+    {
+        // Replace OS temp directory paths with <TEMP> so the catalog is deterministic.
+        var temp = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+        message = message.Replace(temp, "<TEMP>", StringComparison.Ordinal);
+        return message;
+    }
+}

--- a/tools/CreateLayout/Program.cs
+++ b/tools/CreateLayout/Program.cs
@@ -211,9 +211,12 @@ internal sealed class LayoutBuilder : IDisposable
 
         Log($"Creating archive: {archivePath}");
 
-        if (OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
         {
-            // Use .NET TarWriter + GZip on Windows (no system tar available)
+            // Use .NET TarWriter + GZip on Windows (no system tar available) and on macOS
+            // (BSD tar emits PAX extended attributes that .NET's TarReader cannot parse, breaking
+            // bundle extraction at runtime — see https://github.com/dotnet/runtime issues around
+            // PAX extended-header parsing).
             var fileStream = File.Create(archivePath);
             await using (fileStream.ConfigureAwait(false))
             {
@@ -234,6 +237,12 @@ internal sealed class LayoutBuilder : IDisposable
                                 {
                                     DataStream = dataStream
                                 };
+                                if (!OperatingSystem.IsWindows())
+                                {
+                                    // Preserve unix file permissions (notably the executable bit) so payloads
+                                    // like aspire-managed remain executable after the consumer extracts the tar.
+                                    entry.Mode = File.GetUnixFileMode(filePath);
+                                }
                                 await tarWriter.WriteEntryAsync(entry).ConfigureAwait(false);
                             }
                         }


### PR DESCRIPTION
## Description

Adds first-class Dockerfile generation support for JavaScript monorepos using npm, pnpm, yarn, and bun workspaces. This lets users publish JavaScript apps that live under a workspace root without hand-writing Dockerfiles or copying sibling package manifests into the app directory.

### User-facing usage

Users can mark a JavaScript resource as a workspace member with the experimental `WithWorkspaceRoot(...)` API (`ASPIREJAVASCRIPT001`):

```csharp
var builder = DistributedApplication.CreateBuilder(args);

builder.AddViteApp("web", "../monorepo/packages/web")
       .WithWorkspaceRoot("../monorepo")
       .WithPnpm();

builder.Build().Run();
```

When publishing, Aspire now uses the workspace root as the Docker build context, copies root and member package manifests for better Docker layer caching, installs dependencies at the workspace root, and runs package-manager-specific workspace commands for the selected app.

For pnpm workspaces using `PublishAsNpmScript`, Aspire now uses `pnpm deploy` instead of the generic prod-deps overlay. Explicit pnpm 10+ projects use modern deploy when `injectWorkspacePackages: true` is configured; pnpm 8/9/unknown versions use `npm_config_force_legacy_deploy=true` for compatibility.

### Implementation notes

- Adds experimental `WithWorkspaceRoot(...)` API and workspace annotations for JavaScript app resources.
- Generates workspace-aware Dockerfiles for npm, pnpm, yarn, and bun.
- Adds typed DTO parsers for `package.json`, `packageManager` / `devEngines.packageManager`, and `pnpm-workspace.yaml`.
- Adds deferred validation so repo configuration problems surface during publish/run validation as one aggregated `DistributedApplicationException`, not as AppHost construction failures.
- Adds diagnostics coverage and an error UX catalog for malformed workspace declarations, package-manager mismatches, missing lockfiles, missing package names, unsupported workspace patterns, and pnpm deploy requirements.
- Updates YamlDotNet to 17.1.0.
- Preserves executable file modes when creating Linux tar archives in `CreateLayout`.

### Validation

Targeted local validation:

```bash
./dotnet.sh test --project tests/Aspire.Hosting.JavaScript.Tests/Aspire.Hosting.JavaScript.Tests.csproj --no-launch-profile -- --filter-class "*.JavaScriptWorkspaceTests" --filter-class "*.WorkspaceErrorExperienceTests" --filter-class "*.Internal.WorkspaceParserTests*" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Result: 107/107 passed.

Additional coverage added:

- Unit tests for workspace parser, matcher, expander, manifest discovery, package-manager version routing, and diagnostics.
- Dockerfile snapshot updates for pnpm runtime `corepack enable`.
- CLI E2E coverage that publishes a JavaScript workspace and runs `aspire do build`.

Related to #14416. This PR covers workspace-aware Dockerfile/publish support for yarn and pnpm workspaces, but does not add the proposed `AddYarnWorkspaceApp` / `AddPnpmWorkspaceApp` run-mode virtual workspace APIs.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No